### PR TITLE
refactor: remove static map code — companion to datamachine-events#61

### DIFF
--- a/inc/core/location-map.php
+++ b/inc/core/location-map.php
@@ -2,9 +2,12 @@
 /**
  * Location Map
  *
- * Hooks into the datamachine-events/events-map block to display venue maps
- * on location archive pages. Filters venues by city, sets map center from
- * location coordinates, and generates summary text.
+ * Renders the datamachine-events/events-map block on location archive pages.
+ * Sets map center from location coordinates and generates summary text.
+ *
+ * The map operates in dynamic mode — venues are fetched via REST API based
+ * on the taxonomy context passed through data attributes. The extrachill
+ * layer only needs to provide the center point and summary text.
  *
  * @package ExtraChillEvents
  * @since 0.7.0
@@ -18,8 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Render the events-map block on location archive pages.
  *
  * Outputs the block markup via do_blocks() — the block handles its own
- * asset loading and rendering. Filter callbacks below customize the
- * venue list, center point, and summary text.
+ * asset loading and rendering. The map block reads taxonomy/term_id from
+ * data attributes and passes them to the REST endpoint for filtering.
  *
  * @hook extrachill_archive_below_description
  */
@@ -39,57 +42,10 @@ function extrachill_events_render_location_map() {
 		return;
 	}
 
-	// Render the block — filters below provide the data.
+	// Render the block — filters below provide center and summary.
 	echo do_blocks( '<!-- wp:datamachine-events/events-map /-->' );
 }
 add_action( 'extrachill_archive_below_description', 'extrachill_events_render_location_map' );
-
-/**
- * Filter map venues to only show venues in the current location's city.
- *
- * @hook datamachine_events_map_venues
- * @param array $venues  All venues with coordinates.
- * @param array $context Map context with taxonomy/term info.
- * @return array Filtered venues matching the location.
- */
-function extrachill_events_filter_map_venues( array $venues, array $context ): array {
-	if ( ! $context['is_taxonomy'] || 'location' !== $context['taxonomy'] ) {
-		return $venues;
-	}
-
-	$location = get_term( $context['term_id'], 'location' );
-	if ( ! $location || is_wp_error( $location ) ) {
-		return $venues;
-	}
-
-	$city_name = $location->name;
-
-	// Filter to only venues whose _venue_city matches this location.
-	$filtered = array();
-	foreach ( $venues as $venue ) {
-		$venue_city = get_term_meta( $venue['term_id'], '_venue_city', true );
-
-		if ( ! empty( $venue_city ) && strcasecmp( $venue_city, $city_name ) === 0 ) {
-			$filtered[] = $venue;
-		}
-	}
-
-	// Sort by priority first, then by event count descending.
-	$priority_ids = function_exists( 'ec_get_priority_venue_ids' ) ? ec_get_priority_venue_ids() : array();
-	usort( $filtered, function ( $a, $b ) use ( $priority_ids ) {
-		$a_priority = in_array( $a['term_id'], $priority_ids, true ) ? 1 : 0;
-		$b_priority = in_array( $b['term_id'], $priority_ids, true ) ? 1 : 0;
-
-		if ( $a_priority !== $b_priority ) {
-			return $b_priority - $a_priority;
-		}
-
-		return $b['event_count'] - $a['event_count'];
-	} );
-
-	return $filtered;
-}
-add_filter( 'datamachine_events_map_venues', 'extrachill_events_filter_map_venues', 10, 2 );
 
 /**
  * Set map center to the location's coordinates.
@@ -111,9 +67,12 @@ add_filter( 'datamachine_events_map_center', 'extrachill_events_filter_map_cente
 /**
  * Generate summary text with event/venue counts for location maps.
  *
+ * Queries venue and event counts directly from the database instead of
+ * relying on a pre-filtered venue array.
+ *
  * @hook datamachine_events_map_summary
  * @param string $summary Current summary (empty by default).
- * @param array  $venues  Venue data array.
+ * @param array  $venues  Venue data array (empty — dynamic mode).
  * @param array  $context Map context.
  * @return string Summary text.
  */
@@ -122,7 +81,10 @@ function extrachill_events_filter_map_summary( string $summary, array $venues, a
 		return $summary;
 	}
 
-	$venue_count = count( $venues );
+	// Query venue count for this location directly.
+	$location_venues = extrachill_events_get_location_venues( $context['term_id'] );
+	$venue_count     = count( $location_venues );
+
 	if ( $venue_count === 0 ) {
 		return $summary;
 	}

--- a/inc/core/near-me.php
+++ b/inc/core/near-me.php
@@ -156,31 +156,6 @@ function extrachill_events_near_me_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_events_near_me_scripts' );
 
-// --- Map Block: Force Dynamic Mode ---
-
-/**
- * Force the events-map block into dynamic mode on the Near Me page.
- *
- * Dynamic mode means the map fetches venues from the REST API on pan/zoom
- * instead of relying on server-embedded JSON. This is essential because
- * the near-me page starts without a location — venues load after
- * geolocation resolves and the map centers on the user.
- *
- * @hook render_block_data
- */
-function extrachill_events_near_me_force_dynamic_map( array $parsed_block ): array {
-	if ( ! extrachill_events_is_near_me_page() ) {
-		return $parsed_block;
-	}
-
-	if ( 'datamachine-events/events-map' === $parsed_block['blockName'] ) {
-		$parsed_block['attrs']['dynamic'] = true;
-	}
-
-	return $parsed_block;
-}
-add_filter( 'render_block_data', 'extrachill_events_near_me_force_dynamic_map' );
-
 // --- Map Block Filters ---
 
 /**


### PR DESCRIPTION
## Summary

- Removes `extrachill_events_filter_map_venues()` — the `datamachine_events_map_venues` filter no longer fires since the map is always dynamic
- Rewrites summary text function to query venue count directly instead of counting a pre-filtered array
- Removes `render_block_data` hack that forced dynamic mode on near-me page

Companion to https://github.com/Extra-Chill/datamachine-events/pull/61

## Changes

| File | What |
|------|------|
| `location-map.php` | Remove venue filter function (~40 lines), rewrite summary to use `extrachill_events_get_location_venues()` |
| `near-me.php` | Remove `extrachill_events_near_me_force_dynamic_map()` filter |

## Merge order

1. Merge datamachine-events#61 first (removes static mode)
2. Then merge this PR (removes dead code that hooked into static mode)