### PR TITLE
fix(qualify): resume_flow_from_qualified propagates discovered events_url to flow source_url

### DIFF
--- a/inc/Cli/FlowOps.php
+++ b/inc/Cli/FlowOps.php
@@ -49,7 +49,7 @@ class FlowOps {
 			return null;
 		}
 
-		$scheduling = json_decode( (string) ( $row['scheduling_config'] ?? '' ), true );
+		$scheduling               = json_decode( (string) ( $row['scheduling_config'] ?? '' ), true );
 		$row['scheduling_config'] = is_array( $scheduling ) ? $scheduling : array();
 		return $row;
 	}
@@ -174,9 +174,9 @@ class FlowOps {
 	 * Called by the handler after queuing the next recheck so the digest
 	 * can show when the next attempt will fire.
 	 *
-	 * @param int    $flow_id     Flow ID.
-	 * @param int    $action_id   Action Scheduler action ID.
-	 * @param int    $next_run_ts Unix timestamp.
+	 * @param int $flow_id     Flow ID.
+	 * @param int $action_id   Action Scheduler action ID.
+	 * @param int $next_run_ts Unix timestamp.
 	 * @return bool True on success.
 	 */
 	public static function set_recheck_metadata( int $flow_id, int $action_id, int $next_run_ts ): bool {
@@ -265,6 +265,11 @@ class FlowOps {
 	 *    (from scheduling_config.prior_interval; defaults to 'daily').
 	 *  - Clear paused_reason / paused_at / prior_interval / recheck_*
 	 *    fields and any stale_flag.
+	 *  - If qualify discovered an `events_url` that differs from the
+	 *    current flow source_url AND is on the same host, walk
+	 *    flow_config and patch every universal_web_scraper step whose
+	 *    source_url matches the OLD value. Cross-host changes are
+	 *    skipped (operator review required for venue rebrands).
 	 *  - Queue an immediate run via datamachine_run_flow_now so the
 	 *    operator sees a real run on the next tick.
 	 *
@@ -273,17 +278,32 @@ class FlowOps {
 	 *
 	 * @param int   $flow_id Flow ID.
 	 * @param array $result  Qualify result for logging context.
+	 *                       Optional `events_url` triggers source_url
+	 *                       propagation (see issue #81).
 	 * @return bool True on success.
 	 */
 	public static function resume_flow_from_qualified( int $flow_id, array $result ): bool {
 		global $wpdb;
 		$table = $wpdb->prefix . 'datamachine_flows';
 
-		$row = self::fetch_flow_row( $flow_id );
+		// Re-read the row directly here because we also need flow_config
+		// for the events_url propagation path. fetch_flow_row() returns
+		// scheduling_config only, and we keep its narrow contract intact
+		// so the recheck handler's other callers remain unchanged.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT flow_id, scheduling_config, flow_config FROM {$table} WHERE flow_id = %d", $flow_id ),
+			ARRAY_A
+		);
 		if ( ! $row ) {
 			return false;
 		}
-		$scheduling = is_array( $row['scheduling_config'] ?? null ) ? $row['scheduling_config'] : array();
+
+		$scheduling = json_decode( (string) ( $row['scheduling_config'] ?? '' ), true );
+		$scheduling = is_array( $scheduling ) ? $scheduling : array();
+
+		$flow_config = json_decode( (string) ( $row['flow_config'] ?? '' ), true );
+		$flow_config = is_array( $flow_config ) ? $flow_config : array();
 
 		$prior_interval = (string) ( $scheduling['prior_interval'] ?? '' );
 		if ( '' === $prior_interval || 'manual' === $prior_interval ) {
@@ -299,15 +319,58 @@ class FlowOps {
 			$scheduling['recheck_scheduled_for'],
 			$scheduling['stale_flag']
 		);
-		$scheduling['resumed_at']       = current_time( 'mysql' );
+		$scheduling['resumed_at']         = current_time( 'mysql' );
 		$scheduling['resumed_by_qualify'] = true;
+
+		// Decide whether to propagate a discovered events_url onto the
+		// flow's source_url. Same-host only — cross-host changes are
+		// operator review by design.
+		$update_data    = array( 'scheduling_config' => wp_json_encode( $scheduling ) );
+		$update_formats = array( '%s' );
+
+		$events_url        = isset( $result['events_url'] ) ? (string) $result['events_url'] : '';
+		$current_source    = self::extract_source_url_from_flow_config( $flow_config );
+		$source_url_change = null;
+
+		if ( '' !== $events_url && '' !== $current_source && $events_url !== $current_source ) {
+			if ( self::same_host( $events_url, $current_source ) ) {
+				$patched = self::patch_source_url_in_flow_config( $flow_config, $current_source, $events_url );
+				if ( $patched['changed'] > 0 ) {
+					$flow_config                = $patched['config'];
+					$update_data['flow_config'] = wp_json_encode( $flow_config );
+					$update_formats[]           = '%s';
+					$source_url_change          = array(
+						'old'           => $current_source,
+						'new'           => $events_url,
+						'steps_patched' => $patched['changed'],
+					);
+				}
+			} else {
+				do_action(
+					'datamachine_log',
+					'warning',
+					sprintf(
+						'QualifyRecheck: flow %d events_url host differs from current source_url host — skipping propagation (old=%s, new=%s)',
+						$flow_id,
+						$current_source,
+						$events_url
+					),
+					array(
+						'flow_id'        => $flow_id,
+						'action'         => 'flow_source_url_cross_host_skip',
+						'old_source_url' => $current_source,
+						'new_events_url' => $events_url,
+					)
+				);
+			}
+		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$ok = $wpdb->update(
 			$table,
-			array( 'scheduling_config' => wp_json_encode( $scheduling ) ),
+			$update_data,
 			array( 'flow_id' => $flow_id ),
-			array( '%s' ),
+			$update_formats,
 			array( '%d' )
 		);
 
@@ -315,6 +378,28 @@ class FlowOps {
 		// next tick rather than waiting for the next scheduled fire.
 		if ( $ok && function_exists( 'as_enqueue_async_action' ) ) {
 			as_enqueue_async_action( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+		}
+
+		if ( null !== $source_url_change ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				sprintf(
+					'QualifyRecheck: flow %d source_url updated by qualify (%s → %s, %d step%s patched)',
+					$flow_id,
+					$source_url_change['old'],
+					$source_url_change['new'],
+					$source_url_change['steps_patched'],
+					1 === $source_url_change['steps_patched'] ? '' : 's'
+				),
+				array(
+					'flow_id'        => $flow_id,
+					'action'         => 'flow_source_url_updated_by_qualify',
+					'old_source_url' => $source_url_change['old'],
+					'new_source_url' => $source_url_change['new'],
+					'steps_patched'  => $source_url_change['steps_patched'],
+				)
+			);
 		}
 
 		do_action(
@@ -329,5 +414,107 @@ class FlowOps {
 		);
 
 		return false !== $ok;
+	}
+
+	/**
+	 * Extract the universal_web_scraper source_url from a decoded
+	 * flow_config array. Mirrors the parsing in FlowHelpers::extract_web_scraper_meta
+	 * but kept local here so FlowOps does not depend on the trait.
+	 *
+	 * Returns the first non-empty source_url found on an event_import
+	 * step whose handler is universal_web_scraper. Handles both the
+	 * newer handler_slug/handler_config shape and the older
+	 * handler_slugs[]/handler_configs{} shape.
+	 *
+	 * @param array $flow_config Decoded flow_config.
+	 * @return string Source URL or empty string when not found.
+	 */
+	private static function extract_source_url_from_flow_config( array $flow_config ): string {
+		foreach ( $flow_config as $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+			if ( ( $step['step_type'] ?? '' ) !== 'event_import' ) {
+				continue;
+			}
+			if ( isset( $step['handler_slug'] )
+				&& 'universal_web_scraper' === $step['handler_slug']
+				&& isset( $step['handler_config']['source_url'] ) ) {
+				$url = (string) $step['handler_config']['source_url'];
+				if ( '' !== $url ) {
+					return $url;
+				}
+			}
+			if ( isset( $step['handler_configs']['universal_web_scraper']['source_url'] ) ) {
+				$url = (string) $step['handler_configs']['universal_web_scraper']['source_url'];
+				if ( '' !== $url ) {
+					return $url;
+				}
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Walk flow_config and replace every universal_web_scraper
+	 * source_url that matches $old with $new.
+	 *
+	 * Only patches steps whose CURRENT source_url equals $old —
+	 * operator-set or already-divergent values are left untouched.
+	 *
+	 * @param array  $flow_config Decoded flow_config.
+	 * @param string $old_url     Pre-change source URL to match.
+	 * @param string $new_url     Replacement URL.
+	 * @return array{config:array,changed:int}
+	 */
+	private static function patch_source_url_in_flow_config( array $flow_config, string $old_url, string $new_url ): array {
+		$changed = 0;
+		foreach ( $flow_config as $step_key => $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+			if ( ( $step['step_type'] ?? '' ) !== 'event_import' ) {
+				continue;
+			}
+
+			// Newer shape: handler_slug + handler_config.
+			if ( isset( $step['handler_slug'] )
+				&& 'universal_web_scraper' === $step['handler_slug']
+				&& isset( $step['handler_config']['source_url'] )
+				&& (string) $step['handler_config']['source_url'] === $old_url ) {
+				$flow_config[ $step_key ]['handler_config']['source_url'] = $new_url;
+				++$changed;
+			}
+
+			// Older shape: handler_configs{slug: config}.
+			if ( isset( $step['handler_configs']['universal_web_scraper']['source_url'] )
+				&& (string) $step['handler_configs']['universal_web_scraper']['source_url'] === $old_url ) {
+				$flow_config[ $step_key ]['handler_configs']['universal_web_scraper']['source_url'] = $new_url;
+				++$changed;
+			}
+		}
+
+		return array(
+			'config'  => $flow_config,
+			'changed' => $changed,
+		);
+	}
+
+	/**
+	 * True when both URLs share the same host (case-insensitive).
+	 * Missing/unparseable hosts return false — we err on the side of
+	 * skipping propagation rather than silently rewriting.
+	 *
+	 * @param string $a First URL.
+	 * @param string $b Second URL.
+	 * @return bool
+	 */
+	private static function same_host( string $a, string $b ): bool {
+		$ha = function_exists( 'wp_parse_url' ) ? wp_parse_url( $a, PHP_URL_HOST ) : parse_url( $a, PHP_URL_HOST );
+		$hb = function_exists( 'wp_parse_url' ) ? wp_parse_url( $b, PHP_URL_HOST ) : parse_url( $b, PHP_URL_HOST );
+		if ( ! is_string( $ha ) || ! is_string( $hb ) || '' === $ha || '' === $hb ) {
+			return false;
+		}
+		return strtolower( $ha ) === strtolower( $hb );
 	}
 }

--- a/tests/Unit/Core/FlowOpsResumeTest.php
+++ b/tests/Unit/Core/FlowOpsResumeTest.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Tests for FlowOps::resume_flow_from_qualified() — events_url propagation.
+ *
+ * Covers the bug fix from extrachill-events#81: when qualify discovers a
+ * new events_url within the same host, the flow's universal_web_scraper
+ * source_url must be patched as part of the resume. Cross-host changes
+ * are intentionally skipped (operator review).
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+use ExtraChillEvents\Cli\FlowOps;
+
+/**
+ * Exercises the real FlowOps class against a captured $wpdb stub and a
+ * captured do_action() log stream so we can assert both the persisted
+ * payload and the structured log entries.
+ *
+ * Runs each test in a separate process because QualifyRecheckHandlerTest
+ * loads a fake FlowOps in the same namespace; without isolation, whichever
+ * test file loads first wins the class-resolution race.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class FlowOpsResumeTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Loaded here (rather than at file top) so the parent PHPUnit
+		// process that collects tests never pulls in the real FlowOps
+		// class. QualifyRecheckHandlerTest installs a same-namespace
+		// fake FlowOps and needs to win the class-resolution race in
+		// its own process. Tests in THIS class run in isolated
+		// subprocesses (see @runTestsInSeparateProcesses) so the real
+		// FlowOps gets a clean load each time.
+		require_once __DIR__ . '/Stubs/flowops-resume-stubs.php';
+		require_once dirname( __DIR__, 3 ) . '/inc/Cli/FlowOps.php';
+
+		$GLOBALS['wpdb']                       = new FlowOpsFakeWpdb();
+		$GLOBALS['ec_test_log_entries']        = array();
+		$GLOBALS['ec_test_async_actions']      = array();
+	}
+
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['wpdb'],
+			$GLOBALS['ec_test_log_entries'],
+			$GLOBALS['ec_test_async_actions']
+		);
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a paused flow row seeded into the fake $wpdb.
+	 *
+	 * @param int    $flow_id
+	 * @param string $source_url Initial universal_web_scraper source_url.
+	 * @param array  $extra_steps Optional additional steps appended to flow_config.
+	 */
+	private function seed_paused_flow( int $flow_id, string $source_url, array $extra_steps = array() ): void {
+		$flow_config = array_merge(
+			array(
+				array(
+					'step_type'      => 'event_import',
+					'handler_slug'   => 'universal_web_scraper',
+					'handler_config' => array(
+						'source_url' => $source_url,
+					),
+				),
+			),
+			$extra_steps
+		);
+
+		$scheduling = array(
+			'interval'       => 'manual',
+			'prior_interval' => 'daily',
+			'paused_reason'  => 'unreachable',
+			'paused_at'      => '2025-01-01 00:00:00',
+		);
+
+		$GLOBALS['wpdb']->seed_row(
+			$flow_id,
+			array(
+				'flow_id'           => $flow_id,
+				'flow_config'       => json_encode( $flow_config ),
+				'scheduling_config' => json_encode( $scheduling ),
+			)
+		);
+	}
+
+	/**
+	 * Pull the most recent flow_config update applied to a flow_id, decoded.
+	 */
+	private function captured_flow_config( int $flow_id ): ?array {
+		foreach ( array_reverse( $GLOBALS['wpdb']->updates ) as $u ) {
+			if ( ( $u['where']['flow_id'] ?? null ) === $flow_id && isset( $u['data']['flow_config'] ) ) {
+				return json_decode( (string) $u['data']['flow_config'], true );
+			}
+		}
+		return null;
+	}
+
+	private function last_update( int $flow_id ): ?array {
+		foreach ( array_reverse( $GLOBALS['wpdb']->updates ) as $u ) {
+			if ( ( $u['where']['flow_id'] ?? null ) === $flow_id ) {
+				return $u;
+			}
+		}
+		return null;
+	}
+
+	private function find_log_entries( string $action ): array {
+		return array_values( array_filter(
+			$GLOBALS['ec_test_log_entries'],
+			fn( $entry ) => ( $entry['context']['action'] ?? null ) === $action
+		) );
+	}
+
+	public function test_resume_propagates_events_url_when_changed_within_host(): void {
+		$this->seed_paused_flow( 100, 'https://venue.com/calendar' );
+
+		FlowOps::resume_flow_from_qualified( 100, array(
+			'verdict'     => 'qualified_structured',
+			'events_url'  => 'https://venue.com/events',
+			'event_count' => 5,
+		) );
+
+		$patched = $this->captured_flow_config( 100 );
+		$this->assertNotNull( $patched, 'flow_config must be included in the update' );
+		$this->assertSame(
+			'https://venue.com/events',
+			$patched[0]['handler_config']['source_url']
+		);
+
+		// Scheduling restored too.
+		$update     = $this->last_update( 100 );
+		$scheduling = json_decode( (string) $update['data']['scheduling_config'], true );
+		$this->assertSame( 'daily', $scheduling['interval'] );
+		$this->assertArrayNotHasKey( 'paused_reason', $scheduling );
+		$this->assertTrue( $scheduling['resumed_by_qualify'] );
+	}
+
+	public function test_resume_skips_propagation_when_events_url_matches(): void {
+		$this->seed_paused_flow( 101, 'https://venue.com/events' );
+
+		FlowOps::resume_flow_from_qualified( 101, array(
+			'verdict'    => 'qualified_structured',
+			'events_url' => 'https://venue.com/events',
+		) );
+
+		$update = $this->last_update( 101 );
+		$this->assertArrayNotHasKey(
+			'flow_config',
+			$update['data'],
+			'flow_config must not be in the update when events_url matches'
+		);
+		$this->assertArrayHasKey( 'scheduling_config', $update['data'] );
+		$this->assertEmpty( $this->find_log_entries( 'flow_source_url_updated_by_qualify' ) );
+	}
+
+	public function test_resume_skips_propagation_when_events_url_empty(): void {
+		$this->seed_paused_flow( 102, 'https://venue.com/calendar' );
+
+		FlowOps::resume_flow_from_qualified( 102, array(
+			'verdict' => 'qualified_structured',
+			// no events_url key at all
+		) );
+
+		$update = $this->last_update( 102 );
+		$this->assertArrayNotHasKey( 'flow_config', $update['data'] );
+		$this->assertEmpty( $this->find_log_entries( 'flow_source_url_updated_by_qualify' ) );
+	}
+
+	public function test_resume_skips_propagation_when_cross_host(): void {
+		$this->seed_paused_flow( 103, 'https://venue.com/calendar' );
+
+		FlowOps::resume_flow_from_qualified( 103, array(
+			'verdict'    => 'qualified_structured',
+			'events_url' => 'https://different-host.com/events',
+		) );
+
+		$update = $this->last_update( 103 );
+		$this->assertArrayNotHasKey(
+			'flow_config',
+			$update['data'],
+			'Cross-host events_url must not patch flow_config'
+		);
+
+		$warnings = $this->find_log_entries( 'flow_source_url_cross_host_skip' );
+		$this->assertCount( 1, $warnings );
+		$this->assertSame( 'warning', $warnings[0]['level'] );
+		$this->assertSame( 'https://venue.com/calendar', $warnings[0]['context']['old_source_url'] );
+		$this->assertSame( 'https://different-host.com/events', $warnings[0]['context']['new_events_url'] );
+	}
+
+	public function test_resume_patches_only_matching_steps(): void {
+		// Flow has 2 universal_web_scraper steps with DIFFERENT source_urls.
+		// Recheck matches only the first one. The second must remain untouched.
+		$this->seed_paused_flow(
+			104,
+			'https://venue.com/calendar',
+			array(
+				array(
+					'step_type'      => 'event_import',
+					'handler_slug'   => 'universal_web_scraper',
+					'handler_config' => array(
+						'source_url' => 'https://venue.com/special-shows',
+					),
+				),
+			)
+		);
+
+		FlowOps::resume_flow_from_qualified( 104, array(
+			'verdict'    => 'qualified_structured',
+			'events_url' => 'https://venue.com/events',
+		) );
+
+		$patched = $this->captured_flow_config( 104 );
+		$this->assertNotNull( $patched );
+		$this->assertSame( 'https://venue.com/events', $patched[0]['handler_config']['source_url'] );
+		$this->assertSame(
+			'https://venue.com/special-shows',
+			$patched[1]['handler_config']['source_url'],
+			'Operator-set second step must not be auto-rewritten'
+		);
+
+		$updates = $this->find_log_entries( 'flow_source_url_updated_by_qualify' );
+		$this->assertCount( 1, $updates );
+		$this->assertSame( 1, $updates[0]['context']['steps_patched'] );
+	}
+
+	public function test_resume_logs_source_url_change(): void {
+		$this->seed_paused_flow( 105, 'https://venue.com/calendar' );
+
+		FlowOps::resume_flow_from_qualified( 105, array(
+			'verdict'    => 'qualified_structured',
+			'events_url' => 'https://venue.com/events',
+		) );
+
+		$entries = $this->find_log_entries( 'flow_source_url_updated_by_qualify' );
+		$this->assertCount( 1, $entries );
+		$entry = $entries[0];
+
+		$this->assertSame( 'info', $entry['level'] );
+		$this->assertSame( 105, $entry['context']['flow_id'] );
+		$this->assertSame( 'https://venue.com/calendar', $entry['context']['old_source_url'] );
+		$this->assertSame( 'https://venue.com/events', $entry['context']['new_source_url'] );
+		$this->assertSame( 1, $entry['context']['steps_patched'] );
+	}
+
+	public function test_resume_patches_legacy_handler_configs_shape(): void {
+		// Older flow_config shape: handler_configs{slug: config}.
+		$flow_config = array(
+			array(
+				'step_type'       => 'event_import',
+				'handler_slugs'   => array( 'universal_web_scraper' ),
+				'handler_configs' => array(
+					'universal_web_scraper' => array(
+						'source_url' => 'https://venue.com/calendar',
+					),
+				),
+			),
+		);
+		$scheduling  = array(
+			'interval'       => 'manual',
+			'prior_interval' => 'daily',
+			'paused_reason'  => 'unreachable',
+		);
+		$GLOBALS['wpdb']->seed_row( 106, array(
+			'flow_id'           => 106,
+			'flow_config'       => json_encode( $flow_config ),
+			'scheduling_config' => json_encode( $scheduling ),
+		) );
+
+		FlowOps::resume_flow_from_qualified( 106, array(
+			'verdict'    => 'qualified_structured',
+			'events_url' => 'https://venue.com/events',
+		) );
+
+		$patched = $this->captured_flow_config( 106 );
+		$this->assertNotNull( $patched );
+		$this->assertSame(
+			'https://venue.com/events',
+			$patched[0]['handler_configs']['universal_web_scraper']['source_url']
+		);
+	}
+}

--- a/tests/Unit/Core/Stubs/flowops-resume-stubs.php
+++ b/tests/Unit/Core/Stubs/flowops-resume-stubs.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Stubs for FlowOpsResumeTest.
+ *
+ * Provides:
+ *  - A FakeWpdb that records prepare() / get_row() / update() calls and
+ *    seeds rows keyed by flow_id (so the SELECT inside
+ *    resume_flow_from_qualified() returns the right shape).
+ *  - do_action capture into $GLOBALS['ec_test_log_entries'] for the
+ *    `datamachine_log` hook so tests can assert structured log entries.
+ *  - as_enqueue_async_action capture so we can assert the immediate-run
+ *    handoff without depending on Action Scheduler.
+ *
+ * All function definitions are guarded so this file can coexist with the
+ * other Stubs/*.php helpers loaded by the same test suite.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core {
+
+if ( ! class_exists( __NAMESPACE__ . '\\FlowOpsFakeWpdb' ) ) {
+	class FlowOpsFakeWpdb {
+
+		public string $prefix = 'c8c_';
+
+		/**
+		 * Rows seeded for SELECT-by-flow-id, keyed by flow_id.
+		 *
+		 * @var array<int, array<string, mixed>>
+		 */
+		private array $rows = array();
+
+		/**
+		 * Last flow_id parsed out of a prepare() call, used by get_row()
+		 * to return the right seeded row.
+		 */
+		private ?int $last_prepared_flow_id = null;
+
+		/**
+		 * Captured update() invocations.
+		 *
+		 * @var array<int, array{data:array,where:array,format:array,where_format:array}>
+		 */
+		public array $updates = array();
+
+		public function seed_row( int $flow_id, array $row ): void {
+			$this->rows[ $flow_id ] = $row;
+		}
+
+		public function prepare( string $sql, ...$args ): string {
+			// The only %d we care about is the flow_id used by the
+			// resume SELECT. Capture it for the next get_row().
+			foreach ( $args as $arg ) {
+				if ( is_int( $arg ) ) {
+					$this->last_prepared_flow_id = $arg;
+					break;
+				}
+				if ( is_numeric( $arg ) ) {
+					$this->last_prepared_flow_id = (int) $arg;
+					break;
+				}
+			}
+			return $sql;
+		}
+
+		public function get_row( string $sql, $output = ARRAY_A ): ?array {
+			if ( null === $this->last_prepared_flow_id ) {
+				return null;
+			}
+			$row = $this->rows[ $this->last_prepared_flow_id ] ?? null;
+			$this->last_prepared_flow_id = null;
+			return $row;
+		}
+
+		public function update( string $table, array $data, array $where, $format = null, $where_format = null ) {
+			$this->updates[] = array(
+				'table'        => $table,
+				'data'         => $data,
+				'where'        => $where,
+				'format'       => is_array( $format ) ? $format : array(),
+				'where_format' => is_array( $where_format ) ? $where_format : array(),
+			);
+			return 1;
+		}
+	}
+}
+
+}
+
+namespace {
+	if ( ! defined( 'ARRAY_A' ) ) {
+		define( 'ARRAY_A', 'ARRAY_A' );
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( string $hook, ...$args ): void {
+			if ( 'datamachine_log' === $hook ) {
+				$GLOBALS['ec_test_log_entries'][] = array(
+					'level'   => (string) ( $args[0] ?? '' ),
+					'message' => (string) ( $args[1] ?? '' ),
+					'context' => is_array( $args[2] ?? null ) ? $args[2] : array(),
+				);
+			}
+		}
+	}
+
+	if ( ! function_exists( 'as_enqueue_async_action' ) ) {
+		function as_enqueue_async_action( string $hook, array $args = array(), string $group = '' ): int {
+			$GLOBALS['ec_test_async_actions'][] = array(
+				'hook'  => $hook,
+				'args'  => $args,
+				'group' => $group,
+			);
+			return 1;
+		}
+	}
+
+	if ( ! function_exists( 'wp_parse_url' ) ) {
+		function wp_parse_url( $url, $component = -1 ) {
+			return -1 === $component ? parse_url( $url ) : parse_url( $url, $component );
+		}
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+			return json_encode( $data, $options, $depth );
+		}
+	}
+
+	if ( ! function_exists( 'current_time' ) ) {
+		function current_time( $type, $gmt = 0 ) {
+			return 'mysql' === $type ? gmdate( 'Y-m-d H:i:s' ) : time();
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( $hook, $value, ...$args ) {
+			return $value;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #81

## The bug

`FlowOps::resume_flow_from_qualified()` restored the scheduling interval and queued an immediate run, but did **not** update the flow's `source_url` to the `events_url` discovered by qualify. When a venue moved its calendar URL within the same domain (e.g. `/calendar` → `/events`), the recheck loop:

1. Production scrapes `/calendar` (the stored `source_url`) → HTTP 404 → zero yield → pause as `unreachable`.
2. Recheck job fires N days later, runs `extrachill/qualify-venue`.
3. Qualify discovers `/events` via the `EVENT_PATHS` probe, returns `qualified_structured` with `events_url = "https://venue.com/events"`.
4. `resume_flow_from_qualified()` restored `interval`, cleared `paused_reason`, queued an immediate run — **but left `source_url` pointing at `/calendar`**.
5. Immediate run scrapes the old `/calendar` URL → still 404 → zero yield again.
6. Auto-pause loop repeats until stale-flag escalation kicks in at 6 consecutive failures (~18 days for `unreachable`, ~84 days for `extraction_gap`).

End-user symptom: calendar shows nothing for the venue, paused-resume loop in the digest, eventual stale-flag escalation requiring operator review even though the fix is trivial.

## The fix

In `inc/Cli/FlowOps.php::resume_flow_from_qualified()`:

1. **Read the flow's current `source_url`** by re-querying the row (now selects `flow_config` alongside `scheduling_config`) and parsing the first `universal_web_scraper` step. A private `extract_source_url_from_flow_config()` helper handles both the newer `handler_slug`/`handler_config` shape and the legacy `handler_slugs[]`/`handler_configs{}` shape.
2. **Patch matching steps** when `$result['events_url']` is non-empty, differs from the current `source_url`, and shares the same host. A private `patch_source_url_in_flow_config()` walker rewrites every `universal_web_scraper` step whose CURRENT `source_url` equals the OLD value — operator-set or already-divergent values are left untouched.
3. **Include `flow_config` in the same `wpdb->update()` call** that today only updates `scheduling_config` (single round-trip; consistent with the rest of the file's update style).
4. **Log a structured `flow_source_url_updated_by_qualify` event** with old/new URLs, `flow_id`, and `steps_patched` count so the weekly digest can surface URL changes as a separate column.

`pause_flow_by_verdict()` is unchanged. `QualifyRecheckHandler::handle()` is unchanged — `resume_flow_from_qualified()` keeps its existing `(int $flow_id, array $result)` signature.

## Edge cases handled

| Case | Behavior |
|---|---|
| `events_url` empty / missing | No `flow_config` change. Only `scheduling_config` updated. Same as today. |
| `events_url` matches current `source_url` | No `flow_config` change. Only `scheduling_config` updated. Same as today. |
| `events_url` is cross-host (e.g. `venue.com` → `different-host.com`) | Warning log (`flow_source_url_cross_host_skip`), **no** flow_config patch. Cross-host changes are venue rebrands/transfers and stay operator-review by design. |
| Flow has multiple `universal_web_scraper` steps with the same OLD `source_url` | All matching steps patched. |
| Flow has a second `universal_web_scraper` step with an operator-set DIFFERENT `source_url` | Only the matching step is rewritten. The divergent step is left alone. |
| Legacy `handler_configs{universal_web_scraper:{}}` shape | Patched in place via the same walker. |

## Tests

New `tests/Unit/Core/FlowOpsResumeTest.php` (7 tests, 28 assertions):

- `test_resume_propagates_events_url_when_changed_within_host`
- `test_resume_skips_propagation_when_events_url_matches`
- `test_resume_skips_propagation_when_events_url_empty`
- `test_resume_skips_propagation_when_cross_host`
- `test_resume_patches_only_matching_steps`
- `test_resume_logs_source_url_change`
- `test_resume_patches_legacy_handler_configs_shape` _(bonus, covers the older flow_config shape still found in production data)_

Uses a new `tests/Unit/Core/Stubs/flowops-resume-stubs.php` that captures `$wpdb->update()` calls and `do_action('datamachine_log', …)` entries so the test can assert both the persisted payload and the structured log stream.

Runs `@runTestsInSeparateProcesses` with `@preserveGlobalState disabled` so it can load the real `FlowOps` class without colliding with the same-namespace fake that `QualifyRecheckHandlerTest` installs.

### Suite result

\`\`\`
$ ./vendor/bin/phpunit --testsuite=qualify-v2-unit
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

...............................................................  63 / 124 ( 50%)
.............................................................   124 / 124 (100%)

Time: 00:00.420, Memory: 6.00 MB

OK (124 tests, 242 assertions)
\`\`\`

`php -l` clean on all three modified files. `phpcs --standard=WordPress inc/Cli/FlowOps.php` shows only pre-existing baseline issues (file-name convention, two interpolated `{\$table}` queries that already existed at line 45 and the new one at line 295 that matches the established codebase pattern).

## Why this matters now

This lands on top of v0.21.0 (the unattended-safe pausing system shipped earlier today in #80). v0.21.0 made auto-resume real; without this fix, every venue URL change becomes a loop that wastes 6 audit cycles before escalating to operator review. Small fix, large maintenance dividend.

## Out of scope

- Auto-detecting venue rebrands across hosts (cross-host case is explicitly punted to operator review).
- Repointing the venue taxonomy term itself if the venue URL changes — the flow's `source_url` is what scraping reads; venue-term URL metadata is a separate concern.
- Redirect chains (`/calendar` 301 → `/events`) — qualify already follows redirects via `wp_remote_get`; `events_url` is redirect-aware so chains are handled implicitly.