### PR TITLE
fix: sync block.json versions on release so style/script changes bust caches

### DIFF
--- a/blocks/concert-stats/block.json
+++ b/blocks/concert-stats/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "extrachill/concert-stats",
-	"version": "1.0.0",
+	"version": "0.23.1",
 	"title": "Concert Stats",
 	"category": "widgets",
 	"icon": "tickets-alt",

--- a/blocks/event-submission/block.json
+++ b/blocks/event-submission/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "extrachill/event-submission",
-	"version": "0.4.0",
+	"version": "0.23.1",
 	"title": "Event Submission Form",
 	"category": "widgets",
 	"icon": "calendar-alt",

--- a/homeboy.json
+++ b/homeboy.json
@@ -14,6 +14,14 @@
     {
       "file": "extrachill-events.php",
       "pattern": "EXTRACHILL_EVENTS_VERSION',\\s*'([0-9.]+)'"
+    },
+    {
+      "file": "blocks/concert-stats/block.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+    },
+    {
+      "file": "blocks/event-submission/block.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes block.json version drift in `extrachill-events`. WordPress uses each `block.json`'s `version` field as the cache-bust query string (`?ver=`) on the style/script handles registered for that block. When `block.json` drifts behind the plugin version, browsers keep serving stale cached CSS/JS for that block across releases.

Playbook reference: Extra-Chill/data-machine-events#279

## Drift table

| File | Before | After | Plugin |
|------|--------|-------|--------|
| `blocks/concert-stats/block.json` | `1.0.0` | `0.23.1` | `0.23.1` |
| `blocks/event-submission/block.json` | `0.4.0` | `0.23.1` | `0.23.1` |

## Why this matters

WordPress passes `block.json`'s `version` to `wp_register_block_style_handle()` / `wp_register_block_script_handle()` as the asset version string. Browsers cache `style.css?ver=X` aggressively; if `X` never changes across plugin releases, edits to the CSS/JS are invisible to returning users until they hard-refresh or the cache naturally expires.

- **`concert-stats`** at `1.0.0` is the block's own initial version — never bumped since creation. Less severe historically (block is newer), but still broken going forward.
- **`event-submission`** at `0.4.0` is the bigger issue: frozen since the 0.5 series, so its assets have been served as stale `?ver=0.4.0` for ~19 minor versions of plugin changes. Anyone who loaded the event submission form before a recent release has been running outdated CSS/JS.

## What changed

1. Bumped both `block.json` `version` fields to `0.23.1` (current plugin version) so the next deploy busts caches once.
2. Added both `block.json` files to `homeboy.json` `version_targets` so `homeboy release` auto-bumps them alongside the plugin header and `EXTRACHILL_EVENTS_VERSION` constant on every future release. This prevents the drift from recurring.

`homeboy.json` now tracks four version targets: plugin header, `EXTRACHILL_EVENTS_VERSION` constant, and both `block.json` files — all bumped atomically.

## Diff size

```
 blocks/concert-stats/block.json    | 2 +-
 blocks/event-submission/block.json | 2 +-
 homeboy.json                       | 8 ++++++++
 3 files changed, 10 insertions(+), 2 deletions(-)
```

No reformatting, no whitespace churn, no header/changelog edits. Homeboy owns version bumps and CHANGELOG.

## Acceptance criteria

- [x] `blocks/concert-stats/block.json` `version` is `0.23.1`
- [x] `blocks/event-submission/block.json` `version` is `0.23.1`
- [x] `homeboy.json` includes both `block.json` files in `version_targets`
- [x] `homeboy.json` is valid JSON (`python3 -c "import json; json.load(open('homeboy.json'))"` passes)
- [x] No edits to `CHANGELOG.md`, plugin header version, or `EXTRACHILL_EVENTS_VERSION` constant
- [x] Conventional commit prefix (`fix:`) so homeboy auto-detects a patch bump on next release

## After merge

Orchestrator runs `homeboy release extrachill-events` (patch bump) → `homeboy deploy`. From that release onward, future `homeboy release` invocations will keep all four version targets in sync automatically.

cc @chubes