### PR TITLE
fix(roundup): pass date range to DateGrouper to prevent midnight-spanning bleed

### DIFF
--- a/inc/Abilities/EventRoundupAbilities.php
+++ b/inc/Abilities/EventRoundupAbilities.php
@@ -481,7 +481,20 @@ class EventRoundupAbilities {
 			);
 		}
 
-		return \DataMachineEvents\Blocks\Calendar\Grouping\DateGrouper::group_events_by_date( $paged_events );
+		// Pass date_start + date_end to DateGrouper so it filters out
+		// bleed-in from late-night events that span midnight. Without this,
+		// a show that starts Friday 9pm and ends Saturday 12am would land
+		// in the Friday day_group even when the caller asked for Saturday
+		// only. (The underlying query ability deliberately uses overlap
+		// semantics — start_datetime >= range_start OR end_datetime >= range_start —
+		// for calendar-style "in-progress" callers. Roundups want strict
+		// per-day grouping.)
+		return \DataMachineEvents\Blocks\Calendar\Grouping\DateGrouper::group_events_by_date(
+			$paged_events,
+			false,
+			$date_start,
+			$date_end
+		);
 	}
 
 	private function countEvents( array $day_groups ): int {

--- a/inc/handlers/event-roundup/EventRoundupHandler.php
+++ b/inc/handlers/event-roundup/EventRoundupHandler.php
@@ -190,7 +190,15 @@ class EventRoundupHandler extends FetchHandler {
 			);
 		}
 
-		return \DataMachineEvents\Blocks\Calendar\Grouping\DateGrouper::group_events_by_date( $paged_events );
+		// Pass date_start + date_end so DateGrouper filters out bleed-in
+		// from late-night events that span midnight (see EventRoundupAbilities
+		// for the full rationale).
+		return \DataMachineEvents\Blocks\Calendar\Grouping\DateGrouper::group_events_by_date(
+			$paged_events,
+			false,
+			$date_start,
+			$date_end
+		);
 	}
 
 	private function resolve_next_weekday_range( string $week_start_day, string $week_end_day ): array {


### PR DESCRIPTION
## Bug

When asking for events on a specific day (`date_start = date_end`), the roundup was returning events from the previous day too. Concrete repro on production data:

```
$ wp extrachill events roundup --date-start=today --location=charleston \\
    --title="Tonight in Charleston" --user=1 --url=events.extrachill.com
# date is Saturday, Apr 25
# Expected: 15 Saturday events
# Got:      18 events — 3 from Friday Apr 24 + 15 from Saturday Apr 25
```

The 3 leaking events were Friday-night-into-Saturday shows like _"Burgundy: Karaoke Nite"_ with `start_datetime = 2026-04-24 20:00:00` and `end_datetime = 2026-04-25 00:00:00`.

## Why it happened

Two completely defensible design choices interacted to produce surprising output:

1. **`UpcomingFilter::range_start_where()`** uses overlap semantics: `start_datetime >= $range_start OR end_datetime >= $range_start`. This is correct for calendar UIs that want to show "events still in progress at this moment" at the top of an upcoming list.

2. **`DateGrouper::group_events_by_date()`** expands events to all dates they touch and then optionally filters to a date window via its `$date_start` / `$date_end` parameters (DateGrouper.php:112-125).

The query ability has overlap semantics on purpose — that's not the bug. The bug is that **`EventRoundupAbilities::queryEvents()` and `EventRoundupHandler::query_events()` were calling `DateGrouper::group_events_by_date($paged_events)` without passing the date range**, so the grouper had no way to know to filter out the bleed.

The calendar block does it right (`CalendarAbilities.php:334-339` passes `$date_start, $date_end`); we just weren't following the same pattern.

## Fix

One-line change in two places — pass the date range to DateGrouper:

```diff
- return DateGrouper::group_events_by_date( $paged_events );
+ return DateGrouper::group_events_by_date(
+     $paged_events,
+     false,           // show_past
+     $date_start,
+     $date_end
+ );
```

Plus a comment explaining why so future readers understand the overlap-vs-exact semantic and don't break it.

## Files changed (2)

- `inc/Abilities/EventRoundupAbilities.php::queryEvents()` — main on-demand entry point (CLI, agent chat, etc.)
- `inc/handlers/event-roundup/EventRoundupHandler.php::query_events()` — pipeline fetch handler (had the same bug)

Both call sites now pass the date range to DateGrouper, matching the calendar block's pattern.

## Verification

Same command as the repro, after the fix:

```
$ wp extrachill events roundup --date-start=today --location=charleston \\
    --title="Tonight in Charleston" --format=json --user=1 \\
    --url=events.extrachill.com
{
  "date_start": "2026-04-25",
  "date_end": "2026-04-25",
  "total_events": 15,         ← was 18
  "slide_count": 1,
  "event_summary": "Saturday, Apr 25:\n- Lamont Landers @ Charleston Pour House..."
                                ↑ no more Friday section
}
```

Single slide, exactly 15 Saturday events, zero Friday bleed.

## Why not change `range_start_where()` upstream?

I considered it. The OR-with-end overlap semantics are intentional and documented for the calendar block's "still in progress" use case — see `UpcomingFilter::range_start_where()`'s docblock: _"Captures events that start on/after the given datetime OR are still in progress at that datetime."_ Changing that would surprise other consumers (calendar block, FilterAbilities, EventQueryBuilder) that depend on the existing semantics.

`DateGrouper` already has the right post-query filter built in (lines 112-125). We just weren't using it. That's a bug in our caller, not a bug in the upstream primitive.