### PR TITLE
fix: add blog ID guards to prevent hooks firing on wrong sites

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -179,6 +179,20 @@ function extrachill_events() {
 extrachill_events();
 
 /**
+ * Check if the current site is the events site.
+ *
+ * Central guard for all hooks that should only run on events.extrachill.com.
+ * Uses ec_get_blog_id() from extrachill-multisite when available.
+ *
+ * @since 0.9.0
+ * @return bool True if current blog is the events site.
+ */
+function ec_is_events_site() {
+	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : null;
+	return $events_blog_id && get_current_blog_id() === $events_blog_id;
+}
+
+/**
  * Register event-submission block from build directory
  *
  * @hook init
@@ -186,6 +200,9 @@ extrachill_events();
  * @since 0.1.5
  */
 function extrachill_events_register_blocks() {
+	if ( ! ec_is_events_site() ) {
+		return;
+	}
 	register_block_type( EXTRACHILL_EVENTS_PLUGIN_DIR . 'build/event-submission' );
 }
 add_action( 'init', 'extrachill_events_register_blocks' );
@@ -198,6 +215,9 @@ add_action( 'init', 'extrachill_events_register_blocks' );
  * @since 0.1.0
  */
 function ec_events_render_homepage() {
+	if ( ! ec_is_events_site() ) {
+		return;
+	}
 	include EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/templates/homepage.php';
 }
 add_action( 'extrachill_homepage_content', 'ec_events_render_homepage' );

--- a/inc/core/nav.php
+++ b/inc/core/nav.php
@@ -20,6 +20,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array Items with submit link added
  */
 function extrachill_events_secondary_header_items( $items ) {
+    if ( ! ec_is_events_site() ) {
+        return $items;
+    }
     $items[] = array(
         'url'      => home_url( '/submit/' ),
         'label'    => __( 'Submit Event', 'extrachill-events' ),

--- a/inc/single-event/breadcrumbs.php
+++ b/inc/single-event/breadcrumbs.php
@@ -25,6 +25,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 0.1.0
  */
 function ec_events_override_breadcrumbs( $breadcrumbs, $post_id ) {
+	if ( ! ec_is_events_site() ) {
+		return $breadcrumbs;
+	}
 	if ( function_exists( 'extrachill_breadcrumbs' ) ) {
 		ob_start();
 		extrachill_breadcrumbs();
@@ -46,6 +49,9 @@ add_filter( 'data_machine_events_breadcrumbs', 'ec_events_override_breadcrumbs',
  * @since 0.1.0
  */
 function ec_events_breadcrumb_root( $root_link ) {
+	if ( ! ec_is_events_site() ) {
+		return $root_link;
+	}
 	if ( is_front_page() ) {
 		$main_site_url = ec_get_site_url( 'main' );
 		return '<a href="' . esc_url( $main_site_url ) . '">Extra Chill</a>';
@@ -68,6 +74,9 @@ add_filter( 'extrachill_breadcrumbs_root', 'ec_events_breadcrumb_root' );
  * @since 0.1.0
  */
 function ec_events_breadcrumb_trail_homepage( $custom_trail ) {
+	if ( ! ec_is_events_site() ) {
+		return $custom_trail;
+	}
 	if ( is_front_page() ) {
 		return '<span class="network-dropdown-target">Events Calendar</span>';
 	}
@@ -92,6 +101,9 @@ add_filter( 'extrachill_breadcrumbs_override_trail', 'ec_events_breadcrumb_trail
  * @since 0.1.0
  */
 function ec_events_breadcrumb_trail_archives( $custom_trail ) {
+	if ( ! ec_is_events_site() ) {
+		return $custom_trail;
+	}
 	if ( is_tax() ) {
 		$term = get_queried_object();
 		if ( $term && isset( $term->name ) ) {
@@ -121,6 +133,9 @@ add_filter( 'extrachill_breadcrumbs_override_trail', 'ec_events_breadcrumb_trail
  * @since 0.1.0
  */
 function ec_events_breadcrumb_trail_single( $custom_trail ) {
+	if ( ! ec_is_events_site() ) {
+		return $custom_trail;
+	}
 	if ( is_singular( 'data_machine_events' ) ) {
 		return '<span class="breadcrumb-title">' . get_the_title() . '</span>';
 	}
@@ -143,6 +158,9 @@ add_filter( 'extrachill_breadcrumbs_override_trail', 'ec_events_breadcrumb_trail
  * @since 0.1.0
  */
 function ec_events_back_to_home_label( $label, $url ) {
+	if ( ! ec_is_events_site() ) {
+		return $label;
+	}
 	if ( is_front_page() ) {
 		return $label;
 	}
@@ -169,6 +187,9 @@ add_filter( 'extrachill_back_to_home_label', 'ec_events_back_to_home_label', 10,
  * @since 0.2.0
  */
 function ec_events_schema_breadcrumb_items( $items ) {
+	if ( ! ec_is_events_site() ) {
+		return $items;
+	}
 	$main_site_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'main' ) : 'https://extrachill.com';
 
 	// Homepage: Extra Chill → Events Calendar


### PR DESCRIPTION
## Summary

Adds `ec_is_events_site()` helper and guards all frontend hooks that were unconditionally firing on every site in the multisite network.

### The problem

If extrachill-events gets accidentally activated on the main site (or any non-events site), it hooks into:
- Homepage content (`extrachill_homepage_content`) — renders the events calendar template
- Header nav (`extrachill_secondary_header_items`) — adds "Submit Event" link
- Breadcrumbs — overrides root, trail, back label, and schema breadcrumbs
- Block registration — registers event-submission block

### The fix

New `ec_is_events_site()` helper (follows the `is_newsletter_site()` pattern from extrachill-newsletter):

```php
function ec_is_events_site() {
    $events_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : null;
    return $events_blog_id && get_current_blog_id() === $events_blog_id;
}
```

All 10 unguarded callbacks now early-return when not on the events site. Hooks that already had guards (discovery-pages, near-me, location-seo, archive template, post type redirect) are unchanged.

### Files changed

- `extrachill-events.php` — helper function + guards on homepage, block registration
- `inc/core/nav.php` — guard on secondary header items
- `inc/single-event/breadcrumbs.php` — guards on all 7 breadcrumb callbacks