### PR TITLE
feat(abilities): register events-domain abilities (#68)

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -150,6 +150,9 @@ class ExtraChillEvents {
 			return;
 		}
 
+		// Events-domain abilities (procedural, per issue #68).
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/abilities/register.php';
+
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/EventRoundupAbilities.php';
 		new \ExtraChillEvents\Abilities\EventRoundupAbilities();
 

--- a/inc/abilities/events-calendar.php
+++ b/inc/abilities/events-calendar.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Events Calendar Ability
+ *
+ * Returns paginated date-grouped calendar events with optional
+ * taxonomy, geo-proximity, scope, and search filtering.
+ *
+ * Delegates to the data-machine-events/get-calendar-page ability
+ * and transforms the result into a consumer-friendly shape.
+ *
+ * @package ExtraChillEvents
+ * @since   0.19.0
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_events_register_calendar_ability' );
+
+/**
+ * Register extrachill/events-calendar ability.
+ */
+function extrachill_events_register_calendar_ability(): void {
+
+	wp_register_ability(
+		'extrachill/events-calendar',
+		array(
+			'label'               => __( 'Events Calendar', 'extrachill-events' ),
+			'description'         => __( 'Returns paginated date-grouped calendar events with optional taxonomy, geo, scope, and search filtering.', 'extrachill-events' ),
+			'category'            => 'extrachill-events',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'page'     => array(
+						'type'        => 'integer',
+						'description' => 'Page number (1-indexed).',
+						'default'     => 1,
+						'minimum'     => 1,
+					),
+					'venue'    => array(
+						'type'        => 'string',
+						'description' => 'Filter by venue taxonomy slug.',
+					),
+					'promoter' => array(
+						'type'        => 'string',
+						'description' => 'Filter by promoter taxonomy slug.',
+					),
+					'location' => array(
+						'type'        => 'string',
+						'description' => 'Filter by location taxonomy slug.',
+					),
+					'scope'    => array(
+						'type'        => 'string',
+						'description' => 'Time-window scope.',
+						'enum'        => array( 'today', 'tonight', 'this-weekend', 'this-week' ),
+					),
+					'lat'      => array(
+						'type'        => 'number',
+						'description' => 'Latitude for geo filtering.',
+					),
+					'lng'      => array(
+						'type'        => 'number',
+						'description' => 'Longitude for geo filtering.',
+					),
+					'radius'   => array(
+						'type'        => 'integer',
+						'description' => 'Radius in miles for geo filtering.',
+						'default'     => 25,
+					),
+					'search'   => array(
+						'type'        => 'string',
+						'description' => 'Free-text search query.',
+					),
+					'past'     => array(
+						'type'        => 'boolean',
+						'description' => 'Include past events.',
+						'default'     => false,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'dates'    => array(
+						'type'  => 'array',
+						'items' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'date'   => array( 'type' => 'string' ),
+								'label'  => array( 'type' => 'string' ),
+								'events' => array( 'type' => 'array' ),
+							),
+						),
+					),
+					'total'    => array( 'type' => 'integer' ),
+					'page'     => array( 'type' => 'integer' ),
+					'has_more' => array( 'type' => 'boolean' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_events_ability_calendar',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute the events-calendar ability.
+ *
+ * @param array $input Input matching input_schema.
+ * @return array|WP_Error Calendar response or error.
+ */
+function extrachill_events_ability_calendar( array $input ): array|\WP_Error {
+	$ability = wp_get_ability( 'data-machine-events/get-calendar-page' );
+	if ( ! $ability ) {
+		return new \WP_Error(
+			'ability_unavailable',
+			__( 'Calendar ability is not registered.', 'extrachill-events' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	$delegate_input = array(
+		'paged'        => (int) ( $input['page'] ?? 1 ),
+		'include_html' => false,
+		'include_gaps' => false,
+		'past'         => ! empty( $input['past'] ),
+	);
+
+	if ( ! empty( $input['scope'] ) ) {
+		$delegate_input['scope'] = sanitize_text_field( $input['scope'] );
+	}
+
+	if ( ! empty( $input['search'] ) ) {
+		$delegate_input['event_search'] = sanitize_text_field( $input['search'] );
+	}
+
+	// Build taxonomy filter from slug params.
+	$tax_filter = array();
+	$mappings   = array(
+		'venue'    => 'venue',
+		'promoter' => 'promoter',
+		'location' => 'location',
+	);
+
+	foreach ( $mappings as $param => $taxonomy ) {
+		$slug = $input[ $param ] ?? '';
+		if ( empty( $slug ) ) {
+			continue;
+		}
+
+		$term = get_term_by( 'slug', sanitize_text_field( $slug ), $taxonomy );
+		if ( $term && ! is_wp_error( $term ) ) {
+			$tax_filter[ $taxonomy ] = array( $term->term_id );
+		}
+	}
+
+	if ( ! empty( $tax_filter ) ) {
+		$delegate_input['tax_filter'] = $tax_filter;
+	}
+
+	// Geo params.
+	if ( isset( $input['lat'] ) && isset( $input['lng'] ) ) {
+		$delegate_input['geo_lat']    = (float) $input['lat'];
+		$delegate_input['geo_lng']    = (float) $input['lng'];
+		$delegate_input['geo_radius'] = (int) ( $input['radius'] ?? 25 );
+	}
+
+	$result = $ability->execute( $delegate_input );
+
+	if ( is_wp_error( $result ) ) {
+		return new \WP_Error(
+			'calendar_error',
+			$result->get_error_message(),
+			array( 'status' => 500 )
+		);
+	}
+
+	return extrachill_events_transform_calendar_response( $result );
+}
+
+/**
+ * Transform calendar ability result into consumer-friendly shape.
+ *
+ * @param array $result Raw result from data-machine-events/get-calendar-page.
+ * @return array Transformed response.
+ */
+function extrachill_events_transform_calendar_response( array $result ): array {
+	$dates = array();
+
+	foreach ( $result['paged_date_groups'] ?? array() as $group ) {
+		$date_obj = date_create( $group['date'] );
+		$label    = $date_obj ? $date_obj->format( 'l, F j, Y' ) : $group['date'];
+
+		$events = array();
+		foreach ( $group['events'] ?? array() as $event ) {
+			$event_data = $event['event_data'] ?? array();
+			$post_id    = $event['post_id'];
+
+			// Build datetime from startDate + startTime block attributes.
+			$datetime = '';
+			if ( ! empty( $event_data['startDate'] ) ) {
+				$time     = $event_data['startTime'] ?? '00:00:00';
+				$datetime = $event_data['startDate'] . 'T' . $time;
+			}
+
+			$end_datetime = null;
+			if ( ! empty( $event_data['endDate'] ) ) {
+				$end_time     = $event_data['endTime'] ?? '23:59:59';
+				$end_datetime = $event_data['endDate'] . 'T' . $end_time;
+			}
+
+			// Resolve venue from post terms.
+			$venue_data  = null;
+			$venue_terms = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'all' ) );
+			if ( ! empty( $venue_terms ) && ! is_wp_error( $venue_terms ) ) {
+				$venue_data = array(
+					'id'   => $venue_terms[0]->term_id,
+					'name' => $venue_terms[0]->name,
+					'slug' => $venue_terms[0]->slug,
+				);
+			}
+
+			// Ticket URL from block attributes or post meta.
+			$ticket_url = $event_data['ticketUrl'] ?? null;
+			if ( empty( $ticket_url ) ) {
+				$ticket_url = get_post_meta( $post_id, '_datamachine_ticket_url', true ) ?: null;
+			}
+
+			$events[] = array(
+				'id'           => $post_id,
+				'title'        => $event['title'],
+				'datetime'     => $datetime,
+				'end_datetime' => $end_datetime,
+				'venue'        => $venue_data,
+				'ticket_url'   => $ticket_url,
+				'permalink'    => get_permalink( $post_id ),
+			);
+		}
+
+		$dates[] = array(
+			'date'   => $group['date'],
+			'label'  => $label,
+			'events' => $events,
+		);
+	}
+
+	return array(
+		'dates'    => $dates,
+		'total'    => $result['total_event_count'] ?? 0,
+		'page'     => $result['current_page'] ?? 1,
+		'has_more' => ( $result['current_page'] ?? 1 ) < ( $result['max_pages'] ?? 1 ),
+	);
+}

--- a/inc/abilities/events-check-venue-duplicate.php
+++ b/inc/abilities/events-check-venue-duplicate.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Events Check Venue Duplicate Ability
+ *
+ * Checks for existing venues matching a given name.  Used by the
+ * event submission form to warn about potential duplicate venues
+ * before creation.
+ *
+ * @package ExtraChillEvents
+ * @since   0.19.0
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_events_register_check_venue_duplicate_ability' );
+
+/**
+ * Register extrachill/events-check-venue-duplicate ability.
+ */
+function extrachill_events_register_check_venue_duplicate_ability(): void {
+
+	wp_register_ability(
+		'extrachill/events-check-venue-duplicate',
+		array(
+			'label'               => __( 'Check Venue Duplicate', 'extrachill-events' ),
+			'description'         => __( 'Checks for existing venues matching a given name. Returns matching venue records for duplicate detection.', 'extrachill-events' ),
+			'category'            => 'extrachill-events',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'name' ),
+				'properties' => array(
+					'name' => array(
+						'type'        => 'string',
+						'description' => 'Venue name to check.',
+					),
+					'city' => array(
+						'type'        => 'string',
+						'description' => 'City for more accurate matching.',
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'        => array( 'type' => 'integer' ),
+						'name'      => array( 'type' => 'string' ),
+						'slug'      => array( 'type' => 'string' ),
+						'address'   => array( 'type' => 'string' ),
+						'city'      => array( 'type' => 'string' ),
+						'state'     => array( 'type' => 'string' ),
+						'country'   => array( 'type' => 'string' ),
+						'latitude'  => array( 'type' => 'number' ),
+						'longitude' => array( 'type' => 'number' ),
+						'timezone'  => array( 'type' => 'string' ),
+						'website'   => array( 'type' => 'string' ),
+					),
+				),
+			),
+			'execute_callback'    => 'extrachill_events_ability_check_venue_duplicate',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute the events-check-venue-duplicate ability.
+ *
+ * @param array $input Input with 'name' and optional 'city'.
+ * @return array|WP_Error Array of matching venue records or error.
+ */
+function extrachill_events_ability_check_venue_duplicate( array $input ): array|\WP_Error {
+	$name = sanitize_text_field( $input['name'] ?? '' );
+
+	if ( empty( $name ) ) {
+		return new \WP_Error(
+			'missing_name',
+			__( 'Venue name is required.', 'extrachill-events' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	// Search for venues matching the name.
+	$terms = get_terms( array(
+		'taxonomy'   => 'venue',
+		'hide_empty' => false,
+		'name__like' => $name,
+		'number'     => 10,
+	) );
+
+	if ( is_wp_error( $terms ) || empty( $terms ) ) {
+		return array();
+	}
+
+	$matches = array();
+	foreach ( $terms as $term ) {
+		$matches[] = extrachill_events_transform_venue_detail( array(
+			'term_id' => $term->term_id,
+			'name'    => $term->name,
+			'slug'    => $term->slug,
+		) );
+	}
+
+	return $matches;
+}

--- a/inc/abilities/events-filters.php
+++ b/inc/abilities/events-filters.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Events Filters Ability
+ *
+ * Returns available filter options (venues, promoters, locations)
+ * for the events calendar UI.
+ *
+ * Delegates to data-machine-events/get-filter-options and transforms
+ * the response into a flat consumer-friendly shape.
+ *
+ * @package ExtraChillEvents
+ * @since   0.19.0
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_events_register_filters_ability' );
+
+/**
+ * Register extrachill/events-filters ability.
+ */
+function extrachill_events_register_filters_ability(): void {
+
+	wp_register_ability(
+		'extrachill/events-filters',
+		array(
+			'label'               => __( 'Events Filters', 'extrachill-events' ),
+			'description'         => __( 'Returns available filter options (venues, promoters, locations) for the events calendar.', 'extrachill-events' ),
+			'category'            => 'extrachill-events',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'venues'    => array( 'type' => 'array' ),
+					'promoters' => array( 'type' => 'array' ),
+					'locations' => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_events_ability_filters',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute the events-filters ability.
+ *
+ * @param array $input Input (unused — no params).
+ * @return array|WP_Error Filter options or error.
+ */
+function extrachill_events_ability_filters( array $input ): array|\WP_Error {
+	$ability = wp_get_ability( 'data-machine-events/get-filter-options' );
+	if ( ! $ability ) {
+		return new \WP_Error(
+			'ability_unavailable',
+			__( 'Filter options ability is not registered.', 'extrachill-events' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	$result = $ability->execute( array() );
+
+	if ( is_wp_error( $result ) ) {
+		return new \WP_Error(
+			'filters_error',
+			$result->get_error_message(),
+			array( 'status' => 500 )
+		);
+	}
+
+	return extrachill_events_transform_filters_response( $result );
+}
+
+/**
+ * Transform filter-options result into consumer-friendly shape.
+ *
+ * Flattens hierarchical terms into a single list per taxonomy.
+ *
+ * @param array $result Raw result from data-machine-events/get-filter-options.
+ * @return array Transformed response.
+ */
+function extrachill_events_transform_filters_response( array $result ): array {
+	$taxonomies = $result['taxonomies'] ?? array();
+
+	$transform_terms = static function ( array $taxonomy_data ): array {
+		$terms       = $taxonomy_data['terms'] ?? $taxonomy_data;
+		$transformed = array();
+
+		foreach ( $terms as $term ) {
+			$entry = array(
+				'id'    => (int) ( $term['term_id'] ?? $term['id'] ?? 0 ),
+				'name'  => $term['name'] ?? '',
+				'slug'  => $term['slug'] ?? '',
+				'count' => (int) ( $term['event_count'] ?? $term['count'] ?? 0 ),
+			);
+
+			// Flatten children into the same list.
+			if ( ! empty( $term['children'] ) ) {
+				$transformed[] = $entry;
+				foreach ( $term['children'] as $child ) {
+					$transformed[] = array(
+						'id'    => (int) ( $child['term_id'] ?? $child['id'] ?? 0 ),
+						'name'  => $child['name'] ?? '',
+						'slug'  => $child['slug'] ?? '',
+						'count' => (int) ( $child['event_count'] ?? $child['count'] ?? 0 ),
+					);
+				}
+				continue;
+			}
+
+			$transformed[] = $entry;
+		}
+
+		return $transformed;
+	};
+
+	return array(
+		'venues'    => $transform_terms( $taxonomies['venue'] ?? array() ),
+		'promoters' => $transform_terms( $taxonomies['promoter'] ?? array() ),
+		'locations' => $transform_terms( $taxonomies['location'] ?? array() ),
+	);
+}

--- a/inc/abilities/events-geocode.php
+++ b/inc/abilities/events-geocode.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Events Geocode Ability
+ *
+ * Geocodes a search query (address, city, or place name) via
+ * data-machine-events/geocode-search (Nominatim) and returns
+ * lat/lon results scoped to the US.
+ *
+ * @package ExtraChillEvents
+ * @since   0.19.0
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_events_register_geocode_ability' );
+
+/**
+ * Register extrachill/events-geocode ability.
+ */
+function extrachill_events_register_geocode_ability(): void {
+
+	wp_register_ability(
+		'extrachill/events-geocode',
+		array(
+			'label'               => __( 'Events Geocode', 'extrachill-events' ),
+			'description'         => __( 'Geocode a search query to lat/lon coordinates via Nominatim. Results scoped to US.', 'extrachill-events' ),
+			'category'            => 'extrachill-events',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'q' ),
+				'properties' => array(
+					'q' => array(
+						'type'        => 'string',
+						'description' => 'Search query (address, city, or place name).',
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'lat'          => array( 'type' => 'number' ),
+						'lon'          => array( 'type' => 'number' ),
+						'display_name' => array( 'type' => 'string' ),
+					),
+				),
+			),
+			'execute_callback'    => 'extrachill_events_ability_geocode',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute the events-geocode ability.
+ *
+ * @param array $input Input with 'q' search query.
+ * @return array|WP_Error Array of geocode results or error.
+ */
+function extrachill_events_ability_geocode( array $input ): array|\WP_Error {
+	$ability = wp_get_ability( 'data-machine-events/geocode-search' );
+	if ( ! $ability ) {
+		return new \WP_Error(
+			'ability_unavailable',
+			__( 'Geocode search ability is not registered.', 'extrachill-events' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	$query = sanitize_text_field( $input['q'] ?? '' );
+	if ( empty( $query ) ) {
+		return new \WP_Error(
+			'missing_query',
+			__( 'Search query (q) is required.', 'extrachill-events' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$result = $ability->execute( array(
+		'query'        => $query,
+		'countrycodes' => 'us',
+	) );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	// Transform Nominatim results to GeoSearchResult shape.
+	$results = array();
+	foreach ( $result['results'] ?? array() as $item ) {
+		$results[] = array(
+			'lat'          => (float) ( $item['lat'] ?? 0 ),
+			'lon'          => (float) ( $item['lon'] ?? 0 ),
+			'display_name' => $item['display_name'] ?? '',
+		);
+	}
+
+	return $results;
+}

--- a/inc/abilities/events-get-venue.php
+++ b/inc/abilities/events-get-venue.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Events Get Venue Ability
+ *
+ * Returns detailed information for a single venue by term ID,
+ * including address, city, state, country, coordinates, timezone,
+ * and website.
+ *
+ * @package ExtraChillEvents
+ * @since   0.19.0
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_events_register_get_venue_ability' );
+
+/**
+ * Register extrachill/events-get-venue ability.
+ */
+function extrachill_events_register_get_venue_ability(): void {
+
+	wp_register_ability(
+		'extrachill/events-get-venue',
+		array(
+			'label'               => __( 'Get Venue', 'extrachill-events' ),
+			'description'         => __( 'Returns detailed information for a single venue by term ID.', 'extrachill-events' ),
+			'category'            => 'extrachill-events',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'id' ),
+				'properties' => array(
+					'id' => array(
+						'type'        => 'integer',
+						'description' => 'Venue term ID.',
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'        => array( 'type' => 'integer' ),
+					'name'      => array( 'type' => 'string' ),
+					'slug'      => array( 'type' => 'string' ),
+					'address'   => array( 'type' => 'string' ),
+					'city'      => array( 'type' => 'string' ),
+					'state'     => array( 'type' => 'string' ),
+					'country'   => array( 'type' => 'string' ),
+					'latitude'  => array( 'type' => 'number' ),
+					'longitude' => array( 'type' => 'number' ),
+					'timezone'  => array( 'type' => 'string' ),
+					'website'   => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_events_ability_get_venue',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute the events-get-venue ability.
+ *
+ * @param array $input Input with 'id' (venue term ID).
+ * @return array|WP_Error Venue detail or error.
+ */
+function extrachill_events_ability_get_venue( array $input ): array|\WP_Error {
+	$term_id = isset( $input['id'] ) ? absint( $input['id'] ) : 0;
+
+	if ( ! $term_id ) {
+		return new \WP_Error(
+			'missing_id',
+			__( 'Venue term ID is required.', 'extrachill-events' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$term = get_term( $term_id, 'venue' );
+	if ( ! $term || is_wp_error( $term ) ) {
+		return new \WP_Error(
+			'venue_not_found',
+			__( 'Venue not found.', 'extrachill-events' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	// Build venue detail from term meta.
+	$venue_data = array(
+		'term_id' => $term->term_id,
+		'name'    => $term->name,
+		'slug'    => $term->slug,
+	);
+
+	// Read venue meta fields if Venue_Taxonomy helper is available.
+	if ( class_exists( '\\DataMachineEvents\\Core\\Venue_Taxonomy' ) ) {
+		$raw = \DataMachineEvents\Core\Venue_Taxonomy::get_venue_data( $term->term_id );
+		$venue_data['address']     = $raw['address'] ?? '';
+		$venue_data['city']        = $raw['city'] ?? '';
+		$venue_data['state']       = $raw['state'] ?? '';
+		$venue_data['country']     = $raw['country'] ?? '';
+		$venue_data['timezone']    = $raw['timezone'] ?? '';
+		$venue_data['website']     = $raw['website'] ?? '';
+		$venue_data['coordinates'] = get_term_meta( $term->term_id, '_venue_coordinates', true ) ?: '';
+	}
+
+	return extrachill_events_transform_venue_detail( $venue_data );
+}
+
+/**
+ * Transform raw venue data into consumer-friendly detail shape.
+ *
+ * Shared by events-get-venue and events-check-venue-duplicate.
+ *
+ * @param array $venue Raw venue data with optional coordinates string.
+ * @return array Transformed venue detail.
+ */
+function extrachill_events_transform_venue_detail( array $venue ): array {
+	$lat = null;
+	$lon = null;
+
+	if ( ! empty( $venue['coordinates'] ) && strpos( $venue['coordinates'], ',' ) !== false ) {
+		$parts = explode( ',', $venue['coordinates'] );
+		$lat   = (float) trim( $parts[0] );
+		$lon   = (float) trim( $parts[1] );
+	}
+
+	return array(
+		'id'        => (int) ( $venue['term_id'] ?? 0 ),
+		'name'      => $venue['name'] ?? '',
+		'slug'      => $venue['slug'] ?? '',
+		'address'   => $venue['address'] ?? null,
+		'city'      => $venue['city'] ?? null,
+		'state'     => $venue['state'] ?? null,
+		'country'   => $venue['country'] ?? null,
+		'latitude'  => $lat,
+		'longitude' => $lon,
+		'timezone'  => $venue['timezone'] ?? null,
+		'website'   => $venue['website'] ?? null,
+	);
+}

--- a/inc/abilities/events-list-venues.php
+++ b/inc/abilities/events-list-venues.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Events List Venues Ability
+ *
+ * Returns venues with optional geo-proximity, viewport-bounds,
+ * and location-taxonomy filtering.
+ *
+ * Delegates to data-machine-events/list-venues and transforms
+ * venue records into a consumer-friendly shape.
+ *
+ * @package ExtraChillEvents
+ * @since   0.19.0
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_events_register_list_venues_ability' );
+
+/**
+ * Register extrachill/events-list-venues ability.
+ */
+function extrachill_events_register_list_venues_ability(): void {
+
+	wp_register_ability(
+		'extrachill/events-list-venues',
+		array(
+			'label'               => __( 'List Venues', 'extrachill-events' ),
+			'description'         => __( 'Returns venues with optional geo-proximity, viewport-bounds, and location-taxonomy filtering.', 'extrachill-events' ),
+			'category'            => 'extrachill-events',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'location' => array(
+						'type'        => 'string',
+						'description' => 'Filter by location taxonomy slug.',
+					),
+					'sw_lat'   => array(
+						'type'        => 'number',
+						'description' => 'Southwest latitude bound.',
+					),
+					'sw_lng'   => array(
+						'type'        => 'number',
+						'description' => 'Southwest longitude bound.',
+					),
+					'ne_lat'   => array(
+						'type'        => 'number',
+						'description' => 'Northeast latitude bound.',
+					),
+					'ne_lng'   => array(
+						'type'        => 'number',
+						'description' => 'Northeast longitude bound.',
+					),
+					'lat'      => array(
+						'type'        => 'number',
+						'description' => 'Center latitude for proximity search.',
+					),
+					'lng'      => array(
+						'type'        => 'number',
+						'description' => 'Center longitude for proximity search.',
+					),
+					'radius'   => array(
+						'type'        => 'integer',
+						'description' => 'Search radius in miles.',
+						'default'     => 25,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'          => array( 'type' => 'integer' ),
+						'name'        => array( 'type' => 'string' ),
+						'slug'        => array( 'type' => 'string' ),
+						'address'     => array( 'type' => 'string' ),
+						'latitude'    => array( 'type' => 'number' ),
+						'longitude'   => array( 'type' => 'number' ),
+						'event_count' => array( 'type' => 'integer' ),
+					),
+				),
+			),
+			'execute_callback'    => 'extrachill_events_ability_list_venues',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute the events-list-venues ability.
+ *
+ * @param array $input Input matching input_schema.
+ * @return array|WP_Error Array of venue records or error.
+ */
+function extrachill_events_ability_list_venues( array $input ): array|\WP_Error {
+	$ability = wp_get_ability( 'data-machine-events/list-venues' );
+	if ( ! $ability ) {
+		return new \WP_Error(
+			'ability_unavailable',
+			__( 'List venues ability is not registered.', 'extrachill-events' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	$delegate_input = array();
+
+	// Geo proximity params.
+	if ( isset( $input['lat'] ) && isset( $input['lng'] ) ) {
+		$delegate_input['lat']    = (float) $input['lat'];
+		$delegate_input['lng']    = (float) $input['lng'];
+		$delegate_input['radius'] = (int) ( $input['radius'] ?? 25 );
+	}
+
+	// Viewport bounds.
+	if ( isset( $input['sw_lat'], $input['sw_lng'], $input['ne_lat'], $input['ne_lng'] ) ) {
+		$delegate_input['bounds'] = implode( ',', array(
+			(float) $input['sw_lat'],
+			(float) $input['sw_lng'],
+			(float) $input['ne_lat'],
+			(float) $input['ne_lng'],
+		) );
+	}
+
+	// Location taxonomy filter.
+	$location = $input['location'] ?? '';
+	if ( ! empty( $location ) ) {
+		$term = get_term_by( 'slug', sanitize_text_field( $location ), 'location' );
+		if ( $term && ! is_wp_error( $term ) ) {
+			$delegate_input['taxonomy'] = 'location';
+			$delegate_input['term_id']  = $term->term_id;
+		}
+	}
+
+	$result = $ability->execute( $delegate_input );
+
+	if ( is_wp_error( $result ) ) {
+		return new \WP_Error(
+			'venues_error',
+			$result->get_error_message(),
+			array( 'status' => 500 )
+		);
+	}
+
+	return array_map( 'extrachill_events_transform_venue', $result['venues'] ?? array() );
+}
+
+/**
+ * Transform a raw venue record into consumer-friendly shape.
+ *
+ * @param array $venue Raw venue data.
+ * @return array Transformed venue.
+ */
+function extrachill_events_transform_venue( array $venue ): array {
+	return array(
+		'id'          => (int) ( $venue['term_id'] ?? 0 ),
+		'name'        => $venue['name'] ?? '',
+		'slug'        => $venue['slug'] ?? '',
+		'address'     => $venue['address'] ?? null,
+		'latitude'    => isset( $venue['lat'] ) ? (float) $venue['lat'] : null,
+		'longitude'   => isset( $venue['lon'] ) ? (float) $venue['lon'] : null,
+		'event_count' => (int) ( $venue['event_count'] ?? 0 ),
+	);
+}

--- a/inc/abilities/events-submit.php
+++ b/inc/abilities/events-submit.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Events Submit Ability
+ *
+ * Public-facing event submission.  Validates input, verifies Turnstile,
+ * resolves contact info, and delegates to the existing
+ * extrachill/submit-event ability (registered in
+ * inc/Abilities/EventSubmissionAbilities.php).
+ *
+ * This ability is the branded entry-point that matches the
+ * POST /event-submissions REST route. The canonical business logic
+ * already lives in extrachill/submit-event.
+ *
+ * @package ExtraChillEvents
+ * @since   0.19.0
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_events_register_submit_ability' );
+
+/**
+ * Register extrachill/events-submit ability.
+ */
+function extrachill_events_register_submit_ability(): void {
+
+	wp_register_ability(
+		'extrachill/events-submit',
+		array(
+			'label'               => __( 'Submit Event', 'extrachill-events' ),
+			'description'         => __( 'Process a public event submission. Validates input, verifies Turnstile, stores flyer, and queues for review.', 'extrachill-events' ),
+			'category'            => 'extrachill-events',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'event_title', 'event_date' ),
+				'properties' => array(
+					'event_title'        => array(
+						'type'        => 'string',
+						'description' => 'Event title.',
+					),
+					'event_date'         => array(
+						'type'        => 'string',
+						'description' => 'Event date (YYYY-MM-DD).',
+					),
+					'event_time'         => array(
+						'type'        => 'string',
+						'description' => 'Event start time (HH:MM).',
+					),
+					'venue_name'         => array(
+						'type'        => 'string',
+						'description' => 'Venue name.',
+					),
+					'event_city'         => array(
+						'type'        => 'string',
+						'description' => 'City or region.',
+					),
+					'event_lineup'       => array(
+						'type'        => 'string',
+						'description' => 'Lineup or headliners.',
+					),
+					'event_link'         => array(
+						'type'        => 'string',
+						'description' => 'Ticket or info URL.',
+					),
+					'notes'              => array(
+						'type'        => 'string',
+						'description' => 'Additional details.',
+					),
+					'contact_name'       => array(
+						'type'        => 'string',
+						'description' => 'Submitter name (required for anonymous submissions).',
+					),
+					'contact_email'      => array(
+						'type'        => 'string',
+						'description' => 'Submitter email (required for anonymous submissions).',
+					),
+					'turnstile_response' => array(
+						'type'        => 'string',
+						'description' => 'Cloudflare Turnstile verification token.',
+					),
+					'system_prompt'      => array(
+						'type'        => 'string',
+						'description' => 'Custom system prompt for AI processing step.',
+					),
+					'flyer'              => array(
+						'type'        => 'object',
+						'description' => 'Uploaded flyer file data from $_FILES.',
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'message' => array( 'type' => 'string' ),
+					'job_id'  => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_events_ability_submit',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => false,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute the events-submit ability.
+ *
+ * Delegates to the existing extrachill/submit-event ability which
+ * owns the canonical Turnstile + DM workflow logic.
+ *
+ * @param array $input Submission data matching input_schema.
+ * @return array|WP_Error Result with message and job_id, or error.
+ */
+function extrachill_events_ability_submit( array $input ): array|\WP_Error {
+	$ability = wp_get_ability( 'extrachill/submit-event' );
+	if ( ! $ability ) {
+		return new \WP_Error(
+			'ability_unavailable',
+			__( 'Event submission is not available.', 'extrachill-events' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	// Pass the full input through — extrachill/submit-event handles
+	// sanitisation, Turnstile verification, contact resolution, and
+	// DM workflow execution.
+	$result = $ability->execute( $input );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return $result;
+}

--- a/inc/abilities/events-upcoming-counts.php
+++ b/inc/abilities/events-upcoming-counts.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Events Upcoming Counts Ability
+ *
+ * Returns upcoming-event counts per taxonomy term.  Supports bulk
+ * queries (all terms in a taxonomy) and single-term lookups by slug.
+ * Results are cached with a 6-hour transient.
+ *
+ * @package ExtraChillEvents
+ * @since   0.19.0
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_events_register_upcoming_counts_ability' );
+
+/**
+ * Register extrachill/events-upcoming-counts ability.
+ */
+function extrachill_events_register_upcoming_counts_ability(): void {
+
+	wp_register_ability(
+		'extrachill/events-upcoming-counts',
+		array(
+			'label'               => __( 'Events Upcoming Counts', 'extrachill-events' ),
+			'description'         => __( 'Returns upcoming-event counts per taxonomy term. Supports venue, location, artist, and festival taxonomies.', 'extrachill-events' ),
+			'category'            => 'extrachill-events',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'taxonomy' ),
+				'properties' => array(
+					'taxonomy' => array(
+						'type'        => 'string',
+						'description' => 'Taxonomy to query.',
+						'enum'        => array( 'venue', 'location', 'artist', 'festival' ),
+					),
+					'slug'     => array(
+						'type'        => 'string',
+						'description' => 'Specific term slug for single-term lookup. Omit for bulk query.',
+					),
+					'limit'    => array(
+						'type'        => 'integer',
+						'description' => 'Maximum number of results (0 = unlimited).',
+						'default'     => 0,
+						'minimum'     => 0,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type' => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'term_id' => array( 'type' => 'integer' ),
+						'name'    => array( 'type' => 'string' ),
+						'slug'    => array( 'type' => 'string' ),
+						'count'   => array( 'type' => 'integer' ),
+						'url'     => array( 'type' => 'string' ),
+					),
+				),
+			),
+			'execute_callback'    => 'extrachill_events_ability_upcoming_counts',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute the events-upcoming-counts ability.
+ *
+ * @param array $input Input with taxonomy, optional slug and limit.
+ * @return array|WP_Error Array of term counts or error.
+ */
+function extrachill_events_ability_upcoming_counts( array $input ): array|\WP_Error {
+	$taxonomy = sanitize_text_field( $input['taxonomy'] ?? '' );
+	$slug     = sanitize_title( $input['slug'] ?? '' );
+	$limit    = (int) ( $input['limit'] ?? 0 );
+
+	$allowed = array( 'venue', 'location', 'artist', 'festival' );
+	if ( empty( $taxonomy ) || ! in_array( $taxonomy, $allowed, true ) ) {
+		return new \WP_Error(
+			'invalid_taxonomy',
+			__( 'taxonomy must be one of: venue, location, artist, festival.', 'extrachill-events' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	// Single term query.
+	if ( ! empty( $slug ) ) {
+		$single = extrachill_events_single_upcoming_count( $slug, $taxonomy );
+		if ( null === $single ) {
+			return array();
+		}
+		return array( $single );
+	}
+
+	// Bulk query — check transient, run SQL on cold cache.
+	$cache_key = 'ec_upcoming_counts_' . $taxonomy;
+	$cached    = get_transient( $cache_key );
+
+	if ( false !== $cached ) {
+		$results = $cached;
+		if ( $limit > 0 ) {
+			$results = array_slice( $results, 0, $limit );
+		}
+		return $results;
+	}
+
+	// Cold cache — run the query.
+	$terms = extrachill_events_query_upcoming_counts( $taxonomy );
+
+	set_transient( $cache_key, $terms, 6 * HOUR_IN_SECONDS );
+
+	if ( $limit > 0 ) {
+		$terms = array_slice( $terms, 0, $limit );
+	}
+
+	return $terms;
+}
+
+/**
+ * Query upcoming event counts for all terms in a taxonomy.
+ *
+ * @param string $taxonomy Taxonomy slug.
+ * @return array Array of term count data.
+ */
+function extrachill_events_query_upcoming_counts( string $taxonomy ): array {
+	if ( ! taxonomy_exists( $taxonomy ) ) {
+		return array();
+	}
+
+	global $wpdb;
+
+	$today         = gmdate( 'Y-m-d 00:00:00' );
+	$exclude_roots = is_taxonomy_hierarchical( $taxonomy );
+	$parent_clause = $exclude_roots ? 'AND tt.parent != 0' : '';
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	$rows = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT t.term_id, t.name, t.slug, COUNT(DISTINCT p.ID) AS event_count
+			FROM {$wpdb->term_relationships} tr
+			INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+			INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
+			INNER JOIN {$wpdb->posts} p ON tr.object_id = p.ID
+			INNER JOIN {$wpdb->prefix}datamachine_event_dates ed ON p.ID = ed.post_id
+			WHERE tt.taxonomy = %s
+			AND p.post_type = 'data_machine_events'
+			AND p.post_status = 'publish'
+			AND ed.start_datetime >= %s
+			{$parent_clause}
+			GROUP BY t.term_id
+			ORDER BY event_count DESC",
+			$taxonomy,
+			$today
+		)
+	);
+
+	if ( empty( $rows ) ) {
+		return array();
+	}
+
+	$terms = array();
+	foreach ( $rows as $row ) {
+		$url = get_term_link( (int) $row->term_id, $taxonomy );
+		if ( is_wp_error( $url ) ) {
+			continue;
+		}
+
+		$terms[] = array(
+			'term_id' => (int) $row->term_id,
+			'name'    => $row->name,
+			'slug'    => $row->slug,
+			'count'   => (int) $row->event_count,
+			'url'     => $url,
+		);
+	}
+
+	return $terms;
+}
+
+/**
+ * Get upcoming count for a single taxonomy term by slug.
+ *
+ * @param string $slug     Term slug.
+ * @param string $taxonomy Taxonomy slug.
+ * @return array|null Term count data or null if not found / zero.
+ */
+function extrachill_events_single_upcoming_count( string $slug, string $taxonomy ): ?array {
+	if ( ! taxonomy_exists( $taxonomy ) ) {
+		return null;
+	}
+
+	$term = get_term_by( 'slug', $slug, $taxonomy );
+	if ( ! $term || is_wp_error( $term ) ) {
+		return null;
+	}
+
+	global $wpdb;
+	$today = gmdate( 'Y-m-d 00:00:00' );
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	$count = (int) $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT COUNT(DISTINCT p.ID)
+			FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
+			INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+			INNER JOIN {$wpdb->prefix}datamachine_event_dates ed ON p.ID = ed.post_id
+			WHERE tt.term_id = %d
+			AND tt.taxonomy = %s
+			AND p.post_type = 'data_machine_events'
+			AND p.post_status = 'publish'
+			AND ed.start_datetime >= %s",
+			$term->term_id,
+			$taxonomy,
+			$today
+		)
+	);
+
+	if ( $count < 1 ) {
+		return null;
+	}
+
+	$url = get_term_link( $term );
+	if ( is_wp_error( $url ) ) {
+		return null;
+	}
+
+	return array(
+		'term_id' => $term->term_id,
+		'name'    => $term->name,
+		'slug'    => $term->slug,
+		'count'   => $count,
+		'url'     => $url,
+	);
+}

--- a/inc/abilities/register.php
+++ b/inc/abilities/register.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Events-Domain Abilities Registration
+ *
+ * Registers the extrachill-events ability category and loads all
+ * events-domain ability files.  Each file self-registers on the
+ * wp_abilities_api_init hook.
+ *
+ * @package ExtraChillEvents
+ * @since   0.19.0
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_categories_init', 'extrachill_events_register_abilities_category' );
+
+/**
+ * Register the events-domain ability category.
+ */
+function extrachill_events_register_abilities_category(): void {
+	wp_register_ability_category(
+		'extrachill-events',
+		array(
+			'label'       => __( 'Extra Chill Events', 'extrachill-events' ),
+			'description' => __( 'Events calendar, filters, geocoding, venue lookup, submissions, and upcoming-count queries.', 'extrachill-events' ),
+		)
+	);
+}
+
+// Load ability files — each self-registers on wp_abilities_api_init.
+require_once __DIR__ . '/events-calendar.php';
+require_once __DIR__ . '/events-filters.php';
+require_once __DIR__ . '/events-geocode.php';
+require_once __DIR__ . '/events-upcoming-counts.php';
+require_once __DIR__ . '/events-submit.php';
+require_once __DIR__ . '/events-list-venues.php';
+require_once __DIR__ . '/events-get-venue.php';
+require_once __DIR__ . '/events-check-venue-duplicate.php';


### PR DESCRIPTION
## Summary

Registers **8 events-domain abilities** with canonical `execute_callback` implementations per [issue #68](https://github.com/Extra-Chill/extrachill-events/issues/68).

Follows the same procedural pattern established in [extrachill-users#21](https://github.com/Extra-Chill/extrachill-users/issues/21): each ability file self-registers on `wp_abilities_api_init`, the `execute_callback` IS the implementation.

## Abilities registered

| Ability | Type | Source endpoint |
|---------|------|----------------|
| `extrachill/events-calendar` | readonly | `GET /events/calendar` |
| `extrachill/events-filters` | readonly | `GET /events/filters` |
| `extrachill/events-geocode` | readonly | `GET /events/geocode` |
| `extrachill/events-upcoming-counts` | readonly | `GET /events/upcoming-counts` |
| `extrachill/events-submit` | write | `POST /event-submissions` |
| `extrachill/events-list-venues` | readonly | `GET /events/venues` |
| `extrachill/events-get-venue` | readonly | `GET /events/venues/{id}` |
| `extrachill/events-check-venue-duplicate` | readonly | `GET /events/venues/check-duplicate` |

## Details

- All 8 have `meta.show_in_rest: true`
- GETs are `readonly: true`, POST is `readonly: false`
- Permission callbacks match existing REST semantics (all public `__return_true`)
- Schemas match actual response shapes from extrachill-api callbacks
- `declare(strict_types=1)` on all files
- `php -l` passes on all files
- Bootstrap loader updated in `extrachill-events.php` → `init_abilities()`
- One file per ability under `inc/abilities/` + `register.php` bootstrap
- Category `extrachill-events` registered via `wp_register_ability_category()`

## What this does NOT do

- Does NOT modify extrachill-api REST routes (separate refactor)
- Does NOT delete anything — abilities are additive
- Does NOT touch CHANGELOG.md or version strings

Closes #68.