### PR TITLE
Respect continuation sort in priority venue ordering

### DIFF
--- a/inc/core/priority-venue-ordering.php
+++ b/inc/core/priority-venue-ordering.php
@@ -68,6 +68,14 @@ function ec_events_reorder_by_priority( $events, $date_key, $context ) {
 	usort(
 		$events,
 		function ( $a, $b ) use ( $priority_venue_ids, $priority_event_ids ) {
+			// Tier 0: Non-continuation events always before continuation events.
+			$a_continuation = ! empty( $a['display_context']['is_continuation'] );
+			$b_continuation = ! empty( $b['display_context']['is_continuation'] );
+
+			if ( $a_continuation !== $b_continuation ) {
+				return $a_continuation ? 1 : -1;
+			}
+
 			$a_event_priority = extrachill_is_priority_event( $a, $priority_event_ids );
 			$b_event_priority = extrachill_is_priority_event( $b, $priority_event_ids );
 			$a_venue_priority = ec_is_priority_venue_event( $a, $priority_venue_ids );


### PR DESCRIPTION
## Summary
- Adds continuation-awareness to the priority venue sort so multi-day continuation events sort to the bottom even within single-location views

## Problem
The priority venue sort (`ec_events_reorder_by_priority`) did its own `usort` which could override the core continuation-last sort added in data-machine-events. Without this change, single-location views (like filtering to Austin) could still show ongoing multi-day events above tonight's shows.

## Changes
- `priority-venue-ordering.php` — adds Tier 0 check: non-continuation events always sort before continuation events, before priority tiers are evaluated

## Companion PR
- Extra-Chill/data-machine-events — core multi-day display and sort improvements

## Live
Already deployed and verified on events.extrachill.com