### PR TITLE
fix(qualify): per-shape threshold for QUALIFIED_STRUCTURED (detail pages allow 1 event)

### DIFF
--- a/inc/Abilities/VenueQualificationAbilities.php
+++ b/inc/Abilities/VenueQualificationAbilities.php
@@ -216,6 +216,16 @@ class VenueQualificationAbilities {
 			$fingerprint['platforms_detected'] = QualifyFingerprinter::build_platforms_list( $html, $origin );
 		}
 
+		// Event-page shape classification — drives per-shape thresholds in
+		// QualifyVerdictResolver. Always populated (even on fetch failure)
+		// so downstream code can rely on the key. See QualifyFingerprinter
+		// for the decision logic.
+		$fingerprint['structured_data']['event_page_shape'] = QualifyFingerprinter::detect_event_page_shape(
+			$fingerprint['final_url'],
+			is_array( $fingerprint['structured_data'] ) ? $fingerprint['structured_data'] : array(),
+			$html
+		);
+
 		// ---- Stop early if we already have enough signal for a verdict. ----
 		//
 		// For unreachable / bot-blocked / 5xx, the test-event-scraper round

--- a/inc/Core/QualifyFingerprinter.php
+++ b/inc/Core/QualifyFingerprinter.php
@@ -325,6 +325,222 @@ class QualifyFingerprinter {
 	}
 
 	/**
+	 * URL path prefixes considered event-listing roots. Used by the shape
+	 * detector to flag listing-shaped URLs. Kept in sync with the
+	 * VenueQualificationAbilities::EVENT_PATHS list, minus the leading slash
+	 * — but reproduced here so QualifyFingerprinter has no cross-class
+	 * dependency on the abilities layer.
+	 *
+	 * @var array<int,string>
+	 */
+	private const LISTING_PATH_SEGMENTS = array(
+		'events',
+		'calendar',
+		'shows',
+		'schedule',
+		'upcoming',
+		'live-music',
+		'whats-on',
+		'listings',
+		'concerts',
+		'music',
+		'lineup',
+		'happenings',
+		'event',
+		'gigs',
+	);
+
+	/**
+	 * URL path PREFIXES that, when followed by a slug-shaped segment, signal
+	 * a single-event detail page (e.g. `/schedule/<slug>`, `/events/<slug>`).
+	 * Used by the shape detector's URL regex.
+	 *
+	 * @var array<int,string>
+	 */
+	private const DETAIL_PATH_PREFIXES = array(
+		'event',
+		'events',
+		'show',
+		'shows',
+		'schedule',
+		'gig',
+		'gigs',
+		'calendar',
+	);
+
+	/**
+	 * Detect the shape of an event page (detail vs listing vs unknown).
+	 *
+	 * Decision logic — conservative on declaring "detail" because the
+	 * detail-page threshold relaxation (1 event qualifies) creates risk of
+	 * false positives on noisy listing pages. Resolution order matters:
+	 *
+	 *  1. Multiple Events in JSON-LD              → LISTING (unambiguous)
+	 *  2. ItemList / CollectionPage / listing
+	 *     container markers in HTML body
+	 *     (.event-list, .event-listing, repeated
+	 *     data-event-id, etc.)                    → LISTING
+	 *  3. URL path is a known listing root
+	 *     (`/`, `/events`, `/calendar`, ...)      → LISTING
+	 *  4. URL matches detail pattern
+	 *     (`/<prefix>/<slug-with-dash>`) AND
+	 *     exactly 1 Event present                 → DETAIL
+	 *  5. Exactly 1 Event present, no listing
+	 *     markers (covered above), and URL path
+	 *     is not a listing root                   → DETAIL
+	 *  6. Otherwise                                → UNKNOWN
+	 *
+	 * The two DETAIL branches mirror the issue's "ANY of" heuristic spec:
+	 *  (4) is the URL-driven heuristic, (5) is the JSON-LD count + body
+	 *  shape heuristic. Listing-marker / multi-Event checks (1-2) and the
+	 *  listing-root check (3) all short-circuit before either can fire, so
+	 *  detail is never declared when any explicit listing signal is present.
+	 *
+	 * Resolver maps UNKNOWN to the listing threshold (≥2 events) so the
+	 * default is conservative.
+	 *
+	 * @param string $url             Final URL (after redirects) being qualified.
+	 * @param array  $structured_data Output of PlatformDetector::detect_structured_data().
+	 * @param string $html            Homepage HTML body (may be empty).
+	 * @return string One of QualifyVerdict::EVENT_PAGE_SHAPE_* constants.
+	 *
+	 * @since 0.20.1
+	 */
+	public static function detect_event_page_shape( string $url, array $structured_data, string $html ): string {
+		$jsonld_events    = (int) ( $structured_data['jsonld_events'] ?? 0 );
+		$microdata_events = (int) ( $structured_data['microdata_events'] ?? 0 );
+		$total_events     = $jsonld_events + $microdata_events;
+
+		// 1. Multiple events anywhere → unambiguous listing.
+		if ( $total_events >= 2 ) {
+			return QualifyVerdict::EVENT_PAGE_SHAPE_LISTING;
+		}
+
+		// 2. ItemList / CollectionPage / listing-container markers → listing.
+		if ( '' !== $html && self::has_listing_markers( $html ) ) {
+			return QualifyVerdict::EVENT_PAGE_SHAPE_LISTING;
+		}
+
+		// 3. URL-based listing detection: trailing path segment matches a
+		// known listing root, or the URL has no path at all (bare domain).
+		$path = self::url_path( $url );
+		if ( self::path_is_listing_root( $path ) ) {
+			return QualifyVerdict::EVENT_PAGE_SHAPE_LISTING;
+		}
+
+		// 4. URL-driven detail heuristic: /<listing-prefix>/<slug>.
+		if ( self::path_matches_detail_pattern( $path ) && 1 === $total_events ) {
+			return QualifyVerdict::EVENT_PAGE_SHAPE_DETAIL;
+		}
+
+		// 5. JSON-LD-count detail heuristic: exactly 1 Event, no listing
+		// markers (handled above), path is not a listing root (handled
+		// above). Catches detail pages whose URLs don't match the slug regex
+		// (e.g. CMSes that serve `/p/event-name` or query-string-driven).
+		if ( 1 === $total_events && '' !== $path ) {
+			return QualifyVerdict::EVENT_PAGE_SHAPE_DETAIL;
+		}
+
+		return QualifyVerdict::EVENT_PAGE_SHAPE_UNKNOWN;
+	}
+
+	/**
+	 * Whether the HTML body contains markers indicating a listing/calendar
+	 * page (multiple event tiles, ItemList schema, etc.).
+	 *
+	 * Conservative: any single marker is enough to force a listing verdict
+	 * and prevent the detail-page threshold from applying.
+	 */
+	private static function has_listing_markers( string $html ): bool {
+		// ItemList / CollectionPage JSON-LD or microdata. We check both
+		// schema.org-flavored URLs and bare type tokens.
+		if ( preg_match(
+			'#"@type"\s*:\s*"(?:ItemList|CollectionPage|EventSeries)"#i',
+			$html
+		) ) {
+			return true;
+		}
+		if ( preg_match(
+			'#itemtype\s*=\s*["\']https?://schema\.org/(?:ItemList|CollectionPage|EventSeries)["\']#i',
+			$html
+		) ) {
+			return true;
+		}
+
+		// Common listing-container class / data-attribute markers.
+		if ( preg_match(
+			'#class\s*=\s*["\'][^"\']*\b(?:event-list|event-listing|events-list|events-listing|event-grid|events-grid|show-list|shows-list|schedule-list)\b#i',
+			$html
+		) ) {
+			return true;
+		}
+
+		// Repeated data-event-id attributes (>= 2) → listing of events.
+		if ( preg_match_all( '#data-event-id\s*=#i', $html, $m ) && count( $m[0] ) >= 2 ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Extract the lowercase path component of a URL, with trailing slash
+	 * stripped (except for bare "/"). Returns '' when the URL is unparseable.
+	 */
+	private static function url_path( string $url ): string {
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) ) {
+			return '';
+		}
+		$path = isset( $parts['path'] ) ? strtolower( (string) $parts['path'] ) : '';
+		if ( '' === $path ) {
+			return '';
+		}
+		if ( '/' === $path ) {
+			return '/';
+		}
+		return rtrim( $path, '/' );
+	}
+
+	/**
+	 * Whether a URL path is a listing root (bare host, or trailing segment
+	 * matches a known listing slug like /events, /calendar).
+	 */
+	private static function path_is_listing_root( string $path ): bool {
+		if ( '' === $path || '/' === $path ) {
+			return true;
+		}
+		// Last segment is one of the known listing slugs?
+		$segments = array_values( array_filter( explode( '/', $path ) ) );
+		if ( empty( $segments ) ) {
+			return true;
+		}
+		$last = end( $segments );
+		return in_array( $last, self::LISTING_PATH_SEGMENTS, true );
+	}
+
+	/**
+	 * Whether a URL path matches the single-event detail pattern:
+	 * `/<listing-prefix>/<slug>` where the slug contains at least one dash
+	 * AND at least one alphabetic character. The dash + alpha guard prevents
+	 * matching numeric ids (`/events/12345`) and short tokens.
+	 */
+	private static function path_matches_detail_pattern( string $path ): bool {
+		if ( '' === $path || '/' === $path ) {
+			return false;
+		}
+		$prefixes = implode( '|', array_map( 'preg_quote', self::DETAIL_PATH_PREFIXES ) );
+		$pattern  = '#^/(?:' . $prefixes . ')/([a-z0-9][a-z0-9-]*[a-z0-9])(?:/|$)#i';
+		if ( ! preg_match( $pattern, $path, $m ) ) {
+			return false;
+		}
+		$slug = $m[1];
+		// Slug must contain at least one dash AND at least one letter — keeps
+		// us from matching numeric ids or short tokens.
+		return ( false !== strpos( $slug, '-' ) ) && preg_match( '#[a-z]#i', $slug );
+	}
+
+	/**
 	 * Heuristic: derive the extractor class name from extraction metadata
 	 * the test-event-scraper ability returns. Falls back to a generic label
 	 * when nothing useful is available.

--- a/inc/Core/QualifyVerdict.php
+++ b/inc/Core/QualifyVerdict.php
@@ -55,10 +55,36 @@ final class QualifyVerdict {
 
 	/**
 	 * Minimum number of events a non-vision extractor must return before
-	 * qualify v2 will issue a QUALIFIED_STRUCTURED verdict. Single-event pages
-	 * sneak through other tighter checks too easily.
+	 * qualify v2 will issue a QUALIFIED_STRUCTURED verdict for a LISTING
+	 * page (or a page whose shape is unknown). Single-event pages sneak
+	 * through other tighter checks too easily on listing-shaped URLs.
 	 */
 	public const MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION = 2;
+
+	/**
+	 * Minimum events threshold for a single-event DETAIL page. Detail-page
+	 * URLs (e.g. `/schedule/<slug>`) emit exactly one Event by design, so
+	 * the listing-page threshold misclassifies them as extraction_gap.
+	 * Resolver picks this constant when `event_page_shape === "detail"`.
+	 *
+	 * @since 0.20.1
+	 */
+	public const MIN_EVENTS_FOR_DETAIL_PAGE = 1;
+
+	// ---- Event page shape enum ----
+	//
+	// Populated by QualifyFingerprinter::detect_event_page_shape() and stored
+	// on the fingerprint at `structured_data.event_page_shape`. The verdict
+	// resolver reads this to decide which MIN_EVENTS_* threshold to apply.
+
+	/** Single-event detail page (e.g. /schedule/<event-slug>). 1-event pages are legitimate here. */
+	public const EVENT_PAGE_SHAPE_DETAIL = 'detail';
+
+	/** Listing / calendar page. Single events are not enough; ≥2 required. */
+	public const EVENT_PAGE_SHAPE_LISTING = 'listing';
+
+	/** Shape detector did not find sufficient signal. Conservative default — treated as listing. */
+	public const EVENT_PAGE_SHAPE_UNKNOWN = 'unknown';
 
 	/**
 	 * The full enum of valid verdict values. Useful for input validation in

--- a/inc/Core/QualifyVerdictResolver.php
+++ b/inc/Core/QualifyVerdictResolver.php
@@ -120,7 +120,15 @@ class QualifyVerdictResolver {
 			: array();
 
 		// ---- 5. Structured qualification — non-vision extractor returned enough events. ----
-		$best_structured = self::best_structured_attempt( $attempts );
+		// Pick the per-shape threshold: detail pages legitimately serve 1
+		// Event by design; listing pages need ≥2 to guard against
+		// stray-snippet false positives (issue #77).
+		$shape       = (string) ( $fingerprint['structured_data']['event_page_shape'] ?? QualifyVerdict::EVENT_PAGE_SHAPE_UNKNOWN );
+		$min_events  = ( QualifyVerdict::EVENT_PAGE_SHAPE_DETAIL === $shape )
+			? QualifyVerdict::MIN_EVENTS_FOR_DETAIL_PAGE
+			: QualifyVerdict::MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION;
+
+		$best_structured = self::best_structured_attempt( $attempts, $min_events );
 		if ( null !== $best_structured ) {
 			$events = (int) ( $best_structured['events'] ?? 0 );
 			$url    = (string) ( $best_structured['events_url'] ?? ( $fingerprint['final_url'] ?? '' ) );
@@ -229,10 +237,15 @@ class QualifyVerdictResolver {
 	 * Find the extractor attempt with the highest event count that meets the
 	 * structured-qualification threshold (non-vision pathway).
 	 *
-	 * @param array $attempts Extractor attempts from the fingerprint.
+	 * @param array $attempts   Extractor attempts from the fingerprint.
+	 * @param int   $min_events Minimum event count required to qualify.
+	 *                          Defaults to the listing-page threshold for
+	 *                          back-compat; callers select
+	 *                          MIN_EVENTS_FOR_DETAIL_PAGE when the
+	 *                          fingerprint indicates a detail-shaped page.
 	 * @return array|null Best attempt, or null if none qualify.
 	 */
-	private static function best_structured_attempt( array $attempts ): ?array {
+	private static function best_structured_attempt( array $attempts, int $min_events = QualifyVerdict::MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION ): ?array {
 		$best = null;
 		foreach ( $attempts as $attempt ) {
 			if ( ! is_array( $attempt ) ) {
@@ -242,7 +255,7 @@ class QualifyVerdictResolver {
 				continue;
 			}
 			$events = (int) ( $attempt['events'] ?? 0 );
-			if ( $events < QualifyVerdict::MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION ) {
+			if ( $events < $min_events ) {
 				continue;
 			}
 			if ( null === $best || $events > (int) ( $best['events'] ?? 0 ) ) {

--- a/tests/Unit/Core/QualifyFingerprinterTest.php
+++ b/tests/Unit/Core/QualifyFingerprinterTest.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Tests for QualifyFingerprinter::detect_event_page_shape() — the pure
+ * URL + JSON-LD + HTML shape detector that feeds the verdict resolver's
+ * per-shape threshold (issue #77).
+ *
+ * Other methods on QualifyFingerprinter (fetch_homepage, run_extractor_attempt,
+ * etc.) require live HTTP / WP_Ability infrastructure and are exercised via
+ * integration tests in the WP_UnitTestCase suite, not here.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use ExtraChillEvents\Core\QualifyFingerprinter;
+use ExtraChillEvents\Core\QualifyVerdict;
+use PHPUnit\Framework\TestCase;
+
+class QualifyFingerprinterTest extends TestCase {
+
+	// ---- URL-pattern detail detection ----
+
+	public function test_detail_shape_detection_url_pattern_schedule_slug(): void {
+		// Royal American shape: /schedule/<artist>-<date> with one Event.
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://www.theroyalamerican.com/schedule/emma-grace-burton-5-15-26',
+			array( 'jsonld_events' => 1, 'jsonld_event_graph_present' => true, 'microdata_events' => 0 ),
+			''
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_DETAIL, $shape );
+	}
+
+	public function test_detail_shape_detection_url_pattern_events_slug(): void {
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/events/some-show-3-21-26',
+			array( 'jsonld_events' => 1 ),
+			''
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_DETAIL, $shape );
+	}
+
+	public function test_detail_shape_detection_url_pattern_shows_slug(): void {
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/shows/abc-def-ghi',
+			array( 'jsonld_events' => 1 ),
+			''
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_DETAIL, $shape );
+	}
+
+	public function test_detail_url_without_dash_does_not_qualify(): void {
+		// `/events/12345` has no dash + no alpha in slug → not a detail slug
+		// per the issue's heuristic. Falls through to UNKNOWN because 1 event
+		// + path that's not a listing root still resolves via heuristic 5...
+		// actually `/events/12345` lives under a non-listing path so the
+		// JSON-LD-count fallback fires. But the URL-regex itself must NOT
+		// match — verify the regex alone via the no-html unknown-event case.
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/events/12345',
+			array( 'jsonld_events' => 0 ),
+			''
+		);
+		// 0 events + not a listing root → UNKNOWN. Confirms the URL regex
+		// did NOT short-circuit to detail (which would require 1 event).
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_UNKNOWN, $shape );
+	}
+
+	// ---- URL-pattern listing detection ----
+
+	public function test_listing_shape_detection_url_pattern_schedule_root(): void {
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://www.theroyalamerican.com/schedule',
+			array( 'jsonld_events' => 0 ),
+			''
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_LISTING, $shape );
+	}
+
+	public function test_listing_shape_detection_url_pattern_events_root(): void {
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/events',
+			array( 'jsonld_events' => 0 ),
+			''
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_LISTING, $shape );
+	}
+
+	public function test_listing_shape_detection_url_pattern_calendar_root(): void {
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/calendar',
+			array( 'jsonld_events' => 0 ),
+			''
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_LISTING, $shape );
+	}
+
+	public function test_listing_shape_detection_url_pattern_bare_root(): void {
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/',
+			array( 'jsonld_events' => 0 ),
+			''
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_LISTING, $shape );
+	}
+
+	public function test_listing_shape_trailing_slash_normalized(): void {
+		// `/events/` should be treated identically to `/events`.
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/events/',
+			array( 'jsonld_events' => 0 ),
+			''
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_LISTING, $shape );
+	}
+
+	// ---- JSON-LD count / multi-Event listing detection ----
+
+	public function test_listing_shape_detection_multiple_events(): void {
+		// Two or more Events in JSON-LD → always listing, even if URL looks
+		// like a detail slug.
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/events/some-show-3-21-26',
+			array( 'jsonld_events' => 5 ),
+			''
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_LISTING, $shape );
+	}
+
+	public function test_detail_shape_detection_jsonld_count_no_url_match(): void {
+		// URL is ambiguous (root path `/`, but with 1 Event) — wait, root is
+		// a listing root, so root + 1 event → LISTING. Use a non-listing path
+		// that doesn't match the detail regex, e.g. `/show-page`.
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/show-page',
+			array( 'jsonld_events' => 1 ),
+			''
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_DETAIL, $shape );
+	}
+
+	// ---- HTML listing-marker detection ----
+
+	public function test_listing_shape_detection_itemlist_schema(): void {
+		// Even if URL looks like detail + 1 event, ItemList schema → listing.
+		$html  = '<script type="application/ld+json">{"@type":"ItemList"}</script>';
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/schedule/some-show-3-21-26',
+			array( 'jsonld_events' => 1 ),
+			$html
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_LISTING, $shape );
+	}
+
+	public function test_listing_shape_detection_collectionpage_schema(): void {
+		$html  = '<script type="application/ld+json">{"@type":"CollectionPage"}</script>';
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/shows/some-show-3-21-26',
+			array( 'jsonld_events' => 1 ),
+			$html
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_LISTING, $shape );
+	}
+
+	public function test_listing_shape_detection_event_list_class(): void {
+		$html  = '<div class="event-list"><div>...</div></div>';
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/events/some-show-3-21-26',
+			array( 'jsonld_events' => 1 ),
+			$html
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_LISTING, $shape );
+	}
+
+	public function test_listing_shape_detection_repeated_data_event_id(): void {
+		$html  = '<div data-event-id="1"></div><div data-event-id="2"></div>';
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/shows/some-show-3-21-26',
+			array( 'jsonld_events' => 1 ),
+			$html
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_LISTING, $shape );
+	}
+
+	// ---- Unknown / fallthrough ----
+
+	public function test_unknown_shape_zero_events_non_listing_path(): void {
+		// No events, no listing markers, path is neither listing root nor
+		// detail-pattern → UNKNOWN. Resolver maps UNKNOWN → listing threshold.
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'https://example.com/about-us',
+			array( 'jsonld_events' => 0 ),
+			''
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_UNKNOWN, $shape );
+	}
+
+	public function test_unknown_shape_unparseable_url(): void {
+		// Deterministic fallthrough: nonsense URL, 0 events, no HTML → UNKNOWN.
+		// Resolver maps UNKNOWN to the listing threshold, so the detail
+		// relaxation never applies in this case.
+		$shape = QualifyFingerprinter::detect_event_page_shape(
+			'not a url',
+			array( 'jsonld_events' => 0 ),
+			''
+		);
+		$this->assertSame( QualifyVerdict::EVENT_PAGE_SHAPE_UNKNOWN, $shape );
+	}
+}

--- a/tests/Unit/Core/QualifyVerdictResolverTest.php
+++ b/tests/Unit/Core/QualifyVerdictResolverTest.php
@@ -114,7 +114,8 @@ class QualifyVerdictResolverTest extends TestCase {
 
 	public function test_single_event_does_not_qualify_structured(): void {
 		// MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION is 2 — a single event is
-		// not enough to qualify, even from a structured extractor.
+		// not enough to qualify on a non-detail page, even from a structured
+		// extractor. Shape defaults to UNKNOWN here → listing threshold applies.
 		$fingerprint = array(
 			'http_status'        => 200,
 			'extractor_attempts' => array(
@@ -128,6 +129,114 @@ class QualifyVerdictResolverTest extends TestCase {
 		$this->assertNotSame( QualifyVerdict::QUALIFIED_STRUCTURED, $verdict['verdict'] );
 		// Should fall into EXTRACTION_GAP because structured data is present.
 		$this->assertSame( QualifyVerdict::EXTRACTION_GAP, $verdict['verdict'] );
+	}
+
+	public function test_single_event_detail_page_qualifies_with_one_event(): void {
+		// Issue #77: a single-event detail page (Royal American shape) emits
+		// exactly 1 Event by design. Once the fingerprinter classifies it as
+		// `event_page_shape=detail`, the resolver MUST issue
+		// QUALIFIED_STRUCTURED instead of the old EXTRACTION_GAP misverdict.
+		$fingerprint = array(
+			'http_status'        => 200,
+			'final_url'          => 'https://www.theroyalamerican.com/schedule/emma-grace-burton-5-15-26',
+			'structured_data'    => array(
+				'jsonld_events'              => 1,
+				'jsonld_event_graph_present' => true,
+				'event_page_shape'           => QualifyVerdict::EVENT_PAGE_SHAPE_DETAIL,
+			),
+			'extractor_attempts' => array(
+				array(
+					'name'       => 'JsonLdExtractor',
+					'exists'     => true,
+					'matched'    => true,
+					'ran'        => true,
+					'events'     => 1,
+					'events_url' => 'https://www.theroyalamerican.com/schedule/emma-grace-burton-5-15-26',
+				),
+			),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::QUALIFIED_STRUCTURED, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::GUIDANCE_QUALIFIED_STRUCTURED, $verdict['agent_guidance'] );
+		$this->assertSame( 1, $verdict['event_count'] );
+		$this->assertSame(
+			'https://www.theroyalamerican.com/schedule/emma-grace-burton-5-15-26',
+			$verdict['events_url']
+		);
+	}
+
+	public function test_listing_page_still_requires_two_events(): void {
+		// Listing pages keep the ≥2 threshold — a single-event match on a
+		// shape=listing fingerprint must NOT qualify, otherwise the original
+		// stray-snippet false-positive guard would be defeated.
+		$fingerprint = array(
+			'http_status'        => 200,
+			'final_url'          => 'https://example.com/calendar',
+			'structured_data'    => array(
+				'jsonld_events'              => 1,
+				'jsonld_event_graph_present' => true,
+				'event_page_shape'           => QualifyVerdict::EVENT_PAGE_SHAPE_LISTING,
+			),
+			'extractor_attempts' => array(
+				array( 'name' => 'JsonLdExtractor', 'exists' => true, 'matched' => true, 'ran' => true, 'events' => 1 ),
+			),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertNotSame( QualifyVerdict::QUALIFIED_STRUCTURED, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::EXTRACTION_GAP, $verdict['verdict'] );
+	}
+
+	public function test_unknown_shape_still_requires_two_events(): void {
+		// Conservative default: shape=unknown uses the listing threshold.
+		// 1 event + unknown shape → still EXTRACTION_GAP, not QUALIFIED.
+		$fingerprint = array(
+			'http_status'        => 200,
+			'structured_data'    => array(
+				'jsonld_events'              => 1,
+				'jsonld_event_graph_present' => true,
+				'event_page_shape'           => QualifyVerdict::EVENT_PAGE_SHAPE_UNKNOWN,
+			),
+			'extractor_attempts' => array(
+				array( 'name' => 'JsonLdExtractor', 'exists' => true, 'matched' => true, 'ran' => true, 'events' => 1 ),
+			),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertNotSame( QualifyVerdict::QUALIFIED_STRUCTURED, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::EXTRACTION_GAP, $verdict['verdict'] );
+	}
+
+	public function test_detail_shape_with_two_events_still_qualifies(): void {
+		// Detail threshold (1) is a floor, not a ceiling — a page classified
+		// as detail that happens to have 2+ events should still qualify.
+		$fingerprint = array(
+			'http_status'        => 200,
+			'final_url'          => 'https://example.com/events/some-show-3-21-26',
+			'structured_data'    => array(
+				'jsonld_events'    => 2,
+				'event_page_shape' => QualifyVerdict::EVENT_PAGE_SHAPE_DETAIL,
+			),
+			'extractor_attempts' => array(
+				array(
+					'name'       => 'JsonLdExtractor',
+					'exists'     => true,
+					'matched'    => true,
+					'ran'        => true,
+					'events'     => 2,
+					'events_url' => 'https://example.com/events/some-show-3-21-26',
+				),
+			),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::QUALIFIED_STRUCTURED, $verdict['verdict'] );
+		$this->assertSame( 2, $verdict['event_count'] );
 	}
 
 	public function test_vision_only_resolves_qualified_for_flyer(): void {

--- a/tests/Unit/Core/QualifyVerdictResolverTest.php
+++ b/tests/Unit/Core/QualifyVerdictResolverTest.php
@@ -271,4 +271,18 @@ class QualifyVerdictResolverTest extends TestCase {
 		$this->assertFalse( QualifyVerdict::is_requalifiable( QualifyVerdict::RESERVATION_ONLY ) );
 		$this->assertFalse( QualifyVerdict::is_requalifiable( QualifyVerdict::QUALIFIED_STRUCTURED ) );
 	}
+
+	public function test_min_events_thresholds_are_distinct(): void {
+		// Listing-page threshold MUST stay at 2 — the existing guard against
+		// stray-snippet false positives. Detail-page threshold relaxes to 1
+		// because legitimate /schedule/<slug> pages emit exactly 1 Event.
+		$this->assertSame( 2, QualifyVerdict::MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION );
+		$this->assertSame( 1, QualifyVerdict::MIN_EVENTS_FOR_DETAIL_PAGE );
+	}
+
+	public function test_event_page_shape_enum_values(): void {
+		$this->assertSame( 'detail', QualifyVerdict::EVENT_PAGE_SHAPE_DETAIL );
+		$this->assertSame( 'listing', QualifyVerdict::EVENT_PAGE_SHAPE_LISTING );
+		$this->assertSame( 'unknown', QualifyVerdict::EVENT_PAGE_SHAPE_UNKNOWN );
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -67,3 +67,4 @@ if ( ! function_exists( 'mb_substr' ) && function_exists( 'substr' ) ) {
 require_once dirname( __DIR__ ) . '/inc/Core/QualifyVerdict.php';
 require_once dirname( __DIR__ ) . '/inc/Core/QualifyVerdictResolver.php';
 require_once dirname( __DIR__ ) . '/inc/Core/PlatformDetector.php';
+require_once dirname( __DIR__ ) . '/inc/Core/QualifyFingerprinter.php';


### PR DESCRIPTION
Fixes #77

## Summary

`QualifyVerdict::MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION = 2` was set in qualify v2 (v0.20.0, issue #75) to filter out scrapers that match stray "About us" snippets looking event-shaped. That guard is still correct for **listing pages**, but it also misclassifies a legitimate venue shape: **single-event detail URLs** that emit exactly 1 Event in JSON-LD by design (Squarespace / standalone venue sites like The Royal American).

This PR adds a sibling `MIN_EVENTS_FOR_DETAIL_PAGE = 1` constant and an `event_page_shape` fingerprint field so the resolver can pick the right per-shape threshold. The listing-page guard is preserved unchanged.

## Repro (from the issue)

The Royal American serves a stable single-event page per show, each with one `Event` JSON-LD block:

```
https://www.theroyalamerican.com/schedule/emma-grace-burton-5-15-26
```

Before this PR — `wp extrachill venues qualify` against the above URL:

- `JsonLdExtractor.events: 1` (correct — page has 1 Event)
- Verdict: `extraction_gap` (wrong — the JSON-LD is clean, scrapable, and accurate)

After this PR the same URL resolves to `qualified_structured` because the fingerprinter classifies it as `event_page_shape: "detail"` and the resolver applies `MIN_EVENTS_FOR_DETAIL_PAGE = 1` for detail shapes.

## The two-part fix

### 1. `event_page_shape` lives on the fingerprint

`QualifyFingerprinter::detect_event_page_shape($url, $structured_data, $html)` returns one of `"detail" | "listing" | "unknown"`. Decision order (listing wins ties — conservative on declaring detail):

1. ≥2 JSON-LD/microdata Events → **listing**
2. `ItemList` / `CollectionPage` schema or `.event-list` / `.event-listing` / repeated `data-event-id` markers → **listing**
3. URL path is a listing root (`/`, `/events`, `/calendar`, `/schedule`, `/shows`, ...) → **listing**
4. URL matches `/<prefix>/<slug-with-dash-and-letter>` + exactly 1 Event → **detail**
5. Exactly 1 Event on a non-listing path → **detail**
6. Otherwise → **unknown** (resolver maps unknown → listing threshold)

`VenueQualificationAbilities::executeQualifyVenue` writes the result to `$fingerprint['structured_data']['event_page_shape']`.

### 2. Resolver picks the per-shape threshold

`QualifyVerdictResolver::resolve()` step 5 reads `event_page_shape` and selects:

```php
$min_events = ( "detail" === $shape )
    ? QualifyVerdict::MIN_EVENTS_FOR_DETAIL_PAGE          // 1
    : QualifyVerdict::MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION; // 2
```

`best_structured_attempt()` now takes `$min_events` with the listing threshold as the back-compat default, so any caller that doesn't pass shape context behaves identically to before.

## New test cases

All 4 net-new resolver tests + 14 net-new fingerprinter tests pass alongside the existing 62 tests (80 total, 128 assertions).

**Resolver (`tests/Unit/Core/QualifyVerdictResolverTest.php`):**

- `test_single_event_detail_page_qualifies_with_one_event` — Royal American repro, fingerprint with `event_page_shape=detail` + 1 event → `QUALIFIED_STRUCTURED`
- `test_listing_page_still_requires_two_events` — `event_page_shape=listing` + 1 event → `EXTRACTION_GAP`
- `test_unknown_shape_still_requires_two_events` — `event_page_shape=unknown` + 1 event → `EXTRACTION_GAP` (conservative default)
- `test_detail_shape_with_two_events_still_qualifies` — detail threshold is a floor, not a ceiling
- Plus 2 constant-sanity tests (`MIN_EVENTS_*` thresholds, `EVENT_PAGE_SHAPE_*` enum values)

**Fingerprinter (`tests/Unit/Core/QualifyFingerprinterTest.php`, new file):**

- `test_detail_shape_detection_url_pattern_schedule_slug` (Royal American URL)
- `test_detail_shape_detection_url_pattern_events_slug` / `_shows_slug`
- `test_detail_url_without_dash_does_not_qualify` (numeric ids rejected)
- `test_listing_shape_detection_url_pattern_schedule_root` / `_events_root` / `_calendar_root` / `_bare_root`
- `test_listing_shape_trailing_slash_normalized`
- `test_listing_shape_detection_multiple_events` (≥2 Events → always listing)
- `test_detail_shape_detection_jsonld_count_no_url_match` (1 Event on a non-listing path)
- `test_listing_shape_detection_itemlist_schema` / `_collectionpage_schema`
- `test_listing_shape_detection_event_list_class` / `_repeated_data_event_id`
- `test_unknown_shape_zero_events_non_listing_path` / `_unparseable_url`

## Commit structure

Three independently-revertible commits:

1. `feat(verdict): add MIN_EVENTS_FOR_DETAIL_PAGE constant and event_page_shape enum` — vocabulary only, no behavior change
2. `feat(fingerprinter): detect event_page_shape from URL pattern + JSON-LD count` — detector + wiring, but resolver still uses listing threshold
3. `fix(qualify): verdict resolver picks per-shape threshold for QUALIFIED_STRUCTURED` — closes the bug

## Notes

- `MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION = 2` is **unchanged**. The listing-page threshold is the right guard against stray-snippet false positives; the detail-page threshold is a sibling, not a replacement.
- Detector heuristics are scoped strictly to URL pattern + JSON-LD count + listing-marker HTML signals, per the issue's "out of scope" notes.
- No auto-promotion of re-qualified venues. After this lands, `wp extrachill venues requalify-pending --verdict=extraction_gap` will surface previously-misclassified detail URLs naturally; the operator decides.
- `data-machine-events` is untouched (the JsonLdExtractor fix landed separately in #264 / v0.35.0).