### PR TITLE
refactor: move Turnstile check from submit-event ability to REST permission_callback

### DIFF
--- a/inc/Abilities/EventSubmissionAbilities.php
+++ b/inc/Abilities/EventSubmissionAbilities.php
@@ -3,8 +3,12 @@
  * Event Submission Abilities
  *
  * Handles event submissions from the public form — validates input,
- * verifies Turnstile, stores flyers, and executes via Data Machine
- * ephemeral workflow.
+ * stores flyers, and executes via Data Machine ephemeral workflow.
+ *
+ * Captcha / human-verification (Cloudflare Turnstile) is enforced at
+ * the REST route's permission_callback (see extrachill-api), not here.
+ * This keeps the ability callable from non-REST contexts (CLI, admin
+ * forms, scheduled re-runs) without fabricating a Turnstile token.
  *
  * @package ExtraChillEvents\Abilities
  */
@@ -32,7 +36,7 @@ class EventSubmissionAbilities {
 				'extrachill/submit-event',
 				array(
 					'label'               => __( 'Submit Event', 'extrachill-events' ),
-					'description'         => __( 'Process an event submission from the public form. Validates input, verifies Turnstile, stores flyers, and executes an ephemeral Data Machine workflow.', 'extrachill-events' ),
+					'description'         => __( 'Process an event submission from the public form. Validates input, stores flyers, and executes an ephemeral Data Machine workflow.', 'extrachill-events' ),
 					'category'            => 'extrachill-events',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -78,10 +82,6 @@ class EventSubmissionAbilities {
 								'type'        => 'string',
 								'description' => 'Submitter email. Required for anonymous submissions.',
 							),
-							'turnstile_response' => array(
-								'type'        => 'string',
-								'description' => 'Cloudflare Turnstile verification token.',
-							),
 							'system_prompt'      => array(
 								'type'        => 'string',
 								'description' => 'Custom system prompt for AI processing step. Optional.',
@@ -107,7 +107,7 @@ class EventSubmissionAbilities {
 							'readonly'     => false,
 							'idempotent'   => false,
 							'destructive'  => false,
-							'instructions' => __( 'Public-facing ability. Turnstile verification is enforced unless bypassed. Creates pending events for review.', 'extrachill-events' ),
+							'instructions' => __( 'Public-facing ability. Creates pending events for review. Captcha verification is enforced upstream at the REST route.', 'extrachill-events' ),
 						),
 					),
 				)
@@ -124,24 +124,22 @@ class EventSubmissionAbilities {
 	/**
 	 * Execute event submission.
 	 *
+	 * Captcha verification is the caller's responsibility (the REST route
+	 * enforces Turnstile in its permission_callback). This method only
+	 * validates event fields and runs the workflow.
+	 *
 	 * @param array $input Submission data.
 	 * @return array Result with message and job_id, or error.
 	 */
 	public function executeSubmitEvent( array $input ): array|\WP_Error {
 
-		// 1. Verify Turnstile.
-		$turnstile_result = $this->verifyTurnstile( $input['turnstile_response'] ?? '' );
-		if ( is_wp_error( $turnstile_result ) ) {
-			return $turnstile_result;
-		}
-
-		// 2. Resolve contact info (logged-in user or form fields).
+		// 1. Resolve contact info (logged-in user or form fields).
 		$contact = $this->resolveContact( $input );
 		if ( is_wp_error( $contact ) ) {
 			return $contact;
 		}
 
-		// 3. Validate required event fields.
+		// 2. Validate required event fields.
 		$event_title = sanitize_text_field( $input['event_title'] ?? '' );
 		$event_date  = sanitize_text_field( $input['event_date'] ?? '' );
 
@@ -149,7 +147,7 @@ class EventSubmissionAbilities {
 			return new \WP_Error( 'missing_fields', __( 'Event title and date are required.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
 
-		// 4. Build sanitized submission.
+		// 3. Build sanitized submission.
 		$submission = array(
 			'user_id'       => $contact['user_id'],
 			'contact_name'  => $contact['contact_name'],
@@ -164,36 +162,11 @@ class EventSubmissionAbilities {
 			'notes'         => sanitize_textarea_field( $input['notes'] ?? '' ),
 		);
 
-		// 5. Store flyer if provided.
+		// 4. Store flyer if provided.
 		$flyer = $input['flyer'] ?? null;
 
-		// 6. Execute ephemeral workflow.
+		// 5. Execute ephemeral workflow.
 		return $this->executeDirect( $submission, $flyer, sanitize_textarea_field( $input['system_prompt'] ?? '' ) );
-	}
-
-	/**
-	 * Verify Cloudflare Turnstile response.
-	 *
-	 * @param string $token Turnstile token from frontend.
-	 * @return true|\WP_Error True on success, WP_Error on failure.
-	 */
-	private function verifyTurnstile( string $token ) {
-		$is_local   = defined( 'WP_ENVIRONMENT_TYPE' ) && 'local' === WP_ENVIRONMENT_TYPE;
-		$is_bypass  = $is_local || (bool) apply_filters( 'extrachill_bypass_turnstile_verification', false );
-
-		if ( $is_bypass ) {
-			return true;
-		}
-
-		if ( ! function_exists( 'ec_verify_turnstile_response' ) ) {
-			return new \WP_Error( 'turnstile_unavailable', __( 'Security verification unavailable.', 'extrachill-events' ), array( 'status' => 500 ) );
-		}
-
-		if ( empty( $token ) || ! ec_verify_turnstile_response( $token ) ) {
-			return new \WP_Error( 'turnstile_failed', __( 'Security verification failed. Please try again.', 'extrachill-events' ), array( 'status' => 403 ) );
-		}
-
-		return true;
 	}
 
 	/**

--- a/inc/abilities/events-submit.php
+++ b/inc/abilities/events-submit.php
@@ -2,14 +2,16 @@
 /**
  * Events Submit Ability
  *
- * Public-facing event submission.  Validates input, verifies Turnstile,
- * resolves contact info, and delegates to the existing
- * extrachill/submit-event ability (registered in
- * inc/Abilities/EventSubmissionAbilities.php).
+ * Public-facing event submission. Validates input, resolves contact info,
+ * and delegates to the existing extrachill/submit-event ability
+ * (registered in inc/Abilities/EventSubmissionAbilities.php).
  *
  * This ability is the branded entry-point that matches the
  * POST /event-submissions REST route. The canonical business logic
  * already lives in extrachill/submit-event.
+ *
+ * Captcha / human-verification (Cloudflare Turnstile) is enforced at
+ * the REST route's permission_callback, not inside this ability.
  *
  * @package ExtraChillEvents
  * @since   0.19.0
@@ -30,7 +32,7 @@ function extrachill_events_register_submit_ability(): void {
 		'extrachill/events-submit',
 		array(
 			'label'               => __( 'Submit Event', 'extrachill-events' ),
-			'description'         => __( 'Process a public event submission. Validates input, verifies Turnstile, stores flyer, and queues for review.', 'extrachill-events' ),
+			'description'         => __( 'Process a public event submission. Validates input, stores flyer, and queues for review.', 'extrachill-events' ),
 			'category'            => 'extrachill-events',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -76,10 +78,6 @@ function extrachill_events_register_submit_ability(): void {
 						'type'        => 'string',
 						'description' => 'Submitter email (required for anonymous submissions).',
 					),
-					'turnstile_response' => array(
-						'type'        => 'string',
-						'description' => 'Cloudflare Turnstile verification token.',
-					),
 					'system_prompt'      => array(
 						'type'        => 'string',
 						'description' => 'Custom system prompt for AI processing step.',
@@ -115,7 +113,8 @@ function extrachill_events_register_submit_ability(): void {
  * Execute the events-submit ability.
  *
  * Delegates to the existing extrachill/submit-event ability which
- * owns the canonical Turnstile + DM workflow logic.
+ * owns the canonical DM workflow logic. Captcha verification is
+ * handled upstream at the REST route's permission_callback.
  *
  * @param array $input Submission data matching input_schema.
  * @return array|WP_Error Result with message and job_id, or error.
@@ -131,8 +130,7 @@ function extrachill_events_ability_submit( array $input ): array|\WP_Error {
 	}
 
 	// Pass the full input through — extrachill/submit-event handles
-	// sanitisation, Turnstile verification, contact resolution, and
-	// DM workflow execution.
+	// sanitisation, contact resolution, and DM workflow execution.
 	$result = $ability->execute( $input );
 
 	if ( is_wp_error( $result ) ) {

--- a/tests/Unit/Abilities/EventSubmissionAbilitiesTest.php
+++ b/tests/Unit/Abilities/EventSubmissionAbilitiesTest.php
@@ -4,13 +4,15 @@
  *
  * Integration tests for the event submission ability covering:
  * - Ability registration
- * - Turnstile verification (bypass + enforcement)
  * - Contact resolution (logged-in vs anonymous)
  * - Field validation
  * - Ephemeral workflow execution
  * - Workflow step structure
  * - Notification emails
  * - Action hooks
+ *
+ * Turnstile verification is now enforced at the REST route's
+ * permission_callback, so it is intentionally not covered here.
  *
  * @package ExtraChillEvents\Tests\Unit\Abilities
  */
@@ -35,17 +37,16 @@ class EventSubmissionAbilitiesTest extends WP_UnitTestCase {
 	 * Minimal valid input for an anonymous submission.
 	 */
 	private array $valid_input = array(
-		'event_title'        => 'Flight Lessons A Folk Opera',
-		'event_date'         => '2026-04-17',
-		'event_time'         => '19:00',
-		'venue_name'         => 'Rhythmix Cultural Works',
-		'event_city'         => 'Oakland',
-		'event_lineup'       => 'Kwame Copeland, Deborah Crooks',
-		'event_link'         => 'https://www.rhythmix.org/events/flight-lessons-2026/',
-		'notes'              => 'Doors 6pm. $32 General.',
-		'contact_name'       => 'Deborah',
-		'contact_email'      => 'deborahrcrooks@gmail.com',
-		'turnstile_response' => 'test-token',
+		'event_title'   => 'Flight Lessons A Folk Opera',
+		'event_date'    => '2026-04-17',
+		'event_time'    => '19:00',
+		'venue_name'    => 'Rhythmix Cultural Works',
+		'event_city'    => 'Oakland',
+		'event_lineup'  => 'Kwame Copeland, Deborah Crooks',
+		'event_link'    => 'https://www.rhythmix.org/events/flight-lessons-2026/',
+		'notes'         => 'Doors 6pm. $32 General.',
+		'contact_name'  => 'Deborah',
+		'contact_email' => 'deborahrcrooks@gmail.com',
 	);
 
 	public function set_up(): void {
@@ -56,13 +57,9 @@ class EventSubmissionAbilitiesTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->admin_user_id );
 
 		$this->abilities = new EventSubmissionAbilities();
-
-		// Bypass Turnstile in test environment.
-		add_filter( 'extrachill_bypass_turnstile_verification', '__return_true' );
 	}
 
 	public function tear_down(): void {
-		remove_filter( 'extrachill_bypass_turnstile_verification', '__return_true' );
 		parent::tear_down();
 	}
 
@@ -177,33 +174,6 @@ class EventSubmissionAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'job_id', $result );
 	}
 
-	// ─── Turnstile ─────────────────────────────────────────────────────
-
-	public function test_turnstile_rejection_when_not_bypassed(): void {
-		remove_filter( 'extrachill_bypass_turnstile_verification', '__return_true' );
-
-		$input = $this->valid_input;
-		$input['turnstile_response'] = '';
-
-		$result = $this->abilities->executeSubmitEvent( $input );
-
-		$this->assertWPError( $result );
-		// ec_verify_turnstile_response doesn't exist in test env,
-		// so we get turnstile_unavailable, not turnstile_failed.
-		$this->assertSame( 'turnstile_unavailable', $result->get_error_code() );
-	}
-
-	public function test_turnstile_bypass_allows_submission(): void {
-		// Bypass is already active in set_up().
-		$input = $this->valid_input;
-		$input['turnstile_response'] = '';
-
-		$result = $this->abilities->executeSubmitEvent( $input );
-
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'job_id', $result );
-	}
-
 	// ─── Ephemeral Workflow Execution ──────────────────────────────────
 
 	public function test_submission_creates_job(): void {
@@ -266,11 +236,10 @@ class EventSubmissionAbilitiesTest extends WP_UnitTestCase {
 
 	public function test_minimal_submission_with_only_required_fields(): void {
 		$input = array(
-			'event_title'        => 'Test Show',
-			'event_date'         => '2026-05-01',
-			'contact_name'       => 'Test User',
-			'contact_email'      => 'test@example.com',
-			'turnstile_response' => 'bypass',
+			'event_title'   => 'Test Show',
+			'event_date'    => '2026-05-01',
+			'contact_name'  => 'Test User',
+			'contact_email' => 'test@example.com',
 		);
 
 		$result = $this->abilities->executeSubmitEvent( $input );
@@ -282,11 +251,10 @@ class EventSubmissionAbilitiesTest extends WP_UnitTestCase {
 
 	public function test_submission_without_optional_fields_still_works(): void {
 		$input = array(
-			'event_title'        => 'Solo Gig',
-			'event_date'         => '2026-06-15',
-			'contact_name'       => 'Musician',
-			'contact_email'      => 'musician@example.com',
-			'turnstile_response' => 'bypass',
+			'event_title'   => 'Solo Gig',
+			'event_date'    => '2026-06-15',
+			'contact_name'  => 'Musician',
+			'contact_email' => 'musician@example.com',
 		);
 
 		$hook_data = array();
@@ -377,9 +345,8 @@ class EventSubmissionAbilitiesTest extends WP_UnitTestCase {
 		} );
 
 		$input = array(
-			'event_title'        => 'Member Show',
-			'event_date'         => '2026-07-01',
-			'turnstile_response' => 'bypass',
+			'event_title' => 'Member Show',
+			'event_date'  => '2026-07-01',
 		);
 
 		$this->abilities->executeSubmitEvent( $input );


### PR DESCRIPTION
Closes #84.

## Summary

Drops the Cloudflare Turnstile check from the `extrachill/submit-event` ability and its `extrachill/events-submit` delegator. Captcha enforcement moves up to the REST route's `permission_callback` in the coordinating extrachill-api PR, using `ec_turnstile_permission_callback()` from extrachill-multisite v1.13.0 (already deployed).

## Why

Two concerns were tangled inside the ability:

1. **"Is this a real human?"** — captcha
2. **"Is this a valid event?"** — business logic

The captcha is a human-boundary concern. Keeping it inside the ability meant any future caller (CLI, admin form, scheduled rerun of a failed submission) had to fabricate a Turnstile token. After this PR the ability is purely about validating + queuing an event; the route owns captcha.

## Changes

### `inc/Abilities/EventSubmissionAbilities.php`
- Removed `turnstile_response` from the input schema
- Removed the `verifyTurnstile()` call from `executeSubmitEvent()`
- Deleted the private `verifyTurnstile()` method
- Updated class header and `executeSubmitEvent()` PHPDoc to reflect that captcha lives at the route boundary
- Updated the `instructions` annotation accordingly

### `inc/abilities/events-submit.php` (the branded delegator wrapper)
- Removed `turnstile_response` from the input schema
- Updated description, PHPDoc, and inline comment to drop Turnstile references

### `tests/Unit/Abilities/EventSubmissionAbilitiesTest.php`
- Removed `test_turnstile_rejection_when_not_bypassed` and `test_turnstile_bypass_allows_submission`
- Removed the `extrachill_bypass_turnstile_verification` setup/teardown filter
- Removed `turnstile_response` from all input fixtures
- Updated docblock to note Turnstile is now route-enforced

Net diff: **-112 / +50 lines** across the three files (mostly the method deletion + dead test code).

## Coordinating PR

extrachill-api: https://github.com/Extra-Chill/extrachill-api/pull/47

The two PRs must ship together. The ability stops checking Turnstile; the route starts checking it. Reviewing them as a pair is the only way to see the full picture.

## Error-code drift (cosmetic only)

| Condition | Before (ability) | After (route permission_callback) |
|---|---|---|
| `ec_verify_turnstile_response` unavailable | `turnstile_unavailable` (500) | `turnstile_missing` (500) |
| Empty token | `turnstile_failed` (403) | `turnstile_missing_token` (403) |
| Invalid token | `turnstile_failed` (403) | `turnstile_failed` (403) |

Frontend at `blocks/event-submission/view.js` displays `error.message` verbatim, so the drift is cosmetic. The frontend still POSTs `turnstile_response` in form data — that is what the route's `permission_callback` consumes.

## Smoke test checklist

- [ ] `php -l` clean on all three files (confirmed locally)
- [ ] Submit an event via the public form on events.extrachill.com after both PRs ship — confirm it goes through
- [ ] POST `/wp-json/extrachill/v1/event-submissions` with no `turnstile_response` returns 403
- [ ] Invoke `extrachill/submit-event` ability from WP-CLI with no token and confirm it runs (captcha no longer fabricated)
- [ ] Run the events plugin PHPUnit suite

## Acceptance criteria (from #84)

- [x] `inc/Abilities/EventSubmissionAbilities.php` no longer references `ec_verify_turnstile_response` or `turnstile_response`
- [x] `verifyTurnstile()` method deleted
- [x] Input schema no longer declares `turnstile_response`
- [x] Coordinating extrachill-api PR open

---

cc <@532385681268408341>