### PR TITLE
fix: allow null slug input on events-upcoming-counts ability

### DIFF
--- a/inc/abilities/events-upcoming-counts.php
+++ b/inc/abilities/events-upcoming-counts.php
@@ -37,8 +37,8 @@ function extrachill_events_register_upcoming_counts_ability(): void {
 						'enum'        => array( 'venue', 'location', 'artist', 'festival' ),
 					),
 					'slug'     => array(
-						'type'        => 'string',
-						'description' => 'Specific term slug for single-term lookup. Omit for bulk query.',
+						'type'        => array( 'string', 'null' ),
+						'description' => 'Specific term slug for single-term lookup. Omit or pass null/empty for bulk query.',
 					),
 					'limit'    => array(
 						'type'        => 'integer',


### PR DESCRIPTION
## Summary
- `extrachill/events-upcoming-counts` already treats an empty/missing slug as a bulk query.
- Its `input_schema` declared `slug` as a plain string, so stricter Abilities API validation rejects `slug => null` with `ability_invalid_input` before the execute callback even runs.
- This is what was breaking the events homepage location badge cloud (caller in extrachill-api was passing null; companion fix tightens the caller too).

## Fix
Mark `slug` as `[string, null]` in the input schema. The execute callback already normalises with `sanitize_title( \$input['slug'] ?? '' )` and falls through to the bulk path when empty, so behaviour is unchanged for valid callers.

## Companion fix
extrachill-api: https://github.com/Extra-Chill/extrachill-api/pull/new/fix-events-upcoming-counts-slug