### PR TITLE
feat: honor priority venue system in location archive badge ordering

### DIFF
--- a/inc/templates/location-venue-badges.php
+++ b/inc/templates/location-venue-badges.php
@@ -63,10 +63,46 @@ $venue_counts = array_filter(
 if ( empty( $venue_counts ) ) {
 	return;
 }
+
+// Re-key as a list after filtering for predictable iteration.
+$venue_counts = array_values( $venue_counts );
+
+// Honor the priority-venue system: bubble priority venues to the front of
+// the badge graph while preserving count-descending order within each tier.
+// Priority venues are an editorial signal — venues we want surfaced regardless
+// of raw upcoming-event volume. The calendar applies the same priority signal
+// to event ordering via ec_events_reorder_by_priority(); badges should match.
+$priority_venue_ids = function_exists( 'ec_get_priority_venue_ids' )
+	? ec_get_priority_venue_ids()
+	: array();
+
+if ( ! empty( $priority_venue_ids ) ) {
+	usort(
+		$venue_counts,
+		function ( $a, $b ) use ( $priority_venue_ids ) {
+			$a_priority = in_array( (int) ( $a['term_id'] ?? 0 ), $priority_venue_ids, true );
+			$b_priority = in_array( (int) ( $b['term_id'] ?? 0 ), $priority_venue_ids, true );
+
+			if ( $a_priority !== $b_priority ) {
+				return $a_priority ? -1 : 1;
+			}
+
+			// Same tier — preserve count-descending order from the ability.
+			$a_count = (int) ( $a['count'] ?? 0 );
+			$b_count = (int) ( $b['count'] ?? 0 );
+
+			return $b_count <=> $a_count;
+		}
+	);
+}
 ?>
 	<div class="taxonomy-badges ec-edge-gutter location-archive-venue-badges">
-	<?php foreach ( $venue_counts as $venue ) : ?>
-		<a href="<?php echo esc_url( $venue['url'] ); ?>" class="taxonomy-badge venue-badge venue-<?php echo esc_attr( $venue['slug'] ); ?>">
+	<?php
+	foreach ( $venue_counts as $venue ) :
+		$is_priority    = ! empty( $priority_venue_ids ) && in_array( (int) ( $venue['term_id'] ?? 0 ), $priority_venue_ids, true );
+		$priority_class = $is_priority ? ' venue-badge-priority' : '';
+		?>
+		<a href="<?php echo esc_url( $venue['url'] ); ?>" class="taxonomy-badge venue-badge venue-<?php echo esc_attr( $venue['slug'] ); ?><?php echo esc_attr( $priority_class ); ?>">
 			<?php echo esc_html( $venue['name'] ); ?> (<?php echo esc_html( $venue['count'] ); ?>)
 		</a>
 	<?php endforeach; ?>


### PR DESCRIPTION
## Summary

Reorders the location archive venue badge graph so priority venues bubble to the top, matching the editorial signal the calendar already honors via `ec_events_reorder_by_priority()`. Without this, the badges sorted purely by raw upcoming-event count and ignored the editorial elevation of venues like Charleston Pour House and The Royal American.

## Behavior

Two-tier sort, count-descending within each tier:

1. **Priority venues** (`_ec_priority_venue` term meta = true), highest count first
2. **All other venues**, highest count first

Counts and labels unchanged — only ordering shifts. Priority venues also get a `venue-badge-priority` CSS class for optional styling.

## Verification

Charleston archive ordering — before this PR (by raw count):

```
298  The Dinghy
156  The Starlight Motor Inn
 96  Charleston Tin Roof
 82  Charleston Pour House       *priority*
 52  The Bounty Bar
 44  Charleston Music Hall
 41  Commonhouse Aleworks
 38  The Royal American          *priority*
 38  Slightly North of Broad
 ...
 29  Music Farm                  *priority*
 ...
 18  The Refinery                *priority*
 ...
  3  Lo-Fi Brewing               *priority*
```

After this PR:

```
 82  Charleston Pour House       *priority*
 38  The Royal American          *priority*
 29  Music Farm                  *priority*
 18  The Refinery                *priority*
  3  Lo-Fi Brewing               *priority*
298  The Dinghy
156  The Starlight Motor Inn
 96  Charleston Tin Roof
 52  The Bounty Bar
 ...
```

All 5 Charleston priority venues surface first, then the rest by count.

## Why this matters

The priority-venue system is a deliberate editorial mechanism — it captures which venues are part of the Extra Chill scene rather than just which venues happen to have the most data. The calendar respects it; the badges should too.

## Out of scope

- Styling rules for `.venue-badge-priority` (left to theme CSS — class is exposed, visuals are a separate concern)
- Surfacing priority venues with no upcoming events (intentional — empty calendars shouldn't appear in the badge graph)

## Related

- #86 (parent issue)
- #88 (initial venue badge feature)