### PR TITLE
feat(qualify): unattended-safe pausing — confirmation, self-recheck, weekly digest

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -49,6 +49,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCo
 	require_once __DIR__ . '/inc/Cli/RequalifyPendingCommand.php';
 	\WP_CLI::add_command( 'extrachill venues requalify-pending', \ExtraChillEvents\Cli\RequalifyPendingCommand::class );
 
+	require_once __DIR__ . '/inc/Cli/FlowOps.php';
 	require_once __DIR__ . '/inc/Cli/FlowHelpers.php';
 
 	require_once __DIR__ . '/inc/Cli/RequalifyFlowCommand.php';
@@ -57,6 +58,15 @@ if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCo
 	require_once __DIR__ . '/inc/Cli/UnqualifiableFlowsCommand.php';
 	\WP_CLI::add_command( 'extrachill venues unqualifiable-flows', \ExtraChillEvents\Cli\UnqualifiableFlowsCommand::class );
 }
+
+// Recheck handler must be loaded outside the WP_CLI guard so the Action
+// Scheduler hook fires whether the action runs via web request, cron, or
+// CLI runner.
+require_once __DIR__ . '/inc/Core/QualifyVerdict.php';
+require_once __DIR__ . '/inc/Core/QualifyVerdictsTable.php';
+require_once __DIR__ . '/inc/Cli/FlowOps.php';
+require_once __DIR__ . '/inc/Core/QualifyRecheckHandler.php';
+\ExtraChillEvents\Core\QualifyRecheckHandler::register();
 
 /**
  * ExtraChillEvents

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -228,6 +228,9 @@ class ExtraChillEvents {
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/EventTimeAuditAbilities.php';
 		new \ExtraChillEvents\Abilities\EventTimeAuditAbilities();
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/QualifyDigestAbilities.php';
+		new \ExtraChillEvents\Abilities\QualifyDigestAbilities();
 	}
 
 	/**

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -69,6 +69,60 @@ require_once __DIR__ . '/inc/Core/QualifyRecheckHandler.php';
 \ExtraChillEvents\Core\QualifyRecheckHandler::register();
 
 /**
+ * Register the weekly qualify digest task with Data Machine's system-task
+ * surface. Loaded on plugins_loaded so the DM SystemTask base class is
+ * available; gated on its existence so this plugin remains compatible
+ * with installs that don't have data-machine activated.
+ */
+add_action(
+	'plugins_loaded',
+	function () {
+		if ( ! class_exists( '\\DataMachine\\Engine\\AI\\System\\Tasks\\SystemTask' ) ) {
+			return;
+		}
+		require_once __DIR__ . '/inc/Steps/QualifyDigest/QualifyDigestSystemTask.php';
+
+		add_filter(
+			'datamachine_tasks',
+			function ( array $tasks ): array {
+				$tasks[ \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::TASK_TYPE ] = \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::class;
+				return $tasks;
+			}
+		);
+
+		add_filter(
+			'datamachine_recurring_schedules',
+			function ( array $schedules ): array {
+				/**
+				 * Filter the qualify digest schedule definition. Allows
+				 * operators to flip interval, change the first-run anchor,
+				 * etc. without forking the plugin.
+				 */
+				$schedules['extrachill_qualify_digest'] = apply_filters(
+					'dme_qualify_digest_schedule',
+					array(
+						'task_type'          => \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::TASK_TYPE,
+						'interval'           => 'weekly',
+						'enabled_setting'    => 'dme_qualify_digest_enabled',
+						'default_enabled'    => true,
+						'label'              => 'Weekly — Mondays 09:00 UTC',
+						'first_run_callback' => 'strtotime',
+						'first_run_arg'      => 'next monday 09:00 UTC',
+						'task_params'        => array(
+							'since'   => '1 week ago',
+							'format'  => 'html',
+							'dry_run' => false,
+						),
+					)
+				);
+				return $schedules;
+			}
+		);
+	},
+	20
+);
+
+/**
  * ExtraChillEvents
  *
  * Singleton class managing data-machine-events integration with homepage/archive template

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -68,6 +68,9 @@ require_once __DIR__ . '/inc/Cli/FlowOps.php';
 require_once __DIR__ . '/inc/Core/QualifyRecheckHandler.php';
 \ExtraChillEvents\Core\QualifyRecheckHandler::register();
 
+require_once __DIR__ . '/inc/admin/network-settings.php';
+\ExtraChillEvents\Admin\NetworkSettings::register();
+
 /**
  * Register the weekly qualify digest task with Data Machine's system-task
  * surface. Loaded on plugins_loaded so the DM SystemTask base class is

--- a/inc/Abilities/QualifyDigestAbilities.php
+++ b/inc/Abilities/QualifyDigestAbilities.php
@@ -1,0 +1,464 @@
+<?php
+/**
+ * Qualify Digest Abilities
+ *
+ * `extrachill/qualify-digest` — weekly summary of qualify v2 activity:
+ * paused flows, auto-resumed flows, newly-qualified venues, standing
+ * inventory by interval/paused_reason, and the top extraction_gap
+ * fingerprints.
+ *
+ * The digest is informational only. It surfaces what changed and what
+ * the operator may want to look at next — it never auto-decides anything
+ * for them. Silence is meaningful: no email means nothing changed.
+ *
+ * @package ExtraChillEvents\Abilities
+ * @since   0.21.0
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+use ExtraChillEvents\Core\QualifyVerdict;
+use ExtraChillEvents\Core\QualifyVerdictsTable;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class QualifyDigestAbilities {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+		$this->register();
+		self::$registered = true;
+	}
+
+	private function register(): void {
+		$callback = function () {
+			wp_register_ability(
+				'extrachill/qualify-digest',
+				array(
+					'label'               => __( 'Qualify Digest', 'extrachill-events' ),
+					'description'         => __( 'Render and (optionally) send the weekly qualify v2 activity digest email.', 'extrachill-events' ),
+					'category'            => 'extrachill-events',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'since'     => array(
+								'type'        => 'string',
+								'default'     => '1 week ago',
+								'description' => __( 'Window start; any strtotime-parseable string.', 'extrachill-events' ),
+							),
+							'recipient' => array(
+								'type'        => 'string',
+								'default'     => '',
+								'description' => __( 'Override recipient email. Defaults to dme_qualify_digest_recipient site option or admin_email.', 'extrachill-events' ),
+							),
+							'format'    => array(
+								'type'        => 'string',
+								'enum'        => array( 'html', 'text' ),
+								'default'     => 'html',
+								'description' => __( 'Render format.', 'extrachill-events' ),
+							),
+							'dry_run'   => array(
+								'type'        => 'boolean',
+								'default'     => false,
+								'description' => __( 'Render but do not send.', 'extrachill-events' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'window_start' => array( 'type' => 'string' ),
+							'window_end'   => array( 'type' => 'string' ),
+							'recipient'    => array( 'type' => 'string' ),
+							'sent'         => array( 'type' => 'boolean' ),
+							'dry_run'      => array( 'type' => 'boolean' ),
+							'counts'       => array( 'type' => 'object' ),
+							'body'         => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => '__return_true',
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+		};
+
+		if ( function_exists( 'doing_action' ) && doing_action( 'wp_abilities_api_init' ) ) {
+			$callback();
+		} elseif ( function_exists( 'did_action' ) && ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $callback );
+		} else {
+			$callback();
+		}
+	}
+
+	/**
+	 * Execute the digest.
+	 *
+	 * @param array $input { since, recipient, format, dry_run }
+	 * @return array Summary payload.
+	 */
+	public function execute( array $input ): array {
+		$since   = (string) ( $input['since'] ?? '1 week ago' );
+		$format  = 'text' === ( $input['format'] ?? 'html' ) ? 'text' : 'html';
+		$dry_run = ! empty( $input['dry_run'] );
+
+		$window_start_ts = strtotime( $since );
+		if ( false === $window_start_ts ) {
+			$window_start_ts = time() - WEEK_IN_SECONDS;
+		}
+		$window_end_ts = time();
+
+		$recipient = (string) ( $input['recipient'] ?? '' );
+		if ( '' === $recipient ) {
+			$recipient = (string) get_site_option( 'dme_qualify_digest_recipient', '' );
+		}
+		if ( '' === $recipient ) {
+			$recipient = (string) get_option( 'admin_email', '' );
+		}
+
+		$data = $this->gather_data( $window_start_ts, $window_end_ts );
+
+		$body = 'text' === $format
+			? $this->render_text( $data, $window_start_ts, $window_end_ts )
+			: $this->render_html( $data, $window_start_ts, $window_end_ts );
+
+		$sent = false;
+		if ( ! $dry_run && '' !== $recipient && function_exists( 'wp_get_ability' ) ) {
+			$send_ability = wp_get_ability( 'datamachine/send-email' );
+			if ( $send_ability ) {
+				$subject = sprintf(
+					'Event Calendar Qualify Digest — Week of %s–%s',
+					gmdate( 'M j', $window_start_ts ),
+					gmdate( 'M j', $window_end_ts )
+				);
+				$result = $send_ability->execute( array(
+					'to'           => $recipient,
+					'subject'      => $subject,
+					'body'         => $body,
+					'content_type' => 'text' === $format ? 'text/plain' : 'text/html',
+				) );
+				$sent   = is_array( $result ) ? (bool) ( $result['success'] ?? false ) : false;
+
+				do_action(
+					'datamachine_log',
+					$sent ? 'info' : 'warning',
+					$sent
+						? sprintf( 'QualifyDigest: sent to %s', $recipient )
+						: sprintf( 'QualifyDigest: send failed for %s', $recipient ),
+					array(
+						'recipient' => $recipient,
+						'counts'    => $data['counts'],
+						'window'    => array(
+							'start' => gmdate( 'c', $window_start_ts ),
+							'end'   => gmdate( 'c', $window_end_ts ),
+						),
+					)
+				);
+			}
+		}
+
+		return array(
+			'window_start' => gmdate( 'c', $window_start_ts ),
+			'window_end'   => gmdate( 'c', $window_end_ts ),
+			'recipient'    => $recipient,
+			'sent'         => $sent,
+			'dry_run'      => $dry_run,
+			'counts'       => $data['counts'],
+			'body'         => $body,
+		);
+	}
+
+	/**
+	 * Gather the data for the digest. Public so tests can call it
+	 * directly when validating queries.
+	 *
+	 * @param int $start_ts Window start (inclusive).
+	 * @param int $end_ts   Window end (exclusive).
+	 * @return array Structured data: counts + breakdowns.
+	 */
+	public function gather_data( int $start_ts, int $end_ts ): array {
+		global $wpdb;
+
+		$start = gmdate( 'Y-m-d H:i:s', $start_ts );
+		$end   = gmdate( 'Y-m-d H:i:s', $end_ts );
+
+		$verdicts_table = QualifyVerdictsTable::table_name();
+		$flows_table    = $wpdb->prefix . 'datamachine_flows';
+
+		// Paused-this-week — read scheduling_config from datamachine_flows
+		// rows whose paused_at falls in the window. paused_at is stashed as
+		// JSON inside scheduling_config; we use LIKE-then-decode in PHP.
+		$paused_by_verdict = array();
+		$resumed_count     = 0;
+		$stale_flows       = array();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = (array) $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT flow_id, flow_name, scheduling_config FROM {$flows_table} WHERE scheduling_config LIKE %s OR scheduling_config LIKE %s",
+				'%paused_reason%',
+				'%resumed_at%'
+			),
+			ARRAY_A
+		);
+		foreach ( $rows as $row ) {
+			$cfg = json_decode( (string) ( $row['scheduling_config'] ?? '' ), true );
+			if ( ! is_array( $cfg ) ) {
+				continue;
+			}
+			$paused_at_str = (string) ( $cfg['paused_at'] ?? '' );
+			$paused_at_ts  = '' !== $paused_at_str ? strtotime( $paused_at_str . ' UTC' ) : false;
+			if ( $paused_at_ts && $paused_at_ts >= $start_ts && $paused_at_ts <= $end_ts ) {
+				$verdict = (string) ( $cfg['paused_reason'] ?? 'unknown' );
+				$paused_by_verdict[ $verdict ] = ( $paused_by_verdict[ $verdict ] ?? 0 ) + 1;
+			}
+
+			$resumed_at_str = (string) ( $cfg['resumed_at'] ?? '' );
+			$resumed_at_ts  = '' !== $resumed_at_str ? strtotime( $resumed_at_str . ' UTC' ) : false;
+			if ( $resumed_at_ts && $resumed_at_ts >= $start_ts && $resumed_at_ts <= $end_ts && ! empty( $cfg['resumed_by_qualify'] ) ) {
+				++$resumed_count;
+			}
+
+			if ( ! empty( $cfg['stale_flag'] ) && is_array( $cfg['stale_flag'] ) ) {
+				$stale_flows[] = array(
+					'flow_id'              => (int) $row['flow_id'],
+					'flow_name'            => (string) $row['flow_name'],
+					'paused_reason'        => (string) ( $cfg['paused_reason'] ?? '' ),
+					'consecutive_failures' => (int) ( $cfg['stale_flag']['consecutive_failures'] ?? 0 ),
+				);
+			}
+		}
+
+		// Standing inventory — current count by interval / paused_reason.
+		$standing_inventory = array();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$inv_rows = (array) $wpdb->get_results(
+			"SELECT scheduling_config FROM {$flows_table} WHERE flow_config LIKE '%universal_web_scraper%'",
+			ARRAY_A
+		);
+		foreach ( $inv_rows as $row ) {
+			$cfg = json_decode( (string) ( $row['scheduling_config'] ?? '' ), true );
+			if ( ! is_array( $cfg ) ) {
+				continue;
+			}
+			$interval = (string) ( $cfg['interval'] ?? '' );
+			if ( 'manual' === $interval ) {
+				$reason = (string) ( $cfg['paused_reason'] ?? 'unknown' );
+				$key    = 'paused:' . $reason;
+			} else {
+				$key = 'active:' . ( '' === $interval ? 'unknown' : $interval );
+			}
+			$standing_inventory[ $key ] = ( $standing_inventory[ $key ] ?? 0 ) + 1;
+		}
+
+		// Newly-qualified venues this week — count of QUALIFIED_STRUCTURED
+		// verdict rows in the window.
+		$new_qualified = 0;
+		if ( $wpdb->get_var( "SHOW TABLES LIKE '" . $verdicts_table . "'" ) === $verdicts_table ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$new_qualified = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT COUNT(*) FROM {$verdicts_table} WHERE verdict = %s AND qualified_at >= %s AND qualified_at <= %s",
+					QualifyVerdict::QUALIFIED_STRUCTURED,
+					$start,
+					$end
+				)
+			);
+		}
+
+		// Top 3 fingerprints in extraction_gap. The fingerprint is a JSON
+		// blob; we group by `improvement_hint` as a coarse proxy for the
+		// platform / shape signature.
+		$top_extraction_gap = array();
+		if ( $wpdb->get_var( "SHOW TABLES LIKE '" . $verdicts_table . "'" ) === $verdicts_table ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$gap_rows = (array) $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT improvement_hint, COUNT(*) AS c FROM {$verdicts_table}
+					 WHERE verdict = %s AND qualified_at >= %s AND qualified_at <= %s
+					 GROUP BY improvement_hint
+					 ORDER BY c DESC LIMIT 3",
+					QualifyVerdict::EXTRACTION_GAP,
+					$start,
+					$end
+				),
+				ARRAY_A
+			);
+			foreach ( $gap_rows as $g ) {
+				$top_extraction_gap[] = array(
+					'hint'  => (string) ( $g['improvement_hint'] ?? '' ),
+					'count' => (int) ( $g['c'] ?? 0 ),
+				);
+			}
+		}
+
+		$counts = array(
+			'paused_total'        => array_sum( $paused_by_verdict ),
+			'resumed_total'       => $resumed_count,
+			'new_qualified_total' => $new_qualified,
+			'stale_total'         => count( $stale_flows ),
+		);
+
+		return array(
+			'counts'             => $counts,
+			'paused_by_verdict'  => $paused_by_verdict,
+			'standing_inventory' => $standing_inventory,
+			'top_extraction_gap' => $top_extraction_gap,
+			'stale_flows'        => $stale_flows,
+		);
+	}
+
+	/**
+	 * Render the digest as HTML.
+	 *
+	 * @param array $data     Output of gather_data().
+	 * @param int   $start_ts Window start.
+	 * @param int   $end_ts   Window end.
+	 * @return string
+	 */
+	public function render_html( array $data, int $start_ts, int $end_ts ): string {
+		$range = sprintf( '%s – %s UTC', gmdate( 'M j', $start_ts ), gmdate( 'M j, Y', $end_ts ) );
+
+		$h = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Qualify Digest</title>';
+		$h .= '<style>body{font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#222;max-width:680px;margin:24px auto;padding:0 16px}h1{font-size:20px;margin-bottom:4px}h2{font-size:15px;border-bottom:1px solid #eee;padding-bottom:4px;margin-top:24px}.muted{color:#666;font-size:13px}table{border-collapse:collapse;width:100%;margin:8px 0}td,th{text-align:left;padding:6px 8px;border-bottom:1px solid #eee;font-size:14px}.count{font-variant-numeric:tabular-nums;text-align:right}.empty{color:#999;font-style:italic;font-size:13px}</style>';
+		$h .= '</head><body>';
+		$h .= '<h1>Event Calendar Qualify Digest</h1>';
+		$h .= '<div class="muted">Week of ' . esc_html( $range ) . '</div>';
+
+		// Summary card.
+		$h .= '<h2>Summary</h2><table>';
+		$h .= '<tr><td>Flows paused this week</td><td class="count">' . (int) $data['counts']['paused_total'] . '</td></tr>';
+		$h .= '<tr><td>Flows auto-resumed this week</td><td class="count">' . (int) $data['counts']['resumed_total'] . '</td></tr>';
+		$h .= '<tr><td>New venues qualified</td><td class="count">' . (int) $data['counts']['new_qualified_total'] . '</td></tr>';
+		$h .= '<tr><td>Stale paused flows (need review)</td><td class="count">' . (int) $data['counts']['stale_total'] . '</td></tr>';
+		$h .= '</table>';
+
+		// Paused by verdict.
+		$h .= '<h2>Paused this week — by verdict</h2>';
+		if ( empty( $data['paused_by_verdict'] ) ) {
+			$h .= '<p class="empty">Nothing paused this week.</p>';
+		} else {
+			$h .= '<table>';
+			foreach ( $data['paused_by_verdict'] as $verdict => $count ) {
+				$h .= '<tr><td>' . esc_html( (string) $verdict ) . '</td><td class="count">' . (int) $count . '</td></tr>';
+			}
+			$h .= '</table>';
+		}
+
+		// Standing inventory.
+		$h .= '<h2>Standing inventory</h2>';
+		if ( empty( $data['standing_inventory'] ) ) {
+			$h .= '<p class="empty">No universal_web_scraper flows registered.</p>';
+		} else {
+			ksort( $data['standing_inventory'] );
+			$h .= '<table>';
+			foreach ( $data['standing_inventory'] as $key => $count ) {
+				$h .= '<tr><td>' . esc_html( (string) $key ) . '</td><td class="count">' . (int) $count . '</td></tr>';
+			}
+			$h .= '</table>';
+		}
+
+		// Top extraction_gap.
+		$h .= '<h2>Top extraction_gap fingerprints</h2>';
+		if ( empty( $data['top_extraction_gap'] ) ) {
+			$h .= '<p class="empty">No extraction_gap verdicts this week.</p>';
+		} else {
+			$h .= '<table><tr><th>Hint</th><th class="count">Count</th></tr>';
+			foreach ( $data['top_extraction_gap'] as $row ) {
+				$hint = '' === $row['hint'] ? '(no hint)' : $row['hint'];
+				$h   .= '<tr><td>' . esc_html( $hint ) . '</td><td class="count">' . (int) $row['count'] . '</td></tr>';
+			}
+			$h .= '</table>';
+		}
+
+		// Stale flows.
+		if ( ! empty( $data['stale_flows'] ) ) {
+			$h .= '<h2>Stale paused flows — manual review recommended</h2>';
+			$h .= '<table><tr><th>Flow</th><th>Verdict</th><th class="count">Failures</th></tr>';
+			foreach ( $data['stale_flows'] as $f ) {
+				$h .= '<tr><td>#' . (int) $f['flow_id'] . ' ' . esc_html( (string) $f['flow_name'] ) . '</td>';
+				$h .= '<td>' . esc_html( (string) $f['paused_reason'] ) . '</td>';
+				$h .= '<td class="count">' . (int) $f['consecutive_failures'] . '</td></tr>';
+			}
+			$h .= '</table>';
+		}
+
+		$h .= '<p class="muted" style="margin-top:32px">Run <code>wp extrachill venues qualify-stats</code> for the full breakdown.</p>';
+		$h .= '</body></html>';
+
+		return $h;
+	}
+
+	/**
+	 * Render the digest as plain text.
+	 *
+	 * @param array $data     Output of gather_data().
+	 * @param int   $start_ts Window start.
+	 * @param int   $end_ts   Window end.
+	 * @return string
+	 */
+	public function render_text( array $data, int $start_ts, int $end_ts ): string {
+		$range = sprintf( '%s – %s UTC', gmdate( 'M j', $start_ts ), gmdate( 'M j, Y', $end_ts ) );
+		$lines = array();
+		$lines[] = 'EVENT CALENDAR QUALIFY DIGEST';
+		$lines[] = 'Week of ' . $range;
+		$lines[] = '';
+		$lines[] = sprintf( 'Paused this week:        %d flows', (int) $data['counts']['paused_total'] );
+		$lines[] = sprintf( 'Auto-resumed this week:  %d flows', (int) $data['counts']['resumed_total'] );
+		$lines[] = sprintf( 'New venues qualified:    %d', (int) $data['counts']['new_qualified_total'] );
+		$lines[] = sprintf( 'Stale paused flows:      %d', (int) $data['counts']['stale_total'] );
+		$lines[] = '';
+
+		if ( ! empty( $data['paused_by_verdict'] ) ) {
+			$lines[] = 'Paused this week by verdict:';
+			foreach ( $data['paused_by_verdict'] as $verdict => $count ) {
+				$lines[] = sprintf( '  %-25s %d', $verdict, (int) $count );
+			}
+			$lines[] = '';
+		}
+
+		if ( ! empty( $data['standing_inventory'] ) ) {
+			$lines[] = 'Standing inventory:';
+			ksort( $data['standing_inventory'] );
+			foreach ( $data['standing_inventory'] as $key => $count ) {
+				$lines[] = sprintf( '  %-30s %d', $key, (int) $count );
+			}
+			$lines[] = '';
+		}
+
+		if ( ! empty( $data['top_extraction_gap'] ) ) {
+			$lines[] = 'Top 3 extraction_gap fingerprints:';
+			$i = 1;
+			foreach ( $data['top_extraction_gap'] as $row ) {
+				$hint    = '' === $row['hint'] ? '(no hint)' : $row['hint'];
+				$lines[] = sprintf( '  %d. %s — %d', $i++, $hint, (int) $row['count'] );
+			}
+			$lines[] = '';
+		}
+
+		if ( ! empty( $data['stale_flows'] ) ) {
+			$lines[] = 'Stale paused flows — manual review recommended:';
+			foreach ( $data['stale_flows'] as $f ) {
+				$lines[] = sprintf(
+					'  #%d %s — %s (%d failures)',
+					(int) $f['flow_id'],
+					(string) $f['flow_name'],
+					(string) $f['paused_reason'],
+					(int) $f['consecutive_failures']
+				);
+			}
+			$lines[] = '';
+		}
+
+		$lines[] = 'Run: wp extrachill venues qualify-stats   for the full breakdown.';
+
+		return implode( "\n", $lines );
+	}
+}

--- a/inc/Cli/FlowHelpers.php
+++ b/inc/Cli/FlowHelpers.php
@@ -185,11 +185,14 @@ trait FlowHelpers {
 	 * Idempotent — re-pausing an already-paused flow is a no-op except for
 	 * refreshing paused_reason.
 	 *
-	 * @param int    $flow_id Flow ID.
-	 * @param string $verdict Verdict that triggered the pause.
+	 * @param int    $flow_id    Flow ID.
+	 * @param string $verdict    Verdict that triggered the pause.
+	 * @param string $source_url Optional source URL — used by the recheck
+	 *                           scheduler so the rechecker can re-qualify
+	 *                           the URL without re-reading the flow.
 	 * @return bool True on success.
 	 */
-	protected function pause_flow_by_verdict( int $flow_id, string $verdict ): bool {
+	protected function pause_flow_by_verdict( int $flow_id, string $verdict, string $source_url = '' ): bool {
 		global $wpdb;
 		$table = $wpdb->prefix . 'datamachine_flows';
 

--- a/inc/Cli/FlowHelpers.php
+++ b/inc/Cli/FlowHelpers.php
@@ -20,6 +20,8 @@
 
 namespace ExtraChillEvents\Cli;
 
+use ExtraChillEvents\Core\QualifyVerdict;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -185,53 +187,20 @@ trait FlowHelpers {
 	 * Idempotent — re-pausing an already-paused flow is a no-op except for
 	 * refreshing paused_reason.
 	 *
+	 * When the network option `dme_qualify_recheck_enabled` is true (default)
+	 * AND the verdict has a non-null recheck interval, an Action Scheduler
+	 * job is queued for the next recheck. The action ID is stashed inside
+	 * scheduling_config as `recheck_action_id` so a future pause/unpause/
+	 * delete can find and cancel the scheduled job.
+	 *
 	 * @param int    $flow_id    Flow ID.
 	 * @param string $verdict    Verdict that triggered the pause.
-	 * @param string $source_url Optional source URL — used by the recheck
-	 *                           scheduler so the rechecker can re-qualify
-	 *                           the URL without re-reading the flow.
+	 * @param string $source_url Optional source URL — required when
+	 *                           recheck scheduling is enabled so the
+	 *                           rechecker can re-qualify the URL.
 	 * @return bool True on success.
 	 */
 	protected function pause_flow_by_verdict( int $flow_id, string $verdict, string $source_url = '' ): bool {
-		global $wpdb;
-		$table = $wpdb->prefix . 'datamachine_flows';
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$row = $wpdb->get_row(
-			$wpdb->prepare( "SELECT scheduling_config FROM {$table} WHERE flow_id = %d", $flow_id ),
-			ARRAY_A
-		);
-		if ( ! $row ) {
-			return false;
-		}
-
-		$scheduling = json_decode( (string) ( $row['scheduling_config'] ?? '' ), true );
-		if ( ! is_array( $scheduling ) ) {
-			$scheduling = array();
-		}
-
-		$prior_interval = (string) ( $scheduling['interval'] ?? '' );
-		if ( 'manual' !== $prior_interval ) {
-			$scheduling['prior_interval'] = $prior_interval;
-		}
-		$scheduling['interval']      = 'manual';
-		$scheduling['paused_reason'] = $verdict;
-		$scheduling['paused_at']     = current_time( 'mysql' );
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$ok = $wpdb->update(
-			$table,
-			array( 'scheduling_config' => wp_json_encode( $scheduling ) ),
-			array( 'flow_id' => $flow_id ),
-			array( '%s' ),
-			array( '%d' )
-		);
-
-		// Unschedule Action Scheduler hooks so paused flows do not fire.
-		if ( $ok && function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
-		}
-
-		return false !== $ok;
+		return FlowOps::pause_flow_by_verdict( $flow_id, $verdict, $source_url );
 	}
 }

--- a/inc/Cli/FlowOps.php
+++ b/inc/Cli/FlowOps.php
@@ -1,0 +1,333 @@
+<?php
+/**
+ * Qualify v2 — static flow operations.
+ *
+ * Called by both CLI commands (via the FlowHelpers trait) and the recheck
+ * handler (which has no `$this` context). Keeping the read/write logic in
+ * one place keeps idempotency promises predictable: any caller that
+ * touches scheduling_config goes through the same code path.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+use ExtraChillEvents\Core\QualifyVerdict;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Static flow operations called by both CLI commands (via the FlowHelpers
+ * trait) and the recheck handler (which has no `$this` context).
+ *
+ * Keeping the read/write logic in one place keeps idempotency promises
+ * predictable: any caller that touches scheduling_config goes through the
+ * same code path.
+ *
+ * @internal
+ */
+class FlowOps {
+
+	/**
+	 * Read a flow row.
+	 *
+	 * @param int $flow_id Flow ID.
+	 * @return array|null Associative row with decoded scheduling_config.
+	 */
+	public static function fetch_flow_row( int $flow_id ): ?array {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_flows';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT flow_id, flow_name, scheduling_config FROM {$table} WHERE flow_id = %d", $flow_id ),
+			ARRAY_A
+		);
+		if ( ! $row ) {
+			return null;
+		}
+
+		$scheduling = json_decode( (string) ( $row['scheduling_config'] ?? '' ), true );
+		$row['scheduling_config'] = is_array( $scheduling ) ? $scheduling : array();
+		return $row;
+	}
+
+	/**
+	 * Pause a flow by setting scheduling_config.interval = "manual",
+	 * stashing the verdict in paused_reason, and (optionally) queuing the
+	 * next recheck Action Scheduler job.
+	 *
+	 * @param int    $flow_id    Flow ID.
+	 * @param string $verdict    Verdict that triggered the pause.
+	 * @param string $source_url Source URL — required for recheck scheduling.
+	 * @return bool True on success.
+	 */
+	public static function pause_flow_by_verdict( int $flow_id, string $verdict, string $source_url = '' ): bool {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_flows';
+
+		$row = self::fetch_flow_row( $flow_id );
+		if ( ! $row ) {
+			return false;
+		}
+
+		$scheduling = is_array( $row['scheduling_config'] ?? null ) ? $row['scheduling_config'] : array();
+
+		$prior_interval = (string) ( $scheduling['interval'] ?? '' );
+		if ( 'manual' !== $prior_interval ) {
+			$scheduling['prior_interval'] = $prior_interval;
+		}
+		$scheduling['interval']      = 'manual';
+		$scheduling['paused_reason'] = $verdict;
+		$scheduling['paused_at']     = current_time( 'mysql' );
+
+		// Cancel any in-flight recheck before scheduling a new one so a
+		// repeat pause never leaves a stale action behind.
+		$prior_action_id = (int) ( $scheduling['recheck_action_id'] ?? 0 );
+		if ( $prior_action_id > 0 && function_exists( 'as_unschedule_action' ) ) {
+			as_unschedule_action( 'dme/qualify_recheck', null, 'dme_qualify' );
+		}
+		unset( $scheduling['recheck_action_id'] );
+		unset( $scheduling['recheck_scheduled_for'] );
+		unset( $scheduling['stale_flag'] );
+
+		// Schedule the next recheck when enabled and the verdict has a
+		// non-null cadence. Source URL is required — without it the
+		// rechecker has nothing to qualify against.
+		$recheck_enabled = (bool) get_site_option( 'dme_qualify_recheck_enabled', true );
+		$interval        = QualifyVerdict::recheck_interval_for( $verdict );
+		if ( $recheck_enabled && null !== $interval && '' !== $source_url && function_exists( 'as_schedule_single_action' ) ) {
+			$ts        = time() + (int) $interval;
+			$action_id = as_schedule_single_action(
+				$ts,
+				'dme/qualify_recheck',
+				array(
+					array(
+						'flow_id'              => $flow_id,
+						'url'                  => $source_url,
+						'verdict'              => $verdict,
+						'consecutive_failures' => 0,
+					),
+				),
+				'dme_qualify'
+			);
+			if ( $action_id ) {
+				$scheduling['recheck_action_id']     = (int) $action_id;
+				$scheduling['recheck_scheduled_for'] = gmdate( 'Y-m-d H:i:s', $ts );
+			}
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$ok = $wpdb->update(
+			$table,
+			array( 'scheduling_config' => wp_json_encode( $scheduling ) ),
+			array( 'flow_id' => $flow_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		// Unschedule Action Scheduler hooks so paused flows do not fire.
+		if ( $ok && function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+		}
+
+		return false !== $ok;
+	}
+
+	/**
+	 * Update only the paused_reason (used when a recheck returns a
+	 * different non-qualifying verdict — e.g. unreachable → bot_blocked).
+	 *
+	 * @param int    $flow_id Flow ID.
+	 * @param string $verdict New verdict.
+	 * @return bool True on success.
+	 */
+	public static function update_paused_reason( int $flow_id, string $verdict ): bool {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_flows';
+
+		$row = self::fetch_flow_row( $flow_id );
+		if ( ! $row ) {
+			return false;
+		}
+		$scheduling                  = is_array( $row['scheduling_config'] ?? null ) ? $row['scheduling_config'] : array();
+		$scheduling['paused_reason'] = $verdict;
+		$scheduling['paused_at']     = current_time( 'mysql' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$ok = $wpdb->update(
+			$table,
+			array( 'scheduling_config' => wp_json_encode( $scheduling ) ),
+			array( 'flow_id' => $flow_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		return false !== $ok;
+	}
+
+	/**
+	 * Set the recheck-rescheduled metadata on a paused flow.
+	 *
+	 * Called by the handler after queuing the next recheck so the digest
+	 * can show when the next attempt will fire.
+	 *
+	 * @param int    $flow_id     Flow ID.
+	 * @param int    $action_id   Action Scheduler action ID.
+	 * @param int    $next_run_ts Unix timestamp.
+	 * @return bool True on success.
+	 */
+	public static function set_recheck_metadata( int $flow_id, int $action_id, int $next_run_ts ): bool {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_flows';
+
+		$row = self::fetch_flow_row( $flow_id );
+		if ( ! $row ) {
+			return false;
+		}
+		$scheduling                          = is_array( $row['scheduling_config'] ?? null ) ? $row['scheduling_config'] : array();
+		$scheduling['recheck_action_id']     = $action_id;
+		$scheduling['recheck_scheduled_for'] = gmdate( 'Y-m-d H:i:s', $next_run_ts );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$ok = $wpdb->update(
+			$table,
+			array( 'scheduling_config' => wp_json_encode( $scheduling ) ),
+			array( 'flow_id' => $flow_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		return false !== $ok;
+	}
+
+	/**
+	 * Flag a paused flow as stale after N consecutive failed rechecks.
+	 *
+	 * The digest reads `stale_flag` from scheduling_config and surfaces
+	 * these flows under a "manual review recommended" section.
+	 *
+	 * @param int    $flow_id              Flow ID.
+	 * @param string $verdict              The verdict of the most recent failed recheck.
+	 * @param int    $consecutive_failures How many rechecks failed in a row.
+	 * @return bool True on success.
+	 */
+	public static function flag_stale_paused( int $flow_id, string $verdict, int $consecutive_failures ): bool {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_flows';
+
+		$row = self::fetch_flow_row( $flow_id );
+		if ( ! $row ) {
+			return false;
+		}
+		$scheduling = is_array( $row['scheduling_config'] ?? null ) ? $row['scheduling_config'] : array();
+
+		$scheduling['paused_reason'] = $verdict;
+		$scheduling['stale_flag']    = array(
+			'flagged_at'           => current_time( 'mysql' ),
+			'consecutive_failures' => $consecutive_failures,
+			'last_verdict'         => $verdict,
+		);
+		// Cancel any further recheck — operator review required.
+		unset( $scheduling['recheck_action_id'] );
+		unset( $scheduling['recheck_scheduled_for'] );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$ok = $wpdb->update(
+			$table,
+			array( 'scheduling_config' => wp_json_encode( $scheduling ) ),
+			array( 'flow_id' => $flow_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		do_action(
+			'datamachine_log',
+			'warning',
+			sprintf( 'QualifyRecheck: flow %d flagged stale after %d consecutive failures (verdict=%s)', $flow_id, $consecutive_failures, $verdict ),
+			array(
+				'flow_id'              => $flow_id,
+				'verdict'              => $verdict,
+				'consecutive_failures' => $consecutive_failures,
+			)
+		);
+
+		return false !== $ok;
+	}
+
+	/**
+	 * Resume a paused flow because qualify returned QUALIFIED_STRUCTURED.
+	 *
+	 * Steps:
+	 *  - Restore scheduling_config.interval to its pre-pause value
+	 *    (from scheduling_config.prior_interval; defaults to 'daily').
+	 *  - Clear paused_reason / paused_at / prior_interval / recheck_*
+	 *    fields and any stale_flag.
+	 *  - Queue an immediate run via datamachine_run_flow_now so the
+	 *    operator sees a real run on the next tick.
+	 *
+	 * Safe by design: only callers with a positive qualify result should
+	 * invoke this. There is intentionally no force-resume path here.
+	 *
+	 * @param int   $flow_id Flow ID.
+	 * @param array $result  Qualify result for logging context.
+	 * @return bool True on success.
+	 */
+	public static function resume_flow_from_qualified( int $flow_id, array $result ): bool {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_flows';
+
+		$row = self::fetch_flow_row( $flow_id );
+		if ( ! $row ) {
+			return false;
+		}
+		$scheduling = is_array( $row['scheduling_config'] ?? null ) ? $row['scheduling_config'] : array();
+
+		$prior_interval = (string) ( $scheduling['prior_interval'] ?? '' );
+		if ( '' === $prior_interval || 'manual' === $prior_interval ) {
+			$prior_interval = 'daily';
+		}
+
+		$scheduling['interval'] = $prior_interval;
+		unset(
+			$scheduling['prior_interval'],
+			$scheduling['paused_reason'],
+			$scheduling['paused_at'],
+			$scheduling['recheck_action_id'],
+			$scheduling['recheck_scheduled_for'],
+			$scheduling['stale_flag']
+		);
+		$scheduling['resumed_at']       = current_time( 'mysql' );
+		$scheduling['resumed_by_qualify'] = true;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$ok = $wpdb->update(
+			$table,
+			array( 'scheduling_config' => wp_json_encode( $scheduling ) ),
+			array( 'flow_id' => $flow_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		// Queue an immediate run so the operator sees a real result on the
+		// next tick rather than waiting for the next scheduled fire.
+		if ( $ok && function_exists( 'as_enqueue_async_action' ) ) {
+			as_enqueue_async_action( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			sprintf( 'QualifyRecheck: auto-resumed flow %d (verdict=qualified_structured, restored interval=%s)', $flow_id, $prior_interval ),
+			array(
+				'flow_id'     => $flow_id,
+				'interval'    => $prior_interval,
+				'event_count' => (int) ( $result['event_count'] ?? 0 ),
+			)
+		);
+
+		return false !== $ok;
+	}
+}

--- a/inc/Cli/UnqualifiableFlowsCommand.php
+++ b/inc/Cli/UnqualifiableFlowsCommand.php
@@ -14,6 +14,7 @@
 namespace ExtraChillEvents\Cli;
 
 use ExtraChillEvents\Core\QualifyVerdict;
+use ExtraChillEvents\Core\QualifyVerdictsTable;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -47,7 +48,15 @@ class UnqualifiableFlowsCommand {
 	 *
 	 * [--auto-pause]
 	 * : Pause flows whose new verdict is anything other than
-	 * QUALIFIED_STRUCTURED.
+	 * QUALIFIED_STRUCTURED — subject to the per-verdict confirmation rules
+	 * in QualifyVerdict::CONFIRMATION_RULES. Flows that haven't built up
+	 * enough corroborating verdict history are left active; the verdict row
+	 * persists so a future audit can hit confirmation.
+	 *
+	 * [--force]
+	 * : Bypass confirmation entirely and pause on the first failing verdict.
+	 * Use this for operator-driven manual pauses where you already know the
+	 * venue is dead. Requires --auto-pause.
 	 *
 	 * [--dry-run]
 	 * : List candidate flows but do not run qualify or pause anything.
@@ -85,9 +94,14 @@ class UnqualifiableFlowsCommand {
 		$min_runs        = max( 1, (int) ( $assoc_args['min-runs'] ?? 14 ) );
 		$zero_yield_only = ! empty( $assoc_args['zero-yield-only'] );
 		$auto            = ! empty( $assoc_args['auto-pause'] );
+		$force           = ! empty( $assoc_args['force'] );
 		$dry_run         = ! empty( $assoc_args['dry-run'] );
 		$limit           = max( 1, (int) ( $assoc_args['limit'] ?? 200 ) );
 		$format          = $assoc_args['format'] ?? 'table';
+
+		// Network option lets operators disable confirmation globally
+		// (restores pre-v0.21 "pause on first failing verdict" behavior).
+		$confirmation_enabled = (bool) get_site_option( 'dme_qualify_pause_confirmation', true );
 
 		$flows = $this->load_all_web_scraper_flows();
 		if ( empty( $flows ) ) {
@@ -163,8 +177,9 @@ class UnqualifiableFlowsCommand {
 			return;
 		}
 
-		$results = array();
-		$progress = \WP_CLI\Utils\make_progress_bar( 'Auditing', count( $candidates ) );
+		$verdicts_table = new QualifyVerdictsTable();
+		$results        = array();
+		$progress       = \WP_CLI\Utils\make_progress_bar( 'Auditing', count( $candidates ) );
 		foreach ( $candidates as $c ) {
 			$result = $ability->execute( array( 'url' => $c['source_url'] ) );
 			$progress->tick();
@@ -191,7 +206,18 @@ class UnqualifiableFlowsCommand {
 			if ( QualifyVerdict::QUALIFIED_STRUCTURED === $row['new_verdict'] ) {
 				$row['action'] = 'unexpected_pass';
 			} elseif ( $auto ) {
-				$ok            = $this->pause_flow_by_verdict( $c['flow_id'], $row['new_verdict'] );
+				// Confirmation gate — unless --force or the network option
+				// has disabled it, the candidate verdict must clear the
+				// per-verdict CONFIRMATION_RULES threshold before we pause.
+				if ( ! $force && $confirmation_enabled ) {
+					$url_hash = QualifyVerdict::url_hash( $c['source_url'] );
+					if ( '' === $url_hash || ! $verdicts_table->meets_pause_confirmation( $url_hash, $row['new_verdict'] ) ) {
+						$row['action'] = 'awaiting_confirmation';
+						$results[]     = $row;
+						continue;
+					}
+				}
+				$ok            = $this->pause_flow_by_verdict( $c['flow_id'], $row['new_verdict'], $c['source_url'] );
 				$row['action'] = $ok ? 'paused' : 'pause_failed';
 			} else {
 				$row['action'] = 'recommend_pause';
@@ -212,12 +238,20 @@ class UnqualifiableFlowsCommand {
 			array( 'flow_id', 'flow_name', 'new_verdict', 'event_count', 'action' )
 		);
 
-		$paused        = array_filter( $results, fn( $r ) => 'paused' === $r['action'] );
-		$recommended   = array_filter( $results, fn( $r ) => 'recommend_pause' === $r['action'] );
-		$unexpected    = array_filter( $results, fn( $r ) => 'unexpected_pass' === $r['action'] );
+		$paused      = array_filter( $results, fn( $r ) => 'paused' === $r['action'] );
+		$awaiting    = array_filter( $results, fn( $r ) => 'awaiting_confirmation' === $r['action'] );
+		$recommended = array_filter( $results, fn( $r ) => 'recommend_pause' === $r['action'] );
+		$unexpected  = array_filter( $results, fn( $r ) => 'unexpected_pass' === $r['action'] );
 
 		if ( ! empty( $paused ) ) {
 			\WP_CLI::success( sprintf( 'Paused %d flow(s).', count( $paused ) ) );
+		}
+		if ( ! empty( $awaiting ) ) {
+			\WP_CLI::log( '' );
+			\WP_CLI::log( sprintf(
+				'%d flow(s) awaiting confirmation — verdict recorded but pause threshold not yet met. Re-run later, or pass --force to bypass.',
+				count( $awaiting )
+			) );
 		}
 		if ( ! empty( $recommended ) ) {
 			\WP_CLI::log( '' );

--- a/inc/Core/QualifyRecheckHandler.php
+++ b/inc/Core/QualifyRecheckHandler.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Qualify Recheck Handler — Action Scheduler callback for paused flows.
+ *
+ * Every flow paused by qualify v2 gets exactly one `dme/qualify_recheck`
+ * action queued at pause time with a per-verdict cadence. When the action
+ * fires, this handler:
+ *
+ *  - Calls `extrachill/qualify-venue` against the paused flow's source_url.
+ *  - On QUALIFIED_STRUCTURED → auto-resumes the flow + queues an immediate
+ *    run.
+ *  - On a different non-qualifying verdict → updates paused_reason +
+ *    reschedules with the new verdict's cadence.
+ *  - On 6+ consecutive failed rechecks → flags the flow as stale (the
+ *    digest surfaces it as "manual review recommended") and stops
+ *    rescheduling.
+ *  - On permanent verdicts (RESERVATION_ONLY / COVERED_ELSEWHERE) → just
+ *    updates paused_reason and stops (no further rechecks).
+ *
+ * Auto-resume is safe by design: only a positive QUALIFIED_STRUCTURED
+ * outcome resumes the flow. There is no force-resume path.
+ *
+ * @package ExtraChillEvents\Core
+ * @since   0.21.0
+ */
+
+namespace ExtraChillEvents\Core;
+
+use ExtraChillEvents\Cli\FlowOps;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class QualifyRecheckHandler {
+
+	/**
+	 * Maximum consecutive failed rechecks before a flow is flagged stale.
+	 *
+	 * Filterable via `dme_qualify_recheck_max_failures`.
+	 */
+	public const DEFAULT_MAX_FAILURES = 6;
+
+	/**
+	 * Action Scheduler hook.
+	 */
+	public const HOOK = 'dme/qualify_recheck';
+
+	/**
+	 * Action Scheduler group.
+	 */
+	public const GROUP = 'dme_qualify';
+
+	/**
+	 * Register the Action Scheduler hook.
+	 */
+	public static function register(): void {
+		add_action( self::HOOK, array( self::class, 'handle' ), 10, 1 );
+	}
+
+	/**
+	 * Action Scheduler callback.
+	 *
+	 * @param array $args { flow_id, url, verdict, consecutive_failures }
+	 */
+	public static function handle( $args ): void {
+		// Action Scheduler hands us the first positional argument from the
+		// args array we registered — that's our associative payload.
+		if ( ! is_array( $args ) ) {
+			return;
+		}
+
+		$flow_id              = (int) ( $args['flow_id'] ?? 0 );
+		$url                  = (string) ( $args['url'] ?? '' );
+		$consecutive_failures = (int) ( $args['consecutive_failures'] ?? 0 );
+
+		if ( $flow_id <= 0 || '' === $url ) {
+			return;
+		}
+
+		// Sanity: the flow must still exist and still be paused. A manual
+		// unpause cancels the recheck implicitly — we just no-op.
+		$flow = FlowOps::fetch_flow_row( $flow_id );
+		if ( ! $flow ) {
+			return;
+		}
+		$current_interval = (string) ( $flow['scheduling_config']['interval'] ?? '' );
+		if ( 'manual' !== $current_interval ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				sprintf( 'QualifyRecheck: flow %d already unpaused — no-op', $flow_id ),
+				array(
+					'flow_id'  => $flow_id,
+					'interval' => $current_interval,
+				)
+			);
+			return;
+		}
+
+		// Run qualify.
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return;
+		}
+		$ability = wp_get_ability( 'extrachill/qualify-venue' );
+		if ( ! $ability ) {
+			return;
+		}
+
+		$result = $ability->execute( array( 'url' => $url ) );
+		if ( is_wp_error( $result ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				sprintf( 'QualifyRecheck: qualify ability errored for flow %d: %s', $flow_id, $result->get_error_message() ),
+				array(
+					'flow_id' => $flow_id,
+					'url'     => $url,
+					'error'   => $result->get_error_message(),
+				)
+			);
+			// Treat ability error as a failed recheck and reschedule on the
+			// original verdict's cadence (or escalate to stale on threshold).
+			self::reschedule_or_flag( $flow_id, $url, (string) ( $args['verdict'] ?? '' ), $consecutive_failures + 1 );
+			return;
+		}
+
+		$new_verdict = (string) ( $result['verdict'] ?? '' );
+
+		if ( QualifyVerdict::QUALIFIED_STRUCTURED === $new_verdict ) {
+			FlowOps::resume_flow_from_qualified( $flow_id, is_array( $result ) ? $result : array() );
+			return;
+		}
+
+		$next_interval = QualifyVerdict::recheck_interval_for( $new_verdict );
+		if ( null === $next_interval ) {
+			// Permanent disqualification — update paused_reason and stop.
+			FlowOps::update_paused_reason( $flow_id, $new_verdict );
+			do_action(
+				'datamachine_log',
+				'info',
+				sprintf( 'QualifyRecheck: flow %d permanently disqualified (verdict=%s)', $flow_id, $new_verdict ),
+				array(
+					'flow_id' => $flow_id,
+					'verdict' => $new_verdict,
+				)
+			);
+			return;
+		}
+
+		self::reschedule_or_flag( $flow_id, $url, $new_verdict, $consecutive_failures + 1 );
+	}
+
+	/**
+	 * Reschedule the next recheck OR flag the flow stale once consecutive
+	 * failures cross the threshold.
+	 *
+	 * @param int    $flow_id              Flow ID.
+	 * @param string $url                  Source URL.
+	 * @param string $verdict              Verdict to reschedule against.
+	 * @param int    $consecutive_failures Failure count including this run.
+	 */
+	private static function reschedule_or_flag( int $flow_id, string $url, string $verdict, int $consecutive_failures ): void {
+		/**
+		 * Filter the consecutive-failure threshold before a paused flow
+		 * is flagged stale and surfaced in the weekly digest.
+		 *
+		 * @param int    $max_failures Default 6.
+		 * @param int    $flow_id      Flow ID being rechecked.
+		 * @param string $verdict      Current verdict.
+		 */
+		$max_failures = (int) apply_filters(
+			'dme_qualify_recheck_max_failures',
+			self::DEFAULT_MAX_FAILURES,
+			$flow_id,
+			$verdict
+		);
+
+		if ( $consecutive_failures >= $max_failures ) {
+			FlowOps::flag_stale_paused( $flow_id, $verdict, $consecutive_failures );
+			return;
+		}
+
+		$interval = QualifyVerdict::recheck_interval_for( $verdict );
+		if ( null === $interval ) {
+			FlowOps::update_paused_reason( $flow_id, $verdict );
+			return;
+		}
+
+		// Reflect the new (possibly different) verdict on the flow before
+		// queuing the next attempt.
+		FlowOps::update_paused_reason( $flow_id, $verdict );
+
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			return;
+		}
+		$ts        = time() + (int) $interval;
+		$action_id = as_schedule_single_action(
+			$ts,
+			self::HOOK,
+			array(
+				array(
+					'flow_id'              => $flow_id,
+					'url'                  => $url,
+					'verdict'              => $verdict,
+					'consecutive_failures' => $consecutive_failures,
+				),
+			),
+			self::GROUP
+		);
+
+		if ( $action_id ) {
+			FlowOps::set_recheck_metadata( $flow_id, (int) $action_id, $ts );
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			sprintf(
+				'QualifyRecheck: flow %d rescheduled (verdict=%s, consecutive_failures=%d, next_run=%s)',
+				$flow_id,
+				$verdict,
+				$consecutive_failures,
+				gmdate( 'Y-m-d H:i:s', $ts )
+			),
+			array(
+				'flow_id'              => $flow_id,
+				'verdict'              => $verdict,
+				'consecutive_failures' => $consecutive_failures,
+				'next_run'             => $ts,
+			)
+		);
+	}
+}

--- a/inc/Core/QualifyVerdict.php
+++ b/inc/Core/QualifyVerdict.php
@@ -189,6 +189,119 @@ final class QualifyVerdict {
 		);
 	}
 
+	// ---- Pause confirmation rules ----
+	//
+	// Per-verdict rules that govern when `unqualifiable-flows --auto-pause`
+	// will actually pause a flow. The platform is designed to run unattended
+	// for weeks at a time, so a 30-second transient outage during an audit
+	// window must not pause a healthy venue.
+	//
+	// Shape: ['verdicts' => N, 'hours' => H] — the last N verdicts for the
+	//   URL must all match the candidate verdict AND the oldest of those N
+	//   rows must be at least H hours old. `null` means the verdict is never
+	//   auto-paused (qualified states).
+	//
+	// QUALIFIED_STRUCTURED / QUALIFIED_FOR_FLYER: never auto-paused.
+	// EXTRACTION_GAP: 2 verdicts over ≥48h — extractor gaps don't fix
+	//   themselves between consecutive audit runs.
+	// BOT_BLOCKED / UNREACHABLE: 3 verdicts over ≥7 days — Cloudflare rules
+	//   flip; DNS/timeout/5xx is often transient.
+	// RESERVATION_ONLY / COVERED_ELSEWHERE: single verdict — these are
+	//   permanent disqualifications by design.
+
+	/**
+	 * Per-verdict pause-confirmation rules.
+	 *
+	 * @var array<string, ?array{verdicts:int,hours:int}>
+	 */
+	public const CONFIRMATION_RULES = array(
+		self::QUALIFIED_STRUCTURED => null,
+		self::QUALIFIED_FOR_FLYER  => null,
+		self::EXTRACTION_GAP       => array(
+			'verdicts' => 2,
+			'hours'    => 48,
+		),
+		self::BOT_BLOCKED          => array(
+			'verdicts' => 3,
+			'hours'    => 168,
+		),
+		self::UNREACHABLE          => array(
+			'verdicts' => 3,
+			'hours'    => 168,
+		),
+		self::RESERVATION_ONLY     => array(
+			'verdicts' => 1,
+			'hours'    => 0,
+		),
+		self::COVERED_ELSEWHERE    => array(
+			'verdicts' => 1,
+			'hours'    => 0,
+		),
+	);
+
+	/**
+	 * Pause-confirmation rule for a verdict.
+	 *
+	 * Returns the tuple ['verdicts' => N, 'hours' => H] from
+	 * CONFIRMATION_RULES, or null when the verdict is never auto-paused.
+	 *
+	 * @param string $verdict One of the verdict constants.
+	 * @return array{verdicts:int,hours:int}|null
+	 */
+	public static function confirmation_for( string $verdict ): ?array {
+		return self::CONFIRMATION_RULES[ $verdict ] ?? null;
+	}
+
+	// ---- Recheck intervals ----
+	//
+	// Per-verdict cadence for re-running qualify against a paused flow's
+	// source_url. When a recheck job fires, the handler calls qualify; if
+	// the new verdict is QUALIFIED_STRUCTURED the flow is auto-resumed,
+	// otherwise the recheck is rescheduled at the next interval (or escalated
+	// to the digest after 6 consecutive failures).
+	//
+	// EXTRACTION_GAP: 14d — extractor coverage usually ships in batches.
+	// BOT_BLOCKED:    7d  — Cloudflare rules can flip.
+	// UNREACHABLE:    3d  — DNS/timeout/5xx is often short-lived.
+	// QUALIFIED_FOR_FLYER: 21d — operator-review state; long cadence.
+	// RESERVATION_ONLY / COVERED_ELSEWHERE: null — permanent, no recheck.
+
+	/**
+	 * Per-verdict recheck cadence in seconds.
+	 *
+	 * @var array<string, ?int>
+	 */
+	public const RECHECK_INTERVALS = array(
+		self::EXTRACTION_GAP      => 14 * DAY_IN_SECONDS,
+		self::BOT_BLOCKED         => 7 * DAY_IN_SECONDS,
+		self::UNREACHABLE         => 3 * DAY_IN_SECONDS,
+		self::QUALIFIED_FOR_FLYER => 21 * DAY_IN_SECONDS,
+		self::RESERVATION_ONLY    => null,
+		self::COVERED_ELSEWHERE   => null,
+	);
+
+	/**
+	 * Recheck interval for a verdict, in seconds.
+	 *
+	 * Returns null when the verdict is permanently disqualifying (no
+	 * recheck is ever scheduled). Filterable via
+	 * `dme_qualify_recheck_interval` so operators can tune cadence
+	 * without a code change.
+	 *
+	 * @param string $verdict One of the verdict constants.
+	 * @return int|null Interval in seconds, or null for "never recheck".
+	 */
+	public static function recheck_interval_for( string $verdict ): ?int {
+		$default = self::RECHECK_INTERVALS[ $verdict ] ?? null;
+		/**
+		 * Filter the per-verdict recheck cadence.
+		 *
+		 * @param int|null $interval Default interval in seconds (null = never).
+		 * @param string   $verdict  The verdict the interval applies to.
+		 */
+		return apply_filters( 'dme_qualify_recheck_interval', $default, $verdict );
+	}
+
 	/**
 	 * Canonicalize a URL for verdict lookup / dedup.
 	 *

--- a/inc/Core/QualifyVerdictsTable.php
+++ b/inc/Core/QualifyVerdictsTable.php
@@ -204,4 +204,95 @@ class QualifyVerdictsTable {
 
 		return is_array( $row ) ? $row : null;
 	}
+
+	/**
+	 * Fetch the N most recent verdict rows for a URL hash, newest first.
+	 *
+	 * Used by meets_pause_confirmation() to inspect verdict history when
+	 * deciding whether a candidate pause has enough corroborating evidence.
+	 *
+	 * @param string $url_hash 40-char sha1 hash.
+	 * @param int    $limit    Maximum rows to return. Capped at 50 defensively.
+	 * @return array<int, array<string, mixed>> Rows ordered by qualified_at DESC, id DESC.
+	 */
+	public function latest_verdicts_for_url( string $url_hash, int $limit = 10 ): array {
+		global $wpdb;
+		if ( '' === $url_hash ) {
+			return array();
+		}
+		$limit = max( 1, min( 50, $limit ) );
+		$table = self::table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT verdict, qualified_at, id FROM {$table} WHERE url_hash = %s ORDER BY qualified_at DESC, id DESC LIMIT %d",
+				$url_hash,
+				$limit
+			),
+			ARRAY_A
+		);
+
+		return is_array( $rows ) ? $rows : array();
+	}
+
+	/**
+	 * Check whether a verdict has enough corroborating evidence to justify
+	 * auto-pausing a flow.
+	 *
+	 * Looks up CONFIRMATION_RULES for the candidate verdict and walks the
+	 * URL's recent verdict log. Returns true only when:
+	 *
+	 *  - the verdict has a rule (qualified verdicts return false — never paused),
+	 *  - the last N rows all carry the same verdict, AND
+	 *  - the oldest of those N rows is at least H hours old.
+	 *
+	 * Single-row rules (RESERVATION_ONLY / COVERED_ELSEWHERE) effectively
+	 * pause on the latest verdict alone since N=1 and H=0.
+	 *
+	 * @param string $url_hash 40-char sha1 hash.
+	 * @param string $verdict  The candidate verdict.
+	 * @return bool True when the verdict meets its confirmation rule.
+	 */
+	public function meets_pause_confirmation( string $url_hash, string $verdict ): bool {
+		$rule = QualifyVerdict::confirmation_for( $verdict );
+		if ( null === $rule ) {
+			return false;
+		}
+
+		$needed_verdicts = (int) ( $rule['verdicts'] ?? 0 );
+		$needed_hours    = (int) ( $rule['hours'] ?? 0 );
+
+		if ( $needed_verdicts < 1 ) {
+			return false;
+		}
+
+		$rows = $this->latest_verdicts_for_url( $url_hash, $needed_verdicts );
+		if ( count( $rows ) < $needed_verdicts ) {
+			return false;
+		}
+
+		// Every one of the last N rows must match the candidate verdict.
+		foreach ( $rows as $row ) {
+			if ( (string) ( $row['verdict'] ?? '' ) !== $verdict ) {
+				return false;
+			}
+		}
+
+		// Hours window: the oldest of those N rows must be at least
+		// $needed_hours old. A zero-hour rule short-circuits the check.
+		if ( $needed_hours <= 0 ) {
+			return true;
+		}
+
+		$oldest = end( $rows );
+		$oldest_ts = isset( $oldest['qualified_at'] ) ? strtotime( (string) $oldest['qualified_at'] . ' UTC' ) : false;
+		if ( false === $oldest_ts ) {
+			return false;
+		}
+
+		$cutoff = time() - ( $needed_hours * HOUR_IN_SECONDS );
+
+		return $oldest_ts <= $cutoff;
+	}
 }

--- a/inc/Steps/QualifyDigest/QualifyDigestSystemTask.php
+++ b/inc/Steps/QualifyDigest/QualifyDigestSystemTask.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Qualify Digest — Weekly system task.
+ *
+ * Bridges the extrachill/qualify-digest ability into Data Machine's
+ * recurring system-task surface. Registered via the datamachine_tasks
+ * filter; scheduled weekly (Mondays 09:00 UTC by default) via
+ * datamachine_recurring_schedules.
+ *
+ * Gating: the dme_qualify_digest_enabled network option must be true
+ * (default) AND the wp_get_ability( extrachill/qualify-digest ) call must
+ * resolve. Either condition failing produces a "skipped" outcome on the
+ * task body, not a failure.
+ *
+ * @package ExtraChillEvents\Steps\QualifyDigest
+ * @since   0.21.0
+ */
+
+namespace ExtraChillEvents\Steps\QualifyDigest;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+
+class QualifyDigestSystemTask extends SystemTask {
+
+	public const TASK_TYPE = 'extrachill_qualify_digest';
+
+	public function getTaskType(): string {
+		return self::TASK_TYPE;
+	}
+
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Qualify Digest (weekly)',
+			'description'     => 'Weekly summary of qualify v2 activity: paused/resumed flows, new venues, standing inventory, top extraction gaps, stale paused flows.',
+			'setting_key'     => 'dme_qualify_digest_enabled',
+			'default_enabled' => true,
+			'supports_run'    => true,
+		);
+	}
+
+	/**
+	 * Execute the digest ability and report outcome on the job.
+	 *
+	 * @param int   $jobId  Job ID.
+	 * @param array $params Task params (forwarded to the ability).
+	 */
+	public function executeTask( int $jobId, array $params ): void {
+		$enabled = (bool) get_site_option( 'dme_qualify_digest_enabled', true );
+		if ( ! $enabled ) {
+			$this->completeJob(
+				$jobId,
+				array(
+					'skipped' => true,
+					'reason'  => 'Weekly digest disabled (dme_qualify_digest_enabled=false).',
+				)
+			);
+			return;
+		}
+
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->failJob( $jobId, 'Abilities API not available.' );
+			return;
+		}
+
+		$ability = wp_get_ability( 'extrachill/qualify-digest' );
+		if ( ! $ability ) {
+			$this->failJob( $jobId, 'extrachill/qualify-digest ability not registered.' );
+			return;
+		}
+
+		$input = array(
+			'since'   => (string) ( $params['since'] ?? '1 week ago' ),
+			'format'  => (string) ( $params['format'] ?? 'html' ),
+			'dry_run' => (bool) ( $params['dry_run'] ?? false ),
+		);
+		if ( ! empty( $params['recipient'] ) ) {
+			$input['recipient'] = (string) $params['recipient'];
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			$this->failJob( $jobId, $result->get_error_message() );
+			return;
+		}
+
+		$counts = is_array( $result ) ? ( $result['counts'] ?? array() ) : array();
+		$this->completeJob(
+			$jobId,
+			array(
+				'sent'      => (bool) ( $result['sent'] ?? false ),
+				'dry_run'   => (bool) ( $result['dry_run'] ?? false ),
+				'recipient' => (string) ( $result['recipient'] ?? '' ),
+				'counts'    => $counts,
+			)
+		);
+	}
+}

--- a/inc/admin/network-settings.php
+++ b/inc/admin/network-settings.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Network-level admin settings for qualify v2 unattended-safe operation.
+ *
+ * Registers four site options (network-wide via get_site_option) and a
+ * minimal Network Admin → Settings → Qualify v2 page so an operator can
+ * toggle confirmation, recheck, and the weekly digest without reaching
+ * for wp-cli.
+ *
+ * Options:
+ *  - dme_qualify_pause_confirmation  (bool, default true)
+ *  - dme_qualify_recheck_enabled     (bool, default true)
+ *  - dme_qualify_digest_enabled      (bool, default true)
+ *  - dme_qualify_digest_recipient    (string, default '' = admin_email)
+ *
+ * All four are read via get_site_option() so this file works on both
+ * network-activated and single-site activations. The settings UI is
+ * registered on `network_admin_menu` and falls back gracefully on
+ * single-site installs (in which case the page never renders but the
+ * options are still honoured by the runtime code).
+ *
+ * @package ExtraChillEvents\Admin
+ * @since   0.21.0
+ */
+
+namespace ExtraChillEvents\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+class NetworkSettings {
+
+	public const OPTION_PAUSE_CONFIRMATION = 'dme_qualify_pause_confirmation';
+	public const OPTION_RECHECK_ENABLED    = 'dme_qualify_recheck_enabled';
+	public const OPTION_DIGEST_ENABLED     = 'dme_qualify_digest_enabled';
+	public const OPTION_DIGEST_RECIPIENT   = 'dme_qualify_digest_recipient';
+
+	/**
+	 * All four options + their defaults.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function defaults(): array {
+		return array(
+			self::OPTION_PAUSE_CONFIRMATION => true,
+			self::OPTION_RECHECK_ENABLED    => true,
+			self::OPTION_DIGEST_ENABLED     => true,
+			self::OPTION_DIGEST_RECIPIENT   => '',
+		);
+	}
+
+	/**
+	 * Wire admin hooks. Called once at plugin init.
+	 */
+	public static function register(): void {
+		add_action( 'network_admin_menu', array( self::class, 'register_menu' ) );
+		add_action( 'admin_init', array( self::class, 'register_settings' ) );
+		add_action( 'admin_post_extrachill_save_qualify_v2_settings', array( self::class, 'handle_save' ) );
+	}
+
+	/**
+	 * Register the Network Admin menu entry.
+	 */
+	public static function register_menu(): void {
+		add_submenu_page(
+			'settings.php',
+			__( 'Qualify v2 Settings', 'extrachill-events' ),
+			__( 'Qualify v2', 'extrachill-events' ),
+			'manage_network_options',
+			'extrachill-qualify-v2',
+			array( self::class, 'render_page' )
+		);
+	}
+
+	/**
+	 * Register settings (used on single-site activations for UI parity).
+	 */
+	public static function register_settings(): void {
+		register_setting( 'extrachill_qualify_v2', self::OPTION_PAUSE_CONFIRMATION, array( 'type' => 'boolean', 'default' => true ) );
+		register_setting( 'extrachill_qualify_v2', self::OPTION_RECHECK_ENABLED, array( 'type' => 'boolean', 'default' => true ) );
+		register_setting( 'extrachill_qualify_v2', self::OPTION_DIGEST_ENABLED, array( 'type' => 'boolean', 'default' => true ) );
+		register_setting(
+			'extrachill_qualify_v2',
+			self::OPTION_DIGEST_RECIPIENT,
+			array(
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => array( self::class, 'sanitize_recipient' ),
+			)
+		);
+	}
+
+	/**
+	 * Sanitize the digest recipient field — accept an email or an empty
+	 * string. Anything else is rejected back to the previous value.
+	 *
+	 * @param string $input Raw input.
+	 * @return string
+	 */
+	public static function sanitize_recipient( $input ): string {
+		$input = is_string( $input ) ? trim( $input ) : '';
+		if ( '' === $input ) {
+			return '';
+		}
+		return is_email( $input ) ? sanitize_email( $input ) : (string) get_site_option( self::OPTION_DIGEST_RECIPIENT, '' );
+	}
+
+	/**
+	 * Render the settings page.
+	 */
+	public static function render_page(): void {
+		if ( ! current_user_can( 'manage_network_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to access this page.', 'extrachill-events' ) );
+		}
+
+		$saved = isset( $_GET['updated'] ) && '1' === $_GET['updated'];
+
+		$pause_confirmation = (bool) get_site_option( self::OPTION_PAUSE_CONFIRMATION, true );
+		$recheck_enabled    = (bool) get_site_option( self::OPTION_RECHECK_ENABLED, true );
+		$digest_enabled     = (bool) get_site_option( self::OPTION_DIGEST_ENABLED, true );
+		$digest_recipient   = (string) get_site_option( self::OPTION_DIGEST_RECIPIENT, '' );
+
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Qualify v2 Settings', 'extrachill-events' ); ?></h1>
+
+			<?php if ( $saved ) : ?>
+				<div class="notice notice-success is-dismissible">
+					<p><?php esc_html_e( 'Settings saved.', 'extrachill-events' ); ?></p>
+				</div>
+			<?php endif; ?>
+
+			<p><?php esc_html_e( 'Controls for the unattended-safe pause / recheck / digest loop introduced by qualify v2 issue #79.', 'extrachill-events' ); ?></p>
+
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<input type="hidden" name="action" value="extrachill_save_qualify_v2_settings" />
+				<?php wp_nonce_field( 'extrachill_save_qualify_v2_settings' ); ?>
+
+				<table class="form-table" role="presentation">
+					<tr>
+						<th scope="row"><label for="<?php echo esc_attr( self::OPTION_PAUSE_CONFIRMATION ); ?>"><?php esc_html_e( 'Pause confirmation', 'extrachill-events' ); ?></label></th>
+						<td>
+							<label>
+								<input type="checkbox" id="<?php echo esc_attr( self::OPTION_PAUSE_CONFIRMATION ); ?>" name="<?php echo esc_attr( self::OPTION_PAUSE_CONFIRMATION ); ?>" value="1" <?php checked( $pause_confirmation ); ?> />
+								<?php esc_html_e( 'Require multi-verdict confirmation before auto-pause', 'extrachill-events' ); ?>
+							</label>
+							<p class="description"><?php esc_html_e( 'When off, unqualifiable-flows --auto-pause pauses on the first failing verdict (pre-v0.21 behavior).', 'extrachill-events' ); ?></p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="<?php echo esc_attr( self::OPTION_RECHECK_ENABLED ); ?>"><?php esc_html_e( 'Recheck paused flows', 'extrachill-events' ); ?></label></th>
+						<td>
+							<label>
+								<input type="checkbox" id="<?php echo esc_attr( self::OPTION_RECHECK_ENABLED ); ?>" name="<?php echo esc_attr( self::OPTION_RECHECK_ENABLED ); ?>" value="1" <?php checked( $recheck_enabled ); ?> />
+								<?php esc_html_e( 'Enable automatic recheck of paused flows', 'extrachill-events' ); ?>
+							</label>
+							<p class="description"><?php esc_html_e( 'When off, paused flows stay paused until manual operator action.', 'extrachill-events' ); ?></p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="<?php echo esc_attr( self::OPTION_DIGEST_ENABLED ); ?>"><?php esc_html_e( 'Weekly digest email', 'extrachill-events' ); ?></label></th>
+						<td>
+							<label>
+								<input type="checkbox" id="<?php echo esc_attr( self::OPTION_DIGEST_ENABLED ); ?>" name="<?php echo esc_attr( self::OPTION_DIGEST_ENABLED ); ?>" value="1" <?php checked( $digest_enabled ); ?> />
+								<?php esc_html_e( 'Send the weekly qualify v2 activity digest', 'extrachill-events' ); ?>
+							</label>
+							<p class="description"><?php esc_html_e( 'Default schedule: Mondays 09:00 UTC. Filterable via dme_qualify_digest_schedule.', 'extrachill-events' ); ?></p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="<?php echo esc_attr( self::OPTION_DIGEST_RECIPIENT ); ?>"><?php esc_html_e( 'Digest recipient', 'extrachill-events' ); ?></label></th>
+						<td>
+							<input type="email" id="<?php echo esc_attr( self::OPTION_DIGEST_RECIPIENT ); ?>" name="<?php echo esc_attr( self::OPTION_DIGEST_RECIPIENT ); ?>" value="<?php echo esc_attr( $digest_recipient ); ?>" class="regular-text" placeholder="<?php echo esc_attr( (string) get_option( 'admin_email' ) ); ?>" />
+							<p class="description"><?php esc_html_e( 'Override recipient email. Empty falls back to the site\'s admin_email.', 'extrachill-events' ); ?></p>
+						</td>
+					</tr>
+				</table>
+
+				<?php submit_button( __( 'Save settings', 'extrachill-events' ) ); ?>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Persist the settings via update_site_option so they take effect
+	 * network-wide.
+	 */
+	public static function handle_save(): void {
+		if ( ! current_user_can( 'manage_network_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to save these settings.', 'extrachill-events' ) );
+		}
+		check_admin_referer( 'extrachill_save_qualify_v2_settings' );
+
+		update_site_option( self::OPTION_PAUSE_CONFIRMATION, ! empty( $_POST[ self::OPTION_PAUSE_CONFIRMATION ] ) );
+		update_site_option( self::OPTION_RECHECK_ENABLED, ! empty( $_POST[ self::OPTION_RECHECK_ENABLED ] ) );
+		update_site_option( self::OPTION_DIGEST_ENABLED, ! empty( $_POST[ self::OPTION_DIGEST_ENABLED ] ) );
+		update_site_option(
+			self::OPTION_DIGEST_RECIPIENT,
+			self::sanitize_recipient( isset( $_POST[ self::OPTION_DIGEST_RECIPIENT ] ) ? wp_unslash( (string) $_POST[ self::OPTION_DIGEST_RECIPIENT ] ) : '' )
+		);
+
+		$redirect = network_admin_url( 'settings.php?page=extrachill-qualify-v2&updated=1' );
+		wp_safe_redirect( $redirect );
+		exit;
+	}
+}

--- a/tests/Unit/Core/QualifyConfirmationRulesTest.php
+++ b/tests/Unit/Core/QualifyConfirmationRulesTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Tests for QualifyVerdict::confirmation_for() and recheck_interval_for().
+ *
+ * Pure-unit — no WP test framework required.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use ExtraChillEvents\Core\QualifyVerdict;
+use PHPUnit\Framework\TestCase;
+
+class QualifyConfirmationRulesTest extends TestCase {
+
+	public function test_qualified_verdicts_have_no_confirmation_rule(): void {
+		$this->assertNull( QualifyVerdict::confirmation_for( QualifyVerdict::QUALIFIED_STRUCTURED ) );
+		$this->assertNull( QualifyVerdict::confirmation_for( QualifyVerdict::QUALIFIED_FOR_FLYER ) );
+	}
+
+	public function test_extraction_gap_requires_two_verdicts_over_48h(): void {
+		$rule = QualifyVerdict::confirmation_for( QualifyVerdict::EXTRACTION_GAP );
+		$this->assertIsArray( $rule );
+		$this->assertSame( 2, $rule['verdicts'] );
+		$this->assertSame( 48, $rule['hours'] );
+	}
+
+	public function test_bot_blocked_requires_three_verdicts_over_7_days(): void {
+		$rule = QualifyVerdict::confirmation_for( QualifyVerdict::BOT_BLOCKED );
+		$this->assertIsArray( $rule );
+		$this->assertSame( 3, $rule['verdicts'] );
+		$this->assertSame( 168, $rule['hours'] );
+	}
+
+	public function test_unreachable_requires_three_verdicts_over_7_days(): void {
+		$rule = QualifyVerdict::confirmation_for( QualifyVerdict::UNREACHABLE );
+		$this->assertIsArray( $rule );
+		$this->assertSame( 3, $rule['verdicts'] );
+		$this->assertSame( 168, $rule['hours'] );
+	}
+
+	public function test_reservation_only_pauses_on_single_verdict(): void {
+		$rule = QualifyVerdict::confirmation_for( QualifyVerdict::RESERVATION_ONLY );
+		$this->assertIsArray( $rule );
+		$this->assertSame( 1, $rule['verdicts'] );
+		$this->assertSame( 0, $rule['hours'] );
+	}
+
+	public function test_covered_elsewhere_pauses_on_single_verdict(): void {
+		$rule = QualifyVerdict::confirmation_for( QualifyVerdict::COVERED_ELSEWHERE );
+		$this->assertIsArray( $rule );
+		$this->assertSame( 1, $rule['verdicts'] );
+		$this->assertSame( 0, $rule['hours'] );
+	}
+
+	public function test_unknown_verdict_has_no_rule(): void {
+		$this->assertNull( QualifyVerdict::confirmation_for( 'not_a_real_verdict' ) );
+	}
+
+	public function test_extraction_gap_recheck_interval_is_14_days(): void {
+		$this->assertSame( 14 * DAY_IN_SECONDS, QualifyVerdict::recheck_interval_for( QualifyVerdict::EXTRACTION_GAP ) );
+	}
+
+	public function test_bot_blocked_recheck_interval_is_7_days(): void {
+		$this->assertSame( 7 * DAY_IN_SECONDS, QualifyVerdict::recheck_interval_for( QualifyVerdict::BOT_BLOCKED ) );
+	}
+
+	public function test_unreachable_recheck_interval_is_3_days(): void {
+		$this->assertSame( 3 * DAY_IN_SECONDS, QualifyVerdict::recheck_interval_for( QualifyVerdict::UNREACHABLE ) );
+	}
+
+	public function test_qualified_for_flyer_recheck_interval_is_21_days(): void {
+		$this->assertSame( 21 * DAY_IN_SECONDS, QualifyVerdict::recheck_interval_for( QualifyVerdict::QUALIFIED_FOR_FLYER ) );
+	}
+
+	public function test_permanent_verdicts_have_null_recheck_interval(): void {
+		$this->assertNull( QualifyVerdict::recheck_interval_for( QualifyVerdict::RESERVATION_ONLY ) );
+		$this->assertNull( QualifyVerdict::recheck_interval_for( QualifyVerdict::COVERED_ELSEWHERE ) );
+	}
+
+	public function test_qualified_structured_has_null_recheck_interval(): void {
+		$this->assertNull( QualifyVerdict::recheck_interval_for( QualifyVerdict::QUALIFIED_STRUCTURED ) );
+	}
+
+	public function test_unknown_verdict_has_null_recheck_interval(): void {
+		$this->assertNull( QualifyVerdict::recheck_interval_for( 'not_a_real_verdict' ) );
+	}
+}

--- a/tests/Unit/Core/QualifyDigestAbilityTest.php
+++ b/tests/Unit/Core/QualifyDigestAbilityTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tests for QualifyDigestAbilities renderers.
+ *
+ * Renderers are pure: in goes the gather_data() shape, out comes a string.
+ * Tests feed seeded data structures and assert the rendered output
+ * contains the expected sections and counts.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use ExtraChillEvents\Abilities\QualifyDigestAbilities;
+use ExtraChillEvents\Core\QualifyVerdict;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Stubs/digest-stubs.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Abilities/QualifyDigestAbilities.php';
+
+class QualifyDigestAbilityTest extends TestCase {
+
+	private function seed_data(): array {
+		return array(
+			'counts'             => array(
+				'paused_total'        => 4,
+				'resumed_total'       => 12,
+				'new_qualified_total' => 18,
+				'stale_total'         => 1,
+			),
+			'paused_by_verdict'  => array(
+				QualifyVerdict::EXTRACTION_GAP => 3,
+				QualifyVerdict::BOT_BLOCKED    => 1,
+			),
+			'standing_inventory' => array(
+				'active:daily'                              => 147,
+				'paused:' . QualifyVerdict::EXTRACTION_GAP  => 22,
+				'paused:' . QualifyVerdict::BOT_BLOCKED     => 4,
+				'paused:' . QualifyVerdict::COVERED_ELSEWHERE => 2,
+			),
+			'top_extraction_gap' => array(
+				array( 'hint' => 'squarespace — no upcoming array', 'count' => 8 ),
+				array( 'hint' => 'wordpress_generic — no Tribe plugin', 'count' => 5 ),
+				array( 'hint' => 'wix — no events block', 'count' => 3 ),
+			),
+			'stale_flows'        => array(
+				array(
+					'flow_id'              => 99,
+					'flow_name'            => 'Broken Venue',
+					'paused_reason'        => QualifyVerdict::BOT_BLOCKED,
+					'consecutive_failures' => 6,
+				),
+			),
+		);
+	}
+
+	public function test_text_renderer_contains_summary_counts(): void {
+		$ability = new QualifyDigestAbilities();
+		$data    = $this->seed_data();
+		$body    = $ability->render_text( $data, strtotime( '2025-05-18 00:00:00' ), strtotime( '2025-05-24 00:00:00' ) );
+
+		$this->assertStringContainsString( 'EVENT CALENDAR QUALIFY DIGEST', $body );
+		$this->assertStringContainsString( 'Paused this week:        4 flows', $body );
+		$this->assertStringContainsString( 'Auto-resumed this week:  12 flows', $body );
+		$this->assertStringContainsString( 'New venues qualified:    18', $body );
+		$this->assertStringContainsString( 'Stale paused flows:      1', $body );
+	}
+
+	public function test_text_renderer_contains_top_3_fingerprints(): void {
+		$ability = new QualifyDigestAbilities();
+		$body    = $ability->render_text( $this->seed_data(), time() - WEEK_IN_SECONDS, time() );
+
+		$this->assertStringContainsString( 'squarespace — no upcoming array', $body );
+		$this->assertStringContainsString( 'wordpress_generic — no Tribe plugin', $body );
+		$this->assertStringContainsString( 'wix — no events block', $body );
+	}
+
+	public function test_text_renderer_surfaces_stale_flows(): void {
+		$ability = new QualifyDigestAbilities();
+		$body    = $ability->render_text( $this->seed_data(), time() - WEEK_IN_SECONDS, time() );
+
+		$this->assertStringContainsString( 'Stale paused flows — manual review recommended', $body );
+		$this->assertStringContainsString( 'Broken Venue', $body );
+		$this->assertStringContainsString( '6 failures', $body );
+	}
+
+	public function test_html_renderer_contains_all_sections(): void {
+		$ability = new QualifyDigestAbilities();
+		$body    = $ability->render_html( $this->seed_data(), time() - WEEK_IN_SECONDS, time() );
+
+		$this->assertStringContainsString( '<!DOCTYPE html>', $body );
+		$this->assertStringContainsString( 'Event Calendar Qualify Digest', $body );
+		$this->assertStringContainsString( '<h2>Summary</h2>', $body );
+		$this->assertStringContainsString( '<h2>Paused this week — by verdict</h2>', $body );
+		$this->assertStringContainsString( '<h2>Standing inventory</h2>', $body );
+		$this->assertStringContainsString( '<h2>Top extraction_gap fingerprints</h2>', $body );
+		$this->assertStringContainsString( '<h2>Stale paused flows — manual review recommended</h2>', $body );
+	}
+
+	public function test_html_renderer_renders_zero_state_when_nothing_changed(): void {
+		$ability = new QualifyDigestAbilities();
+		$empty   = array(
+			'counts'             => array(
+				'paused_total'        => 0,
+				'resumed_total'       => 0,
+				'new_qualified_total' => 0,
+				'stale_total'         => 0,
+			),
+			'paused_by_verdict'  => array(),
+			'standing_inventory' => array(),
+			'top_extraction_gap' => array(),
+			'stale_flows'        => array(),
+		);
+		$body    = $ability->render_html( $empty, time() - WEEK_IN_SECONDS, time() );
+
+		$this->assertStringContainsString( 'Nothing paused this week.', $body );
+		$this->assertStringContainsString( 'No universal_web_scraper flows registered.', $body );
+		$this->assertStringContainsString( 'No extraction_gap verdicts this week.', $body );
+		// Stale section must be absent when there are no stale flows.
+		$this->assertStringNotContainsString( '<h2>Stale paused flows', $body );
+	}
+
+	public function test_html_renderer_renders_counts(): void {
+		$ability = new QualifyDigestAbilities();
+		$body    = $ability->render_html( $this->seed_data(), time() - WEEK_IN_SECONDS, time() );
+
+		$this->assertStringContainsString( '147', $body, 'standing inventory active:daily count' );
+		$this->assertStringContainsString( '22', $body, 'paused extraction_gap count' );
+		$this->assertStringContainsString( '18', $body, 'new qualified total' );
+	}
+}

--- a/tests/Unit/Core/QualifyDigestSystemTaskTest.php
+++ b/tests/Unit/Core/QualifyDigestSystemTaskTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Tests for QualifyDigestSystemTask scaffolding.
+ *
+ * The task body delegates to the qualify-digest ability; behaviour there
+ * is covered in QualifyDigestAbilityTest. This file asserts the task
+ * declares the contract pieces RecurringScheduleRegistry + TaskRegistry
+ * rely on:
+ *
+ *  - getTaskType() returns the registered slug
+ *  - getTaskMeta() exposes setting_key + label
+ *
+ * We stub the DataMachine SystemTask base class so the test runs without
+ * the WP test framework or DM core booted.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+
+// Provide a stub for DataMachine\Engine\AI\System\Tasks\SystemTask before
+// the task class loads.
+require_once __DIR__ . '/Stubs/digest-stubs.php';
+require_once __DIR__ . '/Stubs/system-task-base-stub.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Steps/QualifyDigest/QualifyDigestSystemTask.php';
+
+class QualifyDigestSystemTaskTest extends TestCase {
+
+	public function test_task_type_slug(): void {
+		$task = new \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask();
+		$this->assertSame( 'extrachill_qualify_digest', $task->getTaskType() );
+		$this->assertSame( 'extrachill_qualify_digest', \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::TASK_TYPE );
+	}
+
+	public function test_task_meta_exposes_setting_key_and_default_enabled(): void {
+		$meta = \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::getTaskMeta();
+
+		$this->assertArrayHasKey( 'label', $meta );
+		$this->assertArrayHasKey( 'description', $meta );
+		$this->assertSame( 'dme_qualify_digest_enabled', $meta['setting_key'] );
+		$this->assertTrue( $meta['default_enabled'] );
+		$this->assertTrue( $meta['supports_run'] );
+	}
+}

--- a/tests/Unit/Core/QualifyRecheckHandlerTest.php
+++ b/tests/Unit/Core/QualifyRecheckHandlerTest.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Tests for QualifyRecheckHandler.
+ *
+ * Stubs FlowOps via a global recorder array + replaces wp_get_ability with
+ * a closure-returning fake. Validates the handler's branching:
+ *
+ *  - qualified_structured → resume + no further schedule.
+ *  - still-failing same verdict → reschedule with incremented failure count.
+ *  - different non-qualifying verdict → update paused_reason + reschedule.
+ *  - permanent verdict → update paused_reason + STOP rescheduling.
+ *  - already-unpaused flow → no-op.
+ *  - consecutive_failures crosses threshold → flag stale + stop.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use ExtraChillEvents\Core\QualifyRecheckHandler;
+use ExtraChillEvents\Core\QualifyVerdict;
+use PHPUnit\Framework\TestCase;
+
+// Stubs MUST load before the handler so the fake FlowOps wins the
+// class-resolution race (the real FlowOps in inc/Cli/FlowOps.php is
+// deliberately not required by this test file).
+require_once __DIR__ . '/Stubs/recheck-handler-stubs.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Core/QualifyRecheckHandler.php';
+
+class QualifyRecheckHandlerTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['ec_test_flow_rows']        = array();
+		$GLOBALS['ec_test_flowops_calls']    = array();
+		$GLOBALS['ec_test_action_scheduler'] = array();
+		$GLOBALS['ec_test_ability_result']   = null;
+	}
+
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['ec_test_flow_rows'],
+			$GLOBALS['ec_test_flowops_calls'],
+			$GLOBALS['ec_test_action_scheduler'],
+			$GLOBALS['ec_test_ability_result']
+		);
+		parent::tearDown();
+	}
+
+	private function seed_paused_flow( int $flow_id ): void {
+		$GLOBALS['ec_test_flow_rows'][ $flow_id ] = array(
+			'flow_id'           => $flow_id,
+			'flow_name'         => 'Test flow',
+			'scheduling_config' => array(
+				'interval'      => 'manual',
+				'paused_reason' => QualifyVerdict::EXTRACTION_GAP,
+			),
+		);
+	}
+
+	public function test_qualified_structured_triggers_resume(): void {
+		$this->seed_paused_flow( 42 );
+		$GLOBALS['ec_test_ability_result'] = array(
+			'verdict'     => QualifyVerdict::QUALIFIED_STRUCTURED,
+			'event_count' => 8,
+		);
+
+		QualifyRecheckHandler::handle( array(
+			'flow_id'              => 42,
+			'url'                  => 'https://example.com/events',
+			'verdict'              => QualifyVerdict::EXTRACTION_GAP,
+			'consecutive_failures' => 0,
+		) );
+
+		$resume_calls = array_filter(
+			$GLOBALS['ec_test_flowops_calls'],
+			fn( $c ) => 'resume_flow_from_qualified' === $c['method']
+		);
+		$this->assertCount( 1, $resume_calls );
+		$this->assertEmpty( $GLOBALS['ec_test_action_scheduler'], 'No reschedule on resume' );
+	}
+
+	public function test_still_failing_reschedules_with_incremented_failures(): void {
+		$this->seed_paused_flow( 43 );
+		$GLOBALS['ec_test_ability_result'] = array(
+			'verdict' => QualifyVerdict::EXTRACTION_GAP,
+		);
+
+		QualifyRecheckHandler::handle( array(
+			'flow_id'              => 43,
+			'url'                  => 'https://example.com/events',
+			'verdict'              => QualifyVerdict::EXTRACTION_GAP,
+			'consecutive_failures' => 2,
+		) );
+
+		$this->assertCount( 1, $GLOBALS['ec_test_action_scheduler'] );
+		$scheduled = $GLOBALS['ec_test_action_scheduler'][0];
+		$this->assertSame( 'dme/qualify_recheck', $scheduled['hook'] );
+		$this->assertSame( 'dme_qualify', $scheduled['group'] );
+		$this->assertSame( 3, $scheduled['args'][0]['consecutive_failures'] );
+	}
+
+	public function test_permanent_verdict_stops_rescheduling(): void {
+		$this->seed_paused_flow( 44 );
+		$GLOBALS['ec_test_ability_result'] = array(
+			'verdict' => QualifyVerdict::RESERVATION_ONLY,
+		);
+
+		QualifyRecheckHandler::handle( array(
+			'flow_id'              => 44,
+			'url'                  => 'https://example.com/events',
+			'verdict'              => QualifyVerdict::UNREACHABLE,
+			'consecutive_failures' => 0,
+		) );
+
+		$this->assertEmpty( $GLOBALS['ec_test_action_scheduler'] );
+		$update_calls = array_filter(
+			$GLOBALS['ec_test_flowops_calls'],
+			fn( $c ) => 'update_paused_reason' === $c['method']
+		);
+		$this->assertNotEmpty( $update_calls );
+	}
+
+	public function test_unpaused_flow_is_noop(): void {
+		// Flow is no longer paused — handler must short-circuit.
+		$GLOBALS['ec_test_flow_rows'][45] = array(
+			'flow_id'           => 45,
+			'flow_name'         => 'Already unpaused',
+			'scheduling_config' => array( 'interval' => 'daily' ),
+		);
+
+		QualifyRecheckHandler::handle( array(
+			'flow_id'              => 45,
+			'url'                  => 'https://example.com/events',
+			'verdict'              => QualifyVerdict::EXTRACTION_GAP,
+			'consecutive_failures' => 0,
+		) );
+
+		$this->assertEmpty( $GLOBALS['ec_test_action_scheduler'] );
+		$this->assertEmpty( $GLOBALS['ec_test_flowops_calls'] );
+	}
+
+	public function test_consecutive_failures_threshold_flags_stale(): void {
+		$this->seed_paused_flow( 46 );
+		$GLOBALS['ec_test_ability_result'] = array(
+			'verdict' => QualifyVerdict::EXTRACTION_GAP,
+		);
+
+		// consecutive_failures=5 + this run = 6 → at threshold.
+		QualifyRecheckHandler::handle( array(
+			'flow_id'              => 46,
+			'url'                  => 'https://example.com/events',
+			'verdict'              => QualifyVerdict::EXTRACTION_GAP,
+			'consecutive_failures' => 5,
+		) );
+
+		$flag_calls = array_filter(
+			$GLOBALS['ec_test_flowops_calls'],
+			fn( $c ) => 'flag_stale_paused' === $c['method']
+		);
+		$this->assertCount( 1, $flag_calls );
+		$this->assertEmpty( $GLOBALS['ec_test_action_scheduler'], 'No reschedule after stale flag' );
+	}
+
+	public function test_missing_flow_is_noop(): void {
+		// No flow seeded — handler should bail without errors.
+		QualifyRecheckHandler::handle( array(
+			'flow_id'              => 999,
+			'url'                  => 'https://example.com/events',
+			'verdict'              => QualifyVerdict::EXTRACTION_GAP,
+			'consecutive_failures' => 0,
+		) );
+
+		$this->assertEmpty( $GLOBALS['ec_test_action_scheduler'] );
+		$this->assertEmpty( $GLOBALS['ec_test_flowops_calls'] );
+	}
+
+	public function test_invalid_payload_is_noop(): void {
+		QualifyRecheckHandler::handle( array() );
+		QualifyRecheckHandler::handle( 'not-an-array' );
+		$this->assertEmpty( $GLOBALS['ec_test_action_scheduler'] );
+	}
+}

--- a/tests/Unit/Core/QualifyVerdictsTablePauseConfirmationTest.php
+++ b/tests/Unit/Core/QualifyVerdictsTablePauseConfirmationTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Tests for QualifyVerdictsTable::meets_pause_confirmation() +
+ * latest_verdicts_for_url().
+ *
+ * Stubs $wpdb to feed seeded rows to the helpers without booting the WP
+ * test framework.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use ExtraChillEvents\Core\QualifyVerdict;
+use ExtraChillEvents\Core\QualifyVerdictsTable;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__, 3 ) . '/inc/Core/QualifyVerdictsTable.php';
+require_once __DIR__ . '/Stubs/FakeWpdb.php';
+
+class QualifyVerdictsTablePauseConfirmationTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['wpdb'] = new FakeWpdb();
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['wpdb'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Helper — seed rows newest-first (matches ORDER BY qualified_at DESC).
+	 *
+	 * @param array<int,array{verdict:string, hours_ago:int}> $seeds
+	 */
+	private function seed( array $seeds ): void {
+		$rows = array();
+		foreach ( $seeds as $i => $seed ) {
+			$ts     = gmdate( 'Y-m-d H:i:s', time() - ( (int) $seed['hours_ago'] * HOUR_IN_SECONDS ) );
+			$rows[] = array(
+				'verdict'      => (string) $seed['verdict'],
+				'qualified_at' => $ts,
+				'id'           => 1000 - $i,
+			);
+		}
+		$GLOBALS['wpdb']->seed_rows( $rows );
+	}
+
+	public function test_returns_false_for_qualified_structured_verdict(): void {
+		$table = new QualifyVerdictsTable();
+		$this->seed( array(
+			array( 'verdict' => QualifyVerdict::QUALIFIED_STRUCTURED, 'hours_ago' => 0 ),
+		) );
+		$this->assertFalse(
+			$table->meets_pause_confirmation( str_repeat( 'a', 40 ), QualifyVerdict::QUALIFIED_STRUCTURED )
+		);
+	}
+
+	public function test_extraction_gap_requires_two_matching_verdicts_over_48h(): void {
+		$table = new QualifyVerdictsTable();
+		$hash  = str_repeat( 'b', 40 );
+
+		// Only one row — not enough.
+		$this->seed( array(
+			array( 'verdict' => QualifyVerdict::EXTRACTION_GAP, 'hours_ago' => 60 ),
+		) );
+		$this->assertFalse( $table->meets_pause_confirmation( $hash, QualifyVerdict::EXTRACTION_GAP ) );
+
+		// Two rows but oldest is only 12h old — window not satisfied.
+		$this->seed( array(
+			array( 'verdict' => QualifyVerdict::EXTRACTION_GAP, 'hours_ago' => 0 ),
+			array( 'verdict' => QualifyVerdict::EXTRACTION_GAP, 'hours_ago' => 12 ),
+		) );
+		$this->assertFalse( $table->meets_pause_confirmation( $hash, QualifyVerdict::EXTRACTION_GAP ) );
+
+		// Two rows and oldest is 60h old — confirmed.
+		$this->seed( array(
+			array( 'verdict' => QualifyVerdict::EXTRACTION_GAP, 'hours_ago' => 1 ),
+			array( 'verdict' => QualifyVerdict::EXTRACTION_GAP, 'hours_ago' => 60 ),
+		) );
+		$this->assertTrue( $table->meets_pause_confirmation( $hash, QualifyVerdict::EXTRACTION_GAP ) );
+	}
+
+	public function test_mismatched_verdict_in_window_blocks_pause(): void {
+		$table = new QualifyVerdictsTable();
+		$hash  = str_repeat( 'c', 40 );
+
+		$this->seed( array(
+			array( 'verdict' => QualifyVerdict::EXTRACTION_GAP, 'hours_ago' => 1 ),
+			array( 'verdict' => QualifyVerdict::QUALIFIED_STRUCTURED, 'hours_ago' => 50 ),
+		) );
+
+		$this->assertFalse( $table->meets_pause_confirmation( $hash, QualifyVerdict::EXTRACTION_GAP ) );
+	}
+
+	public function test_bot_blocked_requires_three_matching_over_7_days(): void {
+		$table = new QualifyVerdictsTable();
+		$hash  = str_repeat( 'd', 40 );
+
+		// Only two rows — short of N=3.
+		$this->seed( array(
+			array( 'verdict' => QualifyVerdict::BOT_BLOCKED, 'hours_ago' => 1 ),
+			array( 'verdict' => QualifyVerdict::BOT_BLOCKED, 'hours_ago' => 200 ),
+		) );
+		$this->assertFalse( $table->meets_pause_confirmation( $hash, QualifyVerdict::BOT_BLOCKED ) );
+
+		// Three rows but window only 100h — short of 168h.
+		$this->seed( array(
+			array( 'verdict' => QualifyVerdict::BOT_BLOCKED, 'hours_ago' => 1 ),
+			array( 'verdict' => QualifyVerdict::BOT_BLOCKED, 'hours_ago' => 50 ),
+			array( 'verdict' => QualifyVerdict::BOT_BLOCKED, 'hours_ago' => 100 ),
+		) );
+		$this->assertFalse( $table->meets_pause_confirmation( $hash, QualifyVerdict::BOT_BLOCKED ) );
+
+		// Three matching rows and oldest beyond 168h — confirmed.
+		$this->seed( array(
+			array( 'verdict' => QualifyVerdict::BOT_BLOCKED, 'hours_ago' => 1 ),
+			array( 'verdict' => QualifyVerdict::BOT_BLOCKED, 'hours_ago' => 80 ),
+			array( 'verdict' => QualifyVerdict::BOT_BLOCKED, 'hours_ago' => 200 ),
+		) );
+		$this->assertTrue( $table->meets_pause_confirmation( $hash, QualifyVerdict::BOT_BLOCKED ) );
+	}
+
+	public function test_reservation_only_pauses_on_single_verdict(): void {
+		$table = new QualifyVerdictsTable();
+		$hash  = str_repeat( 'e', 40 );
+		$this->seed( array(
+			array( 'verdict' => QualifyVerdict::RESERVATION_ONLY, 'hours_ago' => 0 ),
+		) );
+		$this->assertTrue( $table->meets_pause_confirmation( $hash, QualifyVerdict::RESERVATION_ONLY ) );
+	}
+
+	public function test_covered_elsewhere_pauses_on_single_verdict(): void {
+		$table = new QualifyVerdictsTable();
+		$hash  = str_repeat( 'f', 40 );
+		$this->seed( array(
+			array( 'verdict' => QualifyVerdict::COVERED_ELSEWHERE, 'hours_ago' => 0 ),
+		) );
+		$this->assertTrue( $table->meets_pause_confirmation( $hash, QualifyVerdict::COVERED_ELSEWHERE ) );
+	}
+
+	public function test_empty_url_hash_returns_empty_rows(): void {
+		$table = new QualifyVerdictsTable();
+		$this->assertSame( array(), $table->latest_verdicts_for_url( '' ) );
+	}
+
+	public function test_latest_verdicts_for_url_returns_rows(): void {
+		$table = new QualifyVerdictsTable();
+		$this->seed( array(
+			array( 'verdict' => QualifyVerdict::EXTRACTION_GAP, 'hours_ago' => 1 ),
+			array( 'verdict' => QualifyVerdict::EXTRACTION_GAP, 'hours_ago' => 50 ),
+		) );
+
+		$rows = $table->latest_verdicts_for_url( str_repeat( 'g', 40 ), 5 );
+		$this->assertCount( 2, $rows );
+		$this->assertSame( QualifyVerdict::EXTRACTION_GAP, $rows[0]['verdict'] );
+	}
+}

--- a/tests/Unit/Core/Stubs/FakeWpdb.php
+++ b/tests/Unit/Core/Stubs/FakeWpdb.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Minimal $wpdb stub for qualify v2 unit tests.
+ *
+ * Captures prepare() arguments and returns whatever rows were seeded via
+ * seed_rows() / seed_row(). Sufficient for the SELECT-shaped queries our
+ * unit-under-test classes issue. NOT a general-purpose mock.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+class FakeWpdb {
+
+	public string $prefix = 'c8c_';
+
+	/**
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $rows = array();
+
+	/**
+	 * @var array<string, mixed>|null
+	 */
+	private ?array $row = null;
+
+	public array $queries = array();
+
+	public function prepare( string $sql, ...$args ): string {
+		// Naive interpolation good enough to keep a record for assertions.
+		foreach ( $args as $arg ) {
+			$sql = preg_replace( '/%[sd]/', is_string( $arg ) ? "'" . $arg . "'" : (string) $arg, $sql, 1 );
+		}
+		return $sql;
+	}
+
+	public function get_results( string $sql, $output = ARRAY_A ): array {
+		$this->queries[] = $sql;
+		return $this->rows;
+	}
+
+	public function get_row( string $sql, $output = ARRAY_A ): ?array {
+		$this->queries[] = $sql;
+		return $this->row;
+	}
+
+	public function get_var( string $sql ) {
+		$this->queries[] = $sql;
+		return null;
+	}
+
+	public function seed_rows( array $rows ): void {
+		$this->rows = $rows;
+	}
+
+	public function seed_row( array $row ): void {
+		$this->row = $row;
+	}
+}
+
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}

--- a/tests/Unit/Core/Stubs/digest-stubs.php
+++ b/tests/Unit/Core/Stubs/digest-stubs.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Minimal WP polyfills for QualifyDigestAbilityTest.
+ *
+ * Renderers only need esc_html, plus the time constants from
+ * tests/bootstrap.php. The ability's execute() path uses additional WP
+ * functions (get_option, get_site_option, do_action, wp_get_ability) —
+ * those are not exercised by these renderer-only tests.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ): string {
+		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = 'default' ): string {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, $callback, int $priority = 10, int $accepted_args = 1 ): void {}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( string $hook ): bool {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( string $hook ): bool {
+		return false;
+	}
+}

--- a/tests/Unit/Core/Stubs/recheck-handler-stubs.php
+++ b/tests/Unit/Core/Stubs/recheck-handler-stubs.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Stubs for QualifyRecheckHandlerTest.
+ *
+ * Defines a fake ExtraChillEvents\Cli\FlowOps before the real one loads
+ * so the handler's static calls hit instrumented methods. Also defines
+ * the WP / Action Scheduler / abilities helpers the handler relies on.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Cli {
+
+if ( ! class_exists( __NAMESPACE__ . '\\FlowOps' ) ) {
+	class FlowOps {
+
+		public static function fetch_flow_row( int $flow_id ): ?array {
+			return $GLOBALS['ec_test_flow_rows'][ $flow_id ] ?? null;
+		}
+
+		public static function resume_flow_from_qualified( int $flow_id, array $result ): bool {
+			$GLOBALS['ec_test_flowops_calls'][] = array(
+				'method' => 'resume_flow_from_qualified',
+				'args'   => array( $flow_id, $result ),
+			);
+			return true;
+		}
+
+		public static function update_paused_reason( int $flow_id, string $verdict ): bool {
+			$GLOBALS['ec_test_flowops_calls'][] = array(
+				'method' => 'update_paused_reason',
+				'args'   => array( $flow_id, $verdict ),
+			);
+			return true;
+		}
+
+		public static function flag_stale_paused( int $flow_id, string $verdict, int $consecutive_failures ): bool {
+			$GLOBALS['ec_test_flowops_calls'][] = array(
+				'method' => 'flag_stale_paused',
+				'args'   => array( $flow_id, $verdict, $consecutive_failures ),
+			);
+			return true;
+		}
+
+		public static function set_recheck_metadata( int $flow_id, int $action_id, int $next_run_ts ): bool {
+			$GLOBALS['ec_test_flowops_calls'][] = array(
+				'method' => 'set_recheck_metadata',
+				'args'   => array( $flow_id, $action_id, $next_run_ts ),
+			);
+			return true;
+		}
+
+		public static function pause_flow_by_verdict( int $flow_id, string $verdict, string $source_url = '' ): bool {
+			$GLOBALS['ec_test_flowops_calls'][] = array(
+				'method' => 'pause_flow_by_verdict',
+				'args'   => array( $flow_id, $verdict, $source_url ),
+			);
+			return true;
+		}
+	}
+}
+
+}
+
+namespace {
+	// WP / abilities / Action Scheduler stubs in the global namespace.
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		function wp_get_ability( string $name ) {
+			return new class() {
+				public function execute( array $input ) {
+					return $GLOBALS['ec_test_ability_result'];
+				}
+			};
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $message;
+			public function __construct( string $code = '', string $message = '' ) {
+				$this->message = $message;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'as_schedule_single_action' ) ) {
+		function as_schedule_single_action( int $timestamp, string $hook, array $args = array(), string $group = '' ): int {
+			$GLOBALS['ec_test_action_scheduler'][] = array(
+				'timestamp' => $timestamp,
+				'hook'      => $hook,
+				'args'      => $args,
+				'group'     => $group,
+			);
+			return 12345;
+		}
+	}
+
+	if ( ! function_exists( 'as_unschedule_action' ) ) {
+		function as_unschedule_action( string $hook, $args = null, string $group = '' ): void {}
+	}
+
+	if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
+		function as_unschedule_all_actions( string $hook, array $args = array(), string $group = '' ): void {}
+	}
+
+	if ( ! function_exists( 'as_enqueue_async_action' ) ) {
+		function as_enqueue_async_action( string $hook, array $args = array(), string $group = '' ): int {
+			return 1;
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( string $hook, ...$args ): void {}
+	}
+
+	if ( ! function_exists( 'add_action' ) ) {
+		function add_action( string $hook, $callback, int $priority = 10, int $accepted_args = 1 ): void {}
+	}
+
+	if ( ! function_exists( 'get_site_option' ) ) {
+		function get_site_option( string $key, $default = false ) {
+			return $default;
+		}
+	}
+}

--- a/tests/Unit/Core/Stubs/system-task-base-stub.php
+++ b/tests/Unit/Core/Stubs/system-task-base-stub.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Stub for DataMachine\Engine\AI\System\Tasks\SystemTask base class.
+ *
+ * The real class is defined in the data-machine plugin. For unit tests
+ * that exercise our QualifyDigestSystemTask scaffolding we only need
+ * something concrete to extend.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks;
+
+if ( ! class_exists( __NAMESPACE__ . '\\SystemTask' ) ) {
+	abstract class SystemTask {
+
+		abstract public function getTaskType(): string;
+
+		abstract public function executeTask( int $jobId, array $params ): void;
+
+		public static function getTaskMeta(): array {
+			return array(
+				'label'           => '',
+				'description'     => '',
+				'setting_key'     => null,
+				'default_enabled' => true,
+			);
+		}
+
+		protected function completeJob( int $jobId, array $data ): void {
+			$GLOBALS['ec_test_systemtask_calls'][] = array( 'method' => 'completeJob', 'job_id' => $jobId, 'data' => $data );
+		}
+
+		protected function failJob( int $jobId, string $message ): void {
+			$GLOBALS['ec_test_systemtask_calls'][] = array( 'method' => 'failJob', 'job_id' => $jobId, 'message' => $message );
+		}
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,6 +18,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/fixtures/' );
 }
 
+// WordPress time constants used by qualify v2 verdict configuration.
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+	define( 'HOUR_IN_SECONDS', 60 * MINUTE_IN_SECONDS );
+}
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 24 * HOUR_IN_SECONDS );
+}
+if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+	define( 'WEEK_IN_SECONDS', 7 * DAY_IN_SECONDS );
+}
+
 // --- Minimal WP polyfills (only what qualify v2 core code touches). ---
 
 if ( ! function_exists( 'wp_parse_url' ) ) {


### PR DESCRIPTION
Fixes #79

## Summary

Closes the three unattended-safe gaps qualify v2 (#75) shipped without:

- **Pause confirmation** — `unqualifiable-flows --auto-pause` now requires multi-verdict agreement before pausing. A single transient outage cannot mass-pause healthy venues anymore.
- **Self-scheduling recheck** — every paused flow gets exactly one Action Scheduler job queued at pause time on a per-verdict cadence. When qualify positively returns `qualified_structured` the flow auto-resumes and an immediate run is queued.
- **Weekly digest email** — a Monday-morning summary of paused/resumed/qualified activity, top extraction gaps, standing inventory, and stale paused flows. Sent via the `datamachine/send-email` ability (no direct `wp_mail()`).
- **Stale escalation** — after 6 consecutive failed rechecks the flow stops being rescheduled and is surfaced in the digest as "manual review recommended" so the operator can decide.

## Confirmation rules

| Verdict | Confirmation rule | Rationale |
|---|---|---|
| `qualified_structured` | n/a — never paused | Healthy |
| `qualified_for_flyer` | Never auto-paused | Operator review required |
| `extraction_gap` | Last **2** verdicts over **≥48h** agree | Extractor gaps don't fix themselves between consecutive runs |
| `bot_blocked` | Last **3** verdicts over **≥7 days** agree | Cloudflare rules can flip; give time |
| `unreachable` | Last **3** verdicts over **≥7 days** agree | DNS/timeout/5xx often transient |
| `reservation_only` | Single verdict sufficient | Permanent disqualification by design |
| `covered_elsewhere` | Single verdict sufficient | Permanent — TM/Live Nation venue |

## Recheck cadence

| Verdict | Recheck cadence |
|---|---|
| `extraction_gap` | every 14 days |
| `bot_blocked` | every 7 days |
| `unreachable` | every 3 days |
| `qualified_for_flyer` | every 21 days |
| `reservation_only` | never (permanent) |
| `covered_elsewhere` | never (permanent) |

Cadence is filterable via the `dme_qualify_recheck_interval` filter. The 6-failure stale threshold is filterable via `dme_qualify_recheck_max_failures`.

## Network options

| Option | Default | Effect |
|---|---|---|
| `dme_qualify_pause_confirmation` | `true` | Require multi-verdict confirmation before `--auto-pause`. Off restores pre-v0.21 "pause on first failing verdict" behavior. |
| `dme_qualify_recheck_enabled` | `true` | Schedule per-verdict recheck Action Scheduler jobs when a flow is paused. Off means paused flows stay paused until manual operator action. |
| `dme_qualify_digest_enabled` | `true` | Send the weekly qualify-activity digest. |
| `dme_qualify_digest_recipient` | `''` (= `admin_email`) | Override recipient email. |

Settings UI lives under **Network Admin → Settings → Qualify v2**, guarded on `manage_network_options` + nonce + `admin-post` handler.

## Commits

1. `feat(verdict)`: add `CONFIRMATION_RULES` + `RECHECK_INTERVALS` constants
2. `feat(verdicts-table)`: add `meets_pause_confirmation` + `latest_verdicts_for_url`
3. `feat(qualify)`: `unqualifiable-flows --auto-pause` requires confirmation + new `--force` flag
4. `feat(qualify)`: self-scheduling recheck handler + `resume_flow_from_qualified`
5. `feat(digest)`: `extrachill/qualify-digest` ability with HTML + text renderers
6. `feat(digest)`: weekly SystemTask wiring (Monday 09:00 UTC default)
7. `feat(admin)`: register four network options

## Test plan

All unit tests live under `tests/Unit/Core/` and run via `./vendor/bin/phpunit --testsuite=qualify-v2-unit`. Suite at HEAD: **117 tests, 214 assertions, all passing**.

- **QualifyConfirmationRulesTest** — per-verdict rule shape + recheck interval, plus defensive `null` for unknown verdicts. 14 cases.
- **QualifyVerdictsTablePauseConfirmationTest** — single-verdict rules, multi-verdict windows, mismatched verdict in window blocks pause, empty-input safety. 9 cases. Uses `FakeWpdb` stub.
- **QualifyRecheckHandlerTest** — resume on `qualified_structured`, reschedule with incremented failure count on still-failing, permanent-verdict stop, no-op when flow already unpaused, stale-flag at threshold (6), missing flow/invalid payload defensive no-ops. 7 cases. Stubs `FlowOps` + Action Scheduler.
- **QualifyDigestAbilityTest** — both renderers, summary counts, top-3 fingerprints, stale-flows section, HTML zero-state empty rendering, count round-trip. 6 cases.
- **QualifyDigestSystemTaskTest** — task type slug + meta shape (setting_key, default_enabled, supports_run). 2 cases. Stubs the DM `SystemTask` base.

### Integration test status

A full pause → recheck → resume → digest integration path exists in the design but is not implemented as a phpunit test here because the existing test suite is pure-unit (no WP test framework, no DM core bootstrap — same constraint #75 documented). Plan: run the scenario manually on staging once this lands using `wp extrachill venues unqualifiable-flows --auto-pause --dry-run`, then drive a recheck via `wp action-scheduler run --hooks=dme/qualify_recheck`, then `wp ability run extrachill/qualify-digest '{\"dry_run\":true}'` to inspect the digest body.

### DM-core bootstrap issue

Same constraint #75 called out: the legacy `EventSubmissionAbilitiesTest` (extends `WP_UnitTestCase`) still requires the upstream WP test framework + DM-core bootstrap and remains excluded from the `qualify-v2-unit` suite. No regressions there from this PR.

## Out of scope

- **NOT a force-resume mechanism.** Resume requires a positive `qualified_structured` outcome. No bypass path.
- **NOT a workflow for `qualified_for_flyer` flows.** Those stay operator-review-required (no auto-pause, no auto-resume).
- **NOT a way to paper over a permanently broken venue.** After 6 consecutive failed rechecks the flow is flagged stale and surfaced in the digest — manual review required.