### PR TITLE
feat: repair-locations + prune-orphans CLI for flow_config location hygiene

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -57,6 +57,16 @@ if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCo
 
 	require_once __DIR__ . '/inc/Cli/UnqualifiableFlowsCommand.php';
 	\WP_CLI::add_command( 'extrachill venues unqualifiable-flows', \ExtraChillEvents\Cli\UnqualifiableFlowsCommand::class );
+
+	// Location / flow_config hygiene (extrachill-events#98).
+	// Issue #98 — Both commands operate against the events subsite (blog 7).
+	// Always invoke with `--url=events.extrachill.com` so $wpdb->prefix is c8c_7_.
+	require_once __DIR__ . '/inc/Core/FlowLocationGuard.php';
+	require_once __DIR__ . '/inc/Cli/RepairFlowLocationsCommand.php';
+	\WP_CLI::add_command( 'extrachill events flows repair-locations', \ExtraChillEvents\Cli\RepairFlowLocationsCommand::class );
+
+	require_once __DIR__ . '/inc/Cli/PruneOrphanLocationsCommand.php';
+	\WP_CLI::add_command( 'extrachill events locations prune-orphans', \ExtraChillEvents\Cli\PruneOrphanLocationsCommand::class );
 }
 
 // Recheck handler must be loaded outside the WP_CLI guard so the Action

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -67,6 +67,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCo
 
 	require_once __DIR__ . '/inc/Cli/PruneOrphanLocationsCommand.php';
 	\WP_CLI::add_command( 'extrachill events locations prune-orphans', \ExtraChillEvents\Cli\PruneOrphanLocationsCommand::class );
+
+	require_once __DIR__ . '/inc/Cli/BackfillVenueMetaCommand.php';
+	\WP_CLI::add_command( 'extrachill events venues backfill-meta', \ExtraChillEvents\Cli\BackfillVenueMetaCommand::class );
 }
 
 // Recheck handler must be loaded outside the WP_CLI guard so the Action

--- a/inc/Abilities/CityAbilities.php
+++ b/inc/Abilities/CityAbilities.php
@@ -13,6 +13,7 @@
 namespace ExtraChillEvents\Abilities;
 
 use DataMachineEvents\Api\Controllers\Geocoding;
+use ExtraChillEvents\Core\FlowLocationGuard;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -853,6 +854,29 @@ The festival taxonomy should only be used if the event in question is a festival
 			}
 		}
 		unset( $step );
+
+		// Defensive guard against extrachill-events#98 — never let an
+		// upsert_event step ship with ai_decides / empty / skip for
+		// taxonomy_location_selection. The block above writes
+		// $location_term directly, so this is belt-and-braces against
+		// future refactors that might forget to set it.
+		$guard = FlowLocationGuard::coerceUpsertEventLocation( $config, $location_term );
+		if ( ! empty( $guard['coerced'] ) ) {
+			$config = $guard['config'];
+			foreach ( $guard['coerced'] as $row ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					'Coerced taxonomy_location_selection in CityAbilities flow (extrachill-events#98 guard)',
+					array(
+						'flow_id' => $flow_id,
+						'step_id' => $row['step_id'],
+						'old'     => $row['old'],
+						'new'     => $row['new'],
+					)
+				);
+			}
+		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$wpdb->update(

--- a/inc/Abilities/VenueAddAbilities.php
+++ b/inc/Abilities/VenueAddAbilities.php
@@ -11,6 +11,8 @@
 
 namespace ExtraChillEvents\Abilities;
 
+use ExtraChillEvents\Core\FlowLocationGuard;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -380,6 +382,29 @@ class VenueAddAbilities {
 			}
 		}
 		unset( $step );
+
+		// Defensive guard against extrachill-events#98 — never let an
+		// upsert_event step ship with ai_decides / empty / skip for
+		// taxonomy_location_selection. The block above writes
+		// $location_term directly, so this is belt-and-braces against
+		// future refactors that might forget to set it.
+		$guard = FlowLocationGuard::coerceUpsertEventLocation( $config, $location_term );
+		if ( ! empty( $guard['coerced'] ) ) {
+			$config = $guard['config'];
+			foreach ( $guard['coerced'] as $row ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					'Coerced taxonomy_location_selection in VenueAdd flow (extrachill-events#98 guard)',
+					array(
+						'flow_id' => $flow_id,
+						'step_id' => $row['step_id'],
+						'old'     => $row['old'],
+						'new'     => $row['new'],
+					)
+				);
+			}
+		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$wpdb->update(

--- a/inc/Cli/BackfillVenueMetaCommand.php
+++ b/inc/Cli/BackfillVenueMetaCommand.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * `wp extrachill events venues backfill-meta` — copy venue address
+ * fields from `universal_web_scraper` flow configs onto the venue
+ * taxonomy term meta.
+ *
+ * Why this exists: a chunk of the venue terms on events.extrachill.com
+ * have no `_venue_city` / `_venue_state` / `_venue_zip` /
+ * `_venue_address` meta, which means the location-normalizer can't
+ * resolve them to a market. The address data DOES exist — it's stored
+ * on the scraper flow that created the venue (set by
+ * `VenueAddAbilities::patchFlowSteps`), it just never got written back
+ * to the term itself.
+ *
+ * This CLI walks every `universal_web_scraper` flow, reads
+ * `handler_configs.universal_web_scraper.venue` (the term ID) and the
+ * sibling `venue_address|venue_city|venue_state|venue_zip` fields, and
+ * writes them to the term as `_venue_address|_venue_city|_venue_state|
+ * _venue_zip`. Only writes when the meta key is currently empty — never
+ * clobbers existing data.
+ *
+ * Part of the cleanup chain for Extra-Chill/extrachill-events#98.
+ * Correct run order:
+ *
+ *   1. wp extrachill events flows audit-pipelines --commit   (#101)
+ *   2. wp extrachill events flows repair-locations --commit  (#100)
+ *   3. wp extrachill events venues backfill-meta --commit    (this)
+ *   4. wp extrachill events fix-locations --yes              (existing)
+ *   5. wp extrachill events locations prune-orphans --commit (#100)
+ *
+ * Always invoke with `--url=events.extrachill.com` so $wpdb->prefix
+ * resolves to `c8c_7_`.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class BackfillVenueMetaCommand {
+
+	/**
+	 * Backfill `_venue_address|_venue_city|_venue_state|_venue_zip`
+	 * meta on venue terms from the `universal_web_scraper` flow that
+	 * created them.
+	 *
+	 * Idempotent — only writes when the existing term meta is empty.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--commit]
+	 * : Actually write the meta. Default is dry-run.
+	 *
+	 * [--venue-id=<id>]
+	 * : Limit to a single venue term ID. Useful for spot-fix work.
+	 *
+	 * [--format=<format>]
+	 * : Output format for the per-flow report.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill events venues backfill-meta --url=events.extrachill.com
+	 *     wp extrachill events venues backfill-meta --url=events.extrachill.com --commit
+	 *     wp extrachill events venues backfill-meta --url=events.extrachill.com --venue-id=51395
+	 *
+	 * @param array $args       Positional args (unused).
+	 * @param array $assoc_args Named args.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		if ( ! defined( 'WP_CLI' ) || ! \WP_CLI ) {
+			return;
+		}
+
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			\WP_CLI::error( 'The venue taxonomy is not registered on this site. Run with --url=events.extrachill.com.' );
+			return;
+		}
+
+		$commit    = ! empty( $assoc_args['commit'] );
+		$venue_id  = isset( $assoc_args['venue-id'] ) ? (int) $assoc_args['venue-id'] : 0;
+		$format    = (string) ( $assoc_args['format'] ?? 'table' );
+
+		global $wpdb;
+		$flows_table = $wpdb->prefix . 'datamachine_flows';
+
+		// Pull every flow that has a universal_web_scraper step. We
+		// fetch the raw JSON column and parse per-row so we can read
+		// the venue address fields without a complex JOIN.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			"SELECT flow_id, flow_name, flow_config FROM {$flows_table}
+			WHERE flow_config LIKE '%universal_web_scraper%'
+			ORDER BY flow_id ASC",
+			ARRAY_A
+		);
+
+		if ( empty( $rows ) ) {
+			\WP_CLI::log( 'No universal_web_scraper flows found.' );
+			return;
+		}
+
+		// Meta keys we care about, in the order: flow field => term meta key.
+		$field_map = array(
+			'venue_address' => '_venue_address',
+			'venue_city'    => '_venue_city',
+			'venue_state'   => '_venue_state',
+			'venue_zip'     => '_venue_zip',
+		);
+
+		$report = array();
+		$totals = array(
+			'flows_scanned'   => 0,
+			'flows_no_venue'  => 0,
+			'flows_no_addr'   => 0,
+			'terms_seen'      => 0,
+			'fields_would_write' => 0,
+			'fields_written'  => 0,
+			'fields_skipped'  => 0, // already populated
+			'fields_failed'   => 0,
+		);
+
+		// De-dupe at the term level — multiple flows can target the
+		// same venue (rare but possible). First seen wins; later flows
+		// can only contribute to fields that are still empty.
+		$seen_terms = array();
+
+		foreach ( $rows as $row ) {
+			$totals['flows_scanned']++;
+
+			$flow_id   = (int) $row['flow_id'];
+			$flow_name = (string) $row['flow_name'];
+
+			$config = json_decode( (string) $row['flow_config'], true );
+			if ( ! is_array( $config ) ) {
+				continue;
+			}
+
+			// Find the universal_web_scraper handler config.
+			$uws = $this->extractUniversalWebScraperConfig( $config );
+			if ( ! $uws ) {
+				continue;
+			}
+
+			$term_id = isset( $uws['venue'] ) ? (int) $uws['venue'] : 0;
+			if ( $term_id <= 0 ) {
+				$totals['flows_no_venue']++;
+				continue;
+			}
+
+			if ( $venue_id > 0 && $term_id !== $venue_id ) {
+				continue;
+			}
+
+			// Confirm the term exists and is a venue.
+			$term = get_term( $term_id, 'venue' );
+			if ( ! $term || is_wp_error( $term ) ) {
+				$report[] = array(
+					'flow_id'   => $flow_id,
+					'flow_name' => $flow_name,
+					'venue_id'  => $term_id,
+					'venue'     => '',
+					'field'     => '',
+					'value'     => '',
+					'status'    => 'skipped',
+					'reason'    => 'venue_term_not_found',
+				);
+				continue;
+			}
+
+			$venue_label = $term->name;
+
+			// Does the flow actually have any address info to offer?
+			$has_addr = false;
+			foreach ( $field_map as $flow_field => $_meta_key ) {
+				if ( ! empty( $uws[ $flow_field ] ) ) {
+					$has_addr = true;
+					break;
+				}
+			}
+			if ( ! $has_addr ) {
+				$totals['flows_no_addr']++;
+				continue;
+			}
+
+			if ( ! isset( $seen_terms[ $term_id ] ) ) {
+				$seen_terms[ $term_id ] = true;
+				$totals['terms_seen']++;
+			}
+
+			foreach ( $field_map as $flow_field => $meta_key ) {
+				$incoming = isset( $uws[ $flow_field ] ) ? trim( (string) $uws[ $flow_field ] ) : '';
+				if ( '' === $incoming ) {
+					continue;
+				}
+
+				$existing = (string) get_term_meta( $term_id, $meta_key, true );
+				if ( '' !== trim( $existing ) ) {
+					$totals['fields_skipped']++;
+					$report[] = array(
+						'flow_id'   => $flow_id,
+						'flow_name' => $flow_name,
+						'venue_id'  => $term_id,
+						'venue'     => $venue_label,
+						'field'     => $meta_key,
+						'value'     => $incoming,
+						'status'    => 'skipped',
+						'reason'    => 'already_set:' . $this->truncate( $existing ),
+					);
+					continue;
+				}
+
+				if ( ! $commit ) {
+					$totals['fields_would_write']++;
+					$report[] = array(
+						'flow_id'   => $flow_id,
+						'flow_name' => $flow_name,
+						'venue_id'  => $term_id,
+						'venue'     => $venue_label,
+						'field'     => $meta_key,
+						'value'     => $incoming,
+						'status'    => 'would_write',
+						'reason'    => 'dry_run',
+					);
+					continue;
+				}
+
+				$ok = update_term_meta( $term_id, $meta_key, $incoming );
+				if ( false === $ok ) {
+					$totals['fields_failed']++;
+					$report[] = array(
+						'flow_id'   => $flow_id,
+						'flow_name' => $flow_name,
+						'venue_id'  => $term_id,
+						'venue'     => $venue_label,
+						'field'     => $meta_key,
+						'value'     => $incoming,
+						'status'    => 'failed',
+						'reason'    => 'update_term_meta_returned_false',
+					);
+				} else {
+					$totals['fields_written']++;
+					$report[] = array(
+						'flow_id'   => $flow_id,
+						'flow_name' => $flow_name,
+						'venue_id'  => $term_id,
+						'venue'     => $venue_label,
+						'field'     => $meta_key,
+						'value'     => $incoming,
+						'status'    => 'written',
+						'reason'    => 'ok',
+					);
+				}
+			}
+		}
+
+		// Default table view hides already_set rows because they're
+		// noise — the operator wants to see what changed or would
+		// change. Single-venue mode shows everything.
+		$visible = ( $venue_id > 0 )
+			? $report
+			: array_values(
+				array_filter(
+					$report,
+					static fn( $r ) => 'skipped' !== $r['status'] || 'venue_term_not_found' === $r['reason']
+				)
+			);
+
+		if ( empty( $visible ) ) {
+			\WP_CLI::log( 'Nothing to backfill — every relevant venue meta key is already populated.' );
+		} else {
+			\WP_CLI\Utils\format_items(
+				$format,
+				$visible,
+				array( 'flow_id', 'flow_name', 'venue_id', 'venue', 'field', 'value', 'status', 'reason' )
+			);
+		}
+
+		\WP_CLI::log( '' );
+		\WP_CLI::log( sprintf(
+			'Summary: flows_scanned=%d flows_no_venue=%d flows_no_addr=%d terms_seen=%d would_write=%d written=%d already_set=%d failed=%d',
+			$totals['flows_scanned'],
+			$totals['flows_no_venue'],
+			$totals['flows_no_addr'],
+			$totals['terms_seen'],
+			$totals['fields_would_write'],
+			$totals['fields_written'],
+			$totals['fields_skipped'],
+			$totals['fields_failed']
+		) );
+
+		if ( ! $commit ) {
+			\WP_CLI::log( '' );
+			\WP_CLI::log( 'Dry run — no term meta written. Re-run with --commit to apply.' );
+		}
+	}
+
+	/**
+	 * Walk a flow_config array and return the first
+	 * `universal_web_scraper` handler config encountered, or null.
+	 */
+	private function extractUniversalWebScraperConfig( array $flow_config ): ?array {
+		foreach ( $flow_config as $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+			$handler_configs = $step['handler_configs'] ?? array();
+			if ( ! is_array( $handler_configs ) || empty( $handler_configs['universal_web_scraper'] ) ) {
+				continue;
+			}
+			$uws = $handler_configs['universal_web_scraper'];
+			return is_array( $uws ) ? $uws : null;
+		}
+		return null;
+	}
+
+	/**
+	 * Trim long strings for the "already_set" reason column so the
+	 * table doesn't wrap to nine lines per row.
+	 */
+	private function truncate( string $value, int $max = 40 ): string {
+		$value = trim( $value );
+		if ( strlen( $value ) <= $max ) {
+			return $value;
+		}
+		return substr( $value, 0, $max - 1 ) . '…';
+	}
+}

--- a/inc/Cli/PruneOrphanLocationsCommand.php
+++ b/inc/Cli/PruneOrphanLocationsCommand.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * `wp extrachill events locations prune-orphans` — delete empty orphan
+ * `location` terms left behind by the venue-name pollution bug.
+ *
+ * Scope is intentionally narrow: this command ONLY deletes terms where
+ *
+ *   - taxonomy = location
+ *   - parent = 0 (top-level)
+ *   - count = 0 (no posts attached)
+ *   - the term is NOT a parent of any other location term (so we don't
+ *     accidentally delete a country/state node that has been emptied
+ *     temporarily during a migration)
+ *
+ * Terms with count > 0 are reported but NOT deleted — operator must
+ * reassign the attached posts first via
+ *
+ *   wp extrachill events fix-locations --yes --url=events.extrachill.com
+ *
+ * which delegates to extrachill/reconcile-event-locations.
+ *
+ * Companion to RepairFlowLocationsCommand for Extra-Chill/extrachill-events#98.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class PruneOrphanLocationsCommand {
+
+	/**
+	 * Delete empty orphan location terms (parent=0, count=0, no
+	 * children). Reports — but does not touch — orphan terms that still
+	 * have posts attached.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--commit]
+	 * : Actually delete the terms. Default is dry-run.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill events locations prune-orphans --url=events.extrachill.com
+	 *     wp extrachill events locations prune-orphans --url=events.extrachill.com --commit
+	 *
+	 * @param array $args       Positional args (unused).
+	 * @param array $assoc_args Named args.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		if ( ! defined( 'WP_CLI' ) || ! \WP_CLI ) {
+			return;
+		}
+
+		if ( ! taxonomy_exists( 'location' ) ) {
+			\WP_CLI::error( 'The location taxonomy is not registered on this site. Run with --url=events.extrachill.com.' );
+			return;
+		}
+
+		$commit = ! empty( $assoc_args['commit'] );
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
+
+		global $wpdb;
+
+		// All orphan candidates: top-level location terms whose term_id
+		// is not used as a `parent` by any other location term.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$candidates = $wpdb->get_results(
+			"SELECT tt.term_id, tt.term_taxonomy_id, tt.count, t.name, t.slug
+			FROM {$wpdb->term_taxonomy} tt
+			INNER JOIN {$wpdb->terms} t ON t.term_id = tt.term_id
+			WHERE tt.taxonomy = 'location'
+			AND tt.parent = 0
+			AND tt.term_id NOT IN (
+				SELECT DISTINCT parent FROM {$wpdb->term_taxonomy}
+				WHERE taxonomy = 'location' AND parent > 0
+			)
+			ORDER BY tt.count DESC, t.name ASC",
+			ARRAY_A
+		);
+
+		if ( empty( $candidates ) ) {
+			\WP_CLI::log( 'No orphan location terms found.' );
+			return;
+		}
+
+		$report = array();
+		$totals = array(
+			'scanned'        => 0,
+			'deletable'      => 0,
+			'deleted'        => 0,
+			'has_posts'      => 0,
+			'failed'         => 0,
+		);
+
+		foreach ( $candidates as $row ) {
+			$totals['scanned']++;
+			$term_id = (int) $row['term_id'];
+			$count   = (int) $row['count'];
+			$name    = (string) $row['name'];
+			$slug    = (string) $row['slug'];
+
+			if ( $count > 0 ) {
+				$totals['has_posts']++;
+				$report[] = array(
+					'term_id' => $term_id,
+					'name'    => $name,
+					'slug'    => $slug,
+					'count'   => $count,
+					'status'  => 'skipped',
+					'reason'  => 'has_posts_run_fix_locations_first',
+				);
+				continue;
+			}
+
+			$totals['deletable']++;
+
+			if ( ! $commit ) {
+				$report[] = array(
+					'term_id' => $term_id,
+					'name'    => $name,
+					'slug'    => $slug,
+					'count'   => $count,
+					'status'  => 'would_delete',
+					'reason'  => 'dry_run',
+				);
+				continue;
+			}
+
+			$result = wp_delete_term( $term_id, 'location' );
+			if ( true === $result ) {
+				$totals['deleted']++;
+				$report[] = array(
+					'term_id' => $term_id,
+					'name'    => $name,
+					'slug'    => $slug,
+					'count'   => $count,
+					'status'  => 'deleted',
+					'reason'  => 'wp_delete_term_ok',
+				);
+			} else {
+				$totals['failed']++;
+				$reason = is_wp_error( $result ) ? $result->get_error_code() : 'wp_delete_term_returned_' . var_export( $result, true );
+				$report[] = array(
+					'term_id' => $term_id,
+					'name'    => $name,
+					'slug'    => $slug,
+					'count'   => $count,
+					'status'  => 'failed',
+					'reason'  => (string) $reason,
+				);
+			}
+		}
+
+		\WP_CLI\Utils\format_items(
+			$format,
+			$report,
+			array( 'term_id', 'name', 'slug', 'count', 'status', 'reason' )
+		);
+
+		\WP_CLI::log( '' );
+		\WP_CLI::log( sprintf(
+			'Summary: scanned=%d deletable=%d deleted=%d has_posts=%d failed=%d',
+			$totals['scanned'],
+			$totals['deletable'],
+			$totals['deleted'],
+			$totals['has_posts'],
+			$totals['failed']
+		) );
+
+		if ( ! $commit ) {
+			\WP_CLI::log( '' );
+			\WP_CLI::log( 'Dry run — no terms deleted. Re-run with --commit to apply.' );
+		}
+
+		if ( $totals['has_posts'] > 0 ) {
+			\WP_CLI::log( '' );
+			\WP_CLI::warning( sprintf(
+				'%d orphan term(s) still have posts attached. Run `wp extrachill events fix-locations --yes --url=events.extrachill.com` to reassign them, then re-run prune-orphans.',
+				$totals['has_posts']
+			) );
+		}
+	}
+}

--- a/inc/Cli/RepairFlowLocationsCommand.php
+++ b/inc/Cli/RepairFlowLocationsCommand.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * `wp extrachill events flows repair-locations` — repair
+ * `taxonomy_location_selection` on `upsert_event` flows so they point at
+ * the pipeline's market term instead of `ai_decides` / empty / a stale
+ * string.
+ *
+ * Bleeding-source fix for Extra-Chill/extrachill-events#98. Companion to
+ * `wp extrachill events fix-locations` (post-level repair via the
+ * extrachill/reconcile-event-locations ability).
+ *
+ * Reads the events subsite (blog_id=7, prefix `c8c_7_`) — must be invoked
+ * with `--url=events.extrachill.com` so $wpdb->prefix resolves correctly.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+use DataMachine\Core\Database\Flows\Flows;
+use ExtraChillEvents\Core\FlowLocationGuard;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class RepairFlowLocationsCommand {
+
+	/**
+	 * Repair `taxonomy_location_selection` on every `upsert_event` flow
+	 * whose current value would defeat the location-from-venue rule
+	 * (`ai_decides`, empty, `skip`, or a stale string that no longer
+	 * resolves to a real `location` term).
+	 *
+	 * Strategy: resolve each flow's pipeline name to a `location` term
+	 * ID, then rewrite the upsert step. Writes go through
+	 * `Flows::update_flow()` so JSON encoding stays the repository's
+	 * responsibility (MEMORY.md load-bearing rule).
+	 *
+	 * Dry-run is the default. Pass `--commit` to write.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--commit]
+	 * : Actually write the repairs. Default is dry-run (no DB writes).
+	 *
+	 * [--flow-id=<id>]
+	 * : Limit to a single flow_id. Useful for spot-fix work.
+	 *
+	 * [--format=<format>]
+	 * : Output format for the per-flow report.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill events flows repair-locations --url=events.extrachill.com
+	 *     wp extrachill events flows repair-locations --url=events.extrachill.com --commit
+	 *     wp extrachill events flows repair-locations --url=events.extrachill.com --flow-id=727
+	 *
+	 * @param array $args       Positional args (unused).
+	 * @param array $assoc_args Named args.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		if ( ! defined( 'WP_CLI' ) || ! \WP_CLI ) {
+			return;
+		}
+
+		if ( ! class_exists( '\\DataMachine\\Core\\Database\\Flows\\Flows' ) ) {
+			\WP_CLI::error( 'Data Machine Flows repository is not available on this site.' );
+			return;
+		}
+
+		$commit  = ! empty( $assoc_args['commit'] );
+		$flow_id = isset( $assoc_args['flow-id'] ) ? (int) $assoc_args['flow-id'] : 0;
+		$format  = (string) ( $assoc_args['format'] ?? 'table' );
+
+		global $wpdb;
+		$flows_table     = $wpdb->prefix . 'datamachine_flows';
+		$pipelines_table = $wpdb->prefix . 'datamachine_pipelines';
+
+		// Pull every flow whose upsert step references upsert_event. We
+		// intentionally do NOT pre-filter on "ai_decides" — a stale
+		// string value (e.g. a pipeline name that no longer matches a
+		// real term) is also broken and we want the report to catch it.
+		$where  = "f.flow_config LIKE %s";
+		$params = array( '%upsert_event%' );
+
+		if ( $flow_id > 0 ) {
+			$where   .= ' AND f.flow_id = %d';
+			$params[] = $flow_id;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT f.flow_id, f.flow_name, f.pipeline_id, p.pipeline_name
+				FROM {$flows_table} f
+				LEFT JOIN {$pipelines_table} p ON p.pipeline_id = f.pipeline_id
+				WHERE {$where}
+				ORDER BY f.pipeline_id, f.flow_id",
+				...$params
+			),
+			ARRAY_A
+		);
+
+		if ( empty( $rows ) ) {
+			\WP_CLI::log( 'No flows with upsert_event found.' );
+			return;
+		}
+
+		$db_flows = new Flows();
+
+		$report      = array();
+		$totals      = array(
+			'scanned'           => 0,
+			'needs_repair'      => 0,
+			'repaired'          => 0,
+			'skipped_clean'     => 0,
+			'skipped_unresolved'=> 0,
+			'failed'            => 0,
+		);
+
+		foreach ( $rows as $row ) {
+			$totals['scanned']++;
+
+			$fid           = (int) $row['flow_id'];
+			$flow_name     = (string) $row['flow_name'];
+			$pipeline_id   = (int) $row['pipeline_id'];
+			$pipeline_name = (string) ( $row['pipeline_name'] ?? '' );
+
+			$flow_record = $db_flows->get_flow( $fid );
+			if ( ! $flow_record || empty( $flow_record['flow_config'] ) || ! is_array( $flow_record['flow_config'] ) ) {
+				$report[] = array(
+					'flow_id'       => $fid,
+					'flow_name'     => $flow_name,
+					'pipeline_id'   => $pipeline_id,
+					'pipeline_name' => $pipeline_name,
+					'current'       => '',
+					'proposed'      => '',
+					'status'        => 'skipped',
+					'reason'        => 'flow_config_missing',
+				);
+				continue;
+			}
+
+			$current = $this->extractCurrentLocation( $flow_record['flow_config'] );
+
+			// Resolve pipeline's market term.
+			$proposed = FlowLocationGuard::resolvePipelineLocationTermId( $pipeline_name );
+
+			// Determine whether this flow actually needs repair.
+			$needs_repair = false;
+			if ( '' === $current ) {
+				// Flow has an upsert_event step but no location key at
+				// all — treat as needs_repair only if we have a value
+				// to stamp in. Otherwise the upsert handler likely
+				// doesn't expose the field.
+				$needs_repair = ( '' !== $proposed );
+			} elseif ( FlowLocationGuard::isRejectedValue( $current ) ) {
+				$needs_repair = true;
+			} elseif ( is_numeric( $current ) ) {
+				// Numeric — confirm the term still exists.
+				$term = get_term( (int) $current, 'location' );
+				if ( ! $term || is_wp_error( $term ) ) {
+					$needs_repair = true;
+				}
+			} else {
+				// String name — confirm it still resolves to a real
+				// term. If not, mark for repair so a stale name gets
+				// rewritten to a term ID.
+				$term = get_term_by( 'slug', $current, 'location' );
+				if ( ! $term ) {
+					$term = get_term_by( 'name', $current, 'location' );
+				}
+				if ( ! $term ) {
+					$needs_repair = true;
+				}
+			}
+
+			if ( ! $needs_repair ) {
+				$totals['skipped_clean']++;
+				continue;
+			}
+
+			$totals['needs_repair']++;
+
+			if ( '' === $proposed ) {
+				$totals['skipped_unresolved']++;
+				$report[] = array(
+					'flow_id'       => $fid,
+					'flow_name'     => $flow_name,
+					'pipeline_id'   => $pipeline_id,
+					'pipeline_name' => $pipeline_name,
+					'current'       => $current,
+					'proposed'      => '',
+					'status'        => 'skipped',
+					'reason'        => 'pipeline_market_unresolved',
+				);
+				continue;
+			}
+
+			if ( ! $commit ) {
+				$report[] = array(
+					'flow_id'       => $fid,
+					'flow_name'     => $flow_name,
+					'pipeline_id'   => $pipeline_id,
+					'pipeline_name' => $pipeline_name,
+					'current'       => $current,
+					'proposed'      => $proposed,
+					'status'        => 'would_repair',
+					'reason'        => 'dry_run',
+				);
+				continue;
+			}
+
+			// COMMIT path — coerce + write via Flows::update_flow().
+			$coerce = FlowLocationGuard::coerceUpsertEventLocation( $flow_record['flow_config'], $proposed );
+
+			if ( empty( $coerce['coerced'] ) ) {
+				$totals['skipped_clean']++;
+				$report[] = array(
+					'flow_id'       => $fid,
+					'flow_name'     => $flow_name,
+					'pipeline_id'   => $pipeline_id,
+					'pipeline_name' => $pipeline_name,
+					'current'       => $current,
+					'proposed'      => $proposed,
+					'status'        => 'skipped',
+					'reason'        => 'no_change_after_coerce',
+				);
+				continue;
+			}
+
+			$ok = $db_flows->update_flow( $fid, array( 'flow_config' => $coerce['config'] ) );
+
+			if ( $ok ) {
+				$totals['repaired']++;
+				$report[] = array(
+					'flow_id'       => $fid,
+					'flow_name'     => $flow_name,
+					'pipeline_id'   => $pipeline_id,
+					'pipeline_name' => $pipeline_name,
+					'current'       => $current,
+					'proposed'      => $proposed,
+					'status'        => 'repaired',
+					'reason'        => 'flow_config_written',
+				);
+			} else {
+				$totals['failed']++;
+				$report[] = array(
+					'flow_id'       => $fid,
+					'flow_name'     => $flow_name,
+					'pipeline_id'   => $pipeline_id,
+					'pipeline_name' => $pipeline_name,
+					'current'       => $current,
+					'proposed'      => $proposed,
+					'status'        => 'failed',
+					'reason'        => 'update_flow_returned_false',
+				);
+			}
+		}
+
+		// Always include rows that need attention (would_repair, skipped
+		// unresolved, failed); skip already-clean rows from the report
+		// unless --flow-id was used.
+		$visible = array_values(
+			array_filter(
+				$report,
+				static function ( $r ) {
+					return 'skipped' !== $r['status'] || 'pipeline_market_unresolved' === $r['reason'];
+				}
+			)
+		);
+
+		if ( $flow_id > 0 ) {
+			// Single-flow mode — show everything including clean rows.
+			$visible = $report;
+		}
+
+		\WP_CLI\Utils\format_items(
+			$format,
+			$visible,
+			array( 'flow_id', 'flow_name', 'pipeline_id', 'pipeline_name', 'current', 'proposed', 'status', 'reason' )
+		);
+
+		\WP_CLI::log( '' );
+		\WP_CLI::log( sprintf(
+			'Summary: scanned=%d needs_repair=%d repaired=%d skipped_clean=%d skipped_unresolved=%d failed=%d',
+			$totals['scanned'],
+			$totals['needs_repair'],
+			$totals['repaired'],
+			$totals['skipped_clean'],
+			$totals['skipped_unresolved'],
+			$totals['failed']
+		) );
+
+		if ( ! $commit ) {
+			\WP_CLI::log( '' );
+			\WP_CLI::log( 'Dry run — no changes written. Re-run with --commit to apply.' );
+		}
+	}
+
+	/**
+	 * Extract the current taxonomy_location_selection value from a
+	 * decoded flow_config. Returns '' when no upsert_event step exists
+	 * or the field is missing entirely.
+	 */
+	private function extractCurrentLocation( array $flow_config ): string {
+		foreach ( $flow_config as $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+			$handler_configs = $step['handler_configs'] ?? array();
+			if ( ! is_array( $handler_configs ) || empty( $handler_configs['upsert_event'] ) ) {
+				continue;
+			}
+			$upsert = $handler_configs['upsert_event'];
+			if ( ! is_array( $upsert ) ) {
+				continue;
+			}
+			if ( array_key_exists( 'taxonomy_location_selection', $upsert ) ) {
+				$val = $upsert['taxonomy_location_selection'];
+				return is_scalar( $val ) ? (string) $val : '';
+			}
+		}
+		return '';
+	}
+}

--- a/inc/Core/FlowLocationGuard.php
+++ b/inc/Core/FlowLocationGuard.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Flow location guard.
+ *
+ * Centralizes the rule: `taxonomy_location_selection` on an `upsert_event`
+ * flow MUST be a concrete location term ID (as a string) or term-name
+ * fallback. Values of `ai_decides`, empty string, or `skip` are not allowed
+ * because `location` is a derived taxonomy — the market is determined by
+ * the venue's city/state/zip, never by the AI.
+ *
+ * See Extra-Chill/extrachill-events#98 for full context. This guard is
+ * defensive code in extrachill-events because data-machine does not (yet)
+ * expose a `datamachine_flow_config_pre_save` filter. A follow-up issue
+ * tracks adding that hook upstream; until then, every EC writer that
+ * touches flow_config on an `upsert_event` flow must route through this
+ * guard.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class FlowLocationGuard {
+
+	/**
+	 * Values that are NOT acceptable for `taxonomy_location_selection` on
+	 * an `upsert_event` flow. `ai_decides` is the main offender — see
+	 * issue #98. Empty string and `skip` would also defeat the purpose
+	 * (no location at all), so we coerce those too.
+	 */
+	private const REJECTED_VALUES = array( 'ai_decides', '', 'skip' );
+
+	/**
+	 * Walk a flow_config array and coerce any forbidden
+	 * `taxonomy_location_selection` value on an `upsert_event` step to the
+	 * caller-supplied pipeline location term.
+	 *
+	 * Returns a new config (does not mutate $config) plus a list of step
+	 * IDs that were coerced. Caller decides whether to write the result
+	 * back and how to surface the warning.
+	 *
+	 * If $pipeline_location_term is empty (i.e. the pipeline doesn't
+	 * resolve to a market term), no coercion happens — the caller gets
+	 * the original config and an empty coerced list. That avoids
+	 * stamping a bogus value when there's nothing better to substitute.
+	 *
+	 * @param array  $config                  Flow config (associative,
+	 *                                        step_id => step_data).
+	 * @param string $pipeline_location_term  Term ID string (preferred)
+	 *                                        or term name, sourced from
+	 *                                        the pipeline this flow
+	 *                                        belongs to.
+	 * @return array{config:array,coerced:array<int,array{step_id:string,old:string,new:string}>}
+	 */
+	public static function coerceUpsertEventLocation( array $config, string $pipeline_location_term ): array {
+		$coerced = array();
+
+		if ( '' === $pipeline_location_term ) {
+			return array(
+				'config'  => $config,
+				'coerced' => $coerced,
+			);
+		}
+
+		foreach ( $config as $step_id => &$step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+
+			$handler_configs = $step['handler_configs'] ?? array();
+			if ( ! is_array( $handler_configs ) || ! isset( $handler_configs['upsert_event'] ) ) {
+				continue;
+			}
+
+			$upsert = $handler_configs['upsert_event'];
+			if ( ! is_array( $upsert ) ) {
+				continue;
+			}
+
+			$current = $upsert['taxonomy_location_selection'] ?? '';
+			if ( ! is_string( $current ) ) {
+				continue;
+			}
+
+			if ( ! self::isRejectedValue( $current ) ) {
+				continue;
+			}
+
+			$step['handler_configs']['upsert_event']['taxonomy_location_selection'] = $pipeline_location_term;
+
+			$coerced[] = array(
+				'step_id' => (string) $step_id,
+				'old'     => $current,
+				'new'     => $pipeline_location_term,
+			);
+		}
+		unset( $step );
+
+		return array(
+			'config'  => $config,
+			'coerced' => $coerced,
+		);
+	}
+
+	/**
+	 * True if $value would make `location` AI-decided / unset on an
+	 * upsert_event flow and therefore must be rejected.
+	 */
+	public static function isRejectedValue( string $value ): bool {
+		return in_array( strtolower( trim( $value ) ), self::REJECTED_VALUES, true );
+	}
+
+	/**
+	 * Resolve a pipeline's canonical location term, returned as a
+	 * stringified term ID suitable for stamping into
+	 * `taxonomy_location_selection`.
+	 *
+	 * Strategy:
+	 * 1. Strip a trailing " Events" from the pipeline name. This matches
+	 *    the convention every EC city pipeline uses ("Charleston Events",
+	 *    "Pittsburgh Events", …).
+	 * 2. Use a state-aware lookup (parent matches state abbreviation in
+	 *    the name like "Wilmington NC Events") to handle disambiguated
+	 *    pipeline names — see CityAbilities::ensureLocationTerm which
+	 *    creates those.
+	 * 3. Plain name lookup fallback.
+	 *
+	 * Returns '' if no term can be resolved — caller treats that as
+	 * "skip this flow, the operator must fix it manually".
+	 */
+	public static function resolvePipelineLocationTermId( string $pipeline_name ): string {
+		if ( ! taxonomy_exists( 'location' ) ) {
+			return '';
+		}
+
+		$pipeline_name = trim( $pipeline_name );
+		if ( '' === $pipeline_name ) {
+			return '';
+		}
+
+		// Strip trailing " Events" suffix (case-insensitive).
+		$base = preg_replace( '/\s+Events\s*$/i', '', $pipeline_name );
+		$base = is_string( $base ) ? trim( $base ) : '';
+		if ( '' === $base ) {
+			return '';
+		}
+
+		// Detect a disambiguated pipeline name like "Wilmington NC" —
+		// the last token is a US state abbreviation. We use that to
+		// pick the right Wilmington (NC vs DE).
+		$state_abbr = '';
+		$city       = $base;
+		if ( preg_match( '/^(.+)\s+([A-Z]{2})$/', $base, $m ) ) {
+			$city       = trim( $m[1] );
+			$state_abbr = strtoupper( $m[2] );
+		}
+
+		// Build a list of candidate location terms with this name.
+		$candidates = get_terms(
+			array(
+				'taxonomy'   => 'location',
+				'name'       => $city,
+				'hide_empty' => false,
+				'number'     => 0,
+			)
+		);
+
+		if ( is_wp_error( $candidates ) || empty( $candidates ) ) {
+			return '';
+		}
+
+		// If only one match, use it.
+		if ( 1 === count( $candidates ) ) {
+			return (string) $candidates[0]->term_id;
+		}
+
+		// Multiple candidates — try to disambiguate by state.
+		if ( '' !== $state_abbr ) {
+			$state_full = self::stateAbbreviationToName( $state_abbr );
+			foreach ( $candidates as $candidate ) {
+				if ( (int) $candidate->parent <= 0 ) {
+					continue;
+				}
+				$parent = get_term( (int) $candidate->parent, 'location' );
+				if ( ! $parent || is_wp_error( $parent ) ) {
+					continue;
+				}
+				if ( '' !== $state_full && strcasecmp( $parent->name, $state_full ) === 0 ) {
+					return (string) $candidate->term_id;
+				}
+				if ( strcasecmp( $parent->name, $state_abbr ) === 0 ) {
+					return (string) $candidate->term_id;
+				}
+			}
+		}
+
+		// Multiple matches and no state to disambiguate — refuse rather
+		// than guess wrong.
+		return '';
+	}
+
+	/**
+	 * Minimal US state abbreviation → full name map, intentionally
+	 * duplicated from EventLocationAlignmentAbilities so this guard
+	 * doesn't depend on that ability's load order.
+	 */
+	private static function stateAbbreviationToName( string $abbr ): string {
+		static $map = array(
+			'AL' => 'Alabama',       'AK' => 'Alaska',        'AZ' => 'Arizona',
+			'AR' => 'Arkansas',      'CA' => 'California',    'CO' => 'Colorado',
+			'CT' => 'Connecticut',   'DE' => 'Delaware',      'DC' => 'District of Columbia',
+			'FL' => 'Florida',       'GA' => 'Georgia',       'HI' => 'Hawaii',
+			'ID' => 'Idaho',         'IL' => 'Illinois',      'IN' => 'Indiana',
+			'IA' => 'Iowa',          'KS' => 'Kansas',        'KY' => 'Kentucky',
+			'LA' => 'Louisiana',     'ME' => 'Maine',         'MD' => 'Maryland',
+			'MA' => 'Massachusetts', 'MI' => 'Michigan',      'MN' => 'Minnesota',
+			'MS' => 'Mississippi',   'MO' => 'Missouri',      'MT' => 'Montana',
+			'NE' => 'Nebraska',      'NV' => 'Nevada',        'NH' => 'New Hampshire',
+			'NJ' => 'New Jersey',    'NM' => 'New Mexico',    'NY' => 'New York',
+			'NC' => 'North Carolina','ND' => 'North Dakota',  'OH' => 'Ohio',
+			'OK' => 'Oklahoma',      'OR' => 'Oregon',        'PA' => 'Pennsylvania',
+			'RI' => 'Rhode Island',  'SC' => 'South Carolina','SD' => 'South Dakota',
+			'TN' => 'Tennessee',     'TX' => 'Texas',         'UT' => 'Utah',
+			'VT' => 'Vermont',       'VA' => 'Virginia',      'WA' => 'Washington',
+			'WV' => 'West Virginia', 'WI' => 'Wisconsin',     'WY' => 'Wyoming',
+		);
+
+		return $map[ strtoupper( $abbr ) ] ?? '';
+	}
+}


### PR DESCRIPTION
Closes #98 (the flow_config + orphan-term portion). The post-level
fix is already shipped via `wp extrachill events fix-locations`.

## What this adds

### `wp extrachill events flows repair-locations`

Walks every `upsert_event` flow on the events subsite and rewrites
`taxonomy_location_selection` to the pipeline's market term ID
whenever the current value is `ai_decides`, empty, `skip`, or a
stale string that no longer resolves to a real `location` term.

- Resolves the pipeline's market by stripping the trailing
  ` Events` suffix and looking up the resulting term name — uses
  state-abbreviation disambiguation (`Wilmington NC Events`,
  `Charleston WV Events`, …) to pick the correct term when the
  city name is ambiguous.
- Writes go through `Flows::update_flow($flow_id, ['flow_config'
  => $array])` so JSON encoding stays the repository's
  responsibility (per MEMORY.md load-bearing rule).
- Dry-run is the default. `--commit` applies. `--flow-id=<id>`
  scopes to a single flow.

### `wp extrachill events locations prune-orphans`

Deletes empty orphan `location` terms (`parent=0`, `count=0`, not
a parent of another location term). Refuses to touch orphan terms
that still have posts attached — operator must run
`wp extrachill events fix-locations --yes --url=events.extrachill.com`
first to reassign them.

### Save-time guard

`ExtraChillEvents\Core\FlowLocationGuard::coerceUpsertEventLocation()`
is now invoked from both `VenueAddAbilities::patchFlowSteps` and
`CityAbilities::patchFlowSteps`. Both already stamp a concrete
location term, so this is defense-in-depth — it catches future
refactors and emits a `datamachine_log` warning naming the
`flow_id` so we'd notice a regression.

The clean upstream fix is a `datamachine_flow_config_pre_save`
filter that would catch every writer (admin UI, datamachine CLI,
arbitrary abilities). That belongs upstream and will be filed as a
follow-up issue against data-machine; until then, EC owns the only
two writers that touch `upsert_event` flows on this subsite.

## How to test

```
wp extrachill events flows repair-locations --url=events.extrachill.com
wp extrachill events locations prune-orphans --url=events.extrachill.com
```

Both default to dry-run. Once the operator is satisfied:

```
wp extrachill events flows repair-locations --url=events.extrachill.com --commit
wp extrachill events fix-locations --yes --url=events.extrachill.com
wp extrachill events locations prune-orphans --url=events.extrachill.com --commit
```

(The middle step reassigns the 1,604 mis-tagged posts away from
the orphan terms; after that, prune-orphans finishes the job.)

## Acceptance

- After `repair-locations --commit`:
  ```
  SELECT COUNT(*) FROM c8c_7_datamachine_flows
  WHERE flow_config LIKE '%"taxonomy_location_selection":"ai_decides"%'
     OR flow_config LIKE '%"taxonomy_location_selection": "ai_decides"%'
  ```
  returns 0.
- After both commits + `fix-locations`, orphan-term count drops
  from 116 → 0.

## Out of scope

- Issue #99 (wrong-pipeline assignment / Cincinnati-in-Tulsa) is a
  separate bug and not addressed here.
- The upstream `datamachine_flow_config_pre_save` filter will be
  filed against data-machine as a follow-up.