### PR TITLE
fix(qualify): Ticketmaster precheck distinguishes LN-owned pages from promoter aggregators that link to TM

### DIFF
--- a/inc/Abilities/VenueQualificationAbilities.php
+++ b/inc/Abilities/VenueQualificationAbilities.php
@@ -50,18 +50,42 @@ class VenueQualificationAbilities {
 	);
 
 	/**
-	 * Patterns indicating Ticketmaster / Live Nation venue.
+	 * Hostnames that indicate a Ticketmaster / Live Nation OWNED page.
 	 *
-	 * If ANY of these are found in the homepage HTML (or a redirect lands on
-	 * one of these domains), the venue is disqualified because it is already
-	 * covered by the dedicated Ticketmaster pipeline flow.
+	 * A page is "TM/LN-owned" when its (final, post-redirect) URL host is
+	 * one of these or a subdomain thereof. Substring-matching the page body
+	 * for these hostnames is NOT sufficient — promoter aggregator sites
+	 * (Bowery Presents, AEG Presents, etc.) legitimately link out to TM as
+	 * a ticket vendor on a per-show basis without being TM properties.
+	 *
+	 * Compare host with `str_contains(strtolower($host), $pattern)` so
+	 * subdomains (`concerts.livenation.com`, `m.livenation.com`,
+	 * `www1.ticketmaster.com`, country variants like `livenation.de`) all
+	 * match the base brand string.
 	 *
 	 * NOTE: AEG/AXS venues are NOT disqualified — we have a dedicated
 	 * AegAxsExtractor that scrapes their structured JSON feeds.
+	 *
+	 * @var array<int,string>
 	 */
-	private const TICKETMASTER_PATTERNS = array(
+	public const TICKETMASTER_HOSTS = array(
 		'ticketmaster.com',
+		'ticketmaster.ca',
+		'ticketmaster.co.uk',
+		'ticketmaster.de',
+		'ticketmaster.fr',
+		'ticketmaster.es',
+		'ticketmaster.it',
+		'ticketmaster.com.au',
+		'ticketmaster.com.mx',
 		'livenation.com',
+		'livenation.ca',
+		'livenation.co.uk',
+		'livenation.de',
+		'livenation.fr',
+		'livenation.com.au',
+		'livenation.it',
+		'livenation.es',
 	);
 
 	/**
@@ -404,101 +428,293 @@ class VenueQualificationAbilities {
 	/**
 	 * Check whether a venue URL belongs to Ticketmaster or Live Nation.
 	 *
-	 * Fetches the homepage and inspects both the final URL (after redirects)
-	 * and the HTML body for known TM/LN patterns. If any pattern matches,
-	 * the venue is disqualified because it is already covered by the dedicated
-	 * Ticketmaster pipeline flow.
+	 * Fetches the page (following redirects) and delegates classification to
+	 * {@see self::analyzeForTicketmasterMarkers()}, which inspects the FINAL
+	 * (post-redirect) URL host and STRUCTURAL ownership markers in the HTML
+	 * — never substring-matching outbound buy-ticket links.
+	 *
+	 * Rationale: promoter aggregator sites (Bowery Presents, AEG Presents,
+	 * etc.) legitimately link to ticketmaster.com per-event as a ticket
+	 * vendor. Those outbound links are pricing data, not ownership signals,
+	 * and must not disqualify the site. See extrachill-events#90.
 	 *
 	 * @param string $url Venue homepage URL.
-	 * @return array { disqualified: bool, reason: string, matched: string }
+	 * @return array{disqualified:bool,reason:string,matched:string}
 	 */
 	private function checkTicketmasterVenue( string $url ): array {
 		$not_tm = array( 'disqualified' => false, 'reason' => '', 'matched' => '' );
 
-		// Quick domain-level check before even fetching.
-		$host = strtolower( wp_parse_url( $url, PHP_URL_HOST ) ?? '' );
-		foreach ( self::TICKETMASTER_PATTERNS as $pattern ) {
-			if ( str_contains( $host, $pattern ) ) {
-				return array(
-					'disqualified' => true,
-					'reason'       => 'Venue uses Ticketmaster/Live Nation — already covered by TM pipeline flow',
-					'matched'      => $pattern . ' (in URL host)',
-				);
-			}
+		// Quick host check on the INPUT URL before fetching. Catches the
+		// trivial case where someone hands us a ticketmaster.com URL outright.
+		$pre_fetch = self::analyzeForTicketmasterMarkers( $url, '' );
+		if ( $pre_fetch['disqualified'] ) {
+			return array(
+				'disqualified' => true,
+				'reason'       => 'Venue uses Ticketmaster/Live Nation — already covered by TM pipeline flow',
+				'matched'      => $pre_fetch['matched'],
+			);
 		}
 
-		// Fetch the page, following redirects, so we can inspect the final URL
-		// and the HTML body.
-		$response = wp_remote_get( $url, array(
-			'timeout'     => 10,
-			'redirection' => 5,
-			'user-agent'  => 'Mozilla/5.0 (compatible; ExtraChillBot/1.0; +https://extrachill.com)',
-			'headers'     => array( 'Accept' => 'text/html' ),
-		) );
+		// Fetch the page, following redirects, so we can inspect the final
+		// URL and the HTML body.
+		$response = wp_remote_get(
+			$url,
+			array(
+				'timeout'     => 10,
+				'redirection' => 5,
+				'user-agent'  => 'Mozilla/5.0 (compatible; ExtraChillBot/1.0; +https://extrachill.com)',
+				'headers'     => array( 'Accept' => 'text/html' ),
+			)
+		);
 
 		if ( is_wp_error( $response ) ) {
 			return $not_tm;
 		}
 
-		// Check if redirect landed on a TM/LN domain.
-		$final_url  = wp_remote_retrieve_header( $response, 'x-redirect-by' );
-		$response_url = $response['http_response']->get_response_object()->url ?? '';
-		$urls_to_check = array_filter( array( $final_url, $response_url ) );
+		// Resolve the final URL after the redirect chain. WP exposes it on
+		// the Requests response object hung off the wp_remote_get result.
+		$final_url = $url;
+		if ( isset( $response['http_response'] ) && is_object( $response['http_response'] )
+			&& method_exists( $response['http_response'], 'get_response_object' ) ) {
+			$resp_obj = $response['http_response']->get_response_object();
+			if ( isset( $resp_obj->url ) && is_string( $resp_obj->url ) && '' !== $resp_obj->url ) {
+				$final_url = $resp_obj->url;
+			}
+		}
 
-		foreach ( $urls_to_check as $check_url ) {
-			$check_host = strtolower( wp_parse_url( $check_url, PHP_URL_HOST ) ?? '' );
-			foreach ( self::TICKETMASTER_PATTERNS as $pattern ) {
-				if ( str_contains( $check_host, $pattern ) ) {
+		$html = (string) wp_remote_retrieve_body( $response );
+
+		$analysis = self::analyzeForTicketmasterMarkers( $final_url, $html );
+		if ( $analysis['disqualified'] ) {
+			return array(
+				'disqualified' => true,
+				'reason'       => 'Venue uses Ticketmaster/Live Nation — already covered by TM pipeline flow',
+				'matched'      => $analysis['matched'],
+			);
+		}
+
+		return $not_tm;
+	}
+
+	/**
+	 * Pure classifier: does this (final URL, HTML body) pair indicate a
+	 * Ticketmaster/Live Nation-OWNED page?
+	 *
+	 * Distinguishes LN-owned venue pages (which the dedicated TM pipeline
+	 * flow already covers) from promoter aggregator pages that merely LINK
+	 * to TM as a ticket vendor (which should continue through extraction).
+	 *
+	 * Signals checked, in order of decisiveness:
+	 *   1. Final URL host is on {@see self::TICKETMASTER_HOSTS}.
+	 *   2. `<link rel="canonical" href="…">` points to a TM/LN host.
+	 *   3. `<meta property="og:site_name" content="Ticketmaster">` (or
+	 *       "Live Nation"), or `<meta name="application-name" …>` with the
+	 *       same brand value. Must be the SITE_NAME, not arbitrary content.
+	 *   4. JSON-LD `Organization` block whose `@id`/`url`/`sameAs` field
+	 *       targets a TM/LN host.
+	 *   5. Live Nation SDK / tag-manager bootstrap in `<head>` —
+	 *       `window.TMP = …` or `window.LN = …` initialisers. These only
+	 *       ship on LN-controlled pages.
+	 *
+	 * Outbound `<a href="https://www.ticketmaster.com/event/…">` buy links
+	 * are deliberately NOT a disqualifier — they are normal commerce data.
+	 *
+	 * @param string $final_url Final URL after redirects (or the input URL
+	 *                          when called pre-fetch with an empty body).
+	 * @param string $html      Page HTML. May be empty for host-only checks.
+	 * @return array{disqualified:bool,matched:string}
+	 */
+	public static function analyzeForTicketmasterMarkers( string $final_url, string $html ): array {
+		$not_tm = array( 'disqualified' => false, 'matched' => '' );
+
+		// ---- 1. Final URL host check. ----
+		$host = strtolower( (string) ( wp_parse_url( $final_url, PHP_URL_HOST ) ?? '' ) );
+		if ( '' !== $host ) {
+			$matched_host = self::hostMatchesTicketmaster( $host );
+			if ( '' !== $matched_host ) {
+				return array(
+					'disqualified' => true,
+					'matched'      => 'final URL host: ' . $matched_host,
+				);
+			}
+		}
+
+		if ( '' === $html ) {
+			return $not_tm;
+		}
+
+		// ---- 2. <link rel="canonical" href="…"> pointing to TM/LN. ----
+		// Accept either attribute order (rel-first or href-first) by running
+		// both patterns through a single matcher.
+		$canonical_patterns = array(
+			'#<link\s[^>]*rel=["\']canonical["\'][^>]*href=["\']([^"\']+)["\']#i',
+			'#<link\s[^>]*href=["\']([^"\']+)["\'][^>]*rel=["\']canonical["\']#i',
+		);
+		foreach ( $canonical_patterns as $pattern ) {
+			if ( ! preg_match( $pattern, $html, $m ) ) {
+				continue;
+			}
+			$canonical_host  = strtolower( (string) ( wp_parse_url( $m[1], PHP_URL_HOST ) ?? '' ) );
+			$matched_pattern = self::hostMatchesTicketmaster( $canonical_host );
+			if ( '' !== $matched_pattern ) {
+				return array(
+					'disqualified' => true,
+					'matched'      => 'canonical link to ' . $matched_pattern,
+				);
+			}
+		}
+
+		// ---- 3. <meta property="og:site_name" / name="application-name"> ----
+		// with a literal TM/LN brand value. The CONTENT must be the brand,
+		// not just a page title mentioning the brand. Accept either attribute
+		// order (rel/name-first or content-first).
+		$brand_re   = '(?:Ticketmaster|Live\s*Nation)';
+		$brand_attr = '(?:property|name)=["\'](?:og:site_name|application-name)["\']';
+		$meta_patterns = array(
+			'#<meta\s[^>]*' . $brand_attr . '[^>]*content=["\']\s*' . $brand_re . '\s*["\']#i',
+			'#<meta\s[^>]*content=["\']\s*' . $brand_re . '\s*["\'][^>]*' . $brand_attr . '#i',
+		);
+		foreach ( $meta_patterns as $pattern ) {
+			if ( preg_match( $pattern, $html ) ) {
+				return array(
+					'disqualified' => true,
+					'matched'      => 'meta site_name brand tag',
+				);
+			}
+		}
+
+		// ---- 4. JSON-LD Organization with @id/url/sameAs on TM/LN host. ----
+		if ( preg_match_all(
+			'#<script\s[^>]*type=["\']application/ld\+json["\'][^>]*>(.*?)</script>#is',
+			$html,
+			$blocks
+		) ) {
+			foreach ( $blocks[1] as $block ) {
+				$decoded = json_decode( trim( $block ), true );
+				if ( null === $decoded ) {
+					continue;
+				}
+				$marker = self::scanJsonLdForLnOrganization( $decoded );
+				if ( '' !== $marker ) {
 					return array(
 						'disqualified' => true,
-						'reason'       => 'Venue uses Ticketmaster/Live Nation — already covered by TM pipeline flow',
-						'matched'      => $pattern . ' (redirect destination)',
+						'matched'      => 'JSON-LD Organization on ' . $marker,
 					);
 				}
 			}
 		}
 
-		// Inspect the HTML body.
-		$html = strtolower( wp_remote_retrieve_body( $response ) );
-		if ( empty( $html ) ) {
-			return $not_tm;
+		// ---- 5. Inline LN SDK bootstrap in <head>. ----
+		// Scope to head to avoid false positives from third-party content
+		// (analytics scripts referenced via src=, comments, etc.).
+		$head = '';
+		if ( preg_match( '#<head\b[^>]*>(.*?)</head>#is', $html, $m ) ) {
+			$head = $m[1];
 		}
-
-		foreach ( self::TICKETMASTER_PATTERNS as $pattern ) {
-			if ( str_contains( $html, strtolower( $pattern ) ) ) {
+		if ( '' !== $head ) {
+			if ( preg_match( '#window\.TMP\s*=#', $head )
+				|| preg_match( '#window\.LN\s*=#', $head )
+				|| preg_match( '#window\.LiveNation\s*=#i', $head ) ) {
 				return array(
 					'disqualified' => true,
-					'reason'       => 'Venue uses Ticketmaster/Live Nation — already covered by TM pipeline flow',
-					'matched'      => $pattern . ' (in page HTML)',
+					'matched'      => 'LN SDK bootstrap in <head>',
 				);
 			}
-		}
-
-		// Extra checks: TM iframes and event/venue links.
-		$tm_link_patterns = array(
-			'ticketmaster.com/event/',
-			'ticketmaster.com/venue/',
-		);
-		foreach ( $tm_link_patterns as $link_pattern ) {
-			if ( str_contains( $html, $link_pattern ) ) {
-				return array(
-					'disqualified' => true,
-					'reason'       => 'Venue uses Ticketmaster/Live Nation — already covered by TM pipeline flow',
-					'matched'      => $link_pattern . ' (link in HTML)',
-				);
-			}
-		}
-
-		// Check for TM embedded widgets (iframes with ticketmaster.com in src).
-		if ( preg_match( '/<iframe[^>]+src=["\'][^"\']*ticketmaster\.com[^"\']*["\'][^>]*>/i', wp_remote_retrieve_body( $response ) ) ) {
-			return array(
-				'disqualified' => true,
-				'reason'       => 'Venue uses Ticketmaster/Live Nation — already covered by TM pipeline flow',
-				'matched'      => 'ticketmaster.com iframe widget',
-			);
 		}
 
 		return $not_tm;
+	}
+
+	/**
+	 * Return the matching TM/LN host pattern for a hostname, or '' if none.
+	 *
+	 * Matches when the host equals the pattern or ends with `.$pattern` so
+	 * subdomains (`concerts.livenation.com`, `www.ticketmaster.com`) all
+	 * resolve to their brand base.
+	 *
+	 * @param string $host Lowercase hostname.
+	 * @return string Matching pattern or empty string.
+	 */
+	private static function hostMatchesTicketmaster( string $host ): string {
+		if ( '' === $host ) {
+			return '';
+		}
+		foreach ( self::TICKETMASTER_HOSTS as $pattern ) {
+			if ( $host === $pattern || str_ends_with( $host, '.' . $pattern ) ) {
+				return $pattern;
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Walk a decoded JSON-LD structure looking for an Organization node
+	 * whose `@id`/`url`/`sameAs` field points to a TM/LN host. Returns the
+	 * matching host pattern, or '' if none.
+	 *
+	 * Handles top-level objects, `@graph` arrays, and arrays of nodes.
+	 *
+	 * @param mixed $node Decoded JSON-LD fragment.
+	 * @return string
+	 */
+	private static function scanJsonLdForLnOrganization( $node ): string {
+		if ( is_array( $node ) ) {
+			// Sequential array of nodes — recurse into each.
+			if ( array_keys( $node ) === range( 0, count( $node ) - 1 ) ) {
+				foreach ( $node as $child ) {
+					$hit = self::scanJsonLdForLnOrganization( $child );
+					if ( '' !== $hit ) {
+						return $hit;
+					}
+				}
+				return '';
+			}
+
+			// Associative — could be a node OR a wrapper with @graph.
+			if ( isset( $node['@graph'] ) ) {
+				$hit = self::scanJsonLdForLnOrganization( $node['@graph'] );
+				if ( '' !== $hit ) {
+					return $hit;
+				}
+			}
+
+			$type = $node['@type'] ?? '';
+			$types = is_array( $type ) ? $type : array( $type );
+			$is_org = false;
+			foreach ( $types as $t ) {
+				if ( is_string( $t ) && 'organization' === strtolower( $t ) ) {
+					$is_org = true;
+					break;
+				}
+			}
+
+			if ( $is_org ) {
+				$candidates = array();
+				foreach ( array( '@id', 'url' ) as $key ) {
+					if ( isset( $node[ $key ] ) && is_string( $node[ $key ] ) ) {
+						$candidates[] = $node[ $key ];
+					}
+				}
+				if ( isset( $node['sameAs'] ) ) {
+					$same_as = is_array( $node['sameAs'] ) ? $node['sameAs'] : array( $node['sameAs'] );
+					foreach ( $same_as as $s ) {
+						if ( is_string( $s ) ) {
+							$candidates[] = $s;
+						}
+					}
+				}
+
+				foreach ( $candidates as $candidate ) {
+					$cand_host = strtolower( (string) ( wp_parse_url( $candidate, PHP_URL_HOST ) ?? '' ) );
+					$matched   = self::hostMatchesTicketmaster( $cand_host );
+					if ( '' !== $matched ) {
+						return $matched;
+					}
+				}
+			}
+		}
+
+		return '';
 	}
 
 	/**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
 		-->
 		<testsuite name="qualify-v2-unit">
 			<directory>tests/Unit/Core</directory>
+			<file>tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/Fixtures/bowery-presents-shows.html
+++ b/tests/Fixtures/bowery-presents-shows.html
@@ -1,0 +1,1987 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+<meta http-equiv="X-UA-Compatible" content="ie=edge">
+
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-PWK3ZXC');</script>
+<!-- End Google Tag Manager -->
+
+<meta name="description" content="Live Music - The Bowery Presents"/>
+        <meta name="keywords" content="Bowery Presents, Bowery, bowerypresents"/>
+<title>
+                                        Shows - The Bowery Presents
+                            </title>
+<!-- Start Universal Pixel Snippet -->
+<script>
+    !function (e, t, n, a, i, l, o, s, r) {
+        e[i] || (o = e[i] = function () {
+            o.process ? o.process.apply(o, arguments) : o.queue.push(arguments)
+        }, o.queue = [], o.t = 1 * new Date, s = t.createElement(n), s.async = 1, s.src = a + "?t=" + Math.ceil(new Date / l) * l, r = t.getElementsByTagName(n)[0], r.parentNode.insertBefore(s, r))
+    }(window, document, "script", "//tracking.aegpresents.com/universalpixel/universalpixel.js", "kl", 864e5), kl("event", "pageload");
+</script>
+<!-- End Universal Pixel Snippet -->
+<!--[if lt IE 9]>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
+<![endif]-->
+<link href="https://newsletter.apps.aegpresents.com/aeg-mc-newsletter.css" rel="stylesheet" type="text/css">
+<link rel="stylesheet" href="/bundlesFront/main.css">
+<link rel="shortcut icon" href="/assets/img/favicon.png" type="image/png"/>
+<link rel="shortcut icon" href="/assets/img/favicon.ico" type="image/x-icon"/>
+
+<!-- OneTrust Cookies Consent Notice start for bowerypresents.com -->
+<script type="text/javascript" src="https://cdn.cookielaw.org/consent/dbf698bc-a4c7-4468-ad9a-9c224101ebc1/OtAutoBlock.js" ></script>
+<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" type="text/javascript" charset="UTF-8" data-domain-script="dbf698bc-a4c7-4468-ad9a-9c224101ebc1" ></script>
+<script type="text/javascript">
+function OptanonWrapper() { }
+</script>
+<!-- OneTrust Cookies Consent Notice end for bowerypresents.com -->    <script>
+        let baseURL = "https://www.bowerypresents.com/";
+        let currentSection = "all";
+        let showMorePage = 1;
+    </script>
+    <script src="/bundlesFront/helpers.js"></script>
+    <script src="/bundlesFront/promise.min.js"></script>
+
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBk99CzXCDnRMYqTI8Scn0oGR6CEIw2i6w"></script>
+</head>
+
+<body>
+	<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PWK3ZXC"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) --><div class="shows">
+    <div class="loader-page">
+    <div class="logo-wrapper">
+        <img src="assets/img/logo.png">
+        <div class="loader  ">
+	<span></span>
+	<span></span>
+</div>
+    </div>
+</div>
+<script>
+    checkUserAgent(document.querySelector('.loader-page').remove());
+</script>
+    <script src="/bundlesFront/header.js"></script>
+<script src="/bundlesFront/closest.js"></script>
+<script>
+    var slugVenue = "";
+    var selectedRegion = "";
+    var detailVenueSlug = "";
+</script>
+
+<div data-component="header">
+    <div class="header-container">
+        <div class="row small-collapse">
+            <div class="small-12 column">
+                <header>
+                    <a href="/" class="header-logo">
+                        <img src="/assets/img/logo.png" alt="The Bowery Presents">
+                    </a>
+                    <p class="header-location">
+                        <strong>
+                            Shows
+                        </strong>
+                    </p>
+                    <div class="icon-container">
+                        <a href="" class="icon search"></a>
+                        <!-- Search Field -->
+                        <form action="/search/" class="search-form">
+	<label for="search">
+		<input type="text" name="query" id="query" minlength="1" placeholder="Search Artist" required>
+	</label>
+	<a href="" class="icon hamburger close"></a>
+</form>
+                        <!--/ Search Field -->
+                        <a class="icon marker">
+                            <p class="selected-location show-for-large">
+                                <strong>
+                                    Select Region
+                                </strong>
+                            </p>
+                        </a>
+
+
+                        
+<a href="https://www.bowerypresents.com/newsletter/"
+  class="button primary newsletter subscribe"
+        >Subscribe</a>                        <a href="" class="icon hamburger menu"></a>
+                    </div>
+
+                    <!-- Menú -->
+                    <script src="/bundlesFront/nav.js"></script>
+<nav Shows>
+    <ul>
+        <li Shows>
+            <a href="/shows/" class="nav-item">
+                Shows
+            </a>
+
+                    </li>
+        <li Our Venues>
+            <a href="/venues/" class="nav-item">
+                Our Venues
+            </a>
+        </li>
+        <li The House List>
+            <a href="https://thebowerypresents.tumblr.com/" target="_blank" class="nav-item">
+                The House List
+            </a>
+        </li>
+                <li Contact Us>
+            <a href="/contact-us/" class="nav-item">
+                Contact Us
+            </a>
+        </li>
+        <li Calendar>
+            <a href="/calendar/" class="nav-item">
+                Calendar
+            </a>
+        </li>
+            </ul>
+</nav>
+                    <!--/ Menú -->
+                    <!-- Location Dropdown -->
+                    
+<script src="/bundlesFront/location-dropdown.js"></script>
+<script>
+    var indexRoute = "/";
+</script>
+<ul class="location-dropdown">
+    <li>
+        <div class="dropdown-header">
+			<span class="header location">
+				Current Location
+			</span>
+
+        </div>
+    </li>
+
+    <li>
+        <a href="/">
+            <span class="location all-regions">
+                All Regions
+            </span>
+        </a>
+    </li>
+
+
+    
+                    <li>
+                <a href="/new-york-metro/shows/" class="region-link" data-slug="new-york-metro">
+                    <span class="location">
+                        New York Metro
+                    </span>
+                </a>
+            </li>
+            
+                    <li>
+                <a href="/baltimore-dc/shows/" class="region-link" data-slug="baltimore-dc">
+                    <span class="location">
+                        Baltimore/DC
+                    </span>
+                </a>
+            </li>
+            
+                    <li>
+                <a href="/boston/shows/" class="region-link" data-slug="boston">
+                    <span class="location">
+                        Boston
+                    </span>
+                </a>
+            </li>
+            
+                    <li>
+                <a href="/greater-philly/shows/" class="region-link" data-slug="greater-philly">
+                    <span class="location">
+                        Greater Philly
+                    </span>
+                </a>
+            </li>
+            
+                    <li>
+                <a href="/maine/shows/" class="region-link" data-slug="maine">
+                    <span class="location">
+                        Maine
+                    </span>
+                </a>
+            </li>
+            
+                    <li>
+                <a href="/new-jersey/shows/" class="region-link" data-slug="new-jersey">
+                    <span class="location">
+                        New Jersey
+                    </span>
+                </a>
+            </li>
+            
+                    <li>
+                <a href="/upstate-ny/shows/" class="region-link" data-slug="upstate-ny">
+                    <span class="location">
+                        Upstate NY
+                    </span>
+                </a>
+            </li>
+            
+                    <li>
+                <a href="/virginia/shows/" class="region-link" data-slug="virginia">
+                    <span class="location">
+                        Virginia
+                    </span>
+                </a>
+            </li>
+            </ul>
+                    <!--/ Location Dropdown -->
+                    <!-- Subscribe Dropdown -->
+                    <script src="/bundlesFront/subscribe-dropdown.js"></script>
+
+<div class="subscribe-dropdown">
+	<p class="cta-dropdown-text">
+		Join our e-mail list to receive news, show updates and deals for The Bowery Presents.
+	</p>
+	<div class="loader black ">
+	<span></span>
+	<span></span>
+</div>
+	<form action="">
+		<input type="email" placeholder="Your email" class="subscribeFieldDropdown">
+		<input type="text" placeholder="Your Zip Code" class="subscribeFieldZip">
+		
+<a "
+  class="button primary btSuscribeDropdown disabled"
+        >Submit</a>		
+<a "
+  class="button white btCancel"
+        >Cancel</a>	</form>
+</div>
+                    <!--/ Subscribe Dropdown -->
+                </header>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+    <div class="wrapper shows">
+        <div class="content ">
+
+            
+                            <script src="/bundlesFront/fitty.min.js"></script>
+<script src="/bundlesFront/HeroSlider.js"></script>
+
+    <div data-component="hero-slider" class="hero-slider">
+        <div class="slider-container">
+                            <div class="item-bg"
+                     style="background-image: linear-gradient(to bottom, black -15%, transparent 90%),
+                                                                               url(https://images.discovery-prod.axs.com/2026/05/artistree-market-tickets_07-18-26_17_6a078f9141f01.jpg)
+                                                  "></div>
+                <div class="row small-collapse medium-uncollapse large-collapse slider-item" id="380408">
+                    <div class="small-12 medium-7 column">
+                        <div class="hero-poster-wrapper">
+                                                            <div class="show-poster hero-poster">
+						
+							<img src="https://images.discovery-prod.axs.com/2026/05/artistree-market-tickets_07-18-26_17_6a078f9141f01.jpg" class="poster-image-source" />
+			
+		    </div>
+                                                    </div>
+                    </div>
+                    <div class="small-12 medium-5 column">
+                            <div class="show-info hero-info  status-3 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-07-18T15:00:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1449695-artistree-market">
+                            <span itemprop="name">Artistree Market</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="">
+                                
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="Artistree Market" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2026/05/artistree-market-tickets_07-18-26_17_6a078f9141f01.jpg"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="The NorVa"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="The NorVa">The NorVa</strong>,
+                        <span>
+				            Norfolk, VA
+				        </span>
+                        <link itemprop="sameAs" href="http://www.axs.com/venues/101510/the-norva-norfolk-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="Norfolk"/>
+                        <meta itemprop="addressRegion" content="VA"/>
+                        <meta itemprop="postalCode" content="23510"/>
+                        <meta itemprop="streetAddress" content="317 Monticello Avenue, Norfolk, VA 23510"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Sat, July 18, 2026
+                        <span>
+					        | Doors 02:49 AM, Show: 03:00 PM
+				        </span>
+                    </p>
+                </li>
+                
+                                    <li>
+                        <p class="list-disclaimer">
+                            All Ages
+                        </p>
+                    </li>
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Mon, May 18, 2026
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/OutOfStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://www.axs.com/events/1449695/artistree-market-tickets" />
+                
+<a href="https://www.axs.com/events/1449695/artistree-market-tickets"
+  class="button event ticket primary"
+        target="_blank">Free</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="Artistree Market"
+		data-description="All Ages"
+		data-location="317 Monticello Avenue, Norfolk, VA 23510"
+		data-start="2026-07-18T19:00:00Z"
+		data-end="2026-07-18T21:00:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1449695"></a>
+</div>
+
+        </div>
+    
+</div>
+                    </div>
+                </div>
+                            <div class="item-bg"
+                     style="background-image: linear-gradient(to bottom, black -15%, transparent 90%),
+                                                                               url(https://images.discovery-prod.axs.com/2025/12/alison-krauss-union-station-featuring-jerry-douglas-tickets_07-25-26_17_693717151b001.jpg)
+                                                  "></div>
+                <div class="row small-collapse medium-uncollapse large-collapse slider-item" id="373981">
+                    <div class="small-12 medium-7 column">
+                        <div class="hero-poster-wrapper">
+                                                            <div class="show-poster hero-poster">
+						
+							<img src="https://images.discovery-prod.axs.com/2025/12/alison-krauss-union-station-featuring-jerry-douglas-tickets_07-25-26_17_693717151b001.jpg" class="poster-image-source" />
+			
+		    </div>
+                                                    </div>
+                    </div>
+                    <div class="small-12 medium-5 column">
+                            <div class="show-info hero-info  status-1 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-07-25T19:30:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1255625-alison-krauss-union-station-featuring-jerry-douglas">
+                            <span itemprop="name">Alison Krauss &amp; Union Station featuring Jerry Douglas</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="Theo Lawrence">
+                                Theo Lawrence
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="Alison Krauss &amp; Union Station featuring Jerry Douglas" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2025/12/alison-krauss-union-station-featuring-jerry-douglas-tickets_07-25-26_17_693717151b001.jpg"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="CMAC - Constellation Brands-Marvin Sands Performing Arts Center"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="CMAC - Constellation Brands-Marvin Sands Performing Arts Center">CMAC - Constellation Brands-Marvin Sands Performing Arts Center</strong>,
+                        <span>
+				            Rochester, NY
+				        </span>
+                        <link itemprop="sameAs" href="http://www.axs.com/venues/101483/constellation-brands-marvin-sands-performing-arts-center-cmac-rochester-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="Rochester"/>
+                        <meta itemprop="addressRegion" content="NY"/>
+                        <meta itemprop="postalCode" content="14424"/>
+                        <meta itemprop="streetAddress" content="4355 Lakeshore Drive Canandaigua, Rochester, NY 14424"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Sat, July 25, 2026
+                        <span>
+					        | Doors 06:00 PM, Show: 07:30 PM
+				        </span>
+                    </p>
+                </li>
+                
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Fri, December 12, 2025
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/InStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://www.ticketmaster.com/event/00006374B6A9B3EC" />
+                
+<a href="https://www.ticketmaster.com/event/00006374B6A9B3EC"
+  class="button event ticket primary"
+        target="_blank">Buy Tickets</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="Alison Krauss &amp; Union Station featuring Jerry Douglas"
+		data-description=""
+		data-location="4355 Lakeshore Drive Canandaigua, Rochester, NY 14424"
+		data-start="2026-07-25T23:30:00Z"
+		data-end="2026-07-26T01:30:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1255625"></a>
+</div>
+
+        </div>
+    
+</div>
+                    </div>
+                </div>
+                            <div class="item-bg"
+                     style="background-image: linear-gradient(to bottom, black -15%, transparent 90%),
+                                                                               url(https://images.discovery-prod.axs.com/2026/02/sara-landry-tickets_08-01-26_17_69837bed4bd34.png)
+                                                  "></div>
+                <div class="row small-collapse medium-uncollapse large-collapse slider-item" id="376602">
+                    <div class="small-12 medium-7 column">
+                        <div class="hero-poster-wrapper">
+                                                            <div class="show-poster hero-poster">
+						
+							<img src="https://images.discovery-prod.axs.com/2026/02/sara-landry-tickets_08-01-26_17_69837bed4bd34.png" class="poster-image-source" />
+			
+		    </div>
+                                                    </div>
+                    </div>
+                    <div class="small-12 medium-5 column">
+                            <div class="show-info hero-info  status-1 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-08-01T19:00:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1322106-sara-landry">
+                            <span itemprop="name">Sara Landry</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="Boys Noize, Godtripper (live), Jenna Shaw">
+                                Boys Noize, Godtripper (live), Jenna Shaw
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="Sara Landry" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2026/02/sara-landry-tickets_08-01-26_17_69837bed4bd34.png"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="Under the K Bridge Park"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="Under the K Bridge Park">Under the K Bridge Park</strong>,
+                        <span>
+				            Brooklyn, NY
+				        </span>
+                        <link itemprop="sameAs" href="https://www.axs.com/venues/129142/under-the-k-bridge-park-brooklyn-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="Brooklyn"/>
+                        <meta itemprop="addressRegion" content="NY"/>
+                        <meta itemprop="postalCode" content="11222"/>
+                        <meta itemprop="streetAddress" content="Gardner Ave. &amp; Thomas St., Brooklyn, NY 11222"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Sat, August 01, 2026
+                        <span>
+					        | Doors 07:00 PM, Show: 07:00 PM
+				        </span>
+                    </p>
+                </li>
+                
+                                    <li>
+                        <p class="list-disclaimer">
+                            21 &amp; Over
+                        </p>
+                    </li>
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Wed, February 11, 2026
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/InStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://www.axs.com/events/1322106/sara-landry-tickets" />
+                
+<a href="https://www.axs.com/events/1322106/sara-landry-tickets"
+  class="button event ticket primary"
+        target="_blank">Buy Tickets</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="Sara Landry"
+		data-description="21 &amp; Over"
+		data-location="Gardner Ave. &amp; Thomas St., Brooklyn, NY 11222"
+		data-start="2026-08-01T23:00:00Z"
+		data-end="2026-08-02T01:00:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1322106"></a>
+</div>
+
+        </div>
+    
+</div>
+                    </div>
+                </div>
+                    </div>
+                    <div class="slider-dot-container  "></div>
+            </div>
+
+                                    <script src="/bundlesFront/fitty.min.js"></script>
+<script src="/bundlesFront/ShowList.js"></script>
+
+<div data-component="show-list" class="show-list shows">
+
+        <div class="row small-collapse list-filter-container">
+        <div class="small-12 column">
+            <div class="list-filter">
+                                    <div class="filter-current">
+							<span>
+								Just Announced
+							</span>
+                        <button class="filter-button default"></button>
+                    </div>
+                    <div class="sub-filter-button hide-for-medium">
+							<span class="">
+								Filter by
+							</span>
+                        <button class="filter-button sub-filter"></button>
+                    </div>
+                            </div>
+            <ul class="show-list-dropdown">
+	<li>
+		<a href="javascript:void(0);" id="announced">
+			Just Announced
+		</a>
+	</li>
+	<li>
+		<a href="javascript:void(0);" id="all">
+			All Shows
+		</a>
+	</li>
+</ul>
+                            <div class="filter-container " shows>
+	<div>
+					<script src="/bundlesFront/FilterAtoZ.js"></script>
+
+<button class="filter-atoz">
+	A - Z
+</button>
+
+							<script src="/bundlesFront/FilterVenues.js"></script>
+<button class="filter-venues">
+  <span>
+    Filter by Venues
+  </span>
+</button>
+
+<div class="venues-dropdown-container">
+    <ul>
+                    <li>
+                                    <a href="/shows/asbury-lanes">Asbury Lanes</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/brooklyn-steel">Brooklyn Steel</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/browns-island">Brown’s Island</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/cmac-constellation-brands-marvin-sands-performing-arts-center">CMAC - Constellation Brands-Marvin Sands Performing Arts Center</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/fete-music-hall-ballroom">Fête Music Hall - Ballroom</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/fete-music-hall-lounge">Fête Music Hall - Lounge</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/forest-hills-stadium">Forest Hills Stadium</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/franklin-music-hall">Franklin Music Hall</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/keswick-theatre">Keswick Theatre</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/lewis-ginter-botanical-gardens">Lewis Ginter Botanical Gardens</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/music-hall-of-williamsburg">Music Hall of Williamsburg</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/patchogue-theatre">Patchogue Theatre</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/racket">Racket</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/roadrunner">Roadrunner</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/royale">Royale</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/starland-ballroom">Starland Ballroom</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/state-theatre-1">State Theatre</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/terminal-5">Terminal 5</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/the-national">The National</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/the-norva">The NorVa</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/the-sinclair">The Sinclair</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/the-stage-at-suffolk-downs">The Stage at Suffolk Downs</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/the-woodlands">The Woodlands</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/thompsons-point">Thompson’s Point</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/under-the-k-bridge-park">Under the K Bridge Park</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/underground-arts">Underground Arts</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/union-transfer">Union Transfer</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/virginia-credit-union-live-at-richmond-raceway">Virginia Credit Union LIVE! at Richmond Raceway</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/webster-hall">Webster Hall</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/westville-music-bowl">Westville Music Bowl</a>
+                            </li>
+                    <li>
+                                    <a href="/shows/xcite-center-at-parx-casino">Xcite Center at Parx Casino</a>
+                            </li>
+            </ul>
+</div>							</div>
+</div>
+                    </div>
+    </div>
+    
+    <div id="showsList">
+            <div class="show-item">
+    <div class="row small-collapse show-item-row">
+        <div class="small-6 medium-3 large-3 column show-item-row-col-poster">
+            <a href="/shows/detail/1449695-artistree-market">
+                                    <div class="show-poster show-item-img">
+															<div class="poster-image-source-background-wrapper"
+						 style="background-image:url('https://images.discovery-prod.axs.com/2026/05/artistree-market-tickets_07-18-26_18_6a078f924a5bd.jpg')"
+					>
+																			<img src="https://images.discovery-prod.axs.com/2026/05/artistree-market-tickets_07-18-26_18_6a078f924a5bd.jpg" alt="" class="poster-image-source" />
+																	</div>
+							
+			
+		    </div>
+                            </a>
+        </div>
+        <div class="small-6 medium-9 large-9 column show-item-row-col-info">
+                <div class="show-info item-info  status-3 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-07-18T15:00:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1449695-artistree-market">
+                            <span itemprop="name">Artistree Market</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="">
+                                
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="Artistree Market" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2026/05/artistree-market-tickets_07-18-26_17_6a078f9141f01.jpg"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="The NorVa"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="The NorVa">The NorVa</strong>,
+                        <span>
+				            Norfolk, VA
+				        </span>
+                        <link itemprop="sameAs" href="http://www.axs.com/venues/101510/the-norva-norfolk-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="Norfolk"/>
+                        <meta itemprop="addressRegion" content="VA"/>
+                        <meta itemprop="postalCode" content="23510"/>
+                        <meta itemprop="streetAddress" content="317 Monticello Avenue, Norfolk, VA 23510"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Sat, July 18, 2026
+                        <span>
+					        | Doors 02:49 AM, Show: 03:00 PM
+				        </span>
+                    </p>
+                </li>
+                
+                                    <li>
+                        <p class="list-disclaimer">
+                            All Ages
+                        </p>
+                    </li>
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Mon, May 18, 2026
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/OutOfStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://www.axs.com/events/1449695/artistree-market-tickets" />
+                
+<a href="https://www.axs.com/events/1449695/artistree-market-tickets"
+  class="button event ticket primary"
+        target="_blank">Free</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="Artistree Market"
+		data-description="All Ages"
+		data-location="317 Monticello Avenue, Norfolk, VA 23510"
+		data-start="2026-07-18T19:00:00Z"
+		data-end="2026-07-18T21:00:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1449695"></a>
+</div>
+
+        </div>
+    
+</div>
+        </div>
+    </div>
+</div>
+    <div class="show-item">
+    <div class="row small-collapse show-item-row">
+        <div class="small-6 medium-3 large-3 column show-item-row-col-poster">
+            <a href="/shows/detail/1446598-maryjo">
+                                    <div class="show-poster show-item-img">
+															<div class="poster-image-source-background-wrapper"
+						 style="background-image:url('https://images.discovery-prod.axs.com/2026/05/maryjo-tickets_07-30-26_18_6a0632cf0a7a5.jpg')"
+					>
+																			<img src="https://images.discovery-prod.axs.com/2026/05/maryjo-tickets_07-30-26_18_6a0632cf0a7a5.jpg" alt="" class="poster-image-source" />
+																	</div>
+							
+			
+		    </div>
+                            </a>
+        </div>
+        <div class="small-6 medium-9 large-9 column show-item-row-col-info">
+                <div class="show-info item-info  status-1 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-07-30T19:45:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1446598-maryjo">
+                            <span itemprop="name">maryjo</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="">
+                                
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="maryjo" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2026/05/maryjo-tickets_07-30-26_17_6a0632cdeb1a2.jpg"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="The Sinclair"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="The Sinclair">The Sinclair</strong>,
+                        <span>
+				            Cambridge, MA
+				        </span>
+                        <link itemprop="sameAs" href="http://www.axs.com/venues/124878/the-sinclair-cambridge-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="Cambridge"/>
+                        <meta itemprop="addressRegion" content="MA"/>
+                        <meta itemprop="postalCode" content="02138"/>
+                        <meta itemprop="streetAddress" content="52 Church St., Cambridge, MA 02138"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Thu, July 30, 2026
+                        <span>
+					        | Doors 07:00 PM, Show: 07:45 PM
+				        </span>
+                    </p>
+                </li>
+                
+                                    <li>
+                        <p class="list-disclaimer">
+                            All Ages
+                        </p>
+                    </li>
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Fri, May 15, 2026
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/InStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://www.axs.com/events/1446598/maryjo-tickets" />
+                
+<a href="https://www.axs.com/events/1446598/maryjo-tickets?skin=sinclair"
+  class="button event ticket primary"
+        target="_blank">Buy Tickets</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="maryjo"
+		data-description="All Ages"
+		data-location="52 Church St., Cambridge, MA 02138"
+		data-start="2026-07-30T23:45:00Z"
+		data-end="2026-07-31T01:45:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1446598"></a>
+</div>
+
+        </div>
+    
+</div>
+        </div>
+    </div>
+</div>
+    <div class="show-item">
+    <div class="row small-collapse show-item-row">
+        <div class="small-6 medium-3 large-3 column show-item-row-col-poster">
+            <a href="/shows/detail/1446599-shakey-graves-fondness-etc-tour">
+                                    <div class="show-poster show-item-img">
+															<div class="poster-image-source-background-wrapper"
+						 style="background-image:url('https://images.discovery-prod.axs.com/2026/05/shakey-graves-fondness-etc-tour-tickets_12-09-26_18_6a0638f52878b.jpg')"
+					>
+																			<img src="https://images.discovery-prod.axs.com/2026/05/shakey-graves-fondness-etc-tour-tickets_12-09-26_18_6a0638f52878b.jpg" alt="" class="poster-image-source" />
+																	</div>
+							
+			
+		    </div>
+                            </a>
+        </div>
+        <div class="small-6 medium-9 large-9 column show-item-row-col-info">
+                <div class="show-info item-info  status-1 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-12-09T20:00:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1446599-shakey-graves-fondness-etc-tour">
+                            <span itemprop="name">Shakey Graves - Fondness, Etc. Tour</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="Jobi Riccio">
+                                Jobi Riccio
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="Shakey Graves - Fondness, Etc. Tour" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2026/05/shakey-graves-fondness-etc-tour-tickets_12-09-26_17_6a0638f4274e4.jpg"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="Webster Hall"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="Webster Hall">Webster Hall</strong>,
+                        <span>
+				            New York City, NY
+				        </span>
+                        <link itemprop="sameAs" href="http://www.axs.com/venues/101385/webster-hall-new-york-city-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="New York City"/>
+                        <meta itemprop="addressRegion" content="NY"/>
+                        <meta itemprop="postalCode" content="10003"/>
+                        <meta itemprop="streetAddress" content="125 E. 11th Street, New York City, NY 10003"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Wed, December 09, 2026
+                        <span>
+					        | Doors 07:00 PM, Show: 08:00 PM
+				        </span>
+                    </p>
+                </li>
+                
+                                    <li>
+                        <p class="list-disclaimer">
+                            16 &amp; Over
+                        </p>
+                    </li>
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Wed, May 20, 2026
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/InStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://www.axs.com/events/1446599/shakey-graves-fondness-etc-tour-tickets" />
+                
+<a href="https://www.axs.com/events/1446599/shakey-graves-fondness-etc-tour-tickets?skin=websterhall"
+  class="button event ticket primary"
+        target="_blank">Coming Soon</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="Shakey Graves - Fondness, Etc. Tour"
+		data-description="16 &amp; Over"
+		data-location="125 E. 11th Street, New York City, NY 10003"
+		data-start="2026-12-10T01:00:00Z"
+		data-end="2026-12-10T03:00:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1446599"></a>
+</div>
+
+        </div>
+    
+</div>
+        </div>
+    </div>
+</div>
+    <div class="show-item">
+    <div class="row small-collapse show-item-row">
+        <div class="small-6 medium-3 large-3 column show-item-row-col-poster">
+            <a href="/shows/detail/1449348-shakey-graves">
+                                    <div class="show-poster show-item-img">
+															<div class="poster-image-source-background-wrapper"
+						 style="background-image:url('https://images.discovery-prod.axs.com/2026/01/shakey-graves_01-26-26_20_6977c723310eb.png')"
+					>
+																			<img src="https://images.discovery-prod.axs.com/2026/01/shakey-graves_01-26-26_20_6977c723310eb.png" alt="" class="poster-image-source" />
+																	</div>
+							
+			
+		    </div>
+                            </a>
+        </div>
+        <div class="small-6 medium-9 large-9 column show-item-row-col-info">
+                <div class="show-info item-info  status-1 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-12-10T20:00:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1449348-shakey-graves">
+                            <span itemprop="name">Shakey Graves</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="Jobi Riccio">
+                                Jobi Riccio
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="Shakey Graves" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2026/01/shakey-graves_01-26-26_19_6977c721d1eaa.png"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="Roadrunner"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="Roadrunner">Roadrunner</strong>,
+                        <span>
+				            Boston, MA
+				        </span>
+                        <link itemprop="sameAs" href="https://www.axs.com/venues/128223/roadrunner-boston-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="Boston"/>
+                        <meta itemprop="addressRegion" content="MA"/>
+                        <meta itemprop="postalCode" content="02135"/>
+                        <meta itemprop="streetAddress" content="89 Guest Street, Boston, MA 02135"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Thu, December 10, 2026
+                        <span>
+					        | Doors 07:00 PM, Show: 08:00 PM
+				        </span>
+                    </p>
+                </li>
+                
+                                    <li>
+                        <p class="list-disclaimer">
+                            All Ages
+                        </p>
+                    </li>
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Wed, May 20, 2026
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/InStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://www.axs.com/events/1449348/shakey-graves-tickets" />
+                
+<a href="https://www.axs.com/events/1449348/shakey-graves-tickets?skin=roadrunner"
+  class="button event ticket primary"
+        target="_blank">Coming Soon</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="Shakey Graves"
+		data-description="All Ages"
+		data-location="89 Guest Street, Boston, MA 02135"
+		data-start="2026-12-11T01:00:00Z"
+		data-end="2026-12-11T03:00:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1449348"></a>
+</div>
+
+        </div>
+    
+</div>
+        </div>
+    </div>
+</div>
+    <div class="show-item">
+    <div class="row small-collapse show-item-row">
+        <div class="small-6 medium-3 large-3 column show-item-row-col-poster">
+            <a href="/shows/detail/1450158-twisted-teens">
+                                    <div class="show-poster show-item-img">
+															<div class="poster-image-source-background-wrapper"
+						 style="background-image:url('https://images.discovery-prod.axs.com/2026/05/twisted-teens-tickets_07-23-26_18_6a06384a4a592.jpg')"
+					>
+																			<img src="https://images.discovery-prod.axs.com/2026/05/twisted-teens-tickets_07-23-26_18_6a06384a4a592.jpg" alt="" class="poster-image-source" />
+																	</div>
+							
+			
+		    </div>
+                            </a>
+        </div>
+        <div class="small-6 medium-9 large-9 column show-item-row-col-info">
+                <div class="show-info item-info  status-1 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-07-23T20:00:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1450158-twisted-teens">
+                            <span itemprop="name">Twisted Teens</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="">
+                                
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="Twisted Teens" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2026/05/twisted-teens-tickets_07-23-26_17_6a06384945f2b.jpg"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="The Sinclair"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="The Sinclair">The Sinclair</strong>,
+                        <span>
+				            Cambridge, MA
+				        </span>
+                        <link itemprop="sameAs" href="http://www.axs.com/venues/124878/the-sinclair-cambridge-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="Cambridge"/>
+                        <meta itemprop="addressRegion" content="MA"/>
+                        <meta itemprop="postalCode" content="02138"/>
+                        <meta itemprop="streetAddress" content="52 Church St., Cambridge, MA 02138"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Thu, July 23, 2026
+                        <span>
+					        | Doors 07:00 PM, Show: 08:00 PM
+				        </span>
+                    </p>
+                </li>
+                
+                                    <li>
+                        <p class="list-disclaimer">
+                            All Ages
+                        </p>
+                    </li>
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Fri, May 15, 2026
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/InStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://www.axs.com/events/1450158/twisted-teens-tickets" />
+                
+<a href="https://www.axs.com/events/1450158/twisted-teens-tickets?skin=sinclair"
+  class="button event ticket primary"
+        target="_blank">Buy Tickets</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="Twisted Teens"
+		data-description="All Ages"
+		data-location="52 Church St., Cambridge, MA 02138"
+		data-start="2026-07-24T00:00:00Z"
+		data-end="2026-07-24T02:00:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1450158"></a>
+</div>
+
+        </div>
+    
+</div>
+        </div>
+    </div>
+</div>
+    <div class="show-item">
+    <div class="row small-collapse show-item-row">
+        <div class="small-6 medium-3 large-3 column show-item-row-col-poster">
+            <a href="/shows/detail/1450911-rising-tide">
+                                    <div class="show-poster show-item-img">
+															<div class="poster-image-source-background-wrapper"
+						 style="background-image:url('https://images.discovery-prod.axs.com/2026/05/uploadedimage_6a064ca23e0aa.jpg')"
+					>
+																			<img src="https://images.discovery-prod.axs.com/2026/05/uploadedimage_6a064ca23e0aa.jpg" alt="110 Percent" class="poster-image-source" />
+																	</div>
+							
+			
+		    </div>
+                            </a>
+        </div>
+        <div class="small-6 medium-9 large-9 column show-item-row-col-info">
+                <div class="show-info item-info  status-1 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-08-30T08:30:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        110 Percent
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1450911-rising-tide">
+                            <span itemprop="name">Rising Tide</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="">
+                                
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="Rising Tide" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2026/05/uploadedimage_6a064ca127121.jpg"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="Union Transfer"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="Union Transfer">Union Transfer</strong>,
+                        <span>
+				            Philadelphia, PA
+				        </span>
+                        <link itemprop="sameAs" href="http://www.axs.com/venues/126150/union-transfer-philadelphia-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="Philadelphia"/>
+                        <meta itemprop="addressRegion" content="PA"/>
+                        <meta itemprop="postalCode" content="19123"/>
+                        <meta itemprop="streetAddress" content="1026 Spring Garden Street, Philadelphia, PA 19123"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Sun, August 30, 2026
+                        <span>
+					        | Doors 07:30 AM, Show: 08:30 AM
+				        </span>
+                    </p>
+                </li>
+                
+                                    <li>
+                        <p class="list-disclaimer">
+                            All Ages
+                        </p>
+                    </li>
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Fri, May 15, 2026
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/InStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://www.axs.com/events/1450911/rising-tide-tickets" />
+                
+<a href="https://www.axs.com/events/1450911/rising-tide-tickets"
+  class="button event ticket primary"
+        target="_blank">Buy Tickets</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="Rising Tide"
+		data-description="All Ages"
+		data-location="1026 Spring Garden Street, Philadelphia, PA 19123"
+		data-start="2026-08-30T12:30:00Z"
+		data-end="2026-08-30T14:30:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1450911"></a>
+</div>
+
+        </div>
+    
+</div>
+        </div>
+    </div>
+</div>
+    <div class="show-item">
+    <div class="row small-collapse show-item-row">
+        <div class="small-6 medium-3 large-3 column show-item-row-col-poster">
+            <a href="/shows/detail/1450937-rising-tide">
+                                    <div class="show-poster show-item-img">
+															<div class="poster-image-source-background-wrapper"
+						 style="background-image:url('https://images.discovery-prod.axs.com/2026/05/uploadedimage_6a0664d879f69.jpg')"
+					>
+																			<img src="https://images.discovery-prod.axs.com/2026/05/uploadedimage_6a0664d879f69.jpg" alt="110 Presents" class="poster-image-source" />
+																	</div>
+							
+			
+		    </div>
+                            </a>
+        </div>
+        <div class="small-6 medium-9 large-9 column show-item-row-col-info">
+                <div class="show-info item-info  status-1 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-08-30T15:00:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        110 Presents
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1450937-rising-tide">
+                            <span itemprop="name">Rising Tide</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="">
+                                
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="Rising Tide" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2026/05/uploadedimage_6a0664d76d0ea.jpg"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="Union Transfer"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="Union Transfer">Union Transfer</strong>,
+                        <span>
+				            Philadelphia, PA
+				        </span>
+                        <link itemprop="sameAs" href="http://www.axs.com/venues/126150/union-transfer-philadelphia-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="Philadelphia"/>
+                        <meta itemprop="addressRegion" content="PA"/>
+                        <meta itemprop="postalCode" content="19123"/>
+                        <meta itemprop="streetAddress" content="1026 Spring Garden Street, Philadelphia, PA 19123"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Sun, August 30, 2026
+                        <span>
+					        | Doors 02:00 PM, Show: 03:00 PM
+				        </span>
+                    </p>
+                </li>
+                
+                                    <li>
+                        <p class="list-disclaimer">
+                            All Ages
+                        </p>
+                    </li>
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Fri, May 15, 2026
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/InStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://www.axs.com/events/1450937/rising-tide-tickets" />
+                
+<a href="https://www.axs.com/events/1450937/rising-tide-tickets"
+  class="button event ticket primary"
+        target="_blank">Buy Tickets</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="Rising Tide"
+		data-description="All Ages"
+		data-location="1026 Spring Garden Street, Philadelphia, PA 19123"
+		data-start="2026-08-30T19:00:00Z"
+		data-end="2026-08-30T21:00:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1450937"></a>
+</div>
+
+        </div>
+    
+</div>
+        </div>
+    </div>
+</div>
+    <div class="show-item">
+    <div class="row small-collapse show-item-row">
+        <div class="small-6 medium-3 large-3 column show-item-row-col-poster">
+            <a href="/shows/detail/1447903-braxton-keith">
+                                    <div class="show-poster show-item-img">
+															<div class="poster-image-source-background-wrapper"
+						 style="background-image:url('https://images.discovery-prod.axs.com/2025/07/braxton-keith_07-16-25_20_6877aa1ac1aaf.jpg')"
+					>
+																			<img src="https://images.discovery-prod.axs.com/2025/07/braxton-keith_07-16-25_20_6877aa1ac1aaf.jpg" alt="&lt;a href=&quot;https://www.axs.com/artists/1112932/braxton-keith-tickets&quot;&gt;&lt;/a&gt;" class="poster-image-source" />
+																	</div>
+							
+			
+		    </div>
+                            </a>
+        </div>
+        <div class="small-6 medium-9 large-9 column show-item-row-col-info">
+                <div class="show-info item-info  status-1 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-07-26T19:30:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        <a href="https://www.axs.com/artists/1112932/braxton-keith-tickets"></a>
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1447903-braxton-keith">
+                            <span itemprop="name">Braxton Keith</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="Cole Goodwin">
+                                Cole Goodwin
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="Braxton Keith" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2025/07/braxton-keith_07-16-25_19_6877aa16caf72.jpg"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="The National"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="The National">The National</strong>,
+                        <span>
+				            Richmond, VA
+				        </span>
+                        <link itemprop="sameAs" href="http://www.axs.com/venues/125119/the-national-richmond-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="Richmond"/>
+                        <meta itemprop="addressRegion" content="VA"/>
+                        <meta itemprop="postalCode" content="23219"/>
+                        <meta itemprop="streetAddress" content="708 East Broad Street, Richmond, VA 23219"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Sun, July 26, 2026
+                        <span>
+					        | Doors 06:30 PM, Show: 07:30 PM
+				        </span>
+                    </p>
+                </li>
+                
+                                    <li>
+                        <p class="list-disclaimer">
+                            All Ages
+                        </p>
+                    </li>
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Thu, May 21, 2026
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/InStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://www.axs.com/events/1447903/braxton-keith-tickets" />
+                
+<a href="https://www.axs.com/events/1447903/braxton-keith-tickets?skin=nationalva"
+  class="button event ticket primary"
+        target="_blank">Coming Soon</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="Braxton Keith"
+		data-description="All Ages"
+		data-location="708 East Broad Street, Richmond, VA 23219"
+		data-start="2026-07-26T23:30:00Z"
+		data-end="2026-07-27T01:30:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1447903"></a>
+</div>
+
+        </div>
+    
+</div>
+        </div>
+    </div>
+</div>
+    <div class="show-item">
+    <div class="row small-collapse show-item-row">
+        <div class="small-6 medium-3 large-3 column show-item-row-col-poster">
+            <a href="/shows/detail/1444133-johnnyswim">
+                                    <div class="show-poster show-item-img">
+															<div class="poster-image-source-background-wrapper"
+						 style="background-image:url('https://images.discovery-prod.axs.com/2024/12/johnnyswim_12-13-24_20_675c47ef1b986.jpg')"
+					>
+																			<img src="https://images.discovery-prod.axs.com/2024/12/johnnyswim_12-13-24_20_675c47ef1b986.jpg" alt="" class="poster-image-source" />
+																	</div>
+							
+			
+		    </div>
+                            </a>
+        </div>
+        <div class="small-6 medium-9 large-9 column show-item-row-col-info">
+                <div class="show-info item-info  status-1 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-10-18T20:00:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1444133-johnnyswim">
+                            <span itemprop="name">JOHNNYSWIM</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="">
+                                
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="JOHNNYSWIM" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2024/12/johnnyswim_12-13-24_19_675c47ec94ebb.jpg"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="Patchogue Theatre"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="Patchogue Theatre">Patchogue Theatre</strong>,
+                        <span>
+				            Patchogue, NY
+				        </span>
+                        <link itemprop="sameAs" href="https://www.axs.com/venues/124771/patchogue-theatre-patchogue-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="Patchogue"/>
+                        <meta itemprop="addressRegion" content="NY"/>
+                        <meta itemprop="postalCode" content="11772"/>
+                        <meta itemprop="streetAddress" content="71 E Main Street, Patchogue, NY 11772"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Sun, October 18, 2026
+                        <span>
+					        | Doors 07:00 PM, Show: 08:00 PM
+				        </span>
+                    </p>
+                </li>
+                
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Wed, May 20, 2026
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/InStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://ci.ovationtix.com/34780/performance/11813544" />
+                
+<a href="https://ci.ovationtix.com/34780/performance/11813544"
+  class="button event ticket primary"
+        target="_blank">Coming Soon</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="JOHNNYSWIM"
+		data-description=""
+		data-location="71 E Main Street, Patchogue, NY 11772"
+		data-start="2026-10-19T00:00:00Z"
+		data-end="2026-10-19T02:00:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1444133"></a>
+</div>
+
+        </div>
+    
+</div>
+        </div>
+    </div>
+</div>
+    <div class="show-item">
+    <div class="row small-collapse show-item-row">
+        <div class="small-6 medium-3 large-3 column show-item-row-col-poster">
+            <a href="/shows/detail/1448384-isoxo-presents-hardcore-diva">
+                                    <div class="show-poster show-item-img">
+															<div class="poster-image-source-background-wrapper"
+						 style="background-image:url('https://images.discovery-prod.axs.com/2026/03/isoxo_03-02-26_20_69a5ec4e70dd5.jpg')"
+					>
+																			<img src="https://images.discovery-prod.axs.com/2026/03/isoxo_03-02-26_20_69a5ec4e70dd5.jpg" alt="" class="poster-image-source" />
+																	</div>
+							
+			
+		    </div>
+                            </a>
+        </div>
+        <div class="small-6 medium-9 large-9 column show-item-row-col-info">
+                <div class="show-info item-info  status-1 " itemscope="" itemtype="http://schema.org/Event">
+    <meta itemprop="startDate" content="2026-09-11T20:00:00">
+    <div class="show-info-container">
+        <div class="info-wrapper">
+            <div class="info-title">
+                                    <span class="presented-by">
+                        
+                    </span>
+                                <h3>
+                                            <a href="/shows/detail/1448384-isoxo-presents-hardcore-diva">
+                            <span itemprop="name">ISOxo presents: Hardcore Diva</span>
+                        </a>
+                                                                <div class="supporting-acts">
+                            <span itemprop="performer" content="">
+                                
+                            </span>
+                        </div>
+
+                        <meta itemprop="description" content="ISOxo presents: Hardcore Diva" />
+                        <meta itemprop="image" content="https://images.discovery-prod.axs.com/2026/03/isoxo_03-02-26_19_69a5ec4d8539f.jpg"
+                        />
+                                    </h3>
+            </div>
+        </div>
+
+                    <ul class="info-list" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                    <meta itemprop="name" content="Roadrunner"/>
+                <li>
+                    <p class="list-location"  itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                        <strong itemprop="name" content="Roadrunner">Roadrunner</strong>,
+                        <span>
+				            Boston, MA
+				        </span>
+                        <link itemprop="sameAs" href="https://www.axs.com/venues/128223/roadrunner-boston-tickets"/>
+                        <meta itemprop="addressCountry" content="United States"/>
+                        <meta itemprop="addressLocality" content="Boston"/>
+                        <meta itemprop="addressRegion" content="MA"/>
+                        <meta itemprop="postalCode" content="02135"/>
+                        <meta itemprop="streetAddress" content="89 Guest Street, Boston, MA 02135"/>
+                    </p>
+                </li>
+                                                                    <li>
+                    <p class="list-date">
+                        Fri, September 11, 2026
+                        <span>
+					        | Doors 07:00 PM, Show: 08:00 PM
+				        </span>
+                    </p>
+                </li>
+                
+                                    <li>
+                        <p class="list-disclaimer">
+                            18 &amp; Over
+                        </p>
+                    </li>
+                
+                                    <li>
+                        <p class="date-on-sale" style="display: none">
+                            On sale: Wed, May 20, 2026
+                        </p>
+                    </li>
+                            </ul>
+            </div>
+    
+        <div class="info-buttons" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+
+            <meta itemprop="price" content=""/>
+            <meta itemprop="priceCurrency" content="USD" />
+            <link itemprop="availability" href="http://schema.org/InStock"/>
+            
+<a "
+  class="button round white calendar"
+        ></a>
+                            <link itemprop="url" href="https://www.axs.com/events/1448384/isoxo-presents-hardcore-diva-tickets" />
+                
+<a href="https://www.axs.com/events/1448384/isoxo-presents-hardcore-diva-tickets?skin=roadrunner"
+  class="button event ticket primary"
+        target="_blank">Coming Soon</a>            
+            <div class="calendar-dropdown">
+	<a class="calendar-dropdown-item google" href="" target="_blank"
+		data-title="ISOxo presents: Hardcore Diva"
+		data-description="18 &amp; Over"
+		data-location="89 Guest Street, Boston, MA 02135"
+		data-start="2026-09-12T00:00:00Z"
+		data-end="2026-09-12T02:00:00Z"
+	></a>
+	<a class="calendar-dropdown-item apple" href="https://www.bowerypresents.com/info/events/ics/1448384"></a>
+</div>
+
+        </div>
+    
+</div>
+        </div>
+    </div>
+</div>
+    </div>
+
+            <div class="row show-more">
+            <div class="small-12 column">
+                                    
+<a "
+  class="button black btShowMore"
+        >Show more</a>                                <div class="loader  show-list">
+	<span></span>
+	<span></span>
+</div>
+            </div>
+        </div>
+    </div>
+                            
+        </div>
+    </div>
+
+    <footer>
+        <div class="row small-collapse">
+        <div class="small-12 column">
+            <div class="footer-wrapper">
+                <div class="flex-center">
+                    <a href="https://www.t-mobile-concert-perks.com/" target="_blank">
+                        <img src="/assets/img/tmo-logo.png" alt="T-Mobile" class="footer-tmo-image">
+                    </a>    
+                </div>
+                <div class="footer-partners">
+                    <div class="partners-container">
+                                            </div>
+                </div>
+                <div class="footer-nav">
+                    <div class="nav-links-container">
+                        <a href="http://www.americanexpress.com/entertainment" target="_blank">
+                            <img src="/assets/img/amex-logo-footer.png" class="footer-amex-image"
+                                 alt="American Express">
+                        </a>
+                        <div class="nav-links">
+                            <div class="nav-link-wrapper">
+                                <a href="/contact-us/"
+                                   class="nav-link">
+                                    FAQ
+                                </a>
+                                <a href="https://www.aegworldwide.com/careers" target="_blank" class="nav-link">
+                                    Jobs
+                                </a>
+                                <a href="mailto:bowerypartnerships@bowerypresents.com" class="nav-link" target="_blank">
+                                    Partnerships
+                                </a>
+                            </div>
+                            <div class="nav-link-wrapper">
+                                <a href="/page/terms-and-conditions"
+                                   class="nav-link">
+                                    Terms & Conditions
+                                </a>
+                                <a href="http://www.BoweryEvents.com" class="nav-link" target="_blank">
+                                    Private Events
+                                </a>
+                                <a href="/page/terms-and-conditions#accessibility"
+                                   class="nav-link">
+                                    Accessibility
+                                </a>
+                            </div>
+                            <div class="nav-link-wrapper">
+                                <a href="https://www.aegworldwide.com/privacy-policy/" target="_blank" class="nav-link">
+                                    Privacy Policy
+                                </a>
+                                <a href="https://privacyportal.onetrust.com/webform/c7968fb5-dd42-4c76-8f79-3e5198bd1303/7de12396-94a5-474f-872b-fa530ab42b5c" target="_blank" class="nav-link"
+                                   style="display: flex; flex-direction: row-reverse; justify-content: flex-end">
+                                    <img style="margin: 4px 0 0; width: 21px; height: 10px;" src="/assets/img/privacyoptions29x14.png" /><span style="margin-left: 2px;">Your Privacy Options</span>
+                                </a>
+                                <a nohref="nohref" class="ot-sdk-show-settings nav-link" style="cursor:pointer;">
+                                    Manage Cookie Preferences
+                                </a>
+                                <a href="https://coronavirusupdates.bowerypresents.com/" target="_blank" class="nav-link">
+                                    Health & Safety
+                                </a>
+                            </div>
+                            <div class="nav-link-wrapper">
+
+                            </div>
+                        </div>
+                    </div>
+                    <ul class="footer-social">
+                        <li>
+                              <a href="http://www.facebook.com/bowerypresents" target="_blank" class="button-social facebook _"></a>
+
+
+                        </li>
+                        <li>
+                              <a href="http://twitter.com/bowerypresents" target="_blank" class="button-social twitter _"></a>
+
+
+                        </li>
+                        <li>
+                              <a href="http://instagram.com/bowerypresents#" target="_blank" class="button-social instagram _"></a>
+
+
+                        </li>
+                        <li>
+                              <a href="http://thebowerypresents.tumblr.com" target="_blank" class="button-social tumblr _"></a>
+
+
+                        </li>
+                    </ul>
+                    <p class="footer-copyright">
+                        ©  2026 The Bowery Presents
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>
+<div class="rotate-device">
+    <div class="rotate-device-phone-wrapper">
+        <svg class="rotate-device-phone" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 862 459.7"
+             enable-background="new 0 0 862 459.7" xml:space="preserve"> <path fill="#FFFFFF"
+                                                                               d="M0,411.8c0.1,26.4,21.5,47.8,47.9,47.9h766.2c26.4-0.1,47.8-21.5,47.9-47.9v-364 C861.9,21.5,840.5,0.1,814.1,0H47.9C21.5,0.1,0.1,21.5,0,47.9V411.8z M19.2,411.8v-67l19.1-19.2V134.1l-19.1-19.2v-67 C19,32.2,31.6,19.3,47.3,19.2c0.2,0,0.4,0,0.6,0h766.2c15.7-0.2,28.6,12.5,28.7,28.2c0,0.2,0,0.4,0,0.6v364 c0.2,15.7-12.5,28.6-28.2,28.7c-0.2,0-0.4,0-0.6,0H47.9c-15.7,0.2-28.6-12.5-28.7-28.2C19.2,412.2,19.2,412,19.2,411.8z"/></svg>
+    </div>
+    <span class="rotate-device-text">Please rotate your device</span>
+    <div class="rotate-device-overlay"></div>
+</div>
+
+
+</div>
+</body>
+</html>

--- a/tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php
+++ b/tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Tests for VenueQualificationAbilities::analyzeForTicketmasterMarkers() —
+ * the pure (no I/O) classifier that decides whether a (final URL, HTML body)
+ * pair indicates a Ticketmaster/Live Nation OWNED page.
+ *
+ * Regression coverage for extrachill-events#90: the previous precheck
+ * substring-matched `ticketmaster.com` anywhere in the page HTML, which
+ * false-disqualified promoter aggregator sites (Bowery Presents, AEG
+ * Presents, etc.) that legitimately link out to TM only as a ticket vendor.
+ *
+ * The fixture `tests/Fixtures/bowery-presents-shows.html` was captured live
+ * from https://www.bowerypresents.com/shows/ and contains outbound TM event
+ * links — it is the canonical negative-case regression anchor.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Abilities
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Abilities;
+
+use ExtraChillEvents\Abilities\VenueQualificationAbilities;
+use PHPUnit\Framework\TestCase;
+
+class VenueQualificationTicketmasterPrecheckTest extends TestCase {
+
+	// ---- Positive cases: SHOULD disqualify (LN-owned page). ----
+
+	public function test_disqualifies_when_final_url_is_ticketmaster(): void {
+		// Simulates: input URL redirected to a ticketmaster.com venue page.
+		// Body can be empty — the final URL host alone is decisive.
+		$result = VenueQualificationAbilities::analyzeForTicketmasterMarkers(
+			'https://www.ticketmaster.com/venue/123456',
+			'<html><body>anything</body></html>'
+		);
+		$this->assertTrue( $result['disqualified'] );
+		$this->assertStringContainsString( 'final URL', $result['matched'] );
+		$this->assertStringContainsString( 'ticketmaster.com', $result['matched'] );
+	}
+
+	public function test_disqualifies_when_final_url_is_livenation(): void {
+		$result = VenueQualificationAbilities::analyzeForTicketmasterMarkers(
+			'https://concerts.livenation.com/venue/some-slug',
+			''
+		);
+		$this->assertTrue( $result['disqualified'] );
+		$this->assertStringContainsString( 'final URL', $result['matched'] );
+		$this->assertStringContainsString( 'livenation.com', $result['matched'] );
+	}
+
+	public function test_disqualifies_when_canonical_points_to_tm(): void {
+		// Final URL is on a third-party host BUT the canonical link tag
+		// declares the page is really a TM property.
+		$html = <<<HTML
+<html>
+<head>
+  <title>Some Venue</title>
+  <link rel="canonical" href="https://www.ticketmaster.com/venue/some-slug-12345" />
+</head>
+<body>fake mirror</body>
+</html>
+HTML;
+		$result = VenueQualificationAbilities::analyzeForTicketmasterMarkers(
+			'https://some-mirror.example.com/venue/some-slug',
+			$html
+		);
+		$this->assertTrue( $result['disqualified'] );
+		$this->assertStringContainsString( 'canonical', $result['matched'] );
+	}
+
+	public function test_disqualifies_when_jsonld_organization_is_ln(): void {
+		$html = <<<HTML
+<html><head>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://www.livenation.com/#organization",
+  "name": "Live Nation",
+  "url": "https://www.livenation.com"
+}
+</script>
+</head><body></body></html>
+HTML;
+		$result = VenueQualificationAbilities::analyzeForTicketmasterMarkers(
+			'https://example.com/venue/abc',
+			$html
+		);
+		$this->assertTrue( $result['disqualified'] );
+		$this->assertStringContainsString( 'JSON-LD Organization', $result['matched'] );
+		$this->assertStringContainsString( 'livenation.com', $result['matched'] );
+	}
+
+	// ---- Negative cases: must NOT disqualify (extraction should proceed). ----
+
+	public function test_does_not_disqualify_when_only_outbound_tm_links(): void {
+		// Regression anchor for issue #90. Live HTML capture of
+		// https://www.bowerypresents.com/shows/. The page contains outbound
+		// <a href="https://www.ticketmaster.com/event/…"> buy-ticket links
+		// but is hosted on bowerypresents.com, has no LN meta/canonical/SDK.
+		$fixture = dirname( __DIR__, 2 ) . '/Fixtures/bowery-presents-shows.html';
+		$this->assertFileExists(
+			$fixture,
+			'Bowery Presents fixture missing — re-pull it (see test file docblock).'
+		);
+		$html = (string) file_get_contents( $fixture );
+
+		// Sanity check the fixture: it MUST contain at least one outbound TM
+		// link, otherwise the regression-anchor property of this test is
+		// vacuous and we should re-pull.
+		$this->assertMatchesRegularExpression(
+			'#href=["\']https?://(?:www\.)?ticketmaster\.com/event/#i',
+			$html,
+			'Bowery fixture has no outbound TM event links — re-pull it.'
+		);
+
+		$result = VenueQualificationAbilities::analyzeForTicketmasterMarkers(
+			'https://www.bowerypresents.com/shows/',
+			$html
+		);
+		$this->assertFalse(
+			$result['disqualified'],
+			'Bowery Presents must not be disqualified: matched=' . $result['matched']
+		);
+		$this->assertSame( '', $result['matched'] );
+	}
+
+	public function test_does_not_disqualify_when_aeg_presents_aggregator(): void {
+		// Baseline: a similar-shape aggregator with no TM/LN signals at all
+		// must always pass through. Confirms the analyzer does not over-fire
+		// on incidental schedule-page markup.
+		$html = <<<HTML
+<html>
+<head>
+  <title>AEG Presents — Shows</title>
+  <link rel="canonical" href="https://www.aegpresents.com/shows" />
+  <meta property="og:site_name" content="AEG Presents" />
+</head>
+<body>
+  <ul class="shows">
+    <li><a href="https://www.aegpresents.com/event/show-1">Show 1</a></li>
+    <li><a href="https://www.axs.com/event/12345">Show 2 — Buy on AXS</a></li>
+  </ul>
+</body>
+</html>
+HTML;
+		$result = VenueQualificationAbilities::analyzeForTicketmasterMarkers(
+			'https://www.aegpresents.com/shows',
+			$html
+		);
+		$this->assertFalse( $result['disqualified'] );
+		$this->assertSame( '', $result['matched'] );
+	}
+
+	// ---- Bonus coverage: subdomain hosts and brand meta tags. ----
+
+	public function test_disqualifies_when_final_url_is_concerts_livenation_subdomain(): void {
+		$result = VenueQualificationAbilities::analyzeForTicketmasterMarkers(
+			'https://m.livenation.com/event/xyz',
+			''
+		);
+		$this->assertTrue( $result['disqualified'] );
+		$this->assertStringContainsString( 'livenation.com', $result['matched'] );
+	}
+
+	public function test_disqualifies_when_meta_site_name_is_ticketmaster(): void {
+		$html = '<html><head><meta property="og:site_name" content="Ticketmaster"/></head><body></body></html>';
+		$result = VenueQualificationAbilities::analyzeForTicketmasterMarkers(
+			'https://example.com/foo',
+			$html
+		);
+		$this->assertTrue( $result['disqualified'] );
+		$this->assertStringContainsString( 'site_name', $result['matched'] );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -82,3 +82,4 @@ require_once dirname( __DIR__ ) . '/inc/Core/QualifyVerdict.php';
 require_once dirname( __DIR__ ) . '/inc/Core/QualifyVerdictResolver.php';
 require_once dirname( __DIR__ ) . '/inc/Core/PlatformDetector.php';
 require_once dirname( __DIR__ ) . '/inc/Core/QualifyFingerprinter.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/VenueQualificationAbilities.php';


### PR DESCRIPTION
Fixes #90

## Problem

`VenueQualificationAbilities::checkTicketmasterVenue()` substring-matched `ticketmaster.com` anywhere in the page HTML and disqualified the entire site with verdict `covered_elsewhere` / method `ticketmaster_precheck`. A single outbound buy-ticket link like `<a href="https://www.ticketmaster.com/event/...">` was enough to kill extraction before it ever ran.

This false-disqualified **promoter aggregator** sites — Bowery Presents, AEG Presents, Goldenvoice, etc. — that legitimately list shows across multiple venues and use TM only as one of several ticket vendors.

## Production evidence

Current upcoming-event counts on extrachill.com for the Bowery Presents portfolio (from issue #90):

| Venue | Upcoming events | Status |
|---|---:|---|
| Brooklyn Paramount | 70 | ok |
| The Rooftop at Pier 17 | 42 | ok |
| Music Hall of Williamsburg | 32 | ok |
| Mercury Lounge | 4 | low (expected ~30) |
| Webster Hall | 1 | low |
| Terminal 5 | 1 | low |
| **Bowery Ballroom** | **0** | missing |
| **Brooklyn Steel** | **0** | missing |
| **Irving Plaza** | **0** | missing |
| **Forest Hills Stadium** | **0** | missing |

The NYC TM API flow catches roughly half. The Bowery Presents master schedule (https://www.bowerypresents.com/shows/) lists everything across all nine venues — and is exactly the page the precheck was killing.

## Before / after

```
# Before — disqualifies any page that mentions ticketmaster.com
host check
fetch page (timeout=10, redirection=5)
check `x-redirect-by` header  ← wrong header for final URL
check `$response['http_response']->get_response_object()->url` for TM host
strtolower(body); if str_contains(body, "ticketmaster.com") → disqualify
if str_contains(body, "ticketmaster.com/event/") → disqualify
preg_match("/<iframe...ticketmaster.com.../") → disqualify
```

```
# After — disqualifies only LN-OWNED pages
host check on input URL (early exit for trivial cases)
fetch page (timeout=10, redirection=5)
resolve final URL via Requests response object (correctly this time)
analyzeForTicketmasterMarkers(final_url, html):
  1. final URL host ∈ TICKETMASTER_HOSTS                       → disqualify
  2. <link rel="canonical"> host ∈ TICKETMASTER_HOSTS          → disqualify
  3. <meta og:site_name | application-name> = TM / Live Nation → disqualify
  4. JSON-LD Organization with @id/url/sameAs on LN host       → disqualify
  5. window.TMP / window.LN / window.LiveNation in <head>      → disqualify
  6. otherwise → NOT disqualified (extraction continues)
```

Outbound `<a href="https://www.ticketmaster.com/event/...">` buy links are deliberately ignored — they are pricing data, not ownership.

The `matched` field is now actionable:
- `final URL host: ticketmaster.com`
- `canonical link to livenation.com`
- `JSON-LD Organization on livenation.com`
- `meta site_name brand tag`
- `LN SDK bootstrap in <head>`

…instead of the old opaque `ticketmaster.com (in page HTML)`.

## Subdomain handling

`TICKETMASTER_HOSTS` is matched with `str_ends_with($host, '.' . $pattern)`, so all of these resolve correctly to their brand base:

- `www.ticketmaster.com`, `www1.ticketmaster.com`
- `concerts.livenation.com`, `m.livenation.com`
- Country variants: `livenation.de`, `ticketmaster.co.uk`, `ticketmaster.com.au`, etc.

## Refactor shape

Extracted the pure (no-I/O) classifier as a static method:

```php
public static function analyzeForTicketmasterMarkers(
    string $final_url,
    string $html
): array  // {disqualified: bool, matched: string}
```

so it can be unit-tested with fixture HTML. The HTTP-fetching wrapper `checkTicketmasterVenue()` keeps its private signature and call site — no callers were affected. It also now correctly reads the final URL off `$response['http_response']->get_response_object()->url` (the old code was reading the unrelated `x-redirect-by` header).

## Tests

8 unit tests in `tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php`:

1. `test_disqualifies_when_final_url_is_ticketmaster` — TM venue page URL
2. `test_disqualifies_when_final_url_is_livenation` — `concerts.livenation.com`
3. `test_disqualifies_when_canonical_points_to_tm` — third-party host but canonical → TM
4. `test_disqualifies_when_jsonld_organization_is_ln` — JSON-LD Organization with @id on `livenation.com`
5. `test_does_not_disqualify_when_only_outbound_tm_links` — **regression anchor**: live capture of bowerypresents.com/shows (89 KB fixture) with outbound TM event links but no LN ownership signals
6. `test_does_not_disqualify_when_aeg_presents_aggregator` — baseline non-LN aggregator
7. `test_disqualifies_when_final_url_is_concerts_livenation_subdomain` — `m.livenation.com` subdomain match
8. `test_disqualifies_when_meta_site_name_is_ticketmaster` — `og:site_name=Ticketmaster`

The Bowery Presents fixture is the canonical regression anchor — re-pull with:

```
curl -s -A "Mozilla/5.0" --max-time 20 -L "https://www.bowerypresents.com/shows/" \
  > tests/Fixtures/bowery-presents-shows.html
```

All 132 tests in `qualify-v2-unit` pass; `homeboy audit` reports no new findings against this change.

## Out of scope (per issue #90)

- New `aggregator_with_external_ticketing` verdict — simpler answer per the issue is "just don't disqualify, let extraction proceed". Resolver wiring is unchanged.
- Downstream extraction work for `bowerypresents.com` (JS-rendered SPA — likely still extraction_gap). That's data-machine-events#268 territory.
- Why the NYC TM API misses Bowery Ballroom / Brooklyn Steel / Irving Plaza / Forest Hills Stadium in the first place.

## Post-merge follow-up

After this lands and deploys, run:

```
wp extrachill venues requalify-pending --verdict=covered_elsewhere
```

to re-qualify any promoter aggregator currently stuck in the `covered_elsewhere` bucket. Identity-index dedup will handle any per-event overlap with the TM API.