### PR TITLE
fix: roll up Midlothian, TX to Dallas (the stray after #102)

### DIFF
--- a/inc/core/location-normalizer.php
+++ b/inc/core/location-normalizer.php
@@ -198,6 +198,8 @@ function extrachill_events_get_city_market_map() {
 		'midlothian'      => array(
 			'virginia' => 'richmond',
 			'va'       => 'richmond',
+			'texas'    => 'dallas',
+			'tx'       => 'dallas',
 		),
 		'murfreesboro'    => 'nashville',
 		'new york'        => 'new-york-city',


### PR DESCRIPTION
After #102, one orphan post remained on the Midlothian location term. Turns out the actual venue (Union 28) is in Midlothian, **TX** — a Dallas suburb — not Midlothian, VA. Adds the state-scoped mapping. Follow-up to #98 / #102.