### PR TITLE
Add event roundup CTA and shared scopes

### DIFF
--- a/inc/Abilities/EventRoundupAbilities.php
+++ b/inc/Abilities/EventRoundupAbilities.php
@@ -20,6 +20,8 @@
 
 namespace ExtraChillEvents\Abilities;
 
+use DataMachineEvents\Blocks\Calendar\Query\ScopeResolver;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -71,6 +73,11 @@ class EventRoundupAbilities {
 							'type'        => 'string',
 							'description' => __( 'Weekday-name shortcut: resolves to next occurrence after week_start_day (e.g. "sunday").', 'extrachill-events' ),
 						),
+						'scope'            => array(
+							'type'        => 'string',
+							'enum'        => array( 'today', 'tonight', 'this-weekend', 'this-week' ),
+							'description' => __( 'Named date scope shared with the calendar API. Ignored when date_start or week_start_day is provided.', 'extrachill-events' ),
+						),
 						'location'         => array(
 							'type'        => 'string',
 							'description' => __( 'Location taxonomy term slug or numeric term ID. Optional.', 'extrachill-events' ),
@@ -89,8 +96,8 @@ class EventRoundupAbilities {
 						'location_name' => array( 'type' => 'string' ),
 						'total_events'  => array( 'type' => 'integer' ),
 						'day_groups'    => array(
-							'type'  => 'array',
-							'items' => array( 'type' => 'object' ),
+							'type'                 => 'object',
+							'additionalProperties' => array( 'type' => 'object' ),
 						),
 						'event_summary' => array( 'type' => 'string' ),
 					),
@@ -115,13 +122,17 @@ class EventRoundupAbilities {
 					'type'       => 'object',
 					'properties' => array(
 						'day_groups'      => array(
-							'type'        => 'array',
-							'description' => __( 'Day-grouped events from event-roundup-query.', 'extrachill-events' ),
-							'items'       => array( 'type' => 'object' ),
+							'type'                 => 'object',
+							'description'          => __( 'Date-keyed day groups from event-roundup-query.', 'extrachill-events' ),
+							'additionalProperties' => array( 'type' => 'object' ),
 						),
 						'title'           => array(
 							'type'        => 'string',
 							'description' => __( 'Optional title for first slide.', 'extrachill-events' ),
+						),
+						'cta_text'        => array(
+							'type'        => 'string',
+							'description' => __( 'Optional footer CTA. Defaults to the current site host.', 'extrachill-events' ),
 						),
 						'storage_context' => array(
 							'type'        => 'object',
@@ -169,6 +180,11 @@ class EventRoundupAbilities {
 							'type'        => 'string',
 							'description' => __( 'End date (Y-m-d). Defaults to date_start (single-day roundup).', 'extrachill-events' ),
 						),
+						'scope'      => array(
+							'type'        => 'string',
+							'enum'        => array( 'today', 'tonight', 'this-weekend', 'this-week' ),
+							'description' => __( 'Named date scope shared with the calendar API. Ignored when date_start is provided.', 'extrachill-events' ),
+						),
 						'location'   => array(
 							'type'        => 'string',
 							'description' => __( 'Location taxonomy term slug or numeric term ID. Optional.', 'extrachill-events' ),
@@ -176,6 +192,10 @@ class EventRoundupAbilities {
 						'title'      => array(
 							'type'        => 'string',
 							'description' => __( 'Optional title for the first slide.', 'extrachill-events' ),
+						),
+						'cta_text'   => array(
+							'type'        => 'string',
+							'description' => __( 'Optional footer CTA. Defaults to the current site host.', 'extrachill-events' ),
 						),
 					),
 				),
@@ -213,7 +233,13 @@ class EventRoundupAbilities {
 
 		$location_term_id = $this->resolveLocationTermId( $input );
 
-		$day_groups = $this->queryEvents( $date_range['date_start'], $date_range['date_end'], $location_term_id );
+		$day_groups = $this->queryEvents(
+			$date_range['date_start'],
+			$date_range['date_end'],
+			$location_term_id,
+			(string) ( $date_range['time_start'] ?? '' ),
+			(string) ( $date_range['time_end'] ?? '' )
+		);
 
 		if ( empty( $day_groups ) ) {
 			return array(
@@ -239,6 +265,7 @@ class EventRoundupAbilities {
 	public function executeRender( array $input ): array|\WP_Error {
 		$day_groups      = $input['day_groups'] ?? array();
 		$title           = (string) ( $input['title'] ?? '' );
+		$cta_text        = (string) ( $input['cta_text'] ?? '' );
 		$storage_context = (array) ( $input['storage_context'] ?? array() );
 
 		if ( empty( $day_groups ) ) {
@@ -260,6 +287,7 @@ class EventRoundupAbilities {
 				'data'        => array(
 					'day_groups' => $day_groups,
 					'title'      => $title,
+					'cta_text'   => $cta_text,
 				),
 				'preset'      => 'instagram_feed_portrait',
 				'format'      => 'png',
@@ -290,9 +318,9 @@ class EventRoundupAbilities {
 	}
 
 	public function executeBuild( array $input ): array|\WP_Error {
-		// Default date_start to today if neither dates nor weekday names provided.
+		// Default to the shared calendar API's today scope when no date input is provided.
 		if ( empty( $input['date_start'] ) && empty( $input['week_start_day'] ) ) {
-			$input['date_start'] = ( new \DateTime( 'now', \wp_timezone() ) )->format( 'Y-m-d' );
+			$input['scope'] = (string) ( $input['scope'] ?? 'today' );
 		}
 
 		$query_result = $this->executeQuery( $input );
@@ -317,6 +345,7 @@ class EventRoundupAbilities {
 		$render_result = $this->executeRender( array(
 			'day_groups' => $query_result['day_groups'],
 			'title'      => (string) ( $input['title'] ?? '' ),
+			'cta_text'   => (string) ( $input['cta_text'] ?? '' ),
 		) );
 		if ( \is_wp_error( $render_result ) ) {
 			return $render_result;
@@ -338,10 +367,10 @@ class EventRoundupAbilities {
 	/**
 	 * Resolve date_start / date_end from inputs.
 	 *
-	 * Precedence: explicit Y-m-d dates > weekday-name shortcuts > error.
+	 * Precedence: explicit Y-m-d dates > weekday-name shortcuts > named scope > error.
 	 * date_end defaults to date_start (single-day roundup).
 	 *
-	 * @return array{date_start: string, date_end: string}|\WP_Error
+	 * @return array{date_start: string, date_end: string, time_start?: string, time_end?: string}|\WP_Error
 	 */
 	private function resolveDateRange( array $input ): array|\WP_Error {
 		$date_start = isset( $input['date_start'] ) ? trim( (string) $input['date_start'] ) : '';
@@ -391,9 +420,25 @@ class EventRoundupAbilities {
 			return $this->resolveNextWeekdayRange( $week_start_day, $week_end_day );
 		}
 
+		$scope = isset( $input['scope'] ) ? sanitize_key( (string) $input['scope'] ) : '';
+		if ( '' !== $scope && class_exists( ScopeResolver::class ) ) {
+			$scope_range = ScopeResolver::resolve( $scope );
+			if ( $scope_range ) {
+				return array_filter(
+					array(
+						'date_start' => $scope_range['date_start'],
+						'date_end'   => $scope_range['date_end'],
+						'time_start' => $scope_range['time_start'] ?? '',
+						'time_end'   => $scope_range['time_end'] ?? '',
+					),
+					static fn( $value ) => '' !== $value
+				);
+			}
+		}
+
 		return new \WP_Error(
 			'missing_date_inputs',
-			__( 'Provide date_start (Y-m-d) or both week_start_day and week_end_day.', 'extrachill-events' ),
+			__( 'Provide date_start (Y-m-d), both week_start_day and week_end_day, or a valid scope.', 'extrachill-events' ),
 			array( 'status' => 400 )
 		);
 	}
@@ -447,13 +492,20 @@ class EventRoundupAbilities {
 		return (int) ( $input['location_term_id'] ?? 0 );
 	}
 
-	private function queryEvents( string $date_start, string $date_end, int $location_term_id ): array {
+	private function queryEvents( string $date_start, string $date_end, int $location_term_id, string $time_start = '', string $time_end = '' ): array {
 		$query_input = array(
 			'date_start' => $date_start,
 			'date_end'   => $date_end,
 			'per_page'   => -1,
 			'order'      => 'ASC',
 		);
+
+		if ( '' !== $time_start ) {
+			$query_input['time_start'] = $time_start;
+		}
+		if ( '' !== $time_end ) {
+			$query_input['time_end'] = $time_end;
+		}
 
 		if ( $location_term_id > 0 ) {
 			$query_input['tax_filters'] = array(

--- a/inc/Templates/EventRoundupTemplate.php
+++ b/inc/Templates/EventRoundupTemplate.php
@@ -19,6 +19,7 @@
  *   - Title block (first slide only) with accent underline
  *   - Day group sections: day header in day-palette color + event rows
  *   - Each event row: title + venue/time meta line
+ *   - Footer CTA pointing viewers to the full events site
  *
  * Required data fields:
  *   - day_groups (array) — date_key => { date_obj, events[] }, where each
@@ -26,11 +27,13 @@
  *
  * Optional data fields:
  *   - title (string) — appears only on first slide
+ *   - cta_text (string) — footer CTA; defaults to current site host
  *
  * Optional brand token extensions consumed by this template:
  *   - colors['event_roundup_bg']    — slide background (falls back to background_dark)
  *   - colors['event_roundup_text']  — primary text (falls back to text_inverse)
  *   - colors['event_roundup_muted'] — venue/time meta (falls back to text_muted)
+ *   - colors['event_roundup_cta']   — footer CTA (falls back to accent)
  *   - day_palette['sunday'..'saturday'] — hex per weekday (falls back to neutral palette)
  *
  * @package ExtraChillEvents\Templates
@@ -56,6 +59,9 @@ class EventRoundupTemplate implements TemplateInterface {
 	private const DAY_HEADER_SIZE        = 28;
 	private const EVENT_TITLE_SIZE       = 22;
 	private const EVENT_META_SIZE        = 18;
+	private const CTA_SIZE               = 18;
+	private const CTA_LINE_WIDTH         = 180;
+	private const CTA_LINE_GAP           = 18;
 	private const LINE_HEIGHT_MULTIPLIER = 1.4;
 
 	/**
@@ -99,6 +105,11 @@ class EventRoundupTemplate implements TemplateInterface {
 				'type'     => 'string',
 				'required' => false,
 			),
+			'cta_text'   => array(
+				'label'    => 'CTA Text',
+				'type'     => 'string',
+				'required' => false,
+			),
 		);
 	}
 
@@ -113,6 +124,7 @@ class EventRoundupTemplate implements TemplateInterface {
 
 		$day_groups = (array) ( $data['day_groups'] ?? array() );
 		$title      = (string) ( $data['title'] ?? '' );
+		$cta_text   = $this->resolve_cta_text( $data );
 
 		if ( empty( $day_groups ) ) {
 			return array();
@@ -132,6 +144,7 @@ class EventRoundupTemplate implements TemplateInterface {
 		$text_hex  = (string) ( $tokens['colors']['event_roundup_text'] ?? $tokens['colors']['text_inverse'] ?? '#e5e5e5' );
 		$muted_hex = (string) ( $tokens['colors']['event_roundup_muted'] ?? $tokens['colors']['text_muted'] ?? '#b0b0b0' );
 		$accent_hex = (string) ( $tokens['colors']['accent'] ?? '#53940b' );
+		$cta_hex    = (string) ( $tokens['colors']['event_roundup_cta'] ?? $accent_hex );
 
 		$day_palette = isset( $tokens['day_palette'] ) && is_array( $tokens['day_palette'] )
 			? array_merge( self::FALLBACK_DAY_PALETTE, $tokens['day_palette'] )
@@ -162,6 +175,8 @@ class EventRoundupTemplate implements TemplateInterface {
 				$text_hex,
 				$muted_hex,
 				$accent_hex,
+				$cta_hex,
+				$cta_text,
 				$day_palette
 			);
 
@@ -171,6 +186,20 @@ class EventRoundupTemplate implements TemplateInterface {
 		}
 
 		return $image_paths;
+	}
+
+	/**
+	 * Resolve footer CTA text shown on every slide.
+	 */
+	private function resolve_cta_text( array $data ): string {
+		$cta_text = isset( $data['cta_text'] ) ? trim( (string) $data['cta_text'] ) : '';
+
+		if ( '' === $cta_text ) {
+			$host = wp_parse_url( home_url( '/' ), PHP_URL_HOST );
+			$cta_text = $host ? sprintf( 'More shows at %s', $host ) : '';
+		}
+
+		return strtoupper( $cta_text );
 	}
 
 	/**
@@ -285,6 +314,8 @@ class EventRoundupTemplate implements TemplateInterface {
 		string $text_hex,
 		string $muted_hex,
 		string $accent_hex,
+		string $cta_hex,
+		string $cta_text,
 		array $day_palette
 	): ?string {
 		$renderer = new GDRenderer();
@@ -302,6 +333,7 @@ class EventRoundupTemplate implements TemplateInterface {
 		$text_color  = $renderer->color_hex( 'text', $text_hex );
 		$muted_color = $renderer->color_hex( 'muted', $muted_hex );
 		$accent      = $renderer->color_hex( 'accent', $accent_hex );
+		$cta_color   = $renderer->color_hex( 'cta', $cta_hex );
 
 		$renderer->fill( $bg_color );
 
@@ -314,6 +346,8 @@ class EventRoundupTemplate implements TemplateInterface {
 		foreach ( $slide_days as $day_group ) {
 			$y = $this->render_day_group( $renderer, $day_group, $y, $text_color, $muted_color, $day_palette );
 		}
+
+		$this->render_cta( $renderer, $cta_text, $cta_color );
 
 		$filename = sprintf( 'roundup-slide-%d.%s', $slide_number, 'jpeg' === $format ? 'jpg' : 'png' );
 
@@ -355,6 +389,29 @@ class EventRoundupTemplate implements TemplateInterface {
 		$y += self::TITLE_UNDERLINE_HEIGHT + 30;
 
 		return $y;
+	}
+
+	/**
+	 * Render a small footer CTA to send viewers back to the full calendar.
+	 */
+	private function render_cta( GDRenderer $renderer, string $cta_text, int $cta_color ): void {
+		if ( '' === $cta_text ) {
+			return;
+		}
+
+		$baseline = $renderer->get_height() - self::PADDING;
+		$line_y   = $baseline - self::CTA_SIZE - self::CTA_LINE_GAP;
+		$line_x   = (int) ( ( $renderer->get_width() - self::CTA_LINE_WIDTH ) / 2 );
+
+		$renderer->filled_rect(
+			$line_x,
+			$line_y,
+			$line_x + self::CTA_LINE_WIDTH,
+			$line_y + self::TITLE_UNDERLINE_HEIGHT,
+			$cta_color
+		);
+
+		$renderer->draw_text_centered( $cta_text, self::CTA_SIZE, $baseline, $cta_color, 'body' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Add a footer CTA to event roundup graphics, defaulting to the current events site host.
- Let roundup query/build abilities use the same named scopes as the calendar API (`today`, `tonight`, `this-weekend`, `this-week`).
- Correct the `day_groups` ability schema to match the date-keyed grouped event payload.

## Verification
- `php -l inc/Abilities/EventRoundupAbilities.php && php -l inc/Templates/EventRoundupTemplate.php`
- `git diff --check`
- Rendered a sample roundup slide with the new CTA.
- Queried Charleston `2026-04-26` directly and confirmed 14 events.