### PR TITLE
fix(market-report): detect handler types across both flow schema variants

### DIFF
--- a/inc/Abilities/MarketReportAbilities.php
+++ b/inc/Abilities/MarketReportAbilities.php
@@ -406,7 +406,13 @@ class MarketReportAbilities {
 
 			if ( is_array( $config ) ) {
 				foreach ( $config as $step ) {
+					// Normalize handler slugs across schema variants.
+					// event_import / publish steps use 'handler_slug' (singular string) + 'handler_config'.
+					// upsert steps use 'handler_slugs' (plural array) + 'handler_configs'.
 					$slugs = $step['handler_slugs'] ?? array();
+					if ( ! empty( $step['handler_slug'] ) ) {
+						$slugs[] = (string) $step['handler_slug'];
+					}
 
 					// Determine handler type.
 					if ( in_array( 'universal_web_scraper', $slugs, true ) ) {


### PR DESCRIPTION
## Summary

Market report was reporting `scrapers=0` for every city in the opportunity ranking, breaking venue-coverage planning. Confirmed across 3 consecutive agent ping sessions (S23, S24, S25).

One-line root cause: `getFlowBreakdownByCity()` reads `$step['handler_slugs']` (plural array), but the source steps in every flow actually store `handler_slug` (singular string). The plural form only exists on `upsert` steps. So every flow's source step fell through to `$handler = 'other'`, which then got silently discarded by the `isset($city_data[$key][$handler])` guard.

## Root cause evidence

Schema distribution across all 599 flows on production:

```
variant            cnt
singular_only      598   ← every flow has at least one step with handler_slug
plural             599   ← every flow has at least one step with handler_slugs
has_universal      223
has_ticketmaster   189
has_dice_fm        185
total              599
```

Sample Charleston flow 3 config (truncated):

```json
{
  "...event_import step": {
    "step_type": "event_import",
    "handler_slug": "universal_web_scraper",   // ← singular
    "handler_config": { "source_url": "..." }
  },
  "...upsert step": {
    "step_type": "upsert",
    "handler_slugs": ["upsert_event"],         // ← plural
    "handler_configs": { "upsert_event": {...} }
  }
}
```

## Fix

Normalize both forms before classification:

```php
$slugs = $step['handler_slugs'] ?? array();
if ( ! empty( $step['handler_slug'] ) ) {
    $slugs[] = (string) $step['handler_slug'];
}
```

`upsert_event` keeps coming through the plural path; `universal_web_scraper` / `ticketmaster` / `dice_fm` now come through the singular path. Both work.

## Verification on production data

Before (broken — every city reads 0 scrapers):
```
Austin       5818  events   0 scrapers   opportunity 6088
Charleston   2583  events   0 scrapers   opportunity 3628
Chicago      2720  events   0 scrapers   opportunity 2795
...
```

After (correct — supply gaps now visible):
```
Las Vegas       1760  events   2 scrapers   opportunity 978.3
Atlantic City    258  events   0 scrapers   opportunity 958     ← real supply gap
Long Beach       737  events   0 scrapers   opportunity 792     ← real supply gap
Boston          1379  events   1 scraper    opportunity 742
San Francisco   1257  events   1 scraper    opportunity 718.5
Charlotte        522  events   0 scrapers   opportunity 637     ← real supply gap
Columbus         576  events   0 scrapers   opportunity 636     ← real supply gap
Detroit         1180  events   1 scraper    opportunity 632.5
Seattle         1820  events   2 scrapers   opportunity 625
Tucson           460  events   0 scrapers   opportunity 580     ← real supply gap
```

Charleston correctly drops out of the top-10 because its scrapers (real count) and traffic are healthy — exactly the inverse of opportunity-by-supply-gap, which is what the report is supposed to identify.

## When was the bug introduced

Commit `4795319` ("Fix market report: match flows to locations via term ID, not pipeline name", Mar 28 2026) introduced the handler-classification loop with the plural-only key. So the report has been silently mis-reporting scrapers for ~6 weeks. Opportunity scores were directionally OK (events count and impressions dominated the formula) but the scraper supply-gap multiplier `10 / max(1, scrapers + 1)` always returned 10, flattening the ranking.

## References

- Investigation in agent thread: PROGRESS.md Session 25 "Market-report scraper-count regression PERSISTS for 3rd session"
- Related: `MEMORY.md` already notes this bug as filed but it wasn't — this PR is that file-and-fix in one step

🤖 Filed and fixed by Extra Chill agent (Session 25)