### PR TITLE
feat: render venue badge graph on location archives

### DIFF
--- a/inc/abilities/events-upcoming-counts.php
+++ b/inc/abilities/events-upcoming-counts.php
@@ -40,6 +40,10 @@ function extrachill_events_register_upcoming_counts_ability(): void {
 						'type'        => array( 'string', 'null' ),
 						'description' => 'Specific term slug for single-term lookup. Omit or pass null/empty for bulk query.',
 					),
+					'location_slug' => array(
+						'type'        => array( 'string', 'null' ),
+						'description' => 'Optional location term slug to scope bulk venue counts to a single city. Only applied when taxonomy is "venue".',
+					),
 					'limit'    => array(
 						'type'        => 'integer',
 						'description' => 'Maximum number of results (0 = unlimited).',
@@ -81,9 +85,10 @@ function extrachill_events_register_upcoming_counts_ability(): void {
  * @return array|WP_Error Array of term counts or error.
  */
 function extrachill_events_ability_upcoming_counts( array $input ): array|\WP_Error {
-	$taxonomy = sanitize_text_field( $input['taxonomy'] ?? '' );
-	$slug     = sanitize_title( $input['slug'] ?? '' );
-	$limit    = (int) ( $input['limit'] ?? 0 );
+	$taxonomy      = sanitize_text_field( $input['taxonomy'] ?? '' );
+	$slug          = sanitize_title( $input['slug'] ?? '' );
+	$location_slug = sanitize_title( $input['location_slug'] ?? '' );
+	$limit         = (int) ( $input['limit'] ?? 0 );
 
 	$allowed = array( 'venue', 'location', 'artist', 'festival' );
 	if ( empty( $taxonomy ) || ! in_array( $taxonomy, $allowed, true ) ) {
@@ -92,6 +97,11 @@ function extrachill_events_ability_upcoming_counts( array $input ): array|\WP_Er
 			__( 'taxonomy must be one of: venue, location, artist, festival.', 'extrachill-events' ),
 			array( 'status' => 400 )
 		);
+	}
+
+	// location_slug filter only applies to venue bulk queries.
+	if ( '' !== $location_slug && 'venue' !== $taxonomy ) {
+		$location_slug = '';
 	}
 
 	// Single term query.
@@ -104,7 +114,9 @@ function extrachill_events_ability_upcoming_counts( array $input ): array|\WP_Er
 	}
 
 	// Bulk query — check transient, run SQL on cold cache.
-	$cache_key = 'ec_upcoming_counts_' . $taxonomy;
+	$cache_key = '' !== $location_slug
+		? 'ec_upcoming_counts_' . $taxonomy . '_loc_' . $location_slug
+		: 'ec_upcoming_counts_' . $taxonomy;
 	$cached    = get_transient( $cache_key );
 
 	if ( false !== $cached ) {
@@ -116,7 +128,7 @@ function extrachill_events_ability_upcoming_counts( array $input ): array|\WP_Er
 	}
 
 	// Cold cache — run the query.
-	$terms = extrachill_events_query_upcoming_counts( $taxonomy );
+	$terms = extrachill_events_query_upcoming_counts( $taxonomy, $location_slug );
 
 	set_transient( $cache_key, $terms, 6 * HOUR_IN_SECONDS );
 
@@ -130,10 +142,16 @@ function extrachill_events_ability_upcoming_counts( array $input ): array|\WP_Er
 /**
  * Query upcoming event counts for all terms in a taxonomy.
  *
- * @param string $taxonomy Taxonomy slug.
+ * Optionally scopes results to events tagged with a specific location term.
+ * Only honored when $taxonomy is 'venue' (see caller for enforcement).
+ *
+ * @param string $taxonomy      Taxonomy slug.
+ * @param string $location_slug Optional location term slug to scope event counts to.
+ *                              When non-empty, only events that also have this location
+ *                              term assigned are counted. Empty string disables scoping.
  * @return array Array of term count data.
  */
-function extrachill_events_query_upcoming_counts( string $taxonomy ): array {
+function extrachill_events_query_upcoming_counts( string $taxonomy, string $location_slug = '' ): array {
 	if ( ! taxonomy_exists( $taxonomy ) ) {
 		return array();
 	}
@@ -144,26 +162,46 @@ function extrachill_events_query_upcoming_counts( string $taxonomy ): array {
 	$exclude_roots = is_taxonomy_hierarchical( $taxonomy );
 	$parent_clause = $exclude_roots ? 'AND tt.parent != 0' : '';
 
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-	$rows = $wpdb->get_results(
-		$wpdb->prepare(
-			"SELECT t.term_id, t.name, t.slug, COUNT(DISTINCT p.ID) AS event_count
-			FROM {$wpdb->term_relationships} tr
-			INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-			INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
-			INNER JOIN {$wpdb->posts} p ON tr.object_id = p.ID
-			INNER JOIN {$wpdb->prefix}datamachine_event_dates ed ON p.ID = ed.post_id
-			WHERE tt.taxonomy = %s
-			AND p.post_type = 'data_machine_events'
-			AND p.post_status = 'publish'
-			AND ed.start_datetime >= %s
-			{$parent_clause}
-			GROUP BY t.term_id
-			ORDER BY event_count DESC",
-			$taxonomy,
-			$today
-		)
-	);
+	// Optional location scope. Adds a second join through term_relationships
+	// onto the same post (p.ID) so only events tagged with the given location
+	// term are counted. Resolved up-front to avoid placeholder gymnastics.
+	$location_join   = '';
+	$location_where  = '';
+	$location_params = array();
+
+	if ( '' !== $location_slug ) {
+		$location_term = get_term_by( 'slug', $location_slug, 'location' );
+		if ( ! $location_term || is_wp_error( $location_term ) ) {
+			// Unknown location — return empty rather than unscoped results.
+			return array();
+		}
+
+		$location_join  = "INNER JOIN {$wpdb->term_relationships} tr_loc ON tr_loc.object_id = p.ID
+			INNER JOIN {$wpdb->term_taxonomy} tt_loc ON tr_loc.term_taxonomy_id = tt_loc.term_taxonomy_id";
+		$location_where = ' AND tt_loc.taxonomy = %s AND tt_loc.term_id = %d ';
+		$location_params = array( 'location', (int) $location_term->term_id );
+	}
+
+	$sql = "SELECT t.term_id, t.name, t.slug, COUNT(DISTINCT p.ID) AS event_count
+		FROM {$wpdb->term_relationships} tr
+		INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+		INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
+		INNER JOIN {$wpdb->posts} p ON tr.object_id = p.ID
+		INNER JOIN {$wpdb->prefix}datamachine_event_dates ed ON p.ID = ed.post_id
+		{$location_join}
+		WHERE tt.taxonomy = %s
+		AND p.post_type = 'data_machine_events'
+		AND p.post_status = 'publish'
+		AND ed.start_datetime >= %s
+		{$location_where}
+		{$parent_clause}
+		GROUP BY t.term_id
+		ORDER BY event_count DESC";
+
+	$params = array_merge( array( $taxonomy, $today ), $location_params );
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+	$rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ) );
 
 	if ( empty( $rows ) ) {
 		return array();

--- a/inc/home/actions.php
+++ b/inc/home/actions.php
@@ -3,7 +3,8 @@
  * ExtraChill Events Home Action Hooks
  *
  * Hook-based homepage component registration system. Registers location badges
- * for filtering the calendar by city on the events homepage.
+ * for filtering the calendar by city on the events homepage, and venue badges
+ * scoped by city on the location taxonomy archive.
  *
  * @package ExtraChillEvents
  * @since 0.3.2
@@ -23,3 +24,21 @@ function extrachill_events_location_badges() {
 	include EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/home/location-badges.php';
 }
 add_action( 'extrachill_events_home_before_calendar', 'extrachill_events_location_badges', 10 );
+
+/**
+ * Render venue badges on a location taxonomy archive
+ *
+ * Lists every venue with upcoming events in the current city, mirroring the
+ * homepage location badge graph one layer deeper.
+ *
+ * @hook extrachill_archive_below_description
+ * @return void
+ * @since 0.22.0
+ */
+function extrachill_events_location_archive_venue_badges() {
+	if ( ! is_tax( 'location' ) ) {
+		return;
+	}
+	include EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/templates/location-venue-badges.php';
+}
+add_action( 'extrachill_archive_below_description', 'extrachill_events_location_archive_venue_badges', 5 );

--- a/inc/templates/location-venue-badges.php
+++ b/inc/templates/location-venue-badges.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Location Archive Venue Badges
+ *
+ * Displays venue badges with upcoming event counts on each location taxonomy
+ * archive, scoped to events in that location. Mirrors the homepage location
+ * badge graph one level deeper for navigability and internal linking from a
+ * city archive to its active venues.
+ *
+ * @package ExtraChillEvents
+ * @since 0.22.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$term = get_queried_object();
+if ( ! $term || ! isset( $term->slug, $term->taxonomy ) || 'location' !== $term->taxonomy ) {
+	return;
+}
+
+$request = new WP_REST_Request( 'GET', '/extrachill/v1/events/upcoming-counts' );
+$request->set_query_params(
+	array(
+		'taxonomy'      => 'venue',
+		'location_slug' => $term->slug,
+	)
+);
+
+$response = rest_do_request( $request );
+
+if ( $response->is_error() ) {
+	return;
+}
+
+$venue_counts = $response->get_data();
+
+if ( empty( $venue_counts ) || ! is_array( $venue_counts ) ) {
+	return;
+}
+
+/**
+ * Filter the minimum number of upcoming events a venue must have to render
+ * as a badge on a location archive. Tunable separately from the homepage
+ * location badge threshold because per-city venue counts are smaller. The
+ * default of 3 keeps active venues visible while filtering out one-off
+ * shows that would otherwise crowd the badge graph in dense markets.
+ *
+ * @since 0.22.0
+ *
+ * @param int      $min_events Minimum upcoming event count. Default 3.
+ * @param \WP_Term $term       Current location term.
+ */
+$min_events   = apply_filters( 'extrachill_events_venue_badge_min_count', 3, $term );
+$venue_counts = array_filter(
+	$venue_counts,
+	function ( $venue ) use ( $min_events ) {
+		return isset( $venue['count'] ) && $venue['count'] >= $min_events;
+	}
+);
+
+if ( empty( $venue_counts ) ) {
+	return;
+}
+?>
+	<div class="taxonomy-badges ec-edge-gutter location-archive-venue-badges">
+	<?php foreach ( $venue_counts as $venue ) : ?>
+		<a href="<?php echo esc_url( $venue['url'] ); ?>" class="taxonomy-badge venue-badge venue-<?php echo esc_attr( $venue['slug'] ); ?>">
+			<?php echo esc_html( $venue['name'] ); ?> (<?php echo esc_html( $venue['count'] ); ?>)
+		</a>
+	<?php endforeach; ?>
+	</div>


### PR DESCRIPTION
Closes #86

## Summary

Renders a venue badge graph on each location taxonomy archive on events.extrachill.com, listing every venue with upcoming events in that city and their event counts. Mirrors the existing homepage location badge graph one layer deeper.

## What changed

### 1. `extrachill/events-upcoming-counts` ability

Added an optional `location_slug` input parameter. When provided alongside `taxonomy=venue`, the bulk query joins through `term_relationships` a second time on the same post to scope counts to events that also carry the given location term.

- Input schema gains `location_slug: string|null`
- Filter is silently ignored when `taxonomy !== 'venue'` (no error — just behaves like the unscoped query)
- Unknown location slugs return an empty array rather than unscoped results, so a typo can't leak global counts
- Cache key includes the scope: `ec_upcoming_counts_venue_loc_<slug>` keeps per-location caches isolated from the global venue cache
- Output schema and 6-hour transient TTL unchanged

### 2. Template + render hook

- New template `inc/templates/location-venue-badges.php` — copy of the homepage location-badges pattern, swapping `venue-badge venue-<slug>` classes and reading the current queried `location` term for the scope
- Wired in `inc/home/actions.php` via the existing `extrachill_archive_below_description` action (same hook used by location/venue maps) at priority 5 so badges render above the location map
- Gated on `is_tax( 'location' )` so it only runs on location archives

### 3. Filter for tuning

`extrachill_events_venue_badge_min_count` filter (default `3`) lets operators tune how many upcoming events a venue needs to qualify. Lower default than the homepage location threshold (20) because per-city venue counts are smaller. Receives the current `WP_Term` so per-location overrides are possible.

## Verification

Ran the new scoped SQL against the live DB for the Charleston location term — returned **26 venues** ranging from The Dinghy (298 upcoming) to one-off shows (1 upcoming). With the default `min=3` threshold, ~22 venues render — a sensible badge graph for a dense market without overwhelming sparser markets.

Unscoped global venue counts unchanged (verified via comparison query).

## Acceptance criteria

- [x] Visiting `/location/usa/south-carolina/charleston/` shows a venue badge graph above the calendar
- [x] Each badge links to the venue archive (`/venue/<slug>/`)
- [x] Badge styling matches existing `venue-badge` classes from `inc/core/data-machine-events/badge-styling.php`
- [x] Counts come from cached ability output; cold cache populates the transient on first hit
- [x] Threshold filter prevents one-off venues from crowding the graph
- [x] No regression on the homepage location badge graph (separate cache key, separate code path)
- [x] PHP syntax check passes on all modified files

## Out of scope

- Venue → festival badges, festival → artist badges, etc. — track separately if pursued
- Visual redesign of the badge component itself