### PR TITLE
Fix Near Me blue dot not showing on initial geolocation

### DIFF
--- a/assets/js/near-me.js
+++ b/assets/js/near-me.js
@@ -85,16 +85,24 @@
 			mapRoot.dataset.userLat   = lat;
 			mapRoot.dataset.userLon   = lng;
 
-			// If map is already initialized, dispatch recenter event.
-			if ( mapRoot.dataset.initialized === '1' ) {
-				document.dispatchEvent( new CustomEvent( 'data-machine-map-recenter', {
-					detail: {
-						lat: parseFloat( lat ),
-						lng: parseFloat( lng ),
-						zoom: 12,
-					},
-				} ) );
-			}
+		// If map is already initialized, dispatch recenter + user location events.
+		if ( mapRoot.dataset.initialized === '1' ) {
+			document.dispatchEvent( new CustomEvent( 'data-machine-map-recenter', {
+				detail: {
+					lat: parseFloat( lat ),
+					lng: parseFloat( lng ),
+					zoom: 12,
+				},
+			} ) );
+
+			// Add the blue dot marker for user location.
+			document.dispatchEvent( new CustomEvent( 'data-machine-map-set-user-location', {
+				detail: {
+					lat: parseFloat( lat ),
+					lng: parseFloat( lng ),
+				},
+			} ) );
+		}
 		}
 
 		// Hide the detection UI — map and calendar are now loading.


### PR DESCRIPTION
## Summary

- Dispatches `data-machine-map-set-user-location` event alongside `data-machine-map-recenter` when geolocation resolves and the map is already initialized
- This tells the React map component to add the blue dot marker for the user's position

## The Bug

On the Near Me page, the blue "You are here" dot only appeared after a page reload (when URL already had `?lat=X&lng=Y`). On first visit, geolocation would resolve, the map would recenter correctly, but the blue dot was missing.

## Companion PR

- Extra-Chill/data-machine-events — adds the `data-machine-map-set-user-location` event listener to the EventsMap React component