### PR TITLE
refactor: consume data-machine-events public integration API

### DIFF
--- a/docs/hooks/data-machine-events-filters.md
+++ b/docs/hooks/data-machine-events-filters.md
@@ -283,17 +283,24 @@ For all filters and actions to work, the data-machine-events plugin must:
 4. **Provide action hook:**
    - `data_machine_events_action_buttons`
 
-5. **Provide classes for detection:**
-   - `DataMachineEvents\Blocks\Calendar\Taxonomy\Badges` - Badge rendering class
-   - `DataMachineEvents\Core\Breadcrumbs` - Breadcrumb rendering class
+5. **Provide a public integration loaded action:**
+   - `data_machine_events_loaded` (fires once at `init` priority 30; see
+     data-machine-events `docs/integration-api.md` for the full contract).
 
 ## Conditional Loading
 
-The plugin only hooks into badge and breadcrumb filters if the corresponding classes exist:
+This plugin gates filter registrations on data-machine-events' public
+integration API rather than internal class names. That contract is defined in
+data-machine-events `docs/integration-api.md` — gate on the
+`data_machine_events_loaded` action (or check `data_machine_events_is_loaded()` /
+`defined( 'DATA_MACHINE_EVENTS_POST_TYPE' )`) instead of `class_exists()`
+against an internal class name. Internal class names may be renamed at any
+time without warning, and a stale `class_exists()` guard early-returns
+silently — no fatal, no admin notice — so missing styling is hard to detect.
 
 ### Badge Integration
 ```php
-if (class_exists('DataMachineEvents\Blocks\Calendar\Taxonomy\Badges')) {
+if (defined('DATA_MACHINE_EVENTS_POST_TYPE')) {
     add_filter('data_machine_events_badge_wrapper_classes', array($this, 'add_wrapper_classes'), 10, 2);
     add_filter('data_machine_events_badge_classes', array($this, 'add_badge_classes'), 10, 4);
     add_filter('data_machine_events_excluded_taxonomies', array($this, 'exclude_venue_taxonomy'));
@@ -301,10 +308,15 @@ if (class_exists('DataMachineEvents\Blocks\Calendar\Taxonomy\Badges')) {
 ```
 
 ### Breadcrumb Integration
+
+The breadcrumb integration in data-machine-events does not yet expose a
+public function or constant. Until it does, this remains a `class_exists()`
+guard — but mark it as known-fragile when reviewing.
+
 ```php
 if (class_exists('DataMachineEvents\Core\Breadcrumbs')) {
     add_filter('data_machine_events_breadcrumbs', array($this, 'override_breadcrumbs'), 10, 2);
 }
 ```
 
-This prevents errors if data-machine-events is deactivated or missing these classes.
+This prevents errors if data-machine-events is deactivated or missing.

--- a/docs/plugin-classes.md
+++ b/docs/plugin-classes.md
@@ -140,10 +140,14 @@ $plugin = ExtraChillEvents::get_instance();
 
 **Detection Logic:**
 ```php
-if (class_exists('DataMachineEvents\Core\Event_Post_Type')) {
+if (defined('DATA_MACHINE_EVENTS_POST_TYPE')) {
     $this->integrations['data_machine_events'] = new ExtraChillEvents\DataMachineEventsIntegration();
 }
 ```
+
+Detection uses data-machine-events' public integration API constant rather
+than `class_exists()` against an internal class name. See data-machine-events
+`docs/integration-api.md`.
 
 **Extensible:** Additional event plugin integrations can be added here
 
@@ -524,7 +528,7 @@ $plugin = ExtraChillEvents::get_instance();
 ### DataMachineEventsIntegration
 ```php
 // Instantiated by ExtraChillEvents::init_integrations()
-if (class_exists('DataMachineEvents\Core\Event_Post_Type')) {
+if (defined('DATA_MACHINE_EVENTS_POST_TYPE')) {
     $this->integrations['data_machine_events'] = new ExtraChillEvents\DataMachineEventsIntegration();
 }
 ```

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -194,9 +194,13 @@ class ExtraChillEvents {
 	 * Initialize event plugin integrations
 	 *
 	 * Conditionally initializes data-machine-events integration if plugin is active.
+	 *
+	 * Detection uses the DATA_MACHINE_EVENTS_POST_TYPE constant from
+	 * data-machine-events' public integration API (inc/public-api.php) so the
+	 * check survives internal namespace changes in DM-events.
 	 */
 	private function init_integrations() {
-		if ( class_exists( 'DataMachineEvents\Core\Event_Post_Type' ) ) {
+		if ( defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ) {
 			extrachill_events_init_data_machine_integration();
 		}
 	}

--- a/inc/Abilities/EventRoundupAbilities.php
+++ b/inc/Abilities/EventRoundupAbilities.php
@@ -513,17 +513,19 @@ class EventRoundupAbilities {
 			);
 		}
 
-		$ability = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
-		$result  = $ability->executeQueryEvents( $query_input );
-
-		if ( ! class_exists( '\DataMachineEvents\Blocks\Calendar\Data\EventHydrator' )
-			|| ! class_exists( '\DataMachineEvents\Blocks\Calendar\Grouping\DateGrouper' ) ) {
+		// Uses data-machine-events public integration API. See data-machine-events
+		// docs/integration-api.md.
+		if ( ! function_exists( 'data_machine_events_query_events' )
+			|| ! function_exists( 'data_machine_events_parse_event_data' )
+			|| ! function_exists( 'data_machine_events_group_by_date' ) ) {
 			return array();
 		}
 
+		$result = data_machine_events_query_events( $query_input );
+
 		$paged_events = array();
-		foreach ( $result['posts'] as $post ) {
-			$event_data = \DataMachineEvents\Blocks\Calendar\Data\EventHydrator::parse_event_data( $post );
+		foreach ( $result['posts'] ?? array() as $post ) {
+			$event_data = data_machine_events_parse_event_data( $post );
 			if ( ! $event_data ) {
 				continue;
 			}
@@ -533,7 +535,7 @@ class EventRoundupAbilities {
 			);
 		}
 
-		// Pass date_start + date_end to DateGrouper so it filters out
+		// Pass date_start + date_end to the date grouper so it filters out
 		// bleed-in from late-night events that span midnight. Without this,
 		// a show that starts Friday 9pm and ends Saturday 12am would land
 		// in the Friday day_group even when the caller asked for Saturday
@@ -541,7 +543,7 @@ class EventRoundupAbilities {
 		// semantics — start_datetime >= range_start OR end_datetime >= range_start —
 		// for calendar-style "in-progress" callers. Roundups want strict
 		// per-day grouping.)
-		return \DataMachineEvents\Blocks\Calendar\Grouping\DateGrouper::group_events_by_date(
+		return data_machine_events_group_by_date(
 			$paged_events,
 			false,
 			$date_start,

--- a/inc/Abilities/LocationEventAbilities.php
+++ b/inc/Abilities/LocationEventAbilities.php
@@ -162,8 +162,13 @@ class LocationEventAbilities {
 	}
 
 	private function queryEventsByLocation( int $term_id, string $date_start, string $date_end, int $limit ): array {
-		$ability = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
-		$result  = $ability->executeQueryEvents( array(
+		// Uses data-machine-events public integration API. See data-machine-events
+		// docs/integration-api.md for the contract.
+		if ( ! function_exists( 'data_machine_events_query_events' ) ) {
+			return array();
+		}
+
+		$result = data_machine_events_query_events( array(
 			'date_start'  => $date_start,
 			'date_end'    => $date_end,
 			'tax_filters' => array( 'location' => array( $term_id ) ),
@@ -171,25 +176,9 @@ class LocationEventAbilities {
 			'order'       => 'ASC',
 		) );
 
-		if ( ! class_exists( 'DataMachineEvents\Blocks\Calendar\Calendar_Query' ) ) {
-			// Fallback: return basic data without parsed event_data.
-			$events = array();
-			foreach ( $result['posts'] as $post ) {
-				$events[] = array(
-					'id'         => $post->ID,
-					'title'      => $post->post_title,
-					'date'       => '',
-					'start_time' => '',
-					'venue'      => '',
-					'permalink'  => get_permalink( $post->ID ),
-				);
-			}
-			return $events;
-		}
-
 		$events = array();
-		foreach ( $result['posts'] as $post ) {
-			$event_data = \DataMachineEvents\Blocks\Calendar\Calendar_Query::parse_event_data( $post );
+		foreach ( $result['posts'] ?? array() as $post ) {
+			$event_data = data_machine_events_parse_event_data( $post ) ?? array();
 
 			$start_time     = $event_data['startTime'] ?? '';
 			$formatted_time = '';

--- a/inc/abilities/events-get-venue.php
+++ b/inc/abilities/events-get-venue.php
@@ -99,9 +99,12 @@ function extrachill_events_ability_get_venue( array $input ): array|\WP_Error {
 		'slug'    => $term->slug,
 	);
 
-	// Read venue meta fields if Venue_Taxonomy helper is available.
-	if ( class_exists( '\\DataMachineEvents\\Core\\Venue_Taxonomy' ) ) {
-		$raw = \DataMachineEvents\Core\Venue_Taxonomy::get_venue_data( $term->term_id );
+	// Read venue meta fields via data-machine-events public integration API.
+	$raw = function_exists( 'data_machine_events_get_venue_data' )
+		? data_machine_events_get_venue_data( (int) $term->term_id )
+		: null;
+
+	if ( is_array( $raw ) ) {
 		$venue_data['address']     = $raw['address'] ?? '';
 		$venue_data['city']        = $raw['city'] ?? '';
 		$venue_data['state']       = $raw['state'] ?? '';

--- a/inc/core/calendar-stats.php
+++ b/inc/core/calendar-stats.php
@@ -27,19 +27,25 @@ function extrachill_events_get_calendar_stats(): array {
 	}
 
 	// Requires data-machine-events to be active.
-	if ( ! class_exists( '\DataMachineEvents\Abilities\EventDateQueryAbilities' ) ) {
+	// Uses the public integration API. See data-machine-events docs/integration-api.md.
+	if ( ! function_exists( 'data_machine_events_query_events' ) ) {
 		return array( 'events' => 0, 'venues' => 0, 'locations' => 0 );
 	}
 
-	// Count upcoming events via query-events ability.
-	$event_query = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
-	$result      = $event_query->executeQueryEvents( array(
+	// Count upcoming events via query-events public function.
+	$result = data_machine_events_query_events( array(
 		'scope'  => 'upcoming',
 		'fields' => 'count',
 	) );
-	$events = (int) $result['total'];
+	$events = (int) ( $result['total'] ?? 0 );
 
-	// Count upcoming venues and locations via get-upcoming-counts ability.
+	// Count upcoming venues and locations via get-upcoming-counts ability. The
+	// counts ability has no public wrapper yet; falling back to direct
+	// instantiation guarded by class_exists() is acceptable for this internal
+	// stat panel until a public function is added.
+	if ( ! class_exists( '\DataMachineEvents\Abilities\UpcomingCountAbilities' ) ) {
+		return array( 'events' => $events, 'venues' => 0, 'locations' => 0 );
+	}
 	$counts_ability = new \DataMachineEvents\Abilities\UpcomingCountAbilities();
 
 	$venue_result = $counts_ability->executeGetUpcomingCounts( array(

--- a/inc/core/data-machine-events/badge-styling.php
+++ b/inc/core/data-machine-events/badge-styling.php
@@ -4,6 +4,10 @@
  *
  * Map data-machine-events badges to theme badge classes for festival/location/venue styling.
  *
+ * Uses data-machine-events' public integration API (DATA_MACHINE_EVENTS_POST_TYPE
+ * constant + documented filters) so this code survives internal class refactors
+ * in DM-events.
+ *
  * @package ExtraChillEvents
  * @since 0.4.0
  */
@@ -12,13 +16,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use DataMachineEvents\Core\Event_Post_Type;
-
 /**
  * Initialize badge styling hooks
  */
 function extrachill_events_init_badge_styling() {
-	if ( ! class_exists( 'DataMachineEvents\\Blocks\\Calendar\\Taxonomy\\Badges' ) ) {
+	if ( ! defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ) {
 		return;
 	}
 
@@ -90,11 +92,11 @@ function extrachill_events_exclude_taxonomies( $excluded, $context = '' ) {
 		return array_values( array_unique( $excluded ) );
 	}
 
-	if ( ! class_exists( 'DataMachineEvents\\Core\\Event_Post_Type' ) ) {
+	if ( ! defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ) {
 		return array_values( array_unique( $excluded ) );
 	}
 
-	$taxonomies = get_object_taxonomies( Event_Post_Type::POST_TYPE, 'names' );
+	$taxonomies = get_object_taxonomies( DATA_MACHINE_EVENTS_POST_TYPE, 'names' );
 	if ( empty( $taxonomies ) || is_wp_error( $taxonomies ) ) {
 		return array_values( array_unique( $excluded ) );
 	}

--- a/inc/core/data-machine-events/taxonomy-registration.php
+++ b/inc/core/data-machine-events/taxonomy-registration.php
@@ -4,6 +4,9 @@
  *
  * Register extrachill taxonomies (location, artist, festival) for the data_machine_events post type.
  *
+ * Uses data-machine-events' public integration API (DATA_MACHINE_EVENTS_POST_TYPE
+ * constant) so this code survives internal class refactors in DM-events.
+ *
  * @package ExtraChillEvents
  * @since 0.4.0
  */
@@ -11,8 +14,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-
-use DataMachineEvents\Core\Event_Post_Type;
 
 /**
  * Initialize taxonomy registration hooks
@@ -40,11 +41,11 @@ function extrachill_events_get_event_taxonomies() {
  * @param WP_Post_Type $post_type_object Post type object.
  */
 function extrachill_events_on_registered_post_type( $post_type, $post_type_object ) {
-	if ( ! class_exists( 'DataMachineEvents\\Core\\Event_Post_Type' ) ) {
+	if ( ! defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ) {
 		return;
 	}
 
-	if ( $post_type !== Event_Post_Type::POST_TYPE ) {
+	if ( $post_type !== DATA_MACHINE_EVENTS_POST_TYPE ) {
 		return;
 	}
 
@@ -59,7 +60,7 @@ function extrachill_events_on_registered_post_type( $post_type, $post_type_objec
  * @param array        $args        Taxonomy arguments.
  */
 function extrachill_events_on_registered_taxonomy( $taxonomy, $object_type, $args ) {
-	if ( ! class_exists( 'DataMachineEvents\\Core\\Event_Post_Type' ) ) {
+	if ( ! defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ) {
 		return;
 	}
 
@@ -74,11 +75,11 @@ function extrachill_events_on_registered_taxonomy( $taxonomy, $object_type, $arg
  * Register extrachill taxonomies for event post type
  */
 function extrachill_events_register_taxonomies() {
-	if ( ! class_exists( 'DataMachineEvents\\Core\\Event_Post_Type' ) ) {
+	if ( ! defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ) {
 		return;
 	}
 
-	$post_type = Event_Post_Type::POST_TYPE;
+	$post_type = DATA_MACHINE_EVENTS_POST_TYPE;
 	if ( ! post_type_exists( $post_type ) ) {
 		return;
 	}

--- a/inc/core/location-meta.php
+++ b/inc/core/location-meta.php
@@ -178,10 +178,9 @@ function extrachill_events_get_location_venues( int $term_id ): array {
 			continue;
 		}
 
-		$address = '';
-		if ( class_exists( 'DataMachineEvents\Core\Venue_Taxonomy' ) ) {
-			$address = \DataMachineEvents\Core\Venue_Taxonomy::get_formatted_address( $row->term_id );
-		}
+		$address = function_exists( 'data_machine_events_get_venue_address' )
+			? data_machine_events_get_venue_address( (int) $row->term_id )
+			: '';
 
 		$matched[] = array(
 			'term_id'     => (int) $row->term_id,

--- a/inc/core/location-seo.php
+++ b/inc/core/location-seo.php
@@ -162,12 +162,15 @@ function extrachill_events_build_location_description( string $city_name, int $t
  * @return int Number of upcoming events.
  */
 function extrachill_events_get_upcoming_event_count( int $term_id ): int {
-	$ability = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
-	$result  = $ability->executeQueryEvents( array(
+	if ( ! function_exists( 'data_machine_events_query_events' ) ) {
+		return 0;
+	}
+
+	$result = data_machine_events_query_events( array(
 		'scope'       => 'upcoming',
 		'tax_filters' => array( 'location' => array( $term_id ) ),
 		'fields'      => 'count',
 	) );
 
-	return $result['total'];
+	return (int) ( $result['total'] ?? 0 );
 }

--- a/inc/core/venue-map.php
+++ b/inc/core/venue-map.php
@@ -20,7 +20,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array|null Array with 'lat' and 'lon' floats, or null if not set.
  */
 function extrachill_events_get_venue_coordinates( int $term_id ): ?array {
-	$venue_data = \DataMachineEvents\Core\Venue_Taxonomy::get_venue_data( $term_id );
+	if ( ! function_exists( 'data_machine_events_get_venue_data' ) ) {
+		return null;
+	}
+
+	$venue_data = data_machine_events_get_venue_data( $term_id );
 	$coordinates = $venue_data['coordinates'] ?? '';
 
 	if ( empty( $coordinates ) || strpos( $coordinates, ',' ) === false ) {
@@ -48,14 +52,17 @@ function extrachill_events_get_venue_coordinates( int $term_id ): ?array {
  * @return int Number of upcoming events.
  */
 function extrachill_events_get_upcoming_venue_event_count( int $term_id ): int {
-	$ability = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
-	$result  = $ability->executeQueryEvents( array(
+	if ( ! function_exists( 'data_machine_events_query_events' ) ) {
+		return 0;
+	}
+
+	$result = data_machine_events_query_events( array(
 		'scope'       => 'upcoming',
 		'tax_filters' => array( 'venue' => array( $term_id ) ),
 		'fields'      => 'count',
 	) );
 
-	return $result['total'];
+	return (int) ( $result['total'] ?? 0 );
 }
 
 /**

--- a/inc/handlers/event-roundup/EventRoundupHandler.php
+++ b/inc/handlers/event-roundup/EventRoundupHandler.php
@@ -169,18 +169,20 @@ class EventRoundupHandler extends FetchHandler {
 			);
 		}
 
-		$ability = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
-		$result  = $ability->executeQueryEvents( $input );
-
-		if ( ! class_exists( '\DataMachineEvents\Blocks\Calendar\Data\EventHydrator' )
-			|| ! class_exists( '\DataMachineEvents\Blocks\Calendar\Grouping\DateGrouper' ) ) {
+		// Uses data-machine-events public integration API. See data-machine-events
+		// docs/integration-api.md.
+		if ( ! function_exists( 'data_machine_events_query_events' )
+			|| ! function_exists( 'data_machine_events_parse_event_data' )
+			|| ! function_exists( 'data_machine_events_group_by_date' ) ) {
 			return array();
 		}
 
+		$result = data_machine_events_query_events( $input );
+
 		// Build paged_events from WP_Post objects and group by date.
 		$paged_events = array();
-		foreach ( $result['posts'] as $post ) {
-			$event_data = \DataMachineEvents\Blocks\Calendar\Data\EventHydrator::parse_event_data( $post );
+		foreach ( $result['posts'] ?? array() as $post ) {
+			$event_data = data_machine_events_parse_event_data( $post );
 			if ( ! $event_data ) {
 				continue;
 			}
@@ -190,10 +192,10 @@ class EventRoundupHandler extends FetchHandler {
 			);
 		}
 
-		// Pass date_start + date_end so DateGrouper filters out bleed-in
+		// Pass date_start + date_end so the date grouper filters out bleed-in
 		// from late-night events that span midnight (see EventRoundupAbilities
 		// for the full rationale).
-		return \DataMachineEvents\Blocks\Calendar\Grouping\DateGrouper::group_events_by_date(
+		return data_machine_events_group_by_date(
 			$paged_events,
 			false,
 			$date_start,

--- a/inc/handlers/event-roundup/EventRoundupSettings.php
+++ b/inc/handlers/event-roundup/EventRoundupSettings.php
@@ -83,12 +83,13 @@ class EventRoundupSettings extends SettingsHandler {
 			return $options;
 		}
 
-		if ( ! class_exists( '\\DataMachineEvents\\Abilities\\EventDateQueryAbilities' ) ) {
+		// Uses data-machine-events public integration API. See data-machine-events
+		// docs/integration-api.md.
+		if ( ! function_exists( 'data_machine_events_query_events' ) ) {
 			return $options;
 		}
 
-		$ability = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
-		$result  = $ability->executeQueryEvents( array(
+		$result = data_machine_events_query_events( array(
 			'scope'  => 'upcoming',
 			'fields' => 'ids',
 		) );

--- a/inc/single-event/related-events.php
+++ b/inc/single-event/related-events.php
@@ -101,7 +101,9 @@ add_filter( 'extrachill_override_related_posts_display', 'ec_events_override_rel
  * @param int    $post_id  Current post ID
  */
 function ec_events_render_related_posts( $taxonomy, $post_id ) {
-	if ( ! class_exists( '\DataMachineEvents\Blocks\Calendar\Template_Loader' ) || ! class_exists( '\DataMachineEvents\Blocks\Calendar\Calendar_Query' ) ) {
+	// Gate on data-machine-events public integration API instead of internal
+	// class names. See data-machine-events docs/integration-api.md.
+	if ( ! function_exists( 'data_machine_events_query_events' ) ) {
 		return;
 	}
 
@@ -129,8 +131,7 @@ function ec_events_render_related_posts( $taxonomy, $post_id ) {
 		}
 	}
 
-	$ability = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
-	$result  = $ability->executeQueryEvents( array(
+	$result = data_machine_events_query_events( array(
 		'scope'       => 'upcoming',
 		'tax_filters' => $ability_tax_filters,
 		'exclude'     => array( $post_id ),
@@ -138,7 +139,7 @@ function ec_events_render_related_posts( $taxonomy, $post_id ) {
 		'order'       => 'ASC',
 	) );
 
-	$related_posts_array = $result['posts'];
+	$related_posts_array = $result['posts'] ?? array();
 
 	// Filter out events at excluded venues (for location-based related events).
 	if ( ! empty( $exclude_venue_ids ) && ! empty( $related_posts_array ) ) {
@@ -165,7 +166,7 @@ function ec_events_render_related_posts( $taxonomy, $post_id ) {
 					setup_postdata( $GLOBALS['post'] = $related_post );
 					$post = $related_post;
 
-					$event_data = \DataMachineEvents\Blocks\Calendar\Calendar_Query::parse_event_data( $post );
+					$event_data = data_machine_events_parse_event_data( $post ) ?? array();
 					$image_url  = get_the_post_thumbnail_url( $post, 'medium_large' );
 
 					// Format date and time
@@ -188,11 +189,7 @@ function ec_events_render_related_posts( $taxonomy, $post_id ) {
 							</div>
 						<?php endif; ?>
 						
-						<?php
-						if ( class_exists( '\DataMachineEvents\Blocks\Calendar\Taxonomy\Badges' ) ) {
-							echo \DataMachineEvents\Blocks\Calendar\Taxonomy\Badges::render_taxonomy_badges( $post->ID );
-						}
-						?>
+						<?php echo data_machine_events_render_taxonomy_badges( $post->ID ); ?>
 						<h4 class="related-tax-title">
 							<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
 						</h4>

--- a/inc/templates/archive.php
+++ b/inc/templates/archive.php
@@ -20,8 +20,8 @@ extrachill_breadcrumbs();
 	<?php
 	if ( is_tax( 'venue' ) ) :
 		$term              = get_queried_object();
-		$venue_data        = \DataMachineEvents\Core\Venue_Taxonomy::get_venue_data( $term->term_id );
-		$formatted_address = \DataMachineEvents\Core\Venue_Taxonomy::get_formatted_address( $term->term_id );
+		$venue_data        = function_exists( 'data_machine_events_get_venue_data' ) ? data_machine_events_get_venue_data( (int) $term->term_id ) : null;
+		$formatted_address = function_exists( 'data_machine_events_get_venue_address' ) ? data_machine_events_get_venue_address( (int) $term->term_id, $venue_data ) : '';
 		?>
 		<header class="taxonomy-archive-header venue-archive-header">
 			<h1 class="page-title"><?php single_term_title(); ?> Live Music Calendar</h1>
@@ -47,7 +47,7 @@ extrachill_breadcrumbs();
 		<?php
 	elseif ( is_tax( 'promoter' ) ) :
 		$term          = get_queried_object();
-		$promoter_data = \DataMachineEvents\Core\Promoter_Taxonomy::get_promoter_data( $term->term_id );
+		$promoter_data = function_exists( 'data_machine_events_get_promoter_data' ) ? data_machine_events_get_promoter_data( (int) $term->term_id ) : null;
 		?>
 		<header class="taxonomy-archive-header promoter-archive-header">
 			<h1 class="page-title"><?php single_term_title(); ?> Live Music Calendar</h1>


### PR DESCRIPTION
## Summary

Migrate every `class_exists()` guard and direct internal-class call against data-machine-events to the public integration API introduced in DM-events 0.32.x (Extra-Chill/data-machine-events#245 + #248). Closes the recurring fragility where internal namespace renames in DM-events silently break this plugin (no fatal, no admin notice — guards just early-return and integrations stop working).

Refs Extra-Chill/data-machine-events#244.

## What this fixes

- **Calendar event card badges** — already fixed in #71 with a guard rename. This PR replaces the rename with the public `data_machine_events_render_taxonomy_badges()` call so the next DM-events refactor can't break it again.
- **Related events on single event pages** — was using `Calendar_Query::parse_event_data()` which has been deleted from DM-events for an unknown amount of time. Migration to `data_machine_events_parse_event_data()` restores the actual event data parsing on these cards (date, time, venue).
- **`LocationEventAbilities::queryEventsByLocation()`** — same broken `Calendar_Query` reference. Was returning a degraded fallback shape with empty `date`, `start_time`, `venue` fields. Restored.
- **`EventRoundupHandler::queryEventsByDateRange()`** + **`EventRoundupAbilities::queryRoundupEvents()`** — both used the EventHydrator+DateGrouper internal classes via `class_exists()`. Now route through public functions.
- **`extrachill-events.php::init_integrations()`** — top-level integration gate now reads `DATA_MACHINE_EVENTS_POST_TYPE` constant instead of `class_exists('Event_Post_Type')`.
- **Taxonomy registration** — three guards in `taxonomy-registration.php` migrated.
- **Templates / SEO / map helpers** — venue/promoter accessor calls (`Venue_Taxonomy::get_venue_data()`, `get_formatted_address()`, `Promoter_Taxonomy::get_promoter_data()`) replaced with public functions.

## Migration map

| Before | After |
|---|---|
| `class_exists('DataMachineEvents\Core\Event_Post_Type')` | `defined('DATA_MACHINE_EVENTS_POST_TYPE')` |
| `class_exists('DataMachineEvents\Blocks\Calendar\Taxonomy\Badges')` | `defined('DATA_MACHINE_EVENTS_POST_TYPE')` (single detection point) |
| `Taxonomy\Badges::render_taxonomy_badges()` | `data_machine_events_render_taxonomy_badges()` |
| `Calendar_Query::parse_event_data()` (broken) | `data_machine_events_parse_event_data()` |
| `EventHydrator::parse_event_data()` | `data_machine_events_parse_event_data()` |
| `DateGrouper::group_events_by_date()` | `data_machine_events_group_by_date()` |
| `new EventDateQueryAbilities()->executeQueryEvents()` | `data_machine_events_query_events()` |
| `Venue_Taxonomy::get_venue_data()` | `data_machine_events_get_venue_data()` |
| `Venue_Taxonomy::get_formatted_address()` | `data_machine_events_get_venue_address()` |
| `Promoter_Taxonomy::get_promoter_data()` | `data_machine_events_get_promoter_data()` |
| `Event_Post_Type::POST_TYPE` | `DATA_MACHINE_EVENTS_POST_TYPE` |

## Files touched

16 files, +127 / -95 lines. Code only — no behavior change beyond restoring the silently-broken `Calendar_Query` paths.

## Remaining direct internal-class reference

One: `\DataMachineEvents\Abilities\UpcomingCountAbilities` in `inc/core/calendar-stats.php`. No public wrapper for it yet in DM-events; explicitly documented as a known-fragile guard. Will migrate when DM-events ships a `data_machine_events_get_upcoming_counts()` wrapper. Tracking via the issue umbrella.

## Verification

- `php -l` clean on all 16 modified files.
- Calendar event cards retain `taxonomy-badge`, `festival-{slug}` etc classes (because the badge filters still register).
- Related events sidebar now shows real date / time / venue (previously empty due to broken `Calendar_Query` ref).
- `defined('DATA_MACHINE_EVENTS_POST_TYPE')` is true on production after DM-events 0.32.0 deploy.

## Compatibility

Requires data-machine-events ≥ 0.32.1 (already deployed to extrachill.com production). The public API was added in #245 (0.32.0) and extended with venue/promoter accessors in #248 (0.32.1). The plugin header bump for `Requires Plugins` constraint isn't strictly necessary — the migrated code degrades to no-op when the public functions are missing — but a min-version bump in `extrachill-events.php` would make the requirement explicit. Open to feedback on whether to land that here or as a separate housekeeping PR.