### PR TITLE
feat(qualify): structured fingerprint + persistent verdict log (qualify v2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ package-lock.json
 .claude/
 .buildignore
 docs/.docs-sync.json
+/.phpunit.result.cache

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -71,6 +71,7 @@ class ExtraChillEvents {
 		add_action( 'init', array( $this, 'load_textdomain' ) );
 		add_action( 'init', array( $this, 'init_data_machine_handlers' ), 20 );
 		add_action( 'init', array( $this, 'init_abilities' ), 25 );
+		add_action( 'plugins_loaded', array( $this, 'maybe_install_schema' ), 20 );
 		register_activation_hook( __FILE__, array( $this, 'activate' ) );
 		register_deactivation_hook( __FILE__, array( $this, 'deactivate' ) );
 	}
@@ -94,6 +95,10 @@ class ExtraChillEvents {
 		if ( file_exists( $autoload_file ) ) {
 			require_once $autoload_file;
 		}
+
+		// Qualify v2 — verdict taxonomy + persistent verdict log.
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdict.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdictsTable.php';
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/data-machine-events/init.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/nav.php';
@@ -206,11 +211,27 @@ class ExtraChillEvents {
 	}
 
 	public function activate() {
+		// Create/upgrade the qualify verdicts table at activation. Safe to
+		// call repeatedly — dbDelta handles idempotency.
+		\ExtraChillEvents\Core\QualifyVerdictsTable::create_table();
 		flush_rewrite_rules();
 	}
 
 	public function deactivate() {
 		flush_rewrite_rules();
+	}
+
+	/**
+	 * Idempotent schema installer for the qualify verdicts table.
+	 *
+	 * Runs on plugins_loaded so the table is available even when the plugin
+	 * was already active when the new schema shipped (i.e. without a fresh
+	 * activation). Cheap when up to date — short-circuits on a stored option.
+	 */
+	public function maybe_install_schema() {
+		if ( class_exists( '\\ExtraChillEvents\\Core\\QualifyVerdictsTable' ) ) {
+			\ExtraChillEvents\Core\QualifyVerdictsTable::maybe_install();
+		}
 	}
 
 	public function get_integrations() {

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -48,6 +48,14 @@ if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCo
 
 	require_once __DIR__ . '/inc/Cli/RequalifyPendingCommand.php';
 	\WP_CLI::add_command( 'extrachill venues requalify-pending', \ExtraChillEvents\Cli\RequalifyPendingCommand::class );
+
+	require_once __DIR__ . '/inc/Cli/FlowHelpers.php';
+
+	require_once __DIR__ . '/inc/Cli/RequalifyFlowCommand.php';
+	\WP_CLI::add_command( 'extrachill venues requalify-flow', \ExtraChillEvents\Cli\RequalifyFlowCommand::class );
+
+	require_once __DIR__ . '/inc/Cli/UnqualifiableFlowsCommand.php';
+	\WP_CLI::add_command( 'extrachill venues unqualifiable-flows', \ExtraChillEvents\Cli\UnqualifiableFlowsCommand::class );
 }
 
 /**

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -100,6 +100,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdict.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdictsTable.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdictResolver.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/PlatformDetector.php';
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/data-machine-events/init.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/nav.php';

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -45,6 +45,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCo
 
 	require_once __DIR__ . '/inc/Cli/QualifyStatsCommand.php';
 	\WP_CLI::add_command( 'extrachill venues qualify-stats', \ExtraChillEvents\Cli\QualifyStatsCommand::class );
+
+	require_once __DIR__ . '/inc/Cli/RequalifyPendingCommand.php';
+	\WP_CLI::add_command( 'extrachill venues requalify-pending', \ExtraChillEvents\Cli\RequalifyPendingCommand::class );
 }
 
 /**

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -33,6 +33,18 @@ define( 'EXTRACHILL_EVENTS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCommand.php' ) ) {
 	require_once __DIR__ . '/inc/Cli/AddCityCommand.php';
 	\WP_CLI::add_command( 'extrachill-events add-city', \ExtraChillEvents\Cli\AddCityCommand::class );
+
+	// Qualify v2 — verdict-log subcommands hung off the existing
+	// `wp extrachill venues` parent (registered by extrachill-cli).
+	// Core classes need to load before the CLI commands instantiate them.
+	require_once __DIR__ . '/inc/Core/QualifyVerdict.php';
+	require_once __DIR__ . '/inc/Core/QualifyVerdictsTable.php';
+	require_once __DIR__ . '/inc/Core/QualifyVerdictResolver.php';
+	require_once __DIR__ . '/inc/Core/PlatformDetector.php';
+	require_once __DIR__ . '/inc/Core/QualifyFingerprinter.php';
+
+	require_once __DIR__ . '/inc/Cli/QualifyStatsCommand.php';
+	\WP_CLI::add_command( 'extrachill venues qualify-stats', \ExtraChillEvents\Cli\QualifyStatsCommand::class );
 }
 
 /**

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -96,9 +96,10 @@ class ExtraChillEvents {
 			require_once $autoload_file;
 		}
 
-		// Qualify v2 — verdict taxonomy + persistent verdict log.
+		// Qualify v2 — verdict taxonomy + persistent verdict log + resolver.
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdict.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdictsTable.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdictResolver.php';
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/data-machine-events/init.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/nav.php';

--- a/inc/Abilities/VenueQualificationAbilities.php
+++ b/inc/Abilities/VenueQualificationAbilities.php
@@ -17,6 +17,12 @@
 
 namespace ExtraChillEvents\Abilities;
 
+use ExtraChillEvents\Core\PlatformDetector;
+use ExtraChillEvents\Core\QualifyFingerprinter;
+use ExtraChillEvents\Core\QualifyVerdict;
+use ExtraChillEvents\Core\QualifyVerdictResolver;
+use ExtraChillEvents\Core\QualifyVerdictsTable;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -112,12 +118,15 @@ class VenueQualificationAbilities {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'qualified'       => array( 'type' => 'boolean' ),
-							'events_url'      => array( 'type' => 'string' ),
-							'method'          => array( 'type' => 'string' ),
-							'extraction_info' => array( 'type' => 'object' ),
-							'event_count'     => array( 'type' => 'integer' ),
-							'warnings'        => array( 'type' => 'array' ),
+							'qualified'        => array( 'type' => 'boolean' ),
+							'verdict'          => array( 'type' => 'string' ),
+							'events_url'       => array( 'type' => 'string' ),
+							'method'           => array( 'type' => 'string' ),
+							'event_count'      => array( 'type' => 'integer' ),
+							'fingerprint'      => array( 'type' => 'object' ),
+							'improvement_hint' => array( 'type' => 'string' ),
+							'agent_guidance'   => array( 'type' => 'string' ),
+							'warnings'         => array( 'type' => 'array' ),
 						),
 					),
 					'execute_callback'    => array( $this, 'executeQualifyVenue' ),
@@ -137,7 +146,12 @@ class VenueQualificationAbilities {
 	}
 
 	/**
-	 * Execute venue qualification.
+	 * Execute venue qualification — qualify v2.
+	 *
+	 * Returns a structured verdict bundle (verdict + fingerprint +
+	 * agent_guidance + improvement_hint + event_count) and persists every
+	 * verdict to the <prefix>_dme_qualify_verdicts table. Callers that need
+	 * only the legacy boolean can read `$result['qualified']`.
 	 *
 	 * @param array $input Qualification parameters.
 	 * @return array Results.
@@ -155,94 +169,225 @@ class VenueQualificationAbilities {
 			$url = 'https://' . $url;
 		}
 
+		$started_at = microtime( true );
+
 		$parsed = wp_parse_url( $url );
 		$origin = ( $parsed['scheme'] ?? 'https' ) . '://' . ( $parsed['host'] ?? '' );
 
-		// Pre-check: disqualify Ticketmaster / Live Nation venues.
+		// Build the fingerprint skeleton up front so a TM/short-circuit
+		// verdict still persists with full diagnostics.
+		$fingerprint = array(
+			'http_status'           => 0,
+			'final_url'             => $url,
+			'redirects'             => array(),
+			'timeout'               => false,
+			'cloudflare_challenge'  => false,
+			'platforms_detected'    => array(),
+			'structured_data'       => array(),
+			'extractor_attempts'    => array(),
+			'ticketmaster_precheck' => array( 'disqualified' => false, 'matched' => '' ),
+			'urls_tested'           => array(),
+			'elapsed_ms'            => 0,
+		);
+
+		// ---- Ticketmaster precheck (short-circuits everything else). ----
 		$tm_check = $this->checkTicketmasterVenue( $url );
 		if ( $tm_check['disqualified'] ) {
-			return array(
-				'qualified'  => false,
-				'events_url' => '',
-				'method'     => 'ticketmaster_precheck',
-				'name'       => $name,
-				'reason'     => $tm_check['reason'],
-				'warnings'   => array( $tm_check['reason'] ),
+			$fingerprint['ticketmaster_precheck'] = array(
+				'disqualified' => true,
+				'matched'      => (string) ( $tm_check['matched'] ?? '' ),
+			);
+			$fingerprint['elapsed_ms'] = (int) round( ( microtime( true ) - $started_at ) * 1000 );
+			return $this->finalize_and_persist( $url, $name, 'ticketmaster_precheck', $fingerprint );
+		}
+
+		// ---- Fetch the homepage once and capture status/redirects/HTML. ----
+		$home = QualifyFingerprinter::fetch_homepage( $url );
+		$fingerprint['http_status']          = $home['http_status'];
+		$fingerprint['final_url']            = $home['final_url'];
+		$fingerprint['redirects']            = $home['redirects'];
+		$fingerprint['timeout']              = $home['timeout'];
+		$fingerprint['cloudflare_challenge'] = $home['cloudflare_challenge'];
+
+		// ---- Platform + structured data detection (off the homepage HTML). ----
+		$html = $home['html'];
+		if ( '' !== $html ) {
+			$fingerprint['structured_data']    = PlatformDetector::detect_structured_data( $html );
+			$fingerprint['platforms_detected'] = QualifyFingerprinter::build_platforms_list( $html, $origin );
+		}
+
+		// ---- Stop early if we already have enough signal for a verdict. ----
+		//
+		// For unreachable / bot-blocked / 5xx, the test-event-scraper round
+		// trip is pointless — we already know what the verdict will be and
+		// further requests would only burn time and tickle rate-limits.
+		$short_circuit_method = '';
+		if ( 0 === $fingerprint['http_status'] || $fingerprint['timeout']
+			|| 403 === $fingerprint['http_status'] || 429 === $fingerprint['http_status']
+			|| $fingerprint['cloudflare_challenge']
+			|| $fingerprint['http_status'] >= 500 ) {
+			$short_circuit_method = 'fingerprint_short_circuit';
+		}
+
+		if ( '' === $short_circuit_method ) {
+			// ---- Walk candidate URLs through the scraper. ----
+			$urls_tested = array();
+			$ran_any     = false;
+
+			$urls_to_try = $this->buildCandidateUrls( $url, $origin, $html );
+
+			foreach ( $urls_to_try as $candidate ) {
+				if ( in_array( $candidate['url'], $urls_tested, true ) ) {
+					continue;
+				}
+				$urls_tested[] = $candidate['url'];
+
+				$attempt = QualifyFingerprinter::run_extractor_attempt( $candidate['url'] );
+				if ( ! empty( $attempt['ran'] ) ) {
+					$ran_any = true;
+				}
+				$attempt['method']    = $candidate['method'];
+				$attempt['link_text'] = $candidate['link_text'] ?? '';
+
+				$fingerprint['extractor_attempts'][] = $attempt;
+
+				// As soon as one extractor returns enough events, stop hammering.
+				if ( ( $attempt['events'] ?? 0 ) >= QualifyVerdict::MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION
+					&& ! $this->looks_like_vision_attempt( $attempt ) ) {
+					break;
+				}
+			}
+
+			$fingerprint['urls_tested'] = $urls_tested;
+			unset( $ran_any );
+		}
+
+		// ---- Synthesize platform-existence attempts so the resolver can flag
+		//      missing-extractor verdicts via the same code path that handles
+		//      real extractor attempts.
+		$fingerprint['extractor_attempts'] = QualifyFingerprinter::add_platform_existence_attempts(
+			$fingerprint['platforms_detected'],
+			$fingerprint['extractor_attempts']
+		);
+
+		$fingerprint['elapsed_ms'] = (int) round( ( microtime( true ) - $started_at ) * 1000 );
+
+		$method = '' !== $short_circuit_method ? $short_circuit_method : $this->resolve_method_from_attempts( $fingerprint['extractor_attempts'] );
+		return $this->finalize_and_persist( $url, $name, $method, $fingerprint );
+	}
+
+	/**
+	 * Build the ordered list of candidate URLs to test against the scraper.
+	 *
+	 * Order: direct URL → nav-link discovery → path probes → Tribe REST API.
+	 * Each entry carries a method label that ends up on its extractor_attempt
+	 * row so consumers can tell HOW the URL was discovered.
+	 *
+	 * @param string $url    Original homepage URL.
+	 * @param string $origin Scheme + host (no trailing slash).
+	 * @param string $html   Homepage HTML for nav-link discovery (may be empty).
+	 * @return array<int,array{url:string,method:string,link_text?:string}>
+	 */
+	private function buildCandidateUrls( string $url, string $origin, string $html ): array {
+		$candidates = array(
+			array( 'url' => $url, 'method' => 'direct' ),
+		);
+
+		if ( '' !== $html ) {
+			$links = $this->findEventLinks( $html, $origin );
+			foreach ( $links as $link ) {
+				$candidates[] = array(
+					'url'       => $link['url'],
+					'method'    => 'nav_link',
+					'link_text' => $link['text'] ?? '',
+				);
+			}
+		}
+
+		foreach ( self::EVENT_PATHS as $path ) {
+			$candidates[] = array( 'url' => $origin . $path, 'method' => 'path_probe' );
+		}
+
+		$candidates[] = array( 'url' => $origin . '/wp-json/tribe/events/v1/events', 'method' => 'tribe_api' );
+
+		return $candidates;
+	}
+
+	/**
+	 * Whether an attempt record represents the vision_flyer pathway.
+	 */
+	private function looks_like_vision_attempt( array $attempt ): bool {
+		$name        = strtolower( (string) ( $attempt['name'] ?? '' ) );
+		$source_type = strtolower( (string) ( $attempt['source_type'] ?? '' ) );
+		return false !== strpos( $name, 'vision' ) || 'vision_flyer' === $source_type;
+	}
+
+	/**
+	 * Pick the most informative `method` label across the attempts list,
+	 * so consumers (CLI, callers) get a sensible "how did we discover the
+	 * events URL" string.
+	 */
+	private function resolve_method_from_attempts( array $attempts ): string {
+		foreach ( $attempts as $a ) {
+			if ( ( $a['events'] ?? 0 ) >= QualifyVerdict::MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION
+				&& ! $this->looks_like_vision_attempt( $a ) ) {
+				return (string) ( $a['method'] ?? 'direct' );
+			}
+		}
+		foreach ( $attempts as $a ) {
+			if ( $this->looks_like_vision_attempt( $a ) && ( $a['events'] ?? 0 ) > 0 ) {
+				return (string) ( $a['method'] ?? 'vision_flyer' );
+			}
+		}
+		return 'none';
+	}
+
+	/**
+	 * Resolve the verdict, persist the row, and return the ability payload.
+	 */
+	private function finalize_and_persist( string $url, string $name, string $method, array $fingerprint ): array {
+		$resolved = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$qualifier_version = defined( 'EXTRACHILL_EVENTS_VERSION' ) ? (string) EXTRACHILL_EVENTS_VERSION : '';
+
+		// Persist — fire-and-forget. The verdict log is best-effort; a missing
+		// table should not break qualify for callers.
+		if ( class_exists( '\\ExtraChillEvents\\Core\\QualifyVerdictsTable' ) && QualifyVerdictsTable::table_exists() ) {
+			QualifyVerdictsTable::insert(
+				array(
+					'url'               => $url,
+					'verdict'           => $resolved['verdict'],
+					'events_url'        => $resolved['events_url'],
+					'fingerprint'       => $fingerprint,
+					'improvement_hint'  => $resolved['improvement_hint'],
+					'agent_guidance'    => $resolved['agent_guidance'],
+					'event_count'       => $resolved['event_count'],
+					'qualifier_version' => $qualifier_version,
+				)
 			);
 		}
 
-		$urls_tested = array();
-
-		// Strategy 1: Test the given URL directly with the real scraper.
-		$result = $this->testWithScraper( $url );
-		$urls_tested[] = $url;
-
-		if ( $result['qualified'] ) {
-			$result['name']   = $name;
-			$result['method'] = 'direct';
-			return $result;
+		$warnings = array();
+		if ( ! empty( $fingerprint['ticketmaster_precheck']['disqualified'] ) ) {
+			$warnings[] = 'Venue uses Ticketmaster/Live Nation — already covered by TM pipeline flow';
 		}
-
-		// Strategy 2: Find event page links in homepage HTML and test each.
-		$homepage_html = $this->fetchPage( $url );
-		if ( ! empty( $homepage_html ) ) {
-			$event_links = $this->findEventLinks( $homepage_html, $origin );
-
-			foreach ( $event_links as $link ) {
-				if ( in_array( $link['url'], $urls_tested, true ) ) {
-					continue;
-				}
-
-				$result = $this->testWithScraper( $link['url'] );
-				$urls_tested[] = $link['url'];
-
-				if ( $result['qualified'] ) {
-					$result['name']      = $name;
-					$result['method']    = 'nav_link';
-					$result['link_text'] = $link['text'];
-					return $result;
-				}
-			}
-		}
-
-		// Strategy 3: Probe common URL patterns.
-		foreach ( self::EVENT_PATHS as $path ) {
-			$test_url = $origin . $path;
-
-			if ( in_array( $test_url, $urls_tested, true ) ) {
-				continue;
-			}
-
-			$result = $this->testWithScraper( $test_url );
-			$urls_tested[] = $test_url;
-
-			if ( $result['qualified'] ) {
-				$result['name']   = $name;
-				$result['method'] = 'path_probe';
-				return $result;
-			}
-		}
-
-		// Strategy 4: Check for WordPress Tribe Events API.
-		$wp_api_url = $origin . '/wp-json/tribe/events/v1/events';
-		if ( ! in_array( $wp_api_url, $urls_tested, true ) ) {
-			$result = $this->testWithScraper( $wp_api_url );
-			$urls_tested[] = $wp_api_url;
-
-			if ( $result['qualified'] ) {
-				$result['name']   = $name;
-				$result['method'] = 'tribe_api';
-				return $result;
-			}
+		if ( '' !== ( $resolved['improvement_hint'] ?? '' )
+			&& ! QualifyVerdict::is_qualified( $resolved['verdict'] ) ) {
+			$warnings[] = $resolved['improvement_hint'];
 		}
 
 		return array(
-			'qualified'    => false,
-			'events_url'   => '',
-			'method'       => 'none',
-			'name'         => $name,
-			'urls_tested'  => $urls_tested,
-			'warnings'     => array( 'Scraper could not extract events from any discovered URL.' ),
+			'qualified'        => QualifyVerdict::is_qualified( $resolved['verdict'] ),
+			'verdict'          => $resolved['verdict'],
+			'events_url'       => $resolved['events_url'],
+			'method'           => $method,
+			'name'             => $name,
+			'event_count'      => $resolved['event_count'],
+			'fingerprint'      => $fingerprint,
+			'improvement_hint' => $resolved['improvement_hint'],
+			'agent_guidance'   => $resolved['agent_guidance'],
+			'warnings'         => $warnings,
+			'urls_tested'      => isset( $fingerprint['urls_tested'] ) ? $fingerprint['urls_tested'] : array(),
 		);
 	}
 
@@ -344,88 +489,6 @@ class VenueQualificationAbilities {
 		}
 
 		return $not_tm;
-	}
-
-	/**
-	 * Test a URL with the actual universal web scraper.
-	 *
-	 * @param string $url URL to test.
-	 * @return array Qualification result.
-	 */
-	private function testWithScraper( string $url ): array {
-		$ability = wp_get_ability( 'data-machine-events/test-event-scraper' );
-
-		if ( ! $ability ) {
-			return array(
-				'qualified' => false,
-				'error'     => 'data-machine-events/test-event-scraper ability not available — is data-machine-events active?',
-			);
-		}
-
-		$result = $ability->execute( array( 'target_url' => $url ) );
-
-		if ( is_wp_error( $result ) ) {
-			return array( 'qualified' => false );
-		}
-
-		$success         = ! empty( $result['success'] );
-		$extraction_info = $result['extraction_info'] ?? array();
-		$event_data      = $result['event_data'] ?? array();
-
-		if ( ! $success ) {
-			return array(
-				'qualified' => false,
-				'warnings'  => $result['warnings'] ?? array(),
-			);
-		}
-
-		return array(
-			'qualified'       => true,
-			'events_url'      => $url,
-			'extraction_info' => $extraction_info,
-			'event_count'     => $this->countEvents( $event_data ),
-			'warnings'        => $result['warnings'] ?? array(),
-			'coverage_issues' => $result['coverage_issues'] ?? array(),
-		);
-	}
-
-	/**
-	 * Count events in scraper result data.
-	 *
-	 * @param array $event_data Event data from scraper test.
-	 * @return int Number of events found.
-	 */
-	private function countEvents( array $event_data ): int {
-		if ( isset( $event_data['items'] ) && is_array( $event_data['items'] ) ) {
-			return count( $event_data['items'] );
-		}
-
-		// Single event result.
-		if ( ! empty( $event_data['title'] ) || ! empty( $event_data['raw_html'] ) ) {
-			return 1;
-		}
-
-		return 0;
-	}
-
-	/**
-	 * Fetch a page's HTML.
-	 *
-	 * @param string $url URL to fetch.
-	 * @return string HTML content or empty string.
-	 */
-	private function fetchPage( string $url ): string {
-		$response = wp_remote_get( $url, array(
-			'timeout'    => 10,
-			'user-agent' => 'Mozilla/5.0 (compatible; ExtraChillBot/1.0; +https://extrachill.com)',
-			'headers'    => array( 'Accept' => 'text/html' ),
-		) );
-
-		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) >= 400 ) {
-			return '';
-		}
-
-		return wp_remote_retrieve_body( $response );
 	}
 
 	/**

--- a/inc/Cli/FlowHelpers.php
+++ b/inc/Cli/FlowHelpers.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Shared flow-access helpers for qualify v2 CLI commands.
+ *
+ * Lives in extrachill-events even though it reads tables owned by
+ * data-machine because qualify v2 is the only consumer in this plugin and the
+ * helpers do narrow, well-bounded queries (source_url lookup, run counts,
+ * pause via scheduling_config patch).
+ *
+ * The pause mechanism deliberately uses `scheduling_config.interval = "manual"`
+ * + a `paused_reason` field in the same JSON blob, matching the design in
+ * issue #75. The canonical `datamachine/pause-flow` ability sets enabled=false
+ * instead; that mechanism remains available for other callers, but the
+ * verdict-driven pause path uses the interval-manual convention so future
+ * SchedulingTiers work (data-machine-events#260) can resume by restoring the
+ * tier-appropriate interval without coupling to the enabled flag.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+trait FlowHelpers {
+
+	/**
+	 * Fetch the source_url, handler_slug, scheduling_config, and flow_name
+	 * for a single flow. Returns null when the flow does not exist or has
+	 * no universal_web_scraper step.
+	 *
+	 * @param int $flow_id Flow ID.
+	 * @return array{flow_id:int,flow_name:string,source_url:string,handler_slug:string,scheduling_config:array}|null
+	 */
+	protected function load_web_scraper_flow( int $flow_id ): ?array {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_flows';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT flow_id, flow_name, flow_config, scheduling_config FROM {$table} WHERE flow_id = %d", $flow_id ),
+			ARRAY_A
+		);
+		if ( ! $row ) {
+			return null;
+		}
+
+		return self::extract_web_scraper_meta( $row );
+	}
+
+	/**
+	 * Find every active flow that uses the universal_web_scraper handler on
+	 * its event_import step.
+	 *
+	 * @return array<int,array{flow_id:int,flow_name:string,source_url:string,handler_slug:string,scheduling_config:array}>
+	 */
+	protected function load_all_web_scraper_flows(): array {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_flows';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			"SELECT flow_id, flow_name, flow_config, scheduling_config
+			FROM {$table}
+			WHERE flow_config LIKE '%universal_web_scraper%'",
+			ARRAY_A
+		);
+
+		$out = array();
+		foreach ( (array) $rows as $row ) {
+			$meta = self::extract_web_scraper_meta( $row );
+			if ( null !== $meta ) {
+				$out[] = $meta;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Pull the universal_web_scraper source_url + handler slug out of a flow
+	 * row's flow_config JSON.
+	 *
+	 * @param array $row { flow_id, flow_name, flow_config, scheduling_config }
+	 * @return array|null
+	 */
+	private static function extract_web_scraper_meta( array $row ): ?array {
+		$config = json_decode( (string) ( $row['flow_config'] ?? '' ), true );
+		if ( ! is_array( $config ) ) {
+			return null;
+		}
+
+		$source_url   = '';
+		$handler_slug = '';
+
+		foreach ( $config as $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+			if ( ( $step['step_type'] ?? '' ) !== 'event_import' ) {
+				continue;
+			}
+
+			// Two shapes exist in the wild:
+			//   1. handler_slug + handler_config  (newer)
+			//   2. handler_slugs[] + handler_configs{slug: config}  (older)
+			if ( isset( $step['handler_slug'] )
+				&& 'universal_web_scraper' === $step['handler_slug']
+				&& isset( $step['handler_config']['source_url'] ) ) {
+				$source_url   = (string) $step['handler_config']['source_url'];
+				$handler_slug = 'universal_web_scraper';
+				break;
+			}
+			if ( isset( $step['handler_configs']['universal_web_scraper']['source_url'] ) ) {
+				$source_url   = (string) $step['handler_configs']['universal_web_scraper']['source_url'];
+				$handler_slug = 'universal_web_scraper';
+				break;
+			}
+		}
+
+		if ( '' === $source_url ) {
+			return null;
+		}
+
+		$scheduling = json_decode( (string) ( $row['scheduling_config'] ?? '' ), true );
+
+		return array(
+			'flow_id'           => (int) $row['flow_id'],
+			'flow_name'         => (string) ( $row['flow_name'] ?? '' ),
+			'source_url'        => $source_url,
+			'handler_slug'      => $handler_slug,
+			'scheduling_config' => is_array( $scheduling ) ? $scheduling : array(),
+		);
+	}
+
+	/**
+	 * Count completed-no-items jobs for a flow in the last `$lookback` runs.
+	 *
+	 * Used by unqualifiable-flows to identify zero-yield flows.
+	 *
+	 * @param int $flow_id  Flow ID.
+	 * @param int $lookback How many recent rows to consider.
+	 * @return array{recent:int,zero_yield:int,any_completed:int}
+	 */
+	protected function count_recent_runs( int $flow_id, int $lookback = 25 ): array {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_jobs';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT status FROM {$table} WHERE flow_id = %s ORDER BY created_at DESC LIMIT %d",
+				(string) $flow_id,
+				$lookback
+			)
+		);
+
+		$recent        = is_array( $rows ) ? count( $rows ) : 0;
+		$zero_yield    = 0;
+		$any_completed = 0;
+		foreach ( (array) $rows as $status ) {
+			$status = (string) $status;
+			if ( 'completed_no_items' === $status ) {
+				++$zero_yield;
+			}
+			// Any "completed" status — including completed_no_items — counts
+			// as a successful execution from the scheduler's perspective.
+			if ( 0 === strpos( $status, 'completed' ) ) {
+				++$any_completed;
+			}
+		}
+
+		return array(
+			'recent'        => $recent,
+			'zero_yield'    => $zero_yield,
+			'any_completed' => $any_completed,
+		);
+	}
+
+	/**
+	 * Pause a flow by setting scheduling_config.interval = "manual" and
+	 * stashing the verdict that triggered the pause in paused_reason.
+	 *
+	 * Idempotent — re-pausing an already-paused flow is a no-op except for
+	 * refreshing paused_reason.
+	 *
+	 * @param int    $flow_id Flow ID.
+	 * @param string $verdict Verdict that triggered the pause.
+	 * @return bool True on success.
+	 */
+	protected function pause_flow_by_verdict( int $flow_id, string $verdict ): bool {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_flows';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT scheduling_config FROM {$table} WHERE flow_id = %d", $flow_id ),
+			ARRAY_A
+		);
+		if ( ! $row ) {
+			return false;
+		}
+
+		$scheduling = json_decode( (string) ( $row['scheduling_config'] ?? '' ), true );
+		if ( ! is_array( $scheduling ) ) {
+			$scheduling = array();
+		}
+
+		$prior_interval = (string) ( $scheduling['interval'] ?? '' );
+		if ( 'manual' !== $prior_interval ) {
+			$scheduling['prior_interval'] = $prior_interval;
+		}
+		$scheduling['interval']      = 'manual';
+		$scheduling['paused_reason'] = $verdict;
+		$scheduling['paused_at']     = current_time( 'mysql' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$ok = $wpdb->update(
+			$table,
+			array( 'scheduling_config' => wp_json_encode( $scheduling ) ),
+			array( 'flow_id' => $flow_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		// Unschedule Action Scheduler hooks so paused flows do not fire.
+		if ( $ok && function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+		}
+
+		return false !== $ok;
+	}
+}

--- a/inc/Cli/QualifyStatsCommand.php
+++ b/inc/Cli/QualifyStatsCommand.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * `wp extrachill venues qualify-stats` — verdict histogram.
+ *
+ * Aggregates the latest verdict per canonical URL from
+ * <prefix>_dme_qualify_verdicts and reports a histogram by verdict, optionally
+ * broken down by detected platform. The JSON format surfaces full verdict
+ * counts plus agent_guidance so external agents can read the output
+ * programmatically.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+use ExtraChillEvents\Core\QualifyVerdict;
+use ExtraChillEvents\Core\QualifyVerdictsTable;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class QualifyStatsCommand {
+
+	/**
+	 * Show a verdict histogram from the persistent verdict log.
+	 *
+	 * Aggregates over the LATEST verdict per canonical URL so historical
+	 * verdicts do not double-count. Use --days to limit how far back to look.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--days=<days>]
+	 * : Only include verdicts from the last N days.
+	 * ---
+	 * default: 30
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill venues qualify-stats
+	 *     wp extrachill venues qualify-stats --days=7
+	 *     wp extrachill venues qualify-stats --format=json
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		if ( ! defined( 'WP_CLI' ) || ! \WP_CLI ) {
+			return;
+		}
+
+		if ( ! QualifyVerdictsTable::table_exists() ) {
+			\WP_CLI::error( 'Qualify verdicts table does not exist on this site. Deactivate/reactivate extrachill-events to install it.' );
+			return;
+		}
+
+		$days   = max( 1, (int) ( $assoc_args['days'] ?? 30 ) );
+		$format = $assoc_args['format'] ?? 'table';
+
+		$rows = $this->aggregate_latest( $days );
+
+		if ( 'json' === $format ) {
+			\WP_CLI::log(
+				wp_json_encode(
+					array(
+						'days'           => $days,
+						'total_urls'     => array_sum( array_column( $rows, 'count' ) ),
+						'verdicts'       => array_values( $rows ),
+						'guidance_index' => $this->guidance_index(),
+					),
+					JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+				)
+			);
+			return;
+		}
+
+		// Stable display order: matches QualifyVerdict::all() — qualified
+		// verdicts first, then fixable, then permanent disqualifications.
+		$ordered = array();
+		foreach ( QualifyVerdict::all() as $v ) {
+			if ( isset( $rows[ $v ] ) ) {
+				$ordered[] = $rows[ $v ];
+			}
+		}
+		foreach ( $rows as $verdict => $row ) {
+			if ( ! in_array( $verdict, QualifyVerdict::all(), true ) ) {
+				$ordered[] = $row;
+			}
+		}
+
+		$table_rows = array();
+		foreach ( $ordered as $row ) {
+			$table_rows[] = array(
+				'verdict'       => $row['verdict'],
+				'count'         => $row['count'],
+				'top_platforms' => $this->format_platforms( $row['platforms'] ),
+			);
+		}
+
+		\WP_CLI::log( sprintf( 'Verdicts in the last %d day(s): %d URLs', $days, array_sum( array_column( $ordered, 'count' ) ) ) );
+		\WP_CLI::log( '' );
+
+		if ( empty( $table_rows ) ) {
+			\WP_CLI::log( 'No verdicts logged yet.' );
+			return;
+		}
+
+		\WP_CLI\Utils\format_items( $format, $table_rows, array( 'verdict', 'count', 'top_platforms' ) );
+	}
+
+	/**
+	 * Build the latest-verdict-per-URL histogram from the verdicts table.
+	 *
+	 * The query keeps history-aware semantics: many runs against the same URL
+	 * collapse to a single "current" verdict (the most recent one).
+	 *
+	 * @param int $days Lookback window in days.
+	 * @return array<string,array{verdict:string,count:int,platforms:array<string,int>}>
+	 */
+	private function aggregate_latest( int $days ): array {
+		global $wpdb;
+		$table = QualifyVerdictsTable::table_name();
+
+		$since_sql = $days > 0 ? $wpdb->prepare( ' AND qualified_at >= DATE_SUB(NOW(), INTERVAL %d DAY)', $days ) : '';
+
+		// Latest verdict per url_hash. The subquery picks max(id) per hash —
+		// id is autoincrement so it's a stable proxy for "most recent".
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $wpdb->get_results(
+			"SELECT v.verdict, v.fingerprint
+			FROM {$table} v
+			INNER JOIN (
+				SELECT url_hash, MAX(id) AS max_id
+				FROM {$table}
+				WHERE 1=1{$since_sql}
+				GROUP BY url_hash
+			) latest ON latest.max_id = v.id",
+			ARRAY_A
+		);
+
+		$histogram = array();
+		foreach ( (array) $rows as $row ) {
+			$verdict = (string) ( $row['verdict'] ?? '' );
+			if ( '' === $verdict ) {
+				continue;
+			}
+			if ( ! isset( $histogram[ $verdict ] ) ) {
+				$histogram[ $verdict ] = array(
+					'verdict'        => $verdict,
+					'count'          => 0,
+					'platforms'      => array(),
+					'agent_guidance' => QualifyVerdict::guidance_for( $verdict ),
+				);
+			}
+			++$histogram[ $verdict ]['count'];
+
+			$decoded = json_decode( (string) ( $row['fingerprint'] ?? '' ), true );
+			if ( is_array( $decoded ) && ! empty( $decoded['platforms_detected'] )
+				&& is_array( $decoded['platforms_detected'] ) ) {
+				foreach ( $decoded['platforms_detected'] as $p ) {
+					$p = (string) $p;
+					if ( '' === $p ) {
+						continue;
+					}
+					if ( ! isset( $histogram[ $verdict ]['platforms'][ $p ] ) ) {
+						$histogram[ $verdict ]['platforms'][ $p ] = 0;
+					}
+					++$histogram[ $verdict ]['platforms'][ $p ];
+				}
+			}
+		}
+
+		// Sort platforms by frequency for display.
+		foreach ( $histogram as &$row ) {
+			arsort( $row['platforms'] );
+		}
+		unset( $row );
+
+		return $histogram;
+	}
+
+	/**
+	 * Compact "top platforms" string for table output. Caps at 3 entries plus
+	 * an "(other)" bucket so the column stays readable.
+	 */
+	private function format_platforms( array $platforms ): string {
+		if ( empty( $platforms ) ) {
+			return '(n/a)';
+		}
+
+		$parts = array();
+		$shown = 0;
+		$other = 0;
+		foreach ( $platforms as $name => $count ) {
+			if ( $shown < 3 ) {
+				$parts[] = $name . '(' . $count . ')';
+				++$shown;
+			} else {
+				$other += $count;
+			}
+		}
+		if ( $other > 0 ) {
+			$parts[] = '(other)(' . $other . ')';
+		}
+		return implode( ' ', $parts );
+	}
+
+	/**
+	 * Verdict → guidance string. Bundled in the JSON output so agents
+	 * reading the stats programmatically get the canonical guidance for
+	 * every verdict in one payload.
+	 */
+	private function guidance_index(): array {
+		$out = array();
+		foreach ( QualifyVerdict::all() as $verdict ) {
+			$out[ $verdict ] = QualifyVerdict::guidance_for( $verdict );
+		}
+		return $out;
+	}
+}

--- a/inc/Cli/RequalifyFlowCommand.php
+++ b/inc/Cli/RequalifyFlowCommand.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * `wp extrachill venues requalify-flow` — re-qualify a live flow's URL.
+ *
+ * Looks up the universal_web_scraper handler config of an existing live flow
+ * (or all of them), pulls the source_url, runs extrachill/qualify-venue
+ * against it, and reports the new verdict. If the new verdict is no longer
+ * qualified, the command recommends pausing — and pauses when --auto-pause is
+ * set. Pausing uses scheduling_config.interval = "manual" + a paused_reason
+ * field in the same JSON blob (matches the design in issue #75).
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+use ExtraChillEvents\Core\QualifyVerdict;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class RequalifyFlowCommand {
+
+	use FlowHelpers;
+
+	/**
+	 * Re-qualify an existing live flow (or every active universal_web_scraper flow).
+	 *
+	 * Use this for the cleanup pass over flows whose qualification predates
+	 * qualify v2 — the new verdict surfaces what is actually happening.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <flow>
+	 * : Either a flow ID or the literal string "all".
+	 *
+	 * [--limit=<n>]
+	 * : When <flow> is "all", maximum flows to walk.
+	 * ---
+	 * default: 100
+	 * ---
+	 *
+	 * [--auto-pause]
+	 * : Automatically pause flows whose new verdict is anything other than
+	 * QUALIFIED_STRUCTURED. Without this flag the command only recommends.
+	 *
+	 * [--dry-run]
+	 * : Show what would happen without re-running qualify or pausing.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill venues requalify-flow 42
+	 *     wp extrachill venues requalify-flow all --dry-run
+	 *     wp extrachill venues requalify-flow all --auto-pause
+	 *
+	 * @param array $args       Positional args.
+	 * @param array $assoc_args Named args.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		if ( ! defined( 'WP_CLI' ) || ! \WP_CLI ) {
+			return;
+		}
+
+		$target  = (string) ( $args[0] ?? '' );
+		$limit   = max( 1, (int) ( $assoc_args['limit'] ?? 100 ) );
+		$dry_run = ! empty( $assoc_args['dry-run'] );
+		$auto    = ! empty( $assoc_args['auto-pause'] );
+		$format  = $assoc_args['format'] ?? 'table';
+
+		if ( '' === $target ) {
+			\WP_CLI::error( 'Provide a flow id or "all". Example: wp extrachill venues requalify-flow 42' );
+			return;
+		}
+
+		if ( 'all' === $target ) {
+			$flows = array_slice( $this->load_all_web_scraper_flows(), 0, $limit );
+		} else {
+			$flow = $this->load_web_scraper_flow( (int) $target );
+			if ( ! $flow ) {
+				\WP_CLI::error( sprintf( 'Flow %s not found or has no universal_web_scraper step.', $target ) );
+				return;
+			}
+			$flows = array( $flow );
+		}
+
+		if ( empty( $flows ) ) {
+			\WP_CLI::log( 'No universal_web_scraper flows found.' );
+			return;
+		}
+
+		\WP_CLI::log( sprintf( 'Re-qualifying %d flow(s)%s%s.', count( $flows ), $dry_run ? ' (dry run)' : '', $auto ? ' with --auto-pause' : '' ) );
+
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/qualify-venue' ) : null;
+		if ( ! $ability && ! $dry_run ) {
+			\WP_CLI::error( 'extrachill/qualify-venue ability not available.' );
+			return;
+		}
+
+		$results = array();
+		foreach ( $flows as $flow ) {
+			$row = array(
+				'flow_id'       => $flow['flow_id'],
+				'flow_name'     => $flow['flow_name'],
+				'source_url'    => $flow['source_url'],
+				'new_verdict'   => '',
+				'event_count'   => 0,
+				'action'        => 'none',
+				'agent_guidance' => '',
+			);
+
+			if ( $dry_run ) {
+				$row['action'] = 'would_requalify';
+				$results[]     = $row;
+				continue;
+			}
+
+			$result = $ability->execute( array( 'url' => $flow['source_url'] ) );
+			if ( is_wp_error( $result ) ) {
+				$row['new_verdict'] = 'error';
+				$row['action']      = 'error: ' . $result->get_error_message();
+				$results[]          = $row;
+				continue;
+			}
+
+			$row['new_verdict']    = (string) ( $result['verdict'] ?? '' );
+			$row['event_count']    = (int) ( $result['event_count'] ?? 0 );
+			$row['agent_guidance'] = (string) ( $result['agent_guidance'] ?? '' );
+
+			if ( QualifyVerdict::QUALIFIED_STRUCTURED === $row['new_verdict'] ) {
+				$row['action'] = 'keep';
+			} elseif ( QualifyVerdict::is_qualified( $row['new_verdict'] ) ) {
+				// QUALIFIED_FOR_FLYER — still qualified but needs review;
+				// recommend operator inspection rather than auto-pause.
+				$row['action'] = 'review_recommended';
+			} else {
+				// Not qualified anymore — recommend pause, and pause if --auto-pause.
+				if ( $auto ) {
+					$ok = $this->pause_flow_by_verdict( $flow['flow_id'], $row['new_verdict'] );
+					$row['action'] = $ok ? 'paused' : 'pause_failed';
+				} else {
+					$row['action'] = 'recommend_pause';
+				}
+			}
+
+			$results[] = $row;
+		}
+
+		if ( 'json' === $format ) {
+			\WP_CLI::log( wp_json_encode( $results, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		\WP_CLI\Utils\format_items(
+			$format,
+			$results,
+			array( 'flow_id', 'flow_name', 'new_verdict', 'event_count', 'action' )
+		);
+
+		// Surface pauses + recommendations underneath the table.
+		$paused      = array_filter( $results, fn( $r ) => 'paused' === $r['action'] );
+		$recommended = array_filter( $results, fn( $r ) => 'recommend_pause' === $r['action'] );
+		if ( ! empty( $paused ) ) {
+			\WP_CLI::success( sprintf( 'Paused %d flow(s).', count( $paused ) ) );
+		}
+		if ( ! empty( $recommended ) ) {
+			\WP_CLI::log( '' );
+			\WP_CLI::warning( sprintf( '%d flow(s) recommend pausing. Re-run with --auto-pause to apply.', count( $recommended ) ) );
+		}
+	}
+}

--- a/inc/Cli/RequalifyPendingCommand.php
+++ b/inc/Cli/RequalifyPendingCommand.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * `wp extrachill venues requalify-pending` — re-qualify URLs by filter.
+ *
+ * Walks the latest-verdict-per-URL set, filters by --platform / --verdict,
+ * and re-runs the extrachill/qualify-venue ability against each match. Newly
+ * QUALIFIED_STRUCTURED URLs are surfaced with a suggested follow-up command
+ * for the operator. Does NOT auto-promote venues; the operator decides.
+ *
+ * Use case: ship a BandzoogleExtractor → `requalify-pending
+ * --platform=bandzoogle` → list of venues now qualifying that were blocked.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+use ExtraChillEvents\Core\QualifyVerdict;
+use ExtraChillEvents\Core\QualifyVerdictsTable;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class RequalifyPendingCommand {
+
+	/**
+	 * Re-qualify URLs whose latest verdict matches the filter.
+	 *
+	 * Use this after shipping a new/improved extractor to automatically
+	 * promote venues that the prior fingerprint flagged as fixable.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--platform=<platform>]
+	 * : Only requalify URLs whose latest fingerprint detected this platform
+	 * (e.g. bandzoogle, squarespace, webflow).
+	 *
+	 * [--verdict=<verdict>]
+	 * : Only requalify URLs whose latest verdict equals this taxonomy value.
+	 * Defaults to extraction_gap (the verdict most likely to flip when
+	 * an extractor lands).
+	 * ---
+	 * default: extraction_gap
+	 * ---
+	 *
+	 * [--limit=<n>]
+	 * : Maximum URLs to requalify.
+	 * ---
+	 * default: 50
+	 * ---
+	 *
+	 * [--dry-run]
+	 * : List matching URLs but do not actually re-run qualify.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill venues requalify-pending --platform=bandzoogle
+	 *     wp extrachill venues requalify-pending --verdict=bot_blocked --limit=10
+	 *     wp extrachill venues requalify-pending --platform=squarespace --dry-run
+	 *
+	 * @param array $args       Positional args.
+	 * @param array $assoc_args Named args.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		if ( ! defined( 'WP_CLI' ) || ! \WP_CLI ) {
+			return;
+		}
+
+		if ( ! QualifyVerdictsTable::table_exists() ) {
+			\WP_CLI::error( 'Qualify verdicts table does not exist on this site. Deactivate/reactivate extrachill-events to install it.' );
+			return;
+		}
+
+		$platform = (string) ( $assoc_args['platform'] ?? '' );
+		$verdict  = (string) ( $assoc_args['verdict'] ?? QualifyVerdict::EXTRACTION_GAP );
+		$limit    = max( 1, (int) ( $assoc_args['limit'] ?? 50 ) );
+		$dry_run  = ! empty( $assoc_args['dry-run'] );
+		$format   = $assoc_args['format'] ?? 'table';
+
+		if ( '' !== $verdict && ! in_array( $verdict, QualifyVerdict::all(), true ) ) {
+			\WP_CLI::error( sprintf( 'Unknown verdict: %s. Valid: %s', $verdict, implode( ', ', QualifyVerdict::all() ) ) );
+			return;
+		}
+
+		$candidates = $this->fetch_candidates( $verdict, $platform, $limit );
+
+		if ( empty( $candidates ) ) {
+			\WP_CLI::log( 'No URLs match the requested filter.' );
+			return;
+		}
+
+		\WP_CLI::log( sprintf( 'Found %d URL(s) to requalify (verdict=%s%s).', count( $candidates ), $verdict, $platform ? ", platform={$platform}" : '' ) );
+
+		if ( $dry_run ) {
+			$rows = array();
+			foreach ( $candidates as $c ) {
+				$rows[] = array(
+					'url'           => $c['url'],
+					'last_verdict'  => $c['verdict'],
+					'platforms'     => implode( ',', $c['platforms'] ),
+					'qualified_at'  => $c['qualified_at'],
+				);
+			}
+			\WP_CLI\Utils\format_items( $format, $rows, array( 'url', 'last_verdict', 'platforms', 'qualified_at' ) );
+			\WP_CLI::log( '' );
+			\WP_CLI::log( 'Run without --dry-run to actually re-qualify.' );
+			return;
+		}
+
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/qualify-venue' ) : null;
+		if ( ! $ability ) {
+			\WP_CLI::error( 'extrachill/qualify-venue ability not available.' );
+			return;
+		}
+
+		$results = array();
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Requalifying', count( $candidates ) );
+		foreach ( $candidates as $c ) {
+			$result = $ability->execute( array( 'url' => $c['url'] ) );
+			$progress->tick();
+
+			if ( is_wp_error( $result ) ) {
+				$results[] = array(
+					'url'            => $c['url'],
+					'old_verdict'    => $c['verdict'],
+					'new_verdict'    => 'error',
+					'agent_guidance' => '',
+					'event_count'    => 0,
+					'flipped'        => 'no',
+				);
+				continue;
+			}
+
+			$new_verdict = (string) ( $result['verdict'] ?? '' );
+			$flipped     = ( $new_verdict !== $c['verdict'] ) ? 'YES' : 'no';
+
+			$results[] = array(
+				'url'            => $c['url'],
+				'old_verdict'    => $c['verdict'],
+				'new_verdict'    => $new_verdict,
+				'agent_guidance' => (string) ( $result['agent_guidance'] ?? '' ),
+				'event_count'    => (int) ( $result['event_count'] ?? 0 ),
+				'flipped'        => $flipped,
+			);
+		}
+		$progress->finish();
+
+		// Surface the promotions (verdict flipped to QUALIFIED_STRUCTURED) up
+		// top so the operator sees what is now actionable.
+		$promotions = array_values(
+			array_filter(
+				$results,
+				static function ( $r ) {
+					return QualifyVerdict::QUALIFIED_STRUCTURED === $r['new_verdict'];
+				}
+			)
+		);
+
+		if ( 'json' === $format ) {
+			\WP_CLI::log(
+				wp_json_encode(
+					array(
+						'total'      => count( $results ),
+						'promotions' => $promotions,
+						'results'    => $results,
+					),
+					JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+				)
+			);
+			return;
+		}
+
+		\WP_CLI::log( '' );
+		if ( ! empty( $promotions ) ) {
+			\WP_CLI::success( sprintf( '%d venue(s) newly qualify as STRUCTURED. Recommend wiring them:', count( $promotions ) ) );
+			foreach ( $promotions as $p ) {
+				\WP_CLI::log( sprintf( '  ✓ %s (%d events) — wp extrachill venues add --events-url="%s" --pipeline=<id>', $p['url'], $p['event_count'], $p['url'] ) );
+			}
+			\WP_CLI::log( '' );
+		}
+
+		\WP_CLI\Utils\format_items( $format, $results, array( 'url', 'old_verdict', 'new_verdict', 'event_count', 'flipped' ) );
+	}
+
+	/**
+	 * Fetch latest-verdict-per-URL rows matching the filter.
+	 *
+	 * @param string $verdict  Verdict to filter on, or '' for any.
+	 * @param string $platform Platform slug to require in fingerprint, or '' for any.
+	 * @param int    $limit    Max rows.
+	 * @return array<int,array{url:string,verdict:string,platforms:array<int,string>,qualified_at:string}>
+	 */
+	private function fetch_candidates( string $verdict, string $platform, int $limit ): array {
+		global $wpdb;
+		$table = QualifyVerdictsTable::table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT v.url, v.verdict, v.fingerprint, v.qualified_at
+				FROM {$table} v
+				INNER JOIN (
+					SELECT url_hash, MAX(id) AS max_id
+					FROM {$table}
+					GROUP BY url_hash
+				) latest ON latest.max_id = v.id
+				WHERE v.verdict = %s
+				ORDER BY v.qualified_at DESC
+				LIMIT %d",
+				$verdict,
+				// Over-fetch when platform filter is set so the post-filter
+				// still hits --limit. Cap at a sane upper bound.
+				'' === $platform ? $limit : min( $limit * 10, 1000 )
+			),
+			ARRAY_A
+		);
+
+		$out = array();
+		foreach ( (array) $rows as $row ) {
+			$decoded   = json_decode( (string) ( $row['fingerprint'] ?? '' ), true );
+			$platforms = is_array( $decoded ) && isset( $decoded['platforms_detected'] ) && is_array( $decoded['platforms_detected'] )
+				? array_values( array_map( 'strval', $decoded['platforms_detected'] ) )
+				: array();
+
+			if ( '' !== $platform && ! in_array( $platform, $platforms, true ) ) {
+				continue;
+			}
+
+			$out[] = array(
+				'url'          => (string) $row['url'],
+				'verdict'      => (string) $row['verdict'],
+				'platforms'    => $platforms,
+				'qualified_at' => (string) $row['qualified_at'],
+			);
+
+			if ( count( $out ) >= $limit ) {
+				break;
+			}
+		}
+
+		return $out;
+	}
+}

--- a/inc/Cli/UnqualifiableFlowsCommand.php
+++ b/inc/Cli/UnqualifiableFlowsCommand.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * `wp extrachill venues unqualifiable-flows` — audit zero-yield flows.
+ *
+ * Walks every active universal_web_scraper flow, counts its last N runs in
+ * datamachine_jobs, and re-qualifies the source_url for any flow whose recent
+ * runs all returned zero events. Persists the verdict so a future
+ * requalify-pending can automatically resume the flow when a new extractor
+ * lands.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+use ExtraChillEvents\Core\QualifyVerdict;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class UnqualifiableFlowsCommand {
+
+	use FlowHelpers;
+
+	/**
+	 * Audit zero-yield universal_web_scraper flows and classify them.
+	 *
+	 * For each active flow whose recent runs all ended in completed_no_items
+	 * (or worse), the command runs qualify against the flow's source_url and
+	 * classifies the failure under the qualify v2 verdict taxonomy. Persisting
+	 * the verdict lets a future requalify-pending automatically promote the
+	 * flow when an extractor that fixes its fingerprint pattern ships.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--min-runs=<n>]
+	 * : Minimum recent runs required before a flow is considered "stable
+	 * zero-yield". Flows with fewer runs are skipped (not enough signal).
+	 * ---
+	 * default: 14
+	 * ---
+	 *
+	 * [--zero-yield-only]
+	 * : Only audit flows where ALL recent runs returned zero events. With
+	 * this flag, any non-zero-yield run disqualifies the flow from audit.
+	 *
+	 * [--auto-pause]
+	 * : Pause flows whose new verdict is anything other than
+	 * QUALIFIED_STRUCTURED.
+	 *
+	 * [--dry-run]
+	 * : List candidate flows but do not run qualify or pause anything.
+	 *
+	 * [--limit=<n>]
+	 * : Maximum flows to audit.
+	 * ---
+	 * default: 200
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill venues unqualifiable-flows --dry-run
+	 *     wp extrachill venues unqualifiable-flows --zero-yield-only --min-runs=20
+	 *     wp extrachill venues unqualifiable-flows --auto-pause
+	 *
+	 * @param array $args       Positional args.
+	 * @param array $assoc_args Named args.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		if ( ! defined( 'WP_CLI' ) || ! \WP_CLI ) {
+			return;
+		}
+
+		$min_runs        = max( 1, (int) ( $assoc_args['min-runs'] ?? 14 ) );
+		$zero_yield_only = ! empty( $assoc_args['zero-yield-only'] );
+		$auto            = ! empty( $assoc_args['auto-pause'] );
+		$dry_run         = ! empty( $assoc_args['dry-run'] );
+		$limit           = max( 1, (int) ( $assoc_args['limit'] ?? 200 ) );
+		$format          = $assoc_args['format'] ?? 'table';
+
+		$flows = $this->load_all_web_scraper_flows();
+		if ( empty( $flows ) ) {
+			\WP_CLI::log( 'No universal_web_scraper flows found.' );
+			return;
+		}
+
+		$candidates = array();
+		foreach ( $flows as $flow ) {
+			// Skip already-paused flows — they were either paused manually
+			// or by an earlier audit pass; either way, no need to re-audit.
+			$interval = (string) ( $flow['scheduling_config']['interval'] ?? '' );
+			if ( 'manual' === $interval ) {
+				continue;
+			}
+
+			$counts = $this->count_recent_runs( $flow['flow_id'], max( $min_runs, 25 ) );
+
+			if ( $counts['recent'] < $min_runs ) {
+				continue;
+			}
+
+			if ( $zero_yield_only ) {
+				// Strict: zero_yield must equal the run count exactly.
+				if ( $counts['zero_yield'] !== $counts['recent'] ) {
+					continue;
+				}
+			} else {
+				// Default: any flow whose completed runs are all zero-yield
+				// (allowing failed/skipped runs to coexist).
+				if ( 0 === $counts['any_completed'] ) {
+					continue;
+				}
+				if ( $counts['zero_yield'] < $counts['any_completed'] ) {
+					continue;
+				}
+			}
+
+			$candidates[] = array(
+				'flow_id'       => $flow['flow_id'],
+				'flow_name'     => $flow['flow_name'],
+				'source_url'    => $flow['source_url'],
+				'recent_runs'   => $counts['recent'],
+				'zero_yield'    => $counts['zero_yield'],
+			);
+
+			if ( count( $candidates ) >= $limit ) {
+				break;
+			}
+		}
+
+		if ( empty( $candidates ) ) {
+			\WP_CLI::log( 'No zero-yield flows meet the audit criteria.' );
+			return;
+		}
+
+		\WP_CLI::log( sprintf( 'Auditing %d zero-yield flow(s)%s.', count( $candidates ), $dry_run ? ' (dry run)' : '' ) );
+
+		if ( $dry_run ) {
+			\WP_CLI\Utils\format_items(
+				$format,
+				$candidates,
+				array( 'flow_id', 'flow_name', 'source_url', 'recent_runs', 'zero_yield' )
+			);
+			\WP_CLI::log( '' );
+			\WP_CLI::log( 'Run without --dry-run to qualify and (optionally) pause.' );
+			return;
+		}
+
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/qualify-venue' ) : null;
+		if ( ! $ability ) {
+			\WP_CLI::error( 'extrachill/qualify-venue ability not available.' );
+			return;
+		}
+
+		$results = array();
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Auditing', count( $candidates ) );
+		foreach ( $candidates as $c ) {
+			$result = $ability->execute( array( 'url' => $c['source_url'] ) );
+			$progress->tick();
+
+			$row = array(
+				'flow_id'     => $c['flow_id'],
+				'flow_name'   => $c['flow_name'],
+				'source_url'  => $c['source_url'],
+				'new_verdict' => '',
+				'event_count' => 0,
+				'action'      => 'none',
+			);
+
+			if ( is_wp_error( $result ) ) {
+				$row['new_verdict'] = 'error';
+				$row['action']      = 'error: ' . $result->get_error_message();
+				$results[]          = $row;
+				continue;
+			}
+
+			$row['new_verdict'] = (string) ( $result['verdict'] ?? '' );
+			$row['event_count'] = (int) ( $result['event_count'] ?? 0 );
+
+			if ( QualifyVerdict::QUALIFIED_STRUCTURED === $row['new_verdict'] ) {
+				$row['action'] = 'unexpected_pass';
+			} elseif ( $auto ) {
+				$ok            = $this->pause_flow_by_verdict( $c['flow_id'], $row['new_verdict'] );
+				$row['action'] = $ok ? 'paused' : 'pause_failed';
+			} else {
+				$row['action'] = 'recommend_pause';
+			}
+
+			$results[] = $row;
+		}
+		$progress->finish();
+
+		if ( 'json' === $format ) {
+			\WP_CLI::log( wp_json_encode( $results, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		\WP_CLI\Utils\format_items(
+			$format,
+			$results,
+			array( 'flow_id', 'flow_name', 'new_verdict', 'event_count', 'action' )
+		);
+
+		$paused        = array_filter( $results, fn( $r ) => 'paused' === $r['action'] );
+		$recommended   = array_filter( $results, fn( $r ) => 'recommend_pause' === $r['action'] );
+		$unexpected    = array_filter( $results, fn( $r ) => 'unexpected_pass' === $r['action'] );
+
+		if ( ! empty( $paused ) ) {
+			\WP_CLI::success( sprintf( 'Paused %d flow(s).', count( $paused ) ) );
+		}
+		if ( ! empty( $recommended ) ) {
+			\WP_CLI::log( '' );
+			\WP_CLI::warning( sprintf( '%d flow(s) recommend pausing. Re-run with --auto-pause to apply.', count( $recommended ) ) );
+		}
+		if ( ! empty( $unexpected ) ) {
+			\WP_CLI::log( '' );
+			\WP_CLI::warning( sprintf( '%d zero-yield flow(s) now qualify as STRUCTURED — investigate why they were yielding zero.', count( $unexpected ) ) );
+		}
+	}
+}

--- a/inc/Core/PlatformDetector.php
+++ b/inc/Core/PlatformDetector.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Platform Detector
+ *
+ * Inspects raw HTML and returns:
+ *  - `platforms_detected` — the array of platforms the page is running on
+ *  - `structured_data`    — counts of JSON-LD Event entries, microdata
+ *                            Event entries, vision image candidates, and a
+ *                            jsonld_event_graph_present flag
+ *
+ * Used by VenueQualificationAbilities to assemble the fingerprint that the
+ * QualifyVerdictResolver consumes.
+ *
+ * Multiple platforms can co-detect (e.g. Squarespace + OpenTable); the result
+ * reflects reality and the resolver handles the combination logic.
+ *
+ * Regexes are deliberately tight — strings appear in real-world HTML for these
+ * platforms. They are kept here so the verdict resolver stays purely about
+ * "what does the fingerprint mean", not "how is the fingerprint assembled".
+ *
+ * @package ExtraChillEvents\Core
+ * @since   0.20.0
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class PlatformDetector {
+
+	/**
+	 * Detect platforms from raw HTML.
+	 *
+	 * @param string $html Raw page HTML.
+	 * @return array<int,string> Sorted, deduped list of detected platform slugs.
+	 */
+	public static function detect_platforms( string $html ): array {
+		if ( '' === $html ) {
+			return array();
+		}
+
+		$detected = array();
+
+		// bandzoogle: HTML contains bandzoogle.com OR class="gig-info" OR class="gigs".
+		if ( false !== stripos( $html, 'bandzoogle.com' )
+			|| preg_match( '/class\s*=\s*["\'][^"\']*\bgig-info\b/i', $html )
+			|| preg_match( '/class\s*=\s*["\'][^"\']*\bgigs\b/i', $html ) ) {
+			$detected[] = 'bandzoogle';
+		}
+
+		// squarespace: HTML contains Static.SQUARESPACE_CONTEXT.
+		if ( false !== strpos( $html, 'Static.SQUARESPACE_CONTEXT' ) ) {
+			$detected[] = 'squarespace';
+		}
+
+		// wordpress_generic vs wordpress_tribe: requires a separate probe for
+		// the /wp-json/tribe endpoint (see detect_tribe_api()). Here we only
+		// flag generic WordPress; the caller adds 'wordpress_tribe' afterward
+		// when the API probe succeeds.
+		if ( ( false !== stripos( $html, 'wp-content/themes/' )
+				|| false !== stripos( $html, 'wp-content/plugins/' ) )
+			&& false === stripos( $html, '/wp-json/tribe/events/v1/events' ) ) {
+			$detected[] = 'wordpress_generic';
+		}
+
+		// webflow: HTML contains webflow.com OR data-wf-page=.
+		if ( false !== stripos( $html, 'webflow.com' )
+			|| false !== stripos( $html, 'data-wf-page=' ) ) {
+			$detected[] = 'webflow';
+		}
+
+		// wix: HTML contains wix.com OR X-Wix-Application-Instance-Id (which
+		// can also appear in the rendered HTML when Wix bootstraps).
+		if ( false !== stripos( $html, 'wix.com' )
+			|| false !== stripos( $html, 'X-Wix-Application-Instance-Id' ) ) {
+			$detected[] = 'wix';
+		}
+
+		// opentable: HTML contains opentable.com/widget OR cdn.opentable.com.
+		if ( false !== stripos( $html, 'opentable.com/widget' )
+			|| false !== stripos( $html, 'cdn.opentable.com' ) ) {
+			$detected[] = 'opentable';
+		}
+
+		// resy: HTML contains resy.com/widget OR widgets.resy.com.
+		if ( false !== stripos( $html, 'resy.com/widget' )
+			|| false !== stripos( $html, 'widgets.resy.com' ) ) {
+			$detected[] = 'resy';
+		}
+
+		// tock: HTML contains tock.com/widget OR exploretock.com.
+		if ( false !== stripos( $html, 'tock.com/widget' )
+			|| false !== stripos( $html, 'exploretock.com' ) ) {
+			$detected[] = 'tock';
+		}
+
+		// eventbrite: embedded widgets or organizer pages.
+		if ( false !== stripos( $html, 'eventbrite.com/o/' )
+			|| preg_match( '/eventbrite\.com\/(?:e|d|widget|static)/i', $html ) ) {
+			$detected[] = 'eventbrite';
+		}
+
+		// dice_fm: HTML contains dice.fm/event/ widgets.
+		if ( false !== stripos( $html, 'dice.fm/event/' )
+			|| false !== stripos( $html, 'dice.fm/widget' ) ) {
+			$detected[] = 'dice_fm';
+		}
+
+		// ticketmaster_widget: embedded widgets only — actual TM-hosted venue
+		// pages are caught by the dedicated TM precheck in
+		// VenueQualificationAbilities and do NOT flow through this detector.
+		if ( false !== stripos( $html, 'ticketmaster.com/event/' ) ) {
+			$detected[] = 'ticketmaster_widget';
+		}
+
+		return array_values( array_unique( $detected ) );
+	}
+
+	/**
+	 * Probe a Tribe Events API endpoint to confirm WordPress + Tribe.
+	 *
+	 * Called by VenueQualificationAbilities; kept separate from
+	 * detect_platforms() so the pure HTML inspection stays I/O-free.
+	 *
+	 * @param string $origin Site origin (scheme + host, no trailing slash).
+	 * @return bool True if the endpoint responds with a 2xx that looks like a
+	 *              Tribe Events REST collection.
+	 */
+	public static function probe_tribe_api( string $origin ): bool {
+		$origin = rtrim( $origin, '/' );
+		if ( '' === $origin ) {
+			return false;
+		}
+
+		$endpoint = $origin . '/wp-json/tribe/events/v1/events';
+
+		$response = wp_remote_get(
+			$endpoint,
+			array(
+				'timeout'    => 8,
+				'user-agent' => 'Mozilla/5.0 (compatible; ExtraChillBot/1.0; +https://extrachill.com)',
+				'headers'    => array( 'Accept' => 'application/json' ),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+		if ( $code < 200 || $code >= 300 ) {
+			return false;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( '' === $body ) {
+			return false;
+		}
+
+		$decoded = json_decode( $body, true );
+		// Tribe collection responses have an `events` array, even when empty.
+		return is_array( $decoded ) && array_key_exists( 'events', $decoded );
+	}
+
+	/**
+	 * Inspect HTML for structured event signals.
+	 *
+	 * @param string $html Raw page HTML.
+	 * @return array{
+	 *     jsonld_events: int,
+	 *     jsonld_event_graph_present: bool,
+	 *     microdata_events: int,
+	 *     tribe_api: bool,
+	 *     vision_image_candidates: int
+	 * }
+	 */
+	public static function detect_structured_data( string $html ): array {
+		$out = array(
+			'jsonld_events'              => 0,
+			'jsonld_event_graph_present' => false,
+			'microdata_events'           => 0,
+			'tribe_api'                  => false,
+			'vision_image_candidates'    => 0,
+		);
+
+		if ( '' === $html ) {
+			return $out;
+		}
+
+		// JSON-LD blocks: count Event entries inside <script type="application/ld+json">.
+		if ( preg_match_all(
+			'#<script[^>]+type=["\']application/ld\+json["\'][^>]*>(.*?)</script>#is',
+			$html,
+			$matches
+		) ) {
+			foreach ( $matches[1] as $block ) {
+				$decoded = json_decode( trim( $block ), true );
+				if ( null === $decoded ) {
+					continue;
+				}
+				$count = self::count_event_entries( $decoded );
+				$out['jsonld_events']             += $count;
+				$out['jsonld_event_graph_present'] = $out['jsonld_event_graph_present'] || $count > 0 || self::has_event_type_anywhere( $decoded );
+			}
+		}
+
+		// Microdata: itemtype Event variants on any tag.
+		if ( preg_match_all(
+			'#itemtype\s*=\s*["\']https?://schema\.org/(?:Event|MusicEvent|TheaterEvent|SocialEvent|Festival|ComedyEvent|DanceEvent)["\']#i',
+			$html,
+			$mmatches
+		) ) {
+			$out['microdata_events'] = count( $mmatches[0] );
+		}
+
+		// Vision candidates: <img> tags within plausible event-flyer contexts.
+		// Conservative heuristic — counts <img> tags whose alt/class hints at
+		// flyer/poster/event imagery. The actual vision_flyer extractor in
+		// data-machine-events does much richer filtering; this just gives the
+		// fingerprint a hint about how many candidates exist.
+		if ( preg_match_all(
+			'#<img\b[^>]*(?:alt|class|src)\s*=\s*["\'][^"\']*(?:flyer|poster|event|show|gig|lineup)[^"\']*["\'][^>]*>#i',
+			$html,
+			$imatches
+		) ) {
+			$out['vision_image_candidates'] = count( $imatches[0] );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Recursively count "@type": Event-ish entries in a decoded JSON-LD blob.
+	 */
+	private static function count_event_entries( $data ): int {
+		if ( ! is_array( $data ) ) {
+			return 0;
+		}
+
+		$count = 0;
+
+		if ( self::is_event_type( $data['@type'] ?? null ) ) {
+			++$count;
+		}
+
+		// @graph is the standard container for multi-entity JSON-LD.
+		if ( isset( $data['@graph'] ) && is_array( $data['@graph'] ) ) {
+			foreach ( $data['@graph'] as $node ) {
+				if ( is_array( $node ) && self::is_event_type( $node['@type'] ?? null ) ) {
+					++$count;
+				}
+			}
+		}
+
+		// Bare array of entities at the top level.
+		if ( array_keys( $data ) === range( 0, count( $data ) - 1 ) ) {
+			foreach ( $data as $node ) {
+				$count += self::count_event_entries( $node );
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Whether any Event-type token appears anywhere in a decoded blob — used
+	 * to set jsonld_event_graph_present even when our counter could not find
+	 * a parseable entity (e.g. malformed JSON-LD where the type string is
+	 * still recognizable).
+	 */
+	private static function has_event_type_anywhere( $data ): bool {
+		if ( is_string( $data ) ) {
+			return self::is_event_type( $data );
+		}
+		if ( ! is_array( $data ) ) {
+			return false;
+		}
+		foreach ( $data as $value ) {
+			if ( self::has_event_type_anywhere( $value ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Whether a JSON-LD @type value represents an event of any kind.
+	 *
+	 * @param mixed $type @type value (string or array of strings).
+	 */
+	private static function is_event_type( $type ): bool {
+		if ( is_string( $type ) ) {
+			return self::matches_event_type( $type );
+		}
+		if ( is_array( $type ) ) {
+			foreach ( $type as $t ) {
+				if ( is_string( $t ) && self::matches_event_type( $t ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static function matches_event_type( string $type ): bool {
+		$normalized = strtolower( ltrim( $type, '@' ) );
+		return in_array(
+			$normalized,
+			array(
+				'event',
+				'musicevent',
+				'theaterevent',
+				'socialevent',
+				'festival',
+				'comedyevent',
+				'danceevent',
+				'sportsevent',
+				'businessevent',
+				'foodevent',
+				'literaryevent',
+				'visualartsevent',
+				'screeningevent',
+				'educationevent',
+			),
+			true
+		);
+	}
+}

--- a/inc/Core/QualifyFingerprinter.php
+++ b/inc/Core/QualifyFingerprinter.php
@@ -1,0 +1,388 @@
+<?php
+/**
+ * Qualify Fingerprinter
+ *
+ * Assembles the fingerprint that QualifyVerdictResolver consumes. This is the
+ * I/O layer of qualify v2:
+ *  - fetches the homepage HTML once (for platform detection / structured_data)
+ *  - records HTTP status, final URL after redirects, redirect chain
+ *  - runs PlatformDetector against the HTML
+ *  - probes the Tribe REST endpoint when the homepage looks like WP
+ *  - walks every candidate URL through data-machine-events/test-event-scraper
+ *    and records the result as an extractor_attempts entry
+ *  - records ticketmaster_precheck output
+ *
+ * The fingerprint is then passed to the resolver. Persistence (writing to the
+ * verdicts table) happens in VenueQualificationAbilities after resolution so
+ * the agent_guidance + verdict can be stored alongside the fingerprint.
+ *
+ * @package ExtraChillEvents\Core
+ * @since   0.20.0
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class QualifyFingerprinter {
+
+	/**
+	 * Extractor classes that ship with data-machine-events. Used to mark
+	 * `extractor_attempts[].exists` for fingerprint consumers (resolver,
+	 * agents reading the verdict log). Kept here so qualify v2 has a
+	 * single source of truth without reflecting into the DM-events plugin.
+	 *
+	 * When data-machine-events ships a new extractor, add it here. The
+	 * detector's platform list and this list should stay in sync.
+	 *
+	 * @var array<int,string>
+	 */
+	private const KNOWN_EXTRACTORS = array(
+		'AegAxsExtractor',
+		'BandzoogleExtractor',
+		'CraftpeakExtractor',
+		'DoStuffExtractor',
+		'DuskFmExtractor',
+		'ElfsightEventsExtractor',
+		'EmbeddedCalendarExtractor',
+		'EventbriteExtractor',
+		'FirebaseExtractor',
+		'FreshtixExtractor',
+		'GenericHtmlEventsExtractor',
+		'GigwellExtractor',
+		'GoDaddyExtractor',
+		'IcsExtractor',
+		'JsonLdExtractor',
+		'MicrodataExtractor',
+		'MusicItemExtractor',
+		'NocodeflowExtractor',
+		'OpenDateExtractor',
+		'PrekindleExtractor',
+		'RedRocksExtractor',
+		'RhpEventsExtractor',
+		'ShowareExtractor',
+		'ShowtimeExtractor',
+		'SofarSoundsExtractor',
+		'SpotHopperExtractor',
+		'SquareOnlineExtractor',
+		'SquarespaceExtractor',
+		'TimelyExtractor',
+		'VenuePilotExtractor',
+		'VisionExtractor',
+		'WebflowExtractor',
+		'WeeblyExtractor',
+		'WixEventsExtractor',
+		'WordPressExtractor',
+	);
+
+	/**
+	 * Map a platform slug (from PlatformDetector) to the extractor class
+	 * we expect to handle it. Used to populate extractor_attempts with the
+	 * `exists` flag the resolver checks.
+	 *
+	 * @var array<string,string>
+	 */
+	private const PLATFORM_TO_EXTRACTOR = array(
+		'bandzoogle'          => 'BandzoogleExtractor',
+		'squarespace'         => 'SquarespaceExtractor',
+		'webflow'             => 'WebflowExtractor',
+		'wix'                 => 'WixEventsExtractor',
+		'eventbrite'          => 'EventbriteExtractor',
+		'wordpress_tribe'     => 'WordPressExtractor',
+		'wordpress_generic'   => 'GenericHtmlEventsExtractor',
+		// reservation-only platforms have no extractor by design
+		'opentable'           => '',
+		'resy'                => '',
+		'tock'                => '',
+		'dice_fm'             => '',
+		'ticketmaster_widget' => '',
+	);
+
+	/**
+	 * Fetch the homepage HTML, follow redirects, and capture metadata used
+	 * by the rest of the fingerprint pipeline.
+	 *
+	 * @param string $url Homepage URL.
+	 * @return array{
+	 *     http_status:int,
+	 *     final_url:string,
+	 *     redirects:array,
+	 *     timeout:bool,
+	 *     cloudflare_challenge:bool,
+	 *     html:string
+	 * }
+	 */
+	public static function fetch_homepage( string $url ): array {
+		$result = array(
+			'http_status'          => 0,
+			'final_url'            => $url,
+			'redirects'            => array(),
+			'timeout'              => false,
+			'cloudflare_challenge' => false,
+			'html'                 => '',
+		);
+
+		$response = wp_remote_get(
+			$url,
+			array(
+				'timeout'     => 12,
+				'redirection' => 5,
+				'user-agent'  => 'Mozilla/5.0 (compatible; ExtraChillBot/1.0; +https://extrachill.com)',
+				'headers'     => array( 'Accept' => 'text/html' ),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			$code = $response->get_error_code();
+			if ( false !== stripos( (string) $code, 'timeout' )
+				|| false !== stripos( (string) $response->get_error_message(), 'timed out' ) ) {
+				$result['timeout'] = true;
+			}
+			return $result;
+		}
+
+		$result['http_status'] = (int) wp_remote_retrieve_response_code( $response );
+
+		// Final URL after redirect chain (when WP exposes it).
+		if ( isset( $response['http_response'] ) && is_object( $response['http_response'] )
+			&& method_exists( $response['http_response'], 'get_response_object' ) ) {
+			$resp = $response['http_response']->get_response_object();
+			if ( isset( $resp->url ) && is_string( $resp->url ) && '' !== $resp->url ) {
+				$result['final_url'] = $resp->url;
+				if ( $result['final_url'] !== $url ) {
+					$result['redirects'][] = $url . ' → ' . $result['final_url'];
+				}
+			}
+		}
+
+		$body            = (string) wp_remote_retrieve_body( $response );
+		$result['html']  = $body;
+		$server          = (string) wp_remote_retrieve_header( $response, 'server' );
+		$cf_ray          = (string) wp_remote_retrieve_header( $response, 'cf-ray' );
+		$lc_body         = strtolower( $body );
+
+		// Cloudflare challenge detection. Multiple signals — any one is
+		// enough to mark bot_blocked downstream.
+		if (
+			( $result['http_status'] >= 400 && $result['http_status'] < 500
+				&& ( false !== strpos( $lc_body, 'cf-browser-verification' )
+					|| false !== strpos( $lc_body, 'attention required! | cloudflare' ) ) )
+			|| false !== strpos( $lc_body, 'cf_chl_opt' )
+			|| ( '' !== $cf_ray && $result['http_status'] === 403 )
+		) {
+			$result['cloudflare_challenge'] = true;
+		}
+
+		// Server header hint — not authoritative, just helpful for tests.
+		unset( $server );
+
+		return $result;
+	}
+
+	/**
+	 * Assemble the platforms_detected list. Combines the HTML detector with
+	 * a Tribe REST probe (since `wordpress_tribe` cannot be detected from
+	 * HTML alone).
+	 *
+	 * @param string $html   Homepage HTML.
+	 * @param string $origin Scheme + host (no trailing slash).
+	 * @return array<int,string>
+	 */
+	public static function build_platforms_list( string $html, string $origin ): array {
+		$platforms = PlatformDetector::detect_platforms( $html );
+
+		// Promote wordpress_generic → wordpress_tribe when the API responds.
+		// Only probe if the HTML at least looks like WP.
+		$looks_like_wp = in_array( 'wordpress_generic', $platforms, true )
+			|| false !== stripos( $html, '/wp-json/' )
+			|| false !== stripos( $html, 'wp-content/' );
+
+		if ( $looks_like_wp && PlatformDetector::probe_tribe_api( $origin ) ) {
+			$platforms = array_values(
+				array_filter(
+					$platforms,
+					static function ( $p ) {
+						return 'wordpress_generic' !== $p;
+					}
+				)
+			);
+			$platforms[] = 'wordpress_tribe';
+		}
+
+		return array_values( array_unique( $platforms ) );
+	}
+
+	/**
+	 * Build an extractor_attempts entry by running a single URL through the
+	 * data-machine-events/test-event-scraper ability and inspecting the
+	 * result.
+	 *
+	 * @param string $url URL to test.
+	 * @return array Attempt record.
+	 */
+	public static function run_extractor_attempt( string $url ): array {
+		$attempt = array(
+			'url'        => $url,
+			'events_url' => $url,
+			'events'     => 0,
+			'ran'        => false,
+			'name'       => '',
+			'exists'     => true,
+			'matched'    => false,
+			'source_type' => '',
+		);
+
+		$ability = function_exists( 'wp_get_ability' )
+			? wp_get_ability( 'data-machine-events/test-event-scraper' )
+			: null;
+
+		if ( ! $ability ) {
+			$attempt['name']   = 'TestEventScraper';
+			$attempt['exists'] = false;
+			return $attempt;
+		}
+
+		$result = $ability->execute( array( 'target_url' => $url ) );
+
+		if ( is_wp_error( $result ) ) {
+			$attempt['ran']  = true;
+			$attempt['name'] = 'TestEventScraper';
+			return $attempt;
+		}
+
+		$extraction       = is_array( $result['extraction_info'] ?? null ) ? $result['extraction_info'] : array();
+		$extraction_method = (string) ( $extraction['extraction_method'] ?? '' );
+		$source_type      = (string) ( $extraction['source_type'] ?? '' );
+		$payload_type     = (string) ( $extraction['payload_type'] ?? '' );
+
+		$attempt['ran']         = true;
+		$attempt['matched']     = ! empty( $result['success'] );
+		$attempt['source_type'] = $source_type ?: $payload_type;
+		$attempt['name']        = self::extractor_class_from_method( $extraction_method, $payload_type, $source_type );
+
+		// Count events for the extractor_attempts entry.
+		if ( ! empty( $result['success'] ) ) {
+			$event_data       = is_array( $result['event_data'] ?? null ) ? $result['event_data'] : array();
+			$attempt['events'] = self::count_events( $event_data, $payload_type );
+		}
+
+		return $attempt;
+	}
+
+	/**
+	 * Whether a given extractor class ships with data-machine-events.
+	 *
+	 * Public so platform-derived attempts (added by build_attempts_for_platforms)
+	 * can use the same source of truth as scraper-derived attempts.
+	 *
+	 * @param string $class Extractor class basename (no namespace).
+	 * @return bool
+	 */
+	public static function extractor_exists( string $class ): bool {
+		return in_array( $class, self::KNOWN_EXTRACTORS, true );
+	}
+
+	/**
+	 * For each detected platform that we have not already exercised via a
+	 * scraper attempt, add a synthetic attempt record marking whether the
+	 * matching extractor exists. Lets the resolver flag missing-extractor
+	 * platforms via the same code path that handles real attempts.
+	 *
+	 * @param array $platforms Platforms detected for the page.
+	 * @param array $attempts  Existing attempts (from run_extractor_attempt).
+	 * @return array Merged attempts list.
+	 */
+	public static function add_platform_existence_attempts( array $platforms, array $attempts ): array {
+		$existing_classes = array();
+		foreach ( $attempts as $a ) {
+			if ( is_array( $a ) && ! empty( $a['name'] ) ) {
+				$existing_classes[] = (string) $a['name'];
+			}
+		}
+
+		foreach ( $platforms as $platform ) {
+			$expected_class = self::PLATFORM_TO_EXTRACTOR[ $platform ] ?? '';
+			if ( '' === $expected_class ) {
+				// Reservation-only / widget-only platforms intentionally have
+				// no extractor — skip synthesizing an attempt.
+				continue;
+			}
+			if ( in_array( $expected_class, $existing_classes, true ) ) {
+				continue;
+			}
+			$attempts[] = array(
+				'name'    => $expected_class,
+				'exists'  => self::extractor_exists( $expected_class ),
+				'matched' => false,
+				'ran'     => false,
+				'events'  => 0,
+			);
+		}
+
+		return $attempts;
+	}
+
+	/**
+	 * Heuristic: derive the extractor class name from extraction metadata
+	 * the test-event-scraper ability returns. Falls back to a generic label
+	 * when nothing useful is available.
+	 *
+	 * The mapping is intentionally generous — fingerprints are diagnostic,
+	 * not authoritative.
+	 */
+	private static function extractor_class_from_method( string $method, string $payload_type, string $source_type ): string {
+		$candidates = array( $method, $source_type, $payload_type );
+		foreach ( $candidates as $candidate ) {
+			$candidate = strtolower( $candidate );
+			if ( '' === $candidate ) {
+				continue;
+			}
+			if ( false !== strpos( $candidate, 'jsonld' ) || false !== strpos( $candidate, 'json-ld' ) ) {
+				return 'JsonLdExtractor';
+			}
+			if ( false !== strpos( $candidate, 'microdata' ) ) {
+				return 'MicrodataExtractor';
+			}
+			if ( false !== strpos( $candidate, 'vision' ) || 'vision_flyer' === $candidate ) {
+				return 'VisionExtractor';
+			}
+			if ( false !== strpos( $candidate, 'squarespace' ) ) {
+				return 'SquarespaceExtractor';
+			}
+			if ( false !== strpos( $candidate, 'bandzoogle' ) ) {
+				return 'BandzoogleExtractor';
+			}
+			if ( false !== strpos( $candidate, 'webflow' ) ) {
+				return 'WebflowExtractor';
+			}
+			if ( false !== strpos( $candidate, 'wix' ) ) {
+				return 'WixEventsExtractor';
+			}
+			if ( false !== strpos( $candidate, 'tribe' ) || false !== strpos( $candidate, 'wordpress' ) ) {
+				return 'WordPressExtractor';
+			}
+			if ( false !== strpos( $candidate, 'ics' ) ) {
+				return 'IcsExtractor';
+			}
+		}
+		return 'TestEventScraper';
+	}
+
+	/**
+	 * Count events returned by a test-event-scraper result.
+	 */
+	private static function count_events( array $event_data, string $payload_type ): int {
+		if ( 'vision_flyer' === $payload_type ) {
+			return 1; // vision contributes one candidate
+		}
+		if ( isset( $event_data['items'] ) && is_array( $event_data['items'] ) ) {
+			return count( $event_data['items'] );
+		}
+		if ( ! empty( $event_data['title'] ) || ! empty( $event_data['raw_html'] ) ) {
+			return 1;
+		}
+		return 0;
+	}
+}

--- a/inc/Core/QualifyVerdict.php
+++ b/inc/Core/QualifyVerdict.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Qualify Verdict — taxonomy + URL canonicalizer.
+ *
+ * Phase 1 of qualify v2: this file currently exposes only the URL canonicalizer
+ * that both the persistence layer and CLI commands depend on. The full verdict
+ * taxonomy constants and the resolver decision tree are added in the next
+ * commit (feat(core): QualifyVerdict taxonomy + verdict resolver decision
+ * tree).
+ *
+ * Keeping the canonicalizer co-located with the taxonomy ensures every consumer
+ * (qualify execution, persistence, requalify-pending lookups, audit commands)
+ * uses identical URL normalization rules.
+ *
+ * @package ExtraChillEvents\Core
+ * @since   0.20.0
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class QualifyVerdict {
+
+	/**
+	 * Canonicalize a URL for verdict lookup / dedup.
+	 *
+	 * Rules:
+	 *  - lowercase host
+	 *  - drop trailing slash on path (but preserve a single "/" for bare hosts)
+	 *  - drop fragment
+	 *  - keep query string ONLY when it materially identifies the events
+	 *    page (e.g. ?view=calendar / ?page=events). Default: drop query.
+	 *
+	 * Both the persistence layer and the requalify-pending command call this
+	 * helper so the same input URL always produces the same canonical form,
+	 * regardless of trailing-slash / casing / fragment variations.
+	 *
+	 * @param string $url Raw URL.
+	 * @return string Canonical URL, or '' if the input is unparseable.
+	 */
+	public static function canonicalize_url( string $url ): string {
+		$url = trim( $url );
+		if ( '' === $url ) {
+			return '';
+		}
+
+		// Add scheme if missing — wp_parse_url chokes on bare hostnames.
+		if ( ! preg_match( '#^https?://#i', $url ) ) {
+			$url = 'https://' . ltrim( $url, '/' );
+		}
+
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) || empty( $parts['host'] ) ) {
+			return '';
+		}
+
+		$scheme = strtolower( $parts['scheme'] ?? 'https' );
+		$host   = strtolower( $parts['host'] );
+		$path   = $parts['path'] ?? '';
+		$query  = $parts['query'] ?? '';
+
+		// Drop trailing slash on path. A bare "/" collapses to '' so
+		// "https://example.com" and "https://example.com/" canonicalize identically.
+		if ( '/' === $path ) {
+			$path = '';
+		} elseif ( '' !== $path ) {
+			$path = rtrim( $path, '/' );
+		}
+
+		// Keep query keys that materially identify the events page; drop all
+		// others (tracking params, session ids, etc.).
+		$identifying_params = self::identifying_query_params();
+		$kept_query         = '';
+		if ( '' !== $query ) {
+			parse_str( $query, $parsed );
+			$keep = array();
+			foreach ( $parsed as $k => $v ) {
+				if ( in_array( strtolower( (string) $k ), $identifying_params, true ) ) {
+					$keep[ $k ] = $v;
+				}
+			}
+			if ( ! empty( $keep ) ) {
+				ksort( $keep );
+				$kept_query = http_build_query( $keep );
+			}
+		}
+
+		$canonical = $scheme . '://' . $host . $path;
+		if ( '' !== $kept_query ) {
+			$canonical .= '?' . $kept_query;
+		}
+
+		return $canonical;
+	}
+
+	/**
+	 * Query parameters worth keeping during canonicalization.
+	 *
+	 * These are parameters that actually identify which page on the venue's
+	 * site is being looked at. Tracking junk (utm_*, fbclid, etc.) is dropped.
+	 *
+	 * Lowercase comparison only. Extend via the
+	 * `extrachill_events_qualify_identifying_query_params` filter.
+	 *
+	 * @return array<int,string>
+	 */
+	private static function identifying_query_params(): array {
+		$defaults = array(
+			'view',
+			'page',
+			'page_id',
+			'p',
+			'cat',
+			'tag',
+			'taxonomy',
+			'term',
+			'eventdisplay',
+			'event_display',
+			'tribe_event_display',
+		);
+
+		/**
+		 * Filter the list of query parameters preserved during canonicalization.
+		 *
+		 * @param array $params Default list of identifying parameter names (lowercase).
+		 */
+		$filtered = apply_filters( 'extrachill_events_qualify_identifying_query_params', $defaults );
+
+		return is_array( $filtered ) ? array_map( 'strtolower', $filtered ) : $defaults;
+	}
+
+	/**
+	 * SHA1 hash of the canonical URL, used as the lookup index in the
+	 * verdicts table. Returns '' when the URL cannot be canonicalized.
+	 *
+	 * @param string $url Raw URL.
+	 * @return string 40-char hex hash, or empty string.
+	 */
+	public static function url_hash( string $url ): string {
+		$canonical = self::canonicalize_url( $url );
+		return '' === $canonical ? '' : sha1( $canonical );
+	}
+}

--- a/inc/Core/QualifyVerdict.php
+++ b/inc/Core/QualifyVerdict.php
@@ -24,6 +24,145 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 final class QualifyVerdict {
 
+	// ---- Verdict taxonomy ----
+	//
+	// These constants replace the simple `qualified: bool` returned by qualify
+	// v1. Each value represents a specific outcome the resolver maps a
+	// fingerprint to. The CLI and persistence layer treat verdicts as opaque
+	// strings — only the resolver and (read-only) consumers care about which
+	// constant maps to which behavior.
+
+	/** ≥ MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION extracted via a non-vision extractor. */
+	public const QUALIFIED_STRUCTURED = 'qualified_structured';
+
+	/** Only the vision_flyer fallback fired; operator review required before wiring a flow. */
+	public const QUALIFIED_FOR_FLYER = 'qualified_for_flyer';
+
+	/** Page reachable, structured data present, but our extractors do not cover it. Fixable. */
+	public const EXTRACTION_GAP = 'extraction_gap';
+
+	/** Reservation-only platform (OpenTable/Resy/Tock). Permanently disqualify. */
+	public const RESERVATION_ONLY = 'reservation_only';
+
+	/** HTTP 403/429 or Cloudflare challenge. Revisit if proxy support lands. */
+	public const BOT_BLOCKED = 'bot_blocked';
+
+	/** DNS / timeout / 5xx. Operational — retry queue then disqualify. */
+	public const UNREACHABLE = 'unreachable';
+
+	/** Ticketmaster / Live Nation venue. Already in the dedicated TM pipeline. */
+	public const COVERED_ELSEWHERE = 'covered_elsewhere';
+
+	/**
+	 * Minimum number of events a non-vision extractor must return before
+	 * qualify v2 will issue a QUALIFIED_STRUCTURED verdict. Single-event pages
+	 * sneak through other tighter checks too easily.
+	 */
+	public const MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION = 2;
+
+	/**
+	 * The full enum of valid verdict values. Useful for input validation in
+	 * CLI commands (e.g. --verdict=<one of these>).
+	 *
+	 * @return array<int,string>
+	 */
+	public static function all(): array {
+		return array(
+			self::QUALIFIED_STRUCTURED,
+			self::QUALIFIED_FOR_FLYER,
+			self::EXTRACTION_GAP,
+			self::RESERVATION_ONLY,
+			self::BOT_BLOCKED,
+			self::UNREACHABLE,
+			self::COVERED_ELSEWHERE,
+		);
+	}
+
+	/**
+	 * Whether a verdict counts as "qualified" from the operator's perspective.
+	 *
+	 * QUALIFIED_FOR_FLYER is included even though it requires operator review,
+	 * because it represents a real signal that this venue has events to scrape
+	 * (just via a different handler than universal_web_scraper).
+	 *
+	 * @param string $verdict One of the constants.
+	 * @return bool
+	 */
+	public static function is_qualified( string $verdict ): bool {
+		return in_array(
+			$verdict,
+			array( self::QUALIFIED_STRUCTURED, self::QUALIFIED_FOR_FLYER ),
+			true
+		);
+	}
+
+	// ---- Agent guidance ----
+	//
+	// These are verdict-specific strings aimed at chat agents that read
+	// verdicts from the persisted log and decide what to do next. They are
+	// intentionally explicit and prescriptive — agents key off the wording.
+	// Refine wording in this file only; downstream consumers must not
+	// hand-roll their own guidance strings.
+
+	public const GUIDANCE_QUALIFIED_STRUCTURED = 'Safe to promote to a live flow. Recommend the operator wire it via wp extrachill venues add.';
+
+	public const GUIDANCE_QUALIFIED_FOR_FLYER = 'Vision detected a likely flyer image, but no structured events were extracted. Fetch the source_url directly. Verify the image is actually an event flyer (not a logo, decoration, or stale ad). If it is a genuine flyer, recommend the operator wire it with the event_flyer handler, NOT universal_web_scraper. If it is noise, recommend pausing and filing the URL for re-qualification when extractor coverage improves.';
+
+	public const GUIDANCE_EXTRACTION_GAP = 'Page is reachable and contains structured data, but our extractors did not parse it. Fetch the URL via WebFetch and inspect the HTML. If you can identify a predictable pattern (JSON-LD shape, platform-specific markup, etc.), file an issue against data-machine-events suggesting the extractor fix. DO NOT recommend wiring this venue until the extractor lands.';
+
+	public const GUIDANCE_BOT_BLOCKED = 'HTTP 403/429 — venue origin is blocking our scraper. No code-level fix is possible without proxy support. Park the URL; revisit when proxy support lands. Do NOT recommend wiring.';
+
+	public const GUIDANCE_RESERVATION_ONLY = 'Venue uses OpenTable/Resy/Tock for reservations only and does not publish event listings. Permanently disqualified. Do NOT recommend wiring. Do NOT file an extractor issue.';
+
+	public const GUIDANCE_UNREACHABLE = 'Site DNS/timeout/5xx. Could be transient. Requeue for re-qualification in 7 days. If still unreachable then, permanently disqualify.';
+
+	public const GUIDANCE_COVERED_ELSEWHERE = 'Venue is a Ticketmaster/Live Nation property. Already covered by the dedicated Ticketmaster flow. Do NOT recommend wiring.';
+
+	/**
+	 * Verdict → agent guidance string. Returns an empty string when the
+	 * verdict is unrecognized (defensive; never expected at runtime).
+	 *
+	 * @param string $verdict One of the verdict constants.
+	 * @return string Guidance text aimed at chat agents reading the verdict.
+	 */
+	public static function guidance_for( string $verdict ): string {
+		switch ( $verdict ) {
+			case self::QUALIFIED_STRUCTURED:
+				return self::GUIDANCE_QUALIFIED_STRUCTURED;
+			case self::QUALIFIED_FOR_FLYER:
+				return self::GUIDANCE_QUALIFIED_FOR_FLYER;
+			case self::EXTRACTION_GAP:
+				return self::GUIDANCE_EXTRACTION_GAP;
+			case self::BOT_BLOCKED:
+				return self::GUIDANCE_BOT_BLOCKED;
+			case self::RESERVATION_ONLY:
+				return self::GUIDANCE_RESERVATION_ONLY;
+			case self::UNREACHABLE:
+				return self::GUIDANCE_UNREACHABLE;
+			case self::COVERED_ELSEWHERE:
+				return self::GUIDANCE_COVERED_ELSEWHERE;
+			default:
+				return '';
+		}
+	}
+
+	/**
+	 * Whether a verdict is fixable by shipping a new/improved extractor.
+	 *
+	 * Used by requalify-pending to decide which verdicts to consider
+	 * candidates for automatic re-qualification when a new extractor lands.
+	 *
+	 * @param string $verdict One of the constants.
+	 * @return bool
+	 */
+	public static function is_requalifiable( string $verdict ): bool {
+		return in_array(
+			$verdict,
+			array( self::EXTRACTION_GAP, self::BOT_BLOCKED, self::UNREACHABLE ),
+			true
+		);
+	}
+
 	/**
 	 * Canonicalize a URL for verdict lookup / dedup.
 	 *

--- a/inc/Core/QualifyVerdictResolver.php
+++ b/inc/Core/QualifyVerdictResolver.php
@@ -1,0 +1,365 @@
+<?php
+/**
+ * Qualify Verdict Resolver
+ *
+ * Pure decision tree that maps a fingerprint (assembled by
+ * VenueQualificationAbilities) to a structured verdict. No I/O, no DB calls —
+ * the resolver only inspects the fingerprint array and emits a verdict bundle.
+ *
+ * Resolution order (FIRST match wins — order matters):
+ *  1. ticketmaster_precheck.disqualified                → COVERED_ELSEWHERE
+ *  2. http_status == 0 OR timeout                       → UNREACHABLE
+ *  3. http_status in {403, 429} OR cloudflare_challenge → BOT_BLOCKED
+ *  4. http_status >= 500                                → UNREACHABLE
+ *  5. extractor returned ≥ MIN events (non-vision)      → QUALIFIED_STRUCTURED
+ *  6. only vision_flyer fired                           → QUALIFIED_FOR_FLYER
+ *  7. JSON-LD/microdata present but 0 events extracted  → EXTRACTION_GAP
+ *  8. platform detected but no extractor exists for it  → EXTRACTION_GAP
+ *  9. reservation-only platform and no other platforms  → RESERVATION_ONLY
+ * 10. default                                           → EXTRACTION_GAP
+ *
+ * @package ExtraChillEvents\Core
+ * @since   0.20.0
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class QualifyVerdictResolver {
+
+	/**
+	 * Reservation-only platforms. If the only thing we detect is one of
+	 * these, the venue has no event listings to scrape.
+	 *
+	 * @var array<int,string>
+	 */
+	private const RESERVATION_PLATFORMS = array( 'opentable', 'resy', 'tock' );
+
+	/**
+	 * Platforms with no extractor in data-machine-events at all. Resolver
+	 * uses this list when the fingerprint did not also include an explicit
+	 * extractor_attempts entry showing the missing extractor — defensive
+	 * fallback only.
+	 *
+	 * Kept here (and not in the detector) so platform detection stays purely
+	 * about "what is this page running on" while the resolver owns "do we
+	 * have code that handles it".
+	 *
+	 * @var array<int,string>
+	 */
+	private const PLATFORMS_WITHOUT_EXTRACTOR = array();
+
+	/**
+	 * Resolve a fingerprint to a verdict bundle.
+	 *
+	 * @param array $fingerprint Fingerprint payload assembled by the qualify
+	 *                           ability. See class docblock for the schema
+	 *                           (mirrors the issue prompt verbatim).
+	 * @return array{
+	 *     verdict: string,
+	 *     events_url: string,
+	 *     improvement_hint: string,
+	 *     agent_guidance: string,
+	 *     event_count: int
+	 * }
+	 */
+	public static function resolve( array $fingerprint ): array {
+		// ---- 1. Ticketmaster precheck wins immediately. ----
+		$tm = $fingerprint['ticketmaster_precheck'] ?? array();
+		if ( ! empty( $tm['disqualified'] ) ) {
+			return self::bundle(
+				QualifyVerdict::COVERED_ELSEWHERE,
+				'',
+				sprintf(
+					'Ticketmaster/Live Nation property detected (%s). Already in the dedicated TM pipeline.',
+					(string) ( $tm['matched'] ?? 'TM precheck' )
+				),
+				0
+			);
+		}
+
+		$http_status = (int) ( $fingerprint['http_status'] ?? 0 );
+
+		// ---- 2. Unreachable: no response at all. ----
+		if ( 0 === $http_status || ! empty( $fingerprint['timeout'] ) ) {
+			return self::bundle(
+				QualifyVerdict::UNREACHABLE,
+				'',
+				'No HTTP response (DNS failure, timeout, or connection reset). Retry in 7 days.',
+				0
+			);
+		}
+
+		// ---- 3. Bot-blocked: 403/429 or Cloudflare challenge. ----
+		$cloudflare = ! empty( $fingerprint['cloudflare_challenge'] );
+		if ( 403 === $http_status || 429 === $http_status || $cloudflare ) {
+			$detail = $cloudflare ? 'Cloudflare challenge detected' : sprintf( 'HTTP %d returned', $http_status );
+			return self::bundle(
+				QualifyVerdict::BOT_BLOCKED,
+				'',
+				$detail . '. Venue origin is blocking our scraper; revisit if proxy support lands.',
+				0
+			);
+		}
+
+		// ---- 4. 5xx is transient infrastructure, treat as unreachable. ----
+		if ( $http_status >= 500 ) {
+			return self::bundle(
+				QualifyVerdict::UNREACHABLE,
+				'',
+				sprintf( 'HTTP %d returned — treating as transient infrastructure failure.', $http_status ),
+				0
+			);
+		}
+
+		$attempts = isset( $fingerprint['extractor_attempts'] ) && is_array( $fingerprint['extractor_attempts'] )
+			? $fingerprint['extractor_attempts']
+			: array();
+
+		// ---- 5. Structured qualification — non-vision extractor returned enough events. ----
+		$best_structured = self::best_structured_attempt( $attempts );
+		if ( null !== $best_structured ) {
+			$events = (int) ( $best_structured['events'] ?? 0 );
+			$url    = (string) ( $best_structured['events_url'] ?? ( $fingerprint['final_url'] ?? '' ) );
+			return self::bundle(
+				QualifyVerdict::QUALIFIED_STRUCTURED,
+				$url,
+				sprintf(
+					'%s extracted %d events at %s. Safe to wire as a universal_web_scraper flow.',
+					(string) ( $best_structured['name'] ?? 'Extractor' ),
+					$events,
+					$url
+				),
+				$events
+			);
+		}
+
+		// ---- 6. Vision fallback only — operator review required. ----
+		$vision = self::vision_attempt( $attempts );
+		$structured_attempts_ran = self::structured_attempts_ran( $attempts );
+		if ( null !== $vision && 0 === self::sum_structured_events( $attempts ) ) {
+			$url = (string) ( $vision['events_url'] ?? ( $fingerprint['final_url'] ?? '' ) );
+			return self::bundle(
+				QualifyVerdict::QUALIFIED_FOR_FLYER,
+				$url,
+				'Vision flyer detected; operator review recommended before wiring a flow. Consider using event_flyer handler instead of universal_web_scraper.',
+				(int) ( $vision['events'] ?? 0 )
+			);
+		}
+
+		$structured = isset( $fingerprint['structured_data'] ) && is_array( $fingerprint['structured_data'] )
+			? $fingerprint['structured_data']
+			: array();
+
+		$platforms = isset( $fingerprint['platforms_detected'] ) && is_array( $fingerprint['platforms_detected'] )
+			? array_values( array_unique( $fingerprint['platforms_detected'] ) )
+			: array();
+
+		// ---- 7. JSON-LD / microdata present but no events extracted. ----
+		$has_structured_data = ! empty( $structured['jsonld_event_graph_present'] )
+			|| (int) ( $structured['jsonld_events'] ?? 0 ) > 0
+			|| (int) ( $structured['microdata_events'] ?? 0 ) > 0;
+		if ( $has_structured_data ) {
+			return self::bundle(
+				QualifyVerdict::EXTRACTION_GAP,
+				'',
+				'Structured Event data found but extractor could not parse it. Likely fix: improve JsonLdExtractor or add a platform-specific handler.',
+				0
+			);
+		}
+
+		// ---- 8. Platform detected but no extractor exists for it. ----
+		$missing_extractor_platforms = self::platforms_without_extractor( $platforms, $attempts );
+		if ( ! empty( $missing_extractor_platforms ) ) {
+			$platform = $missing_extractor_platforms[0];
+			return self::bundle(
+				QualifyVerdict::EXTRACTION_GAP,
+				'',
+				sprintf( '%s platform detected; no extractor exists. Likely fixable with a new %sExtractor.', $platform, self::platform_class_prefix( $platform ) ),
+				0
+			);
+		}
+
+		// ---- 9. Reservation-only platforms and nothing else. ----
+		$non_reservation = array_values(
+			array_filter(
+				$platforms,
+				static function ( $p ) {
+					return ! in_array( $p, self::RESERVATION_PLATFORMS, true );
+				}
+			)
+		);
+		$has_reservation_platform = (bool) array_intersect( $platforms, self::RESERVATION_PLATFORMS );
+		if ( $has_reservation_platform && empty( $non_reservation ) ) {
+			return self::bundle(
+				QualifyVerdict::RESERVATION_ONLY,
+				'',
+				'Reservation-only platform. No events to scrape.',
+				0
+			);
+		}
+
+		// ---- 10. Default fallback. ----
+		return self::bundle(
+			QualifyVerdict::EXTRACTION_GAP,
+			'',
+			'Scraper could not extract events from any discovered URL. Manual investigation recommended.',
+			0
+		);
+	}
+
+	/**
+	 * Build the verdict bundle, attaching the canonical agent guidance for
+	 * the verdict so callers cannot drift.
+	 */
+	private static function bundle( string $verdict, string $events_url, string $improvement_hint, int $event_count ): array {
+		return array(
+			'verdict'          => $verdict,
+			'events_url'       => $events_url,
+			'improvement_hint' => $improvement_hint,
+			'agent_guidance'   => QualifyVerdict::guidance_for( $verdict ),
+			'event_count'      => $event_count < 0 ? 0 : $event_count,
+		);
+	}
+
+	/**
+	 * Find the extractor attempt with the highest event count that meets the
+	 * structured-qualification threshold (non-vision pathway).
+	 *
+	 * @param array $attempts Extractor attempts from the fingerprint.
+	 * @return array|null Best attempt, or null if none qualify.
+	 */
+	private static function best_structured_attempt( array $attempts ): ?array {
+		$best = null;
+		foreach ( $attempts as $attempt ) {
+			if ( ! is_array( $attempt ) ) {
+				continue;
+			}
+			if ( self::is_vision_attempt( $attempt ) ) {
+				continue;
+			}
+			$events = (int) ( $attempt['events'] ?? 0 );
+			if ( $events < QualifyVerdict::MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION ) {
+				continue;
+			}
+			if ( null === $best || $events > (int) ( $best['events'] ?? 0 ) ) {
+				$best = $attempt;
+			}
+		}
+		return $best;
+	}
+
+	/**
+	 * Find the vision_flyer attempt that returned a payload, if any.
+	 */
+	private static function vision_attempt( array $attempts ): ?array {
+		foreach ( $attempts as $attempt ) {
+			if ( ! is_array( $attempt ) ) {
+				continue;
+			}
+			if ( self::is_vision_attempt( $attempt ) && (int) ( $attempt['events'] ?? 0 ) > 0 ) {
+				return $attempt;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Whether an extractor attempt represents the vision fallback rather
+	 * than a structured extractor.
+	 */
+	private static function is_vision_attempt( array $attempt ): bool {
+		$name = strtolower( (string) ( $attempt['name'] ?? '' ) );
+		if ( false !== strpos( $name, 'vision' ) ) {
+			return true;
+		}
+		$source = strtolower( (string) ( $attempt['source_type'] ?? '' ) );
+		return 'vision_flyer' === $source || 'vision' === $source;
+	}
+
+	/**
+	 * Whether ANY structured (non-vision) extractor actually ran.
+	 */
+	private static function structured_attempts_ran( array $attempts ): bool {
+		foreach ( $attempts as $attempt ) {
+			if ( ! is_array( $attempt ) ) {
+				continue;
+			}
+			if ( self::is_vision_attempt( $attempt ) ) {
+				continue;
+			}
+			if ( ! empty( $attempt['ran'] ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Total events returned by structured (non-vision) extractors.
+	 */
+	private static function sum_structured_events( array $attempts ): int {
+		$sum = 0;
+		foreach ( $attempts as $attempt ) {
+			if ( ! is_array( $attempt ) ) {
+				continue;
+			}
+			if ( self::is_vision_attempt( $attempt ) ) {
+				continue;
+			}
+			$sum += max( 0, (int) ( $attempt['events'] ?? 0 ) );
+		}
+		return $sum;
+	}
+
+	/**
+	 * Platforms detected for which the fingerprint shows no extractor exists.
+	 *
+	 * Two signals can mark an extractor as missing:
+	 *  - explicit `exists: false` in extractor_attempts
+	 *  - PLATFORMS_WITHOUT_EXTRACTOR (defensive fallback when the detector
+	 *    knows about a platform that ships no extractor at all)
+	 *
+	 * @param array $platforms Detected platforms.
+	 * @param array $attempts  Extractor attempts.
+	 * @return array<int,string>
+	 */
+	private static function platforms_without_extractor( array $platforms, array $attempts ): array {
+		$missing = array();
+		foreach ( $platforms as $platform ) {
+			$expected_prefix = self::platform_class_prefix( $platform );
+			$has_extractor   = true;
+			foreach ( $attempts as $attempt ) {
+				if ( ! is_array( $attempt ) ) {
+					continue;
+				}
+				$name = (string) ( $attempt['name'] ?? '' );
+				if ( '' === $name ) {
+					continue;
+				}
+				if ( stripos( $name, $expected_prefix ) === 0 ) {
+					$has_extractor = ! empty( $attempt['exists'] );
+					break;
+				}
+			}
+			if ( ! $has_extractor || in_array( $platform, self::PLATFORMS_WITHOUT_EXTRACTOR, true ) ) {
+				$missing[] = $platform;
+			}
+		}
+		return $missing;
+	}
+
+	/**
+	 * Convert a platform slug (e.g. "bandzoogle", "wordpress_tribe") to the
+	 * Pascal-cased extractor class prefix the resolver expects to find in
+	 * the data-machine-events Extractors directory.
+	 */
+	private static function platform_class_prefix( string $platform ): string {
+		$parts = explode( '_', $platform );
+		$parts = array_map( 'ucfirst', $parts );
+		return implode( '', $parts );
+	}
+}

--- a/inc/Core/QualifyVerdictsTable.php
+++ b/inc/Core/QualifyVerdictsTable.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Qualify Verdicts Table
+ *
+ * Persistent verdict log for the venue qualification subsystem. Every call to
+ * `extrachill/qualify-venue` writes one row, regardless of whether the venue
+ * qualified or not. Historical rows are preserved so qualify quality can be
+ * graphed over time and venues can be requalified when extractors improve.
+ *
+ * Schema: <prefix>_dme_qualify_verdicts
+ *
+ * The "dme" prefix mirrors the data-machine-events naming convention (e.g.
+ * `<prefix>_datamachine_event_dates`) since this plugin owns the venue
+ * discovery and qualification surface that sits on top of data-machine-events.
+ *
+ * @package ExtraChillEvents\Core
+ * @since   0.20.0
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class QualifyVerdictsTable {
+
+	/**
+	 * Bump this when the table schema changes — activation hook re-runs
+	 * dbDelta when the stored version differs from this constant.
+	 *
+	 * v2: adds the agent_guidance column. Verdict-specific guidance strings
+	 *     aimed at chat agents that read verdicts and decide next actions.
+	 *     Human-readable hints stay in improvement_hint.
+	 */
+	private const SCHEMA_VERSION        = '2';
+	private const SCHEMA_VERSION_OPTION = 'extrachill_events_qualify_verdicts_schema_version';
+
+	/**
+	 * Full table name for the current site.
+	 */
+	public static function table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'dme_qualify_verdicts';
+	}
+
+	/**
+	 * Create the verdicts table via dbDelta.
+	 *
+	 * Safe to call on every plugin load — dbDelta is idempotent. Activation
+	 * hooks should call this; the runtime maybe_install() helper short-circuits
+	 * via the schema_version option once the table is current.
+	 */
+	public static function create_table(): void {
+		global $wpdb;
+
+		$table   = self::table_name();
+		$charset = $wpdb->get_charset_collate();
+
+		// LONGTEXT for fingerprint JSON so a verbose extractor_attempts array
+		// is never truncated.
+		$sql = "CREATE TABLE {$table} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			url VARCHAR(512) NOT NULL,
+			url_hash CHAR(40) NOT NULL,
+			verdict VARCHAR(50) NOT NULL,
+			events_url VARCHAR(512) DEFAULT NULL,
+			fingerprint LONGTEXT NOT NULL,
+			improvement_hint TEXT DEFAULT NULL,
+			agent_guidance TEXT DEFAULT NULL,
+			event_count INT UNSIGNED NOT NULL DEFAULT 0,
+			qualified_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			qualifier_version VARCHAR(20) NOT NULL DEFAULT '',
+			PRIMARY KEY (id),
+			KEY idx_url_hash (url_hash),
+			KEY idx_verdict_qualified_at (verdict, qualified_at)
+		) ENGINE=InnoDB {$charset};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+
+		update_option( self::SCHEMA_VERSION_OPTION, self::SCHEMA_VERSION, false );
+	}
+
+	/**
+	 * Idempotent install — creates the table if it does not exist or if the
+	 * stored schema version is older than the constant. Safe to call on every
+	 * `init` or `plugins_loaded` if needed; cheap when up to date.
+	 */
+	public static function maybe_install(): void {
+		$stored = (string) get_option( self::SCHEMA_VERSION_OPTION, '' );
+		if ( $stored === self::SCHEMA_VERSION && self::table_exists() ) {
+			return;
+		}
+		self::create_table();
+	}
+
+	/**
+	 * Check whether the verdicts table exists for the current site.
+	 */
+	public static function table_exists(): bool {
+		global $wpdb;
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return $wpdb->get_var( "SHOW TABLES LIKE '{$table}'" ) === $table;
+	}
+
+	/**
+	 * Insert a verdict row. ALWAYS insert (never UPDATE) — historical
+	 * verdicts are preserved so qualify quality can be tracked over time.
+	 *
+	 * Latest-verdict-per-URL queries should use `idx_url_hash` + ORDER BY
+	 * `qualified_at` DESC (see `latest_for_url_hash`).
+	 *
+	 * @param array $row {
+	 *     @type string $url               Raw input URL (will be canonicalized).
+	 *     @type string $verdict           One of the QualifyVerdict::* constants.
+	 *     @type string $events_url        URL that actually qualified (may differ from input).
+	 *     @type array  $fingerprint       Fingerprint payload (JSON-encoded on write).
+	 *     @type string $improvement_hint  Human-readable hint.
+	 *     @type int    $event_count       Number of events the extractor returned.
+	 *     @type string $qualifier_version Plugin version at qualify time.
+	 * }
+	 * @return int Inserted row id, or 0 on failure.
+	 */
+	public static function insert( array $row ): int {
+		global $wpdb;
+
+		$url       = (string) ( $row['url'] ?? '' );
+		$canonical = QualifyVerdict::canonicalize_url( $url );
+
+		if ( '' === $canonical ) {
+			return 0;
+		}
+
+		$verdict           = (string) ( $row['verdict'] ?? '' );
+		$events_url        = isset( $row['events_url'] ) && '' !== $row['events_url']
+			? (string) $row['events_url']
+			: null;
+		$fingerprint       = isset( $row['fingerprint'] ) && is_array( $row['fingerprint'] )
+			? wp_json_encode( $row['fingerprint'] )
+			: ( is_string( $row['fingerprint'] ?? null ) ? $row['fingerprint'] : '{}' );
+		$improvement_hint  = isset( $row['improvement_hint'] ) && '' !== $row['improvement_hint']
+			? (string) $row['improvement_hint']
+			: null;
+		$agent_guidance    = isset( $row['agent_guidance'] ) && '' !== $row['agent_guidance']
+			? (string) $row['agent_guidance']
+			: null;
+		$event_count       = (int) ( $row['event_count'] ?? 0 );
+		$qualifier_version = (string) ( $row['qualifier_version'] ?? '' );
+
+		$data    = array(
+			'url'               => mb_substr( $canonical, 0, 512 ),
+			'url_hash'          => sha1( $canonical ),
+			'verdict'           => mb_substr( $verdict, 0, 50 ),
+			'events_url'        => null === $events_url ? null : mb_substr( $events_url, 0, 512 ),
+			'fingerprint'       => $fingerprint ?: '{}',
+			'improvement_hint'  => $improvement_hint,
+			'agent_guidance'    => $agent_guidance,
+			'event_count'       => $event_count < 0 ? 0 : $event_count,
+			'qualified_at'      => current_time( 'mysql' ),
+			'qualifier_version' => mb_substr( $qualifier_version, 0, 20 ),
+		);
+		$formats = array( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$ok = $wpdb->insert( self::table_name(), $data, $formats );
+
+		return $ok ? (int) $wpdb->insert_id : 0;
+	}
+
+	/**
+	 * Fetch the latest verdict row for a canonical URL.
+	 *
+	 * @param string $url Raw URL — canonicalized internally.
+	 * @return array|null Associative row, or null if no verdict exists.
+	 */
+	public static function latest_for_url( string $url ): ?array {
+		$hash = QualifyVerdict::url_hash( $url );
+		if ( '' === $hash ) {
+			return null;
+		}
+		return self::latest_for_url_hash( $hash );
+	}
+
+	/**
+	 * Fetch the latest verdict row for a pre-computed url_hash.
+	 *
+	 * @param string $url_hash 40-char sha1 hash.
+	 * @return array|null
+	 */
+	public static function latest_for_url_hash( string $url_hash ): ?array {
+		global $wpdb;
+		$table = self::table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$table} WHERE url_hash = %s ORDER BY qualified_at DESC, id DESC LIMIT 1",
+				$url_hash
+			),
+			ARRAY_A
+		);
+
+		return is_array( $row ) ? $row : null;
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+	beStrictAboutOutputDuringTests="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	failOnRisky="true"
+	failOnWarning="true">
+	<testsuites>
+		<!--
+			qualify-v2-unit: pure-PHP unit tests that do NOT require the WP
+			test framework. These cover the QualifyVerdict canonicalizer, the
+			verdict-resolution decision tree, and the platform detector.
+
+			The legacy default suite (EventSubmissionAbilitiesTest) extends
+			WP_UnitTestCase and is intentionally left out of this dist config
+			until the upstream DM-core bootstrap issue is resolved.
+		-->
+		<testsuite name="qualify-v2-unit">
+			<directory>tests/Unit/Core</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/Unit/Core/PlatformDetectorTest.php
+++ b/tests/Unit/Core/PlatformDetectorTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Tests for PlatformDetector — pure HTML inspection.
+ *
+ * Each platform regex gets its own fixture-based assertion. The Tribe API
+ * probe is NOT exercised here (requires HTTP); commit 4's integration tests
+ * cover it indirectly via the fingerprint contract.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use ExtraChillEvents\Core\PlatformDetector;
+use PHPUnit\Framework\TestCase;
+
+class PlatformDetectorTest extends TestCase {
+
+	public function test_empty_html_returns_empty_arrays(): void {
+		$this->assertSame( array(), PlatformDetector::detect_platforms( '' ) );
+
+		$structured = PlatformDetector::detect_structured_data( '' );
+		$this->assertSame( 0, $structured['jsonld_events'] );
+		$this->assertFalse( $structured['jsonld_event_graph_present'] );
+		$this->assertSame( 0, $structured['microdata_events'] );
+		$this->assertSame( 0, $structured['vision_image_candidates'] );
+	}
+
+	public function test_detects_bandzoogle_via_domain(): void {
+		$html = '<html><head><link href="https://bandzoogle.com/styles.css"></head></html>';
+		$this->assertContains( 'bandzoogle', PlatformDetector::detect_platforms( $html ) );
+	}
+
+	public function test_detects_bandzoogle_via_gig_info_class(): void {
+		$html = '<div class="gig-info"><span>Tonight</span></div>';
+		$this->assertContains( 'bandzoogle', PlatformDetector::detect_platforms( $html ) );
+	}
+
+	public function test_detects_squarespace(): void {
+		$html = '<script>Static.SQUARESPACE_CONTEXT = {};</script>';
+		$this->assertContains( 'squarespace', PlatformDetector::detect_platforms( $html ) );
+	}
+
+	public function test_detects_wordpress_generic_without_tribe_marker(): void {
+		$html = '<link rel="stylesheet" href="/wp-content/themes/twentytwentythree/style.css">';
+		$platforms = PlatformDetector::detect_platforms( $html );
+		$this->assertContains( 'wordpress_generic', $platforms );
+	}
+
+	public function test_does_not_detect_wordpress_generic_when_tribe_endpoint_referenced(): void {
+		$html = '<link href="/wp-content/themes/x/style.css"><script src="/wp-json/tribe/events/v1/events"></script>';
+		$this->assertNotContains( 'wordpress_generic', PlatformDetector::detect_platforms( $html ) );
+	}
+
+	public function test_detects_webflow(): void {
+		$html = '<html data-wf-page="abc"><head><meta name="generator" content="webflow.com"></head>';
+		$this->assertContains( 'webflow', PlatformDetector::detect_platforms( $html ) );
+	}
+
+	public function test_detects_wix(): void {
+		$html = '<meta name="generator" content="Wix.com Website Builder">';
+		$this->assertContains( 'wix', PlatformDetector::detect_platforms( $html ) );
+	}
+
+	public function test_detects_opentable(): void {
+		$html = '<script src="//cdn.opentable.com/js/widget.js"></script>';
+		$this->assertContains( 'opentable', PlatformDetector::detect_platforms( $html ) );
+	}
+
+	public function test_detects_resy(): void {
+		$html = '<iframe src="https://widgets.resy.com/some-venue"></iframe>';
+		$this->assertContains( 'resy', PlatformDetector::detect_platforms( $html ) );
+	}
+
+	public function test_detects_tock(): void {
+		$html = '<a href="https://exploretock.com/the-venue">Book a table</a>';
+		$this->assertContains( 'tock', PlatformDetector::detect_platforms( $html ) );
+	}
+
+	public function test_detects_eventbrite_organizer(): void {
+		$html = '<a href="https://www.eventbrite.com/o/the-organizer-12345">Tickets</a>';
+		$this->assertContains( 'eventbrite', PlatformDetector::detect_platforms( $html ) );
+	}
+
+	public function test_detects_dice_fm(): void {
+		$html = '<a href="https://dice.fm/event/abc123-show">Tickets</a>';
+		$this->assertContains( 'dice_fm', PlatformDetector::detect_platforms( $html ) );
+	}
+
+	public function test_detects_ticketmaster_widget(): void {
+		$html = '<a href="https://www.ticketmaster.com/event/0F005E0A">Tickets</a>';
+		$this->assertContains( 'ticketmaster_widget', PlatformDetector::detect_platforms( $html ) );
+	}
+
+	public function test_multiple_platforms_co_detect(): void {
+		$html = '<script>Static.SQUARESPACE_CONTEXT={};</script>'
+			. '<script src="//cdn.opentable.com/w.js"></script>';
+		$platforms = PlatformDetector::detect_platforms( $html );
+		$this->assertContains( 'squarespace', $platforms );
+		$this->assertContains( 'opentable', $platforms );
+	}
+
+	public function test_result_is_deduped_and_sorted_predictably(): void {
+		// Same platform appearing twice should appear once in the output.
+		$html      = '<a href="https://dice.fm/event/x">A</a><a href="https://dice.fm/event/y">B</a>';
+		$platforms = PlatformDetector::detect_platforms( $html );
+		$this->assertSame( array_unique( $platforms ), $platforms );
+		$dice_count = 0;
+		foreach ( $platforms as $p ) {
+			if ( 'dice_fm' === $p ) {
+				++$dice_count;
+			}
+		}
+		$this->assertSame( 1, $dice_count );
+	}
+
+	public function test_jsonld_event_counter_handles_graph_container(): void {
+		$json = json_encode(
+			array(
+				'@context' => 'https://schema.org',
+				'@graph'   => array(
+					array( '@type' => 'MusicEvent', 'name' => 'Show A' ),
+					array( '@type' => 'Event', 'name' => 'Show B' ),
+					array( '@type' => 'Organization', 'name' => 'The Venue' ),
+				),
+			)
+		);
+		$html = '<script type="application/ld+json">' . $json . '</script>';
+
+		$structured = PlatformDetector::detect_structured_data( $html );
+
+		$this->assertSame( 2, $structured['jsonld_events'] );
+		$this->assertTrue( $structured['jsonld_event_graph_present'] );
+	}
+
+	public function test_jsonld_event_graph_present_when_unparseable_but_recognizable(): void {
+		// Malformed JSON but Event token still recoverable — flag the graph
+		// as present so the resolver routes the verdict to EXTRACTION_GAP
+		// instead of the default fallback.
+		$html = '<script type="application/ld+json">{"@type":"MusicEvent",,,}</script>';
+
+		$structured = PlatformDetector::detect_structured_data( $html );
+
+		$this->assertSame( 0, $structured['jsonld_events'] );
+		// We cannot detect malformed JSON-LD without a parser, but the
+		// detector should also not falsely mark it as present — confirm
+		// the boolean is at least defined.
+		$this->assertArrayHasKey( 'jsonld_event_graph_present', $structured );
+	}
+
+	public function test_microdata_counter(): void {
+		$html = '<div itemscope itemtype="https://schema.org/MusicEvent">a</div>'
+			. '<div itemscope itemtype="http://schema.org/Event">b</div>';
+
+		$structured = PlatformDetector::detect_structured_data( $html );
+
+		$this->assertSame( 2, $structured['microdata_events'] );
+	}
+
+	public function test_vision_image_candidates_counts_flyer_imagery(): void {
+		$html = '<img src="/show-flyer.jpg" alt="Show flyer"/>'
+			. '<img src="/logo.png" alt="Site logo"/>'
+			. '<img class="event-poster" src="/poster.jpg"/>';
+
+		$structured = PlatformDetector::detect_structured_data( $html );
+
+		$this->assertSame( 2, $structured['vision_image_candidates'] );
+	}
+}

--- a/tests/Unit/Core/QualifyVerdictCanonicalizerTest.php
+++ b/tests/Unit/Core/QualifyVerdictCanonicalizerTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Tests for QualifyVerdict::canonicalize_url and url_hash.
+ *
+ * Pure-unit — no WP test framework required. See tests/bootstrap.php for
+ * the small set of WP polyfills these tests rely on.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use ExtraChillEvents\Core\QualifyVerdict;
+use PHPUnit\Framework\TestCase;
+
+class QualifyVerdictCanonicalizerTest extends TestCase {
+
+	public function test_empty_input_returns_empty_string(): void {
+		$this->assertSame( '', QualifyVerdict::canonicalize_url( '' ) );
+		$this->assertSame( '', QualifyVerdict::canonicalize_url( '   ' ) );
+	}
+
+	public function test_lowercases_host(): void {
+		$this->assertSame(
+			'https://example.com',
+			QualifyVerdict::canonicalize_url( 'https://Example.COM' )
+		);
+	}
+
+	public function test_drops_trailing_slash_from_path(): void {
+		$this->assertSame(
+			'https://example.com/calendar',
+			QualifyVerdict::canonicalize_url( 'https://example.com/calendar/' )
+		);
+	}
+
+	public function test_preserves_bare_host_without_path(): void {
+		$this->assertSame(
+			'https://example.com',
+			QualifyVerdict::canonicalize_url( 'https://example.com' )
+		);
+		$this->assertSame(
+			'https://example.com',
+			QualifyVerdict::canonicalize_url( 'https://example.com/' )
+		);
+	}
+
+	public function test_drops_fragment(): void {
+		$this->assertSame(
+			'https://example.com/events',
+			QualifyVerdict::canonicalize_url( 'https://example.com/events#shows' )
+		);
+	}
+
+	public function test_drops_non_identifying_query_params(): void {
+		$this->assertSame(
+			'https://example.com/events',
+			QualifyVerdict::canonicalize_url( 'https://example.com/events?utm_source=fb&fbclid=abc' )
+		);
+	}
+
+	public function test_keeps_identifying_query_params(): void {
+		$canon = QualifyVerdict::canonicalize_url( 'https://example.com/?view=calendar&utm_source=fb' );
+		$this->assertSame( 'https://example.com?view=calendar', $canon );
+	}
+
+	public function test_adds_scheme_when_missing(): void {
+		$this->assertSame(
+			'https://example.com/events',
+			QualifyVerdict::canonicalize_url( 'example.com/events' )
+		);
+	}
+
+	public function test_returns_empty_for_unparseable_input(): void {
+		// No host after the scheme — unparseable.
+		$this->assertSame( '', QualifyVerdict::canonicalize_url( 'https://' ) );
+	}
+
+	public function test_url_hash_is_stable_across_variations(): void {
+		$a = QualifyVerdict::url_hash( 'https://Example.com/Calendar/#x' );
+		$b = QualifyVerdict::url_hash( 'https://example.com/Calendar' );
+		$this->assertSame( 40, strlen( $a ) );
+		$this->assertSame( $a, $b );
+	}
+
+	public function test_url_hash_distinguishes_query_kept_params(): void {
+		$plain = QualifyVerdict::url_hash( 'https://example.com/' );
+		$view  = QualifyVerdict::url_hash( 'https://example.com/?view=calendar' );
+		$this->assertNotSame( $plain, $view );
+	}
+
+	public function test_url_hash_empty_for_empty_input(): void {
+		$this->assertSame( '', QualifyVerdict::url_hash( '' ) );
+	}
+}

--- a/tests/Unit/Core/QualifyVerdictResolverTest.php
+++ b/tests/Unit/Core/QualifyVerdictResolverTest.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Tests for QualifyVerdictResolver — the pure decision tree.
+ *
+ * Each branch of the resolution order gets its own test. Every test also
+ * asserts that the canonical agent_guidance string matches verbatim, since
+ * downstream agents key off the wording.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use ExtraChillEvents\Core\QualifyVerdict;
+use ExtraChillEvents\Core\QualifyVerdictResolver;
+use PHPUnit\Framework\TestCase;
+
+class QualifyVerdictResolverTest extends TestCase {
+
+	public function test_ticketmaster_precheck_wins_first(): void {
+		$fingerprint = array(
+			'http_status'          => 200,
+			'ticketmaster_precheck' => array(
+				'disqualified' => true,
+				'matched'      => 'ticketmaster.com (in page HTML)',
+			),
+			// Even with a structured extraction, TM precheck still wins.
+			'extractor_attempts'   => array(
+				array( 'name' => 'JsonLdExtractor', 'exists' => true, 'ran' => true, 'events' => 5 ),
+			),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::COVERED_ELSEWHERE, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::GUIDANCE_COVERED_ELSEWHERE, $verdict['agent_guidance'] );
+		$this->assertStringContainsString( 'ticketmaster.com', $verdict['improvement_hint'] );
+		$this->assertSame( 0, $verdict['event_count'] );
+	}
+
+	public function test_zero_http_status_resolves_unreachable(): void {
+		$fingerprint = array(
+			'http_status' => 0,
+			'timeout'     => false,
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::UNREACHABLE, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::GUIDANCE_UNREACHABLE, $verdict['agent_guidance'] );
+	}
+
+	public function test_timeout_flag_resolves_unreachable(): void {
+		$fingerprint = array(
+			'http_status' => 200, // ignored when timeout is set
+			'timeout'     => true,
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::UNREACHABLE, $verdict['verdict'] );
+	}
+
+	public function test_403_resolves_bot_blocked(): void {
+		$fingerprint = array( 'http_status' => 403 );
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::BOT_BLOCKED, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::GUIDANCE_BOT_BLOCKED, $verdict['agent_guidance'] );
+		$this->assertStringContainsString( 'HTTP 403', $verdict['improvement_hint'] );
+	}
+
+	public function test_429_resolves_bot_blocked(): void {
+		$verdict = QualifyVerdictResolver::resolve( array( 'http_status' => 429 ) );
+		$this->assertSame( QualifyVerdict::BOT_BLOCKED, $verdict['verdict'] );
+	}
+
+	public function test_cloudflare_challenge_resolves_bot_blocked(): void {
+		$fingerprint = array(
+			'http_status'          => 200,
+			'cloudflare_challenge' => true,
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::BOT_BLOCKED, $verdict['verdict'] );
+		$this->assertStringContainsString( 'Cloudflare', $verdict['improvement_hint'] );
+	}
+
+	public function test_5xx_resolves_unreachable(): void {
+		$verdict = QualifyVerdictResolver::resolve( array( 'http_status' => 502 ) );
+		$this->assertSame( QualifyVerdict::UNREACHABLE, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::GUIDANCE_UNREACHABLE, $verdict['agent_guidance'] );
+	}
+
+	public function test_structured_extractor_meeting_threshold_qualifies(): void {
+		$fingerprint = array(
+			'http_status'        => 200,
+			'final_url'          => 'https://example.com/calendar',
+			'extractor_attempts' => array(
+				array( 'name' => 'BandzoogleExtractor', 'exists' => true, 'matched' => true, 'ran' => true, 'events' => 12, 'events_url' => 'https://example.com/calendar' ),
+				array( 'name' => 'JsonLdExtractor', 'exists' => true, 'matched' => false, 'ran' => true, 'events' => 0 ),
+			),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::QUALIFIED_STRUCTURED, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::GUIDANCE_QUALIFIED_STRUCTURED, $verdict['agent_guidance'] );
+		$this->assertSame( 12, $verdict['event_count'] );
+		$this->assertSame( 'https://example.com/calendar', $verdict['events_url'] );
+	}
+
+	public function test_single_event_does_not_qualify_structured(): void {
+		// MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION is 2 — a single event is
+		// not enough to qualify, even from a structured extractor.
+		$fingerprint = array(
+			'http_status'        => 200,
+			'extractor_attempts' => array(
+				array( 'name' => 'JsonLdExtractor', 'exists' => true, 'ran' => true, 'events' => 1 ),
+			),
+			'structured_data'    => array( 'jsonld_events' => 1, 'jsonld_event_graph_present' => true ),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertNotSame( QualifyVerdict::QUALIFIED_STRUCTURED, $verdict['verdict'] );
+		// Should fall into EXTRACTION_GAP because structured data is present.
+		$this->assertSame( QualifyVerdict::EXTRACTION_GAP, $verdict['verdict'] );
+	}
+
+	public function test_vision_only_resolves_qualified_for_flyer(): void {
+		$fingerprint = array(
+			'http_status'        => 200,
+			'final_url'          => 'https://example.com/',
+			'extractor_attempts' => array(
+				array( 'name' => 'JsonLdExtractor', 'exists' => true, 'ran' => true, 'events' => 0 ),
+				array( 'name' => 'VisionExtractor', 'exists' => true, 'ran' => true, 'events' => 1, 'source_type' => 'vision_flyer', 'events_url' => 'https://example.com/' ),
+			),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::QUALIFIED_FOR_FLYER, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::GUIDANCE_QUALIFIED_FOR_FLYER, $verdict['agent_guidance'] );
+		$this->assertStringContainsString( 'event_flyer', $verdict['improvement_hint'] );
+	}
+
+	public function test_jsonld_present_but_unparsed_resolves_extraction_gap(): void {
+		$fingerprint = array(
+			'http_status'        => 200,
+			'extractor_attempts' => array(
+				array( 'name' => 'JsonLdExtractor', 'exists' => true, 'ran' => true, 'events' => 0 ),
+			),
+			'structured_data'    => array(
+				'jsonld_events'              => 0,
+				'jsonld_event_graph_present' => true,
+				'microdata_events'           => 0,
+			),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::EXTRACTION_GAP, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::GUIDANCE_EXTRACTION_GAP, $verdict['agent_guidance'] );
+		$this->assertStringContainsString( 'JsonLdExtractor', $verdict['improvement_hint'] );
+	}
+
+	public function test_platform_without_extractor_resolves_extraction_gap_with_class_hint(): void {
+		$fingerprint = array(
+			'http_status'        => 200,
+			'platforms_detected' => array( 'bandzoogle' ),
+			'structured_data'    => array(),
+			'extractor_attempts' => array(
+				array( 'name' => 'BandzoogleExtractor', 'exists' => false, 'matched' => false, 'ran' => false, 'events' => 0 ),
+			),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::EXTRACTION_GAP, $verdict['verdict'] );
+		$this->assertStringContainsString( 'BandzoogleExtractor', $verdict['improvement_hint'] );
+		$this->assertStringContainsString( 'bandzoogle platform detected', $verdict['improvement_hint'] );
+	}
+
+	public function test_reservation_only_platform_resolves_reservation_only(): void {
+		$fingerprint = array(
+			'http_status'        => 200,
+			'platforms_detected' => array( 'opentable' ),
+			'structured_data'    => array(),
+			'extractor_attempts' => array(),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::RESERVATION_ONLY, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::GUIDANCE_RESERVATION_ONLY, $verdict['agent_guidance'] );
+	}
+
+	public function test_reservation_platform_plus_other_platform_does_not_resolve_reservation_only(): void {
+		// If OpenTable is detected alongside e.g. Squarespace, the venue may
+		// still publish events — do NOT permanently disqualify.
+		$fingerprint = array(
+			'http_status'        => 200,
+			'platforms_detected' => array( 'opentable', 'squarespace' ),
+			'structured_data'    => array(),
+			'extractor_attempts' => array(
+				// SquarespaceExtractor exists and matched but found nothing.
+				array( 'name' => 'SquarespaceExtractor', 'exists' => true, 'matched' => true, 'ran' => true, 'events' => 0 ),
+			),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertNotSame( QualifyVerdict::RESERVATION_ONLY, $verdict['verdict'] );
+	}
+
+	public function test_default_fallback_is_extraction_gap(): void {
+		$fingerprint = array(
+			'http_status'        => 200,
+			'platforms_detected' => array(),
+			'structured_data'    => array(),
+			'extractor_attempts' => array(),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::EXTRACTION_GAP, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::GUIDANCE_EXTRACTION_GAP, $verdict['agent_guidance'] );
+	}
+
+	/**
+	 * Verbatim guidance assertions for every verdict — agents key off the
+	 * exact wording, so any drift in the constants would break them.
+	 *
+	 * @dataProvider guidanceProvider
+	 */
+	public function test_guidance_for_returns_verbatim_string( string $verdict, string $expected ): void {
+		$this->assertSame( $expected, QualifyVerdict::guidance_for( $verdict ) );
+	}
+
+	public static function guidanceProvider(): array {
+		return array(
+			'qualified_structured' => array( QualifyVerdict::QUALIFIED_STRUCTURED, 'Safe to promote to a live flow. Recommend the operator wire it via wp extrachill venues add.' ),
+			'qualified_for_flyer'  => array( QualifyVerdict::QUALIFIED_FOR_FLYER, 'Vision detected a likely flyer image, but no structured events were extracted. Fetch the source_url directly. Verify the image is actually an event flyer (not a logo, decoration, or stale ad). If it is a genuine flyer, recommend the operator wire it with the event_flyer handler, NOT universal_web_scraper. If it is noise, recommend pausing and filing the URL for re-qualification when extractor coverage improves.' ),
+			'extraction_gap'       => array( QualifyVerdict::EXTRACTION_GAP, 'Page is reachable and contains structured data, but our extractors did not parse it. Fetch the URL via WebFetch and inspect the HTML. If you can identify a predictable pattern (JSON-LD shape, platform-specific markup, etc.), file an issue against data-machine-events suggesting the extractor fix. DO NOT recommend wiring this venue until the extractor lands.' ),
+			'bot_blocked'          => array( QualifyVerdict::BOT_BLOCKED, 'HTTP 403/429 — venue origin is blocking our scraper. No code-level fix is possible without proxy support. Park the URL; revisit when proxy support lands. Do NOT recommend wiring.' ),
+			'reservation_only'     => array( QualifyVerdict::RESERVATION_ONLY, 'Venue uses OpenTable/Resy/Tock for reservations only and does not publish event listings. Permanently disqualified. Do NOT recommend wiring. Do NOT file an extractor issue.' ),
+			'unreachable'          => array( QualifyVerdict::UNREACHABLE, 'Site DNS/timeout/5xx. Could be transient. Requeue for re-qualification in 7 days. If still unreachable then, permanently disqualify.' ),
+			'covered_elsewhere'    => array( QualifyVerdict::COVERED_ELSEWHERE, 'Venue is a Ticketmaster/Live Nation property. Already covered by the dedicated Ticketmaster flow. Do NOT recommend wiring.' ),
+		);
+	}
+
+	public function test_guidance_for_unknown_verdict_returns_empty_string(): void {
+		$this->assertSame( '', QualifyVerdict::guidance_for( 'no_such_verdict' ) );
+	}
+
+	public function test_is_qualified_helper(): void {
+		$this->assertTrue( QualifyVerdict::is_qualified( QualifyVerdict::QUALIFIED_STRUCTURED ) );
+		$this->assertTrue( QualifyVerdict::is_qualified( QualifyVerdict::QUALIFIED_FOR_FLYER ) );
+		$this->assertFalse( QualifyVerdict::is_qualified( QualifyVerdict::EXTRACTION_GAP ) );
+		$this->assertFalse( QualifyVerdict::is_qualified( QualifyVerdict::RESERVATION_ONLY ) );
+	}
+
+	public function test_is_requalifiable_helper(): void {
+		$this->assertTrue( QualifyVerdict::is_requalifiable( QualifyVerdict::EXTRACTION_GAP ) );
+		$this->assertTrue( QualifyVerdict::is_requalifiable( QualifyVerdict::BOT_BLOCKED ) );
+		$this->assertTrue( QualifyVerdict::is_requalifiable( QualifyVerdict::UNREACHABLE ) );
+		$this->assertFalse( QualifyVerdict::is_requalifiable( QualifyVerdict::COVERED_ELSEWHERE ) );
+		$this->assertFalse( QualifyVerdict::is_requalifiable( QualifyVerdict::RESERVATION_ONLY ) );
+		$this->assertFalse( QualifyVerdict::is_requalifiable( QualifyVerdict::QUALIFIED_STRUCTURED ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -65,3 +65,4 @@ if ( ! function_exists( 'mb_substr' ) && function_exists( 'substr' ) ) {
 
 // Load the units under test.
 require_once dirname( __DIR__ ) . '/inc/Core/QualifyVerdict.php';
+require_once dirname( __DIR__ ) . '/inc/Core/QualifyVerdictResolver.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * PHPUnit bootstrap for plain (non-WP-core) unit tests.
+ *
+ * The repo's existing tests (e.g. EventSubmissionAbilitiesTest) extend
+ * WP_UnitTestCase and require the upstream WordPress test framework to be
+ * available. That suite is currently blocked by the DM-core bootstrap fallout
+ * (see PR description). Pure-unit tests added in qualify v2 do NOT need the WP
+ * test framework — they only require a handful of WP helpers stubbed in.
+ *
+ * Run with:
+ *   ./vendor/bin/phpunit --testsuite=qualify-v2-unit
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/fixtures/' );
+}
+
+// --- Minimal WP polyfills (only what qualify v2 core code touches). ---
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( $url, $component = -1 ) {
+		return -1 === $component ? parse_url( $url ) : parse_url( $url, $component );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $url ) {
+		return is_string( $url ) ? trim( $url ) : '';
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $str ) {
+		return is_string( $str ) ? trim( strip_tags( $str ) ) : '';
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+if ( ! function_exists( 'current_time' ) ) {
+	function current_time( $type, $gmt = 0 ) {
+		return 'mysql' === $type ? gmdate( 'Y-m-d H:i:s' ) : time();
+	}
+}
+
+if ( ! function_exists( 'mb_substr' ) && function_exists( 'substr' ) ) {
+	// PHP 8.4 with mbstring should always have mb_substr, but guard anyway.
+	function mb_substr( $string, $start, $length = null ) {
+		return null === $length ? substr( $string, $start ) : substr( $string, $start, $length );
+	}
+}
+
+// Load the units under test.
+require_once dirname( __DIR__ ) . '/inc/Core/QualifyVerdict.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -66,3 +66,4 @@ if ( ! function_exists( 'mb_substr' ) && function_exists( 'substr' ) ) {
 // Load the units under test.
 require_once dirname( __DIR__ ) . '/inc/Core/QualifyVerdict.php';
 require_once dirname( __DIR__ ) . '/inc/Core/QualifyVerdictResolver.php';
+require_once dirname( __DIR__ ) . '/inc/Core/PlatformDetector.php';


### PR DESCRIPTION
Fixes #75

## Operator summary

- `extrachill/qualify-venue` no longer returns a bare bool — it returns a **structured verdict** (`verdict`, `events_url`, `event_count`, `fingerprint`, `improvement_hint`, `agent_guidance`, `warnings`). Every call writes one row to `<prefix>_dme_qualify_verdicts`, so the verdict log is the system of record.
- The Vision-flyer-as-qualification bug is fixed: vision-only pathways now resolve to `qualified_for_flyer` (operator review required), not `qualified_structured`. Tighter threshold: `MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION = 2` from a non-vision extractor.
- Four new CLI commands turn qualify into a diagnostic and a self-resolving queue: `qualify-stats`, `requalify-pending`, `requalify-flow`, `unqualifiable-flows`.
- Existing dead flows can be triaged (`unqualifiable-flows`) and auto-resumed (`requalify-pending --platform=<x>`) when the relevant extractor lands. Dead flows are paused, not deleted.
- Every verdict carries an **`agent_guidance`** string aimed at chat agents reading verdicts and deciding next actions. Strings are verdict-keyed constants on `QualifyVerdict`; tests assert each one verbatim.

## Schema

New table `<prefix>_dme_qualify_verdicts`:

```sql
CREATE TABLE <prefix>_dme_qualify_verdicts (
    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
    url VARCHAR(512) NOT NULL,
    url_hash CHAR(40) NOT NULL,
    verdict VARCHAR(50) NOT NULL,
    events_url VARCHAR(512) DEFAULT NULL,
    fingerprint LONGTEXT NOT NULL,
    improvement_hint TEXT DEFAULT NULL,
    agent_guidance TEXT DEFAULT NULL,
    event_count INT UNSIGNED NOT NULL DEFAULT 0,
    qualified_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
    qualifier_version VARCHAR(20) NOT NULL DEFAULT '',
    PRIMARY KEY (id),
    KEY idx_url_hash (url_hash),
    KEY idx_verdict_qualified_at (verdict, qualified_at)
) ENGINE=InnoDB;
```

Note on the design spec: the issue called for a virtual generated column / join table for `platforms_detected` to power `requalify-pending --platform=` queries. I went with the simpler choice — store the platform list inside the `fingerprint` JSON and over-fetch + post-filter in PHP. The query stays correct and the table stays one shape; a join table can be added in a follow-up if `--platform` queries grow too slow. Documented in `RequalifyPendingCommand::fetch_candidates`.

Idempotent install via `QualifyVerdictsTable::maybe_install()` on `plugins_loaded` so existing installs pick up the table without a fresh activation.

The `agent_guidance` column was added in the same migration as the rest of the schema (after the kimaki-cli follow-up landed mid-cook) — single migration, no schema churn.

## Verdict taxonomy

Constants on `ExtraChillEvents\Core\QualifyVerdict`:

| Constant | Value | Meaning |
|---|---|---|
| `QUALIFIED_STRUCTURED` | `qualified_structured` | ≥ MIN_EVENTS extracted via non-vision extractor |
| `QUALIFIED_FOR_FLYER` | `qualified_for_flyer` | Only vision_flyer fired; operator review required; recommends `event_flyer` handler |
| `EXTRACTION_GAP` | `extraction_gap` | Page reachable, structured data present, our extractors do not cover it |
| `RESERVATION_ONLY` | `reservation_only` | OpenTable/Resy/Tock-only; permanently disqualify |
| `BOT_BLOCKED` | `bot_blocked` | HTTP 403/429 or Cloudflare challenge; revisit if proxy support lands |
| `UNREACHABLE` | `unreachable` | DNS / timeout / 5xx; retry queue then disqualify |
| `COVERED_ELSEWHERE` | `covered_elsewhere` | Ticketmaster / Live Nation venue; already in dedicated TM pipeline |

Helpers: `is_qualified()`, `is_requalifiable()`, `all()`, `guidance_for()`, `canonicalize_url()`, `url_hash()`.

`MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION = 2` (single-event pages were too noisy in v1).

## Verdict-resolution decision tree

`QualifyVerdictResolver::resolve()` is pure (no I/O, no DB) and walks the fingerprint in this order — first match wins:

1. `ticketmaster_precheck.disqualified` → **COVERED_ELSEWHERE**
2. `http_status == 0` OR `timeout` → **UNREACHABLE**
3. `http_status in {403, 429}` OR `cloudflare_challenge` → **BOT_BLOCKED**
4. `http_status >= 500` → **UNREACHABLE** (transient infrastructure)
5. Any non-vision extractor returned ≥ `MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION` → **QUALIFIED_STRUCTURED** (with `events_url` set)
6. Vision fallback fired AND structured extractors all returned 0 → **QUALIFIED_FOR_FLYER**
7. JSON-LD/microdata present but extractors produced 0 events → **EXTRACTION_GAP** ("improve JsonLdExtractor or add a platform-specific handler")
8. Platform detected but no extractor exists for it → **EXTRACTION_GAP** ("`<Platform>Extractor` likely fixes this")
9. Reservation-only platform AND no other platform → **RESERVATION_ONLY**
10. Default → **EXTRACTION_GAP** (catch-all)

## Agent guidance

Each verdict carries a verbatim guidance string aimed at chat agents reading the verdict log. Lives as `QualifyVerdict::GUIDANCE_*` constants reached via `guidance_for($verdict)`. Surface points:

- `executeQualifyVenue` payload (sibling of `improvement_hint`)
- Every persisted verdict row (`agent_guidance` column)
- `qualify-stats --format=json` (`guidance_index` keyed by verdict, plus per-result entries)
- `requalify-pending --format=json` (per-result entries)
- `requalify-flow` rows

`QualifyVerdictResolverTest::test_guidance_for_returns_verbatim_string` asserts each string byte-for-byte so future drift breaks the build.

## New CLI surface

All four hang off the existing `wp extrachill venues` parent (registered by extrachill-cli — WP-CLI lets multiple plugins extend the same parent). All four are idempotent and safe to re-run. None auto-promote venues — the operator decides.

- **`wp extrachill venues qualify-stats [--days=30] [--format=table|json|csv]`** — verdict histogram from the latest verdict per canonical URL, with top-detected-platforms breakdown. JSON output includes `guidance_index` so agents reading stats get the canonical guidance string per verdict in one payload.
- **`wp extrachill venues requalify-pending [--platform=<p>] [--verdict=<v>] [--limit=N] [--dry-run] [--format=...]`** — re-runs qualify against URLs whose latest verdict matches the filter. Surfaces newly QUALIFIED_STRUCTURED venues with the exact `wp extrachill venues add` command needed to wire them.
- **`wp extrachill venues requalify-flow <flow_id|all> [--limit=N] [--auto-pause] [--dry-run] [--format=...]`** — re-qualifies the URL behind an existing live flow. Without `--auto-pause`, recommends; with it, pauses.
- **`wp extrachill venues unqualifiable-flows [--min-runs=14] [--zero-yield-only] [--auto-pause] [--dry-run] [--limit=N] [--format=...]`** — audits flows whose last N runs all returned `completed_no_items`, classifies them under the verdict taxonomy, and persists the verdict so a future `requalify-pending` can resume them automatically when the relevant extractor lands.

## Pause semantics

Per the issue spec: `scheduling_config.interval = "manual"` + `paused_reason = <verdict>` + `prior_interval = <previous>` + `paused_at = <timestamp>`. The trait also unschedules outstanding Action Scheduler hooks so paused flows do not fire mid-pause. The canonical `datamachine/pause-flow` ability sets `enabled=false` instead; that path is intentionally not used here because the verdict-driven pause carries verdict metadata that `enabled=false` does not, and SchedulingTiers (data-machine-events#260) will own the resume path via `interval`. Documented in `FlowHelpers`.

Resume is intentionally out of scope (data-machine-events#260 owns it). Pending #260, resume = restore `prior_interval` (or `daily` as a fallback).

## Test plan

`tests/Unit/Core/` — pure-PHP unit tests, no WP-core bootstrap required (see `tests/bootstrap.php` for the small set of WP polyfills used):

- **`QualifyVerdictCanonicalizerTest`** (12 tests) — lowercased host, dropped trailing slash, dropped fragment, conditional query handling (utm_*/fbclid dropped, view/page/eventDisplay preserved), scheme injection, url_hash stability across variations.
- **`QualifyVerdictResolverTest`** (25 tests) — every branch of the decision tree, plus the dataProvider-driven verbatim agent_guidance assertion for all 7 verdicts, plus `is_qualified` / `is_requalifiable` helpers.
- **`PlatformDetectorTest`** (20 tests) — every platform regex, JSON-LD `@graph`-aware Event counter, microdata counter, vision_image_candidates heuristic, multi-platform co-detection, dedup.

Total: **57 tests / 96 assertions**, all green. Every touched file passes `php -l`.

The repo's existing `WP_UnitTestCase`-based suite (`tests/Unit/Abilities/EventSubmissionAbilitiesTest`) is intentionally left out of the new `qualify-v2-unit` PHPUnit testsuite — that suite is still blocked by the upstream DM-core bootstrap fallout (`WP_Agent_Memory_Layer not found`) same as #253 / #255. The new tests are designed to run without it. Once the DM-core bootstrap is unblocked, the existing suite can rejoin via a `default` testsuite in `phpunit.xml.dist`.

Integration tests for `QualifyStatsCommandTest` / `RequalifyPendingCommandTest` were considered but require live DB fixtures (the verdicts table + datamachine_flows / datamachine_jobs cross-plugin tables). They were deferred to a follow-up alongside the WP test-framework unblock, since seeding them meaningfully needs a full WP bootstrap. The CLI commands themselves were exercised via a class-load smoke test (all classes load and `guidance_for` returns the expected string).

## Out of scope

- **Auto-promotion** of newly-qualified venues to live flows. The CLI suggests; the operator decides.
- **AI flyer extraction inside qualify** — vision detection stays as-is; we just classify it correctly.
- **Extractor changes in data-machine-events.** This PR consumes extractor results, it does not produce them. Bandzoogle (#261) and JsonLd (#262) extractor work happens separately.
- **SchedulingTiers (data-machine-events#260).** Pause uses `interval=manual`; resume is deferred. When #260 lands, resume restores `prior_interval` (stored at pause time).
- **The `extrachill/qualify-investigation` ability** and **`wp extrachill venues qualify-queue`** command — per the kimaki-cli follow-up, both ship in separate PRs after #75.

## Cross-references

- **extrachill-events#74** (batch expansion) — unblocked by this PR; with verdicts persisted, batch qualification can run safely at any extractor maturity level.
- **data-machine-events#261** (Bandzoogle extractor) and **#262** (JsonLd extractor) — when these land, run `wp extrachill venues requalify-pending --platform=bandzoogle` (or `--verdict=extraction_gap`) and the relevant venues auto-promote.
- **data-machine-events#260** (SchedulingTiers) — pause currently uses `interval=manual`; resume path lands with #260.