### PR TITLE
fix(calendar): guard against renamed Taxonomy\Badges class

### DIFF
--- a/docs/hooks/data-machine-events-filters.md
+++ b/docs/hooks/data-machine-events-filters.md
@@ -284,7 +284,7 @@ For all filters and actions to work, the data-machine-events plugin must:
    - `data_machine_events_action_buttons`
 
 5. **Provide classes for detection:**
-   - `DataMachineEvents\Core\Taxonomy_Badges` - Badge rendering class
+   - `DataMachineEvents\Blocks\Calendar\Taxonomy\Badges` - Badge rendering class
    - `DataMachineEvents\Core\Breadcrumbs` - Breadcrumb rendering class
 
 ## Conditional Loading
@@ -293,7 +293,7 @@ The plugin only hooks into badge and breadcrumb filters if the corresponding cla
 
 ### Badge Integration
 ```php
-if (class_exists('DataMachineEvents\Core\Taxonomy_Badges')) {
+if (class_exists('DataMachineEvents\Blocks\Calendar\Taxonomy\Badges')) {
     add_filter('data_machine_events_badge_wrapper_classes', array($this, 'add_wrapper_classes'), 10, 2);
     add_filter('data_machine_events_badge_classes', array($this, 'add_badge_classes'), 10, 4);
     add_filter('data_machine_events_excluded_taxonomies', array($this, 'exclude_venue_taxonomy'));

--- a/docs/plugin-classes.md
+++ b/docs/plugin-classes.md
@@ -214,7 +214,7 @@ if (isset($integrations['data_machine_events'])) {
 **Purpose:** Register all WordPress filters and actions
 
 **Conditional Filters (require class existence):**
-- Badge filters (require `DataMachineEvents\Core\Taxonomy_Badges`)
+- Badge filters (require `DataMachineEvents\Blocks\Calendar\Taxonomy\Badges`)
 - Breadcrumb filter (require `DataMachineEvents\Core\Breadcrumbs`)
 
 **Always Registered:**

--- a/inc/core/data-machine-events/badge-styling.php
+++ b/inc/core/data-machine-events/badge-styling.php
@@ -18,7 +18,7 @@ use DataMachineEvents\Core\Event_Post_Type;
  * Initialize badge styling hooks
  */
 function extrachill_events_init_badge_styling() {
-	if ( ! class_exists( 'DataMachineEvents\\Blocks\\Calendar\\Taxonomy_Badges' ) ) {
+	if ( ! class_exists( 'DataMachineEvents\\Blocks\\Calendar\\Taxonomy\\Badges' ) ) {
 		return;
 	}
 

--- a/inc/single-event/related-events.php
+++ b/inc/single-event/related-events.php
@@ -189,8 +189,8 @@ function ec_events_render_related_posts( $taxonomy, $post_id ) {
 						<?php endif; ?>
 						
 						<?php
-						if ( class_exists( '\DataMachineEvents\Blocks\Calendar\Taxonomy_Badges' ) ) {
-							echo \DataMachineEvents\Blocks\Calendar\Taxonomy_Badges::render_taxonomy_badges( $post->ID );
+						if ( class_exists( '\DataMachineEvents\Blocks\Calendar\Taxonomy\Badges' ) ) {
+							echo \DataMachineEvents\Blocks\Calendar\Taxonomy\Badges::render_taxonomy_badges( $post->ID );
 						}
 						?>
 						<h4 class="related-tax-title">


### PR DESCRIPTION
## Summary

Fixes #70.

Two `class_exists()` guards still referenced `DataMachineEvents\Blocks\Calendar\Taxonomy_Badges`, which was renamed to `DataMachineEvents\Blocks\Calendar\Taxonomy\Badges` in data-machine-events 0.31.5 (Extra-Chill/data-machine-events#239). Both guards silently early-returned, so:

- **Calendar event cards** lost theme-side classes (`taxonomy-badge`, `festival-{slug}`, `location-{slug}`, `venue-{slug}`) and the wrapper's `taxonomy-badges` class. The `artist` taxonomy was no longer excluded from the badge row.
- **Related events sidebar** on single event pages rendered with no taxonomy badges at all.

## Changes

- `inc/core/data-machine-events/badge-styling.php`: updated guard to new namespace so the three calendar badge filters register again.
- `inc/single-event/related-events.php`: updated guard + call site so badges render on related-event cards.
- `docs/hooks/data-machine-events-filters.md`, `docs/plugin-classes.md`: updated doc references that pointed at the original (pre-#239) `Core\Taxonomy_Badges` location, so future integrators copy the right guard.

## Verification

After deploy, on events.extrachill.com:
- Calendar event cards have `taxonomy-badge` + `festival-{slug}` / `location-{slug}` / `venue-{slug}` classes; wrapper has `taxonomy-badges`.
- Artist terms not shown in badge row.
- Single event page related-events cards show badges.

## Notes

The fragility of `class_exists()` guards on internal data-machine-events class names is real — every internal namespace move silently breaks downstream integrations with no fatal and no admin notice. Out of scope for this PR; flagged in the issue.