### PR TITLE
feat: near-me page is fully reactive — no page reloads

### DIFF
--- a/assets/css/near-me.css
+++ b/assets/css/near-me.css
@@ -39,7 +39,7 @@
 	margin: 0;
 }
 
-/* Map controls (radius + change location) */
+/* Map controls (change location link) */
 .near-me-controls {
 	display: flex;
 	align-items: center;
@@ -48,26 +48,6 @@
 	margin-top: 0.375rem;
 	font-size: 0.8125rem;
 	color: var(--muted-text, #6b7280);
-}
-
-.near-me-radius-label {
-	display: inline-flex;
-	align-items: center;
-	gap: 0.3rem;
-}
-
-.near-me-radius-select {
-	padding: 0.125rem 0.375rem;
-	font-size: 0.8125rem;
-	border: 1px solid var(--border-color, #e5e7eb);
-	border-radius: 4px;
-	background: var(--card-background, #fff);
-	color: var(--text-color, #1a1a1a);
-	cursor: pointer;
-}
-
-.near-me-separator {
-	color: var(--border-color, #e5e7eb);
 }
 
 .near-me-reset {


### PR DESCRIPTION
## Summary

- Rewrites the near-me page as a fully reactive experience with zero page reloads
- Map is forced to dynamic mode — fetches venues via REST on pan/zoom
- Geolocation resolves → map recenters → venues load → calendar syncs (all via REST)
- Removes radius dropdown — the map viewport IS the radius
- Dispatches `datamachine-map-recenter` custom event for post-init map centering

Closes #29

## How it works

```
Page loads
    ↓
Loading spinner + geolocation request
    ↓ (1-3 seconds)
onSuccess: lat/lng received
    ↓
URL updated via History API (shareable)
    ↓
datamachine-map-recenter dispatched
    ↓
Map setView() → centers on user at zoom 12
    ↓
Map dynamic mode → REST fetch venues in viewport
    ↓
Venues render as markers
    ↓
Map fires datamachine-map-bounds-changed
    ↓
Calendar geo-sync catches → REST fetch events
    ↓
Calendar DOM swaps in-place
    ↓
User pans/zooms → cycle repeats automatically
```

## What changed

| File | What |
|------|------|
| `inc/core/near-me.php` | Force dynamic map, remove venue filter + radius dropdown, always render blocks |
| `assets/js/near-me.js` | History API instead of redirect, dispatch recenter event, remove radius handler |
| `assets/css/near-me.css` | Remove radius dropdown styles |

## What was removed

- `extrachill_events_near_me_map_venues()` — PHP-side haversine filtering (dynamic map handles this)
- `extrachill_events_near_me_map_summary()` — static venue count summary (dynamic map updates this)
- Radius dropdown (`<select>` + JS handler + CSS)
- `window.location.href` redirect on geolocation success
- `window.location.href` redirect on radius change

## What was kept

- SEO hooks (title, meta description, skip seo)
- City grid fallback for geo denied / no-JS
- User location blue dot marker
- Map center from URL params (shareable links still work)
- "Change location" link
- Haversine utility function (used elsewhere)
- Secondary header nav item

## Dependencies

- datamachine-events PR #60 — calendar geo-sync module + map recenter listener

## Testing

1. Visit `/near-me/` with no params → should see loading spinner, then map + calendar load
2. Allow geolocation → map centers on you, venues appear, calendar updates
3. Deny geolocation → city grid fallback appears
4. Pan/zoom map → calendar updates automatically (~800ms debounce)
5. Visit `/near-me/?lat=30.2672&lng=-97.7431` → should render immediately with Austin data
6. No page reloads at any point after initial load