### PR TITLE
feat(archive): per-archive upcoming-events stats line on artist / location / venue archives

### DIFF
--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -49,7 +49,8 @@
 }
 
 /* Calendar Stats Counter */
-.page-title + .calendar-stats {
+.page-title + .calendar-stats,
+.taxonomy-description + .calendar-stats {
     margin-top: calc(-1 * var(--spacing-sm));
 }
 
@@ -57,6 +58,10 @@
     color: var(--muted-text);
     font-size: var(--font-size-sm);
     margin-bottom: 0;
+}
+
+.taxonomy-archive-header .calendar-stats {
+    margin-bottom: var(--spacing-md);
 }
 
 /* Priority event indicator */

--- a/inc/core/calendar-stats.php
+++ b/inc/core/calendar-stats.php
@@ -90,3 +90,179 @@ function extrachill_events_render_calendar_stats(): void {
 		esc_html( number_format( $stats['locations'] ) )
 	);
 }
+
+/**
+ * Get upcoming stats scoped to a single taxonomy term.
+ *
+ * Returns counts of upcoming events for the term, plus distinct venues
+ * (for artist/location archives) and distinct locations (for artist
+ * archives) of those upcoming events.
+ *
+ * Implementation:
+ *   - Events count uses `data_machine_events_query_events()` with
+ *     `tax_filters` + `fields=count`. Verified in
+ *     `inc/Abilities/EventDateQueryAbilities.php::executeQueryEvents()`
+ *     which accepts `tax_filters` keyed by taxonomy slug.
+ *   - Venue / location counts use the new co-occurrence filter in
+ *     `UpcomingCountAbilities::executeGetUpcomingCounts()`
+ *     (`filter_taxonomy` + `filter_term_id`), shipped in
+ *     data-machine-events PR #307.
+ *
+ * Partial failures degrade gracefully: if the venues/locations counts
+ * return WP_Error, the function still returns a valid events count and
+ * zeros for the missing axes. The render function will then drop the
+ * affected clause from the sentence.
+ *
+ * Cached for 6h in a per-term transient
+ * (`extrachill_calendar_stats_{taxonomy}_{term_id}`). Lazy on first
+ * request — NOT pre-warmed (the cross-product of artist+location+venue
+ * terms is too large for blanket warming).
+ *
+ * @param string $taxonomy 'artist'|'location'|'venue'.
+ * @param int    $term_id  Term ID.
+ * @return array{events:int, venues:int, locations:int}
+ *   - artist: all three populated
+ *   - location: events + venues populated, locations = 0
+ *   - venue: events populated, venues = 0, locations = 0
+ */
+function extrachill_events_get_term_calendar_stats( string $taxonomy, int $term_id ): array {
+	$zero = array( 'events' => 0, 'venues' => 0, 'locations' => 0 );
+
+	if ( ! in_array( $taxonomy, array( 'artist', 'location', 'venue' ), true ) ) {
+		return $zero;
+	}
+	if ( $term_id < 1 ) {
+		return $zero;
+	}
+
+	$cache_key = "extrachill_calendar_stats_{$taxonomy}_{$term_id}";
+	$cached    = get_transient( $cache_key );
+	if ( false !== $cached && is_array( $cached ) ) {
+		return $cached;
+	}
+
+	if ( ! function_exists( 'data_machine_events_query_events' ) ) {
+		return $zero;
+	}
+
+	// Events count: events tagged with this term that are upcoming.
+	$events_result = data_machine_events_query_events( array(
+		'scope'       => 'upcoming',
+		'fields'      => 'count',
+		'tax_filters' => array( $taxonomy => array( $term_id ) ),
+	) );
+	$events = (int) ( $events_result['total'] ?? 0 );
+
+	$venues    = 0;
+	$locations = 0;
+
+	// Co-occurrence counts require the new UpcomingCountAbilities signature
+	// (filter_taxonomy + filter_term_id), shipped in data-machine-events #307.
+	if ( $events > 0 && class_exists( '\DataMachineEvents\Abilities\UpcomingCountAbilities' ) ) {
+		$counts_ability = new \DataMachineEvents\Abilities\UpcomingCountAbilities();
+
+		// Venues count for artist + location archives.
+		if ( 'artist' === $taxonomy || 'location' === $taxonomy ) {
+			$venue_result = $counts_ability->executeGetUpcomingCounts( array(
+				'taxonomy'        => 'venue',
+				'exclude_roots'   => false,
+				'filter_taxonomy' => $taxonomy,
+				'filter_term_id'  => $term_id,
+			) );
+
+			if ( is_wp_error( $venue_result ) ) {
+				error_log( sprintf(
+					'[extrachill-events] term calendar stats: venue count failed for %s=%d: %s',
+					$taxonomy,
+					$term_id,
+					$venue_result->get_error_message()
+				) );
+			} else {
+				$venues = count( $venue_result['terms'] ?? array() );
+			}
+		}
+
+		// Locations count for artist archives only.
+		if ( 'artist' === $taxonomy ) {
+			$location_result = $counts_ability->executeGetUpcomingCounts( array(
+				'taxonomy'        => 'location',
+				'exclude_roots'   => false,
+				'filter_taxonomy' => $taxonomy,
+				'filter_term_id'  => $term_id,
+			) );
+
+			if ( is_wp_error( $location_result ) ) {
+				error_log( sprintf(
+					'[extrachill-events] term calendar stats: location count failed for %s=%d: %s',
+					$taxonomy,
+					$term_id,
+					$location_result->get_error_message()
+				) );
+			} else {
+				$locations = count( $location_result['terms'] ?? array() );
+			}
+		}
+	}
+
+	$stats = array(
+		'events'    => $events,
+		'venues'    => $venues,
+		'locations' => $locations,
+	);
+
+	set_transient( $cache_key, $stats, 6 * HOUR_IN_SECONDS );
+
+	return $stats;
+}
+
+/**
+ * Render the term-scoped stats line. Hides itself when events == 0.
+ *
+ * Output examples:
+ *   - artist:   "123 upcoming events at 45 venues in 12 locations"
+ *   - location: "123 upcoming events at 45 venues"
+ *   - venue:    "123 upcoming events"
+ *
+ * If venues/locations counts failed in the helper (returned 0), the
+ * affected clause is dropped from the sentence so the line still
+ * provides useful information rather than reading "N events at 0
+ * venues."
+ *
+ * @param string $taxonomy 'artist'|'location'|'venue'.
+ * @param int    $term_id  Term ID.
+ */
+function extrachill_events_render_term_calendar_stats( string $taxonomy, int $term_id ): void {
+	if ( ! in_array( $taxonomy, array( 'artist', 'location', 'venue' ), true ) ) {
+		return;
+	}
+
+	$stats = extrachill_events_get_term_calendar_stats( $taxonomy, $term_id );
+
+	if ( $stats['events'] < 1 ) {
+		return;
+	}
+
+	$events_fmt    = esc_html( number_format( $stats['events'] ) );
+	$venues_fmt    = esc_html( number_format( $stats['venues'] ) );
+	$locations_fmt = esc_html( number_format( $stats['locations'] ) );
+
+	if ( 'artist' === $taxonomy ) {
+		if ( $stats['venues'] > 0 && $stats['locations'] > 0 ) {
+			$sentence = "{$events_fmt} upcoming events at {$venues_fmt} venues in {$locations_fmt} locations";
+		} elseif ( $stats['venues'] > 0 ) {
+			$sentence = "{$events_fmt} upcoming events at {$venues_fmt} venues";
+		} else {
+			$sentence = "{$events_fmt} upcoming events";
+		}
+	} elseif ( 'location' === $taxonomy ) {
+		if ( $stats['venues'] > 0 ) {
+			$sentence = "{$events_fmt} upcoming events at {$venues_fmt} venues";
+		} else {
+			$sentence = "{$events_fmt} upcoming events";
+		}
+	} else { // venue
+		$sentence = "{$events_fmt} upcoming events";
+	}
+
+	echo '<p class="calendar-stats">' . $sentence . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- All interpolated values are esc_html()'d above.
+}

--- a/inc/core/location-map.php
+++ b/inc/core/location-map.php
@@ -65,45 +65,27 @@ function extrachill_events_filter_map_center( $center, array $context ) {
 add_filter( 'data_machine_events_map_center', 'extrachill_events_filter_map_center', 10, 2 );
 
 /**
- * Generate summary text with event/venue counts for location maps.
+ * Suppress the map summary on location archives.
  *
- * Queries venue and event counts directly from the database instead of
- * relying on a pre-filtered venue array.
+ * As of #107, the archive header now renders a canonical upcoming-events
+ * stats line ("N upcoming events at N venues") via
+ * `extrachill_events_render_term_calendar_stats()`. Showing the same
+ * counts inside the map's summary slot duplicated the number on the
+ * page, so we return an empty string here. The map itself still
+ * renders — only its overlay summary text is dropped.
  *
  * @hook data_machine_events_map_summary
  * @param string $summary Current summary (empty by default).
  * @param array  $venues  Venue data array (empty — dynamic mode).
  * @param array  $context Map context.
- * @return string Summary text.
+ * @return string Summary text. Empty on location archives.
  */
 function extrachill_events_filter_map_summary( string $summary, array $venues, array $context ): string {
 	if ( ! $context['is_taxonomy'] || 'location' !== $context['taxonomy'] ) {
 		return $summary;
 	}
 
-	// Query venue count for this location directly.
-	$location_venues = extrachill_events_get_location_venues( $context['term_id'] );
-	$venue_count     = count( $location_venues );
-
-	if ( 0 === $venue_count ) {
-		return $summary;
-	}
-
-	$event_count = extrachill_events_get_upcoming_event_count( $context['term_id'] );
-
-	if ( $event_count > 0 ) {
-		return sprintf(
-			/* translators: 1: number of events, 2: number of venues */
-			__( '%1$d events at %2$d venues', 'extrachill-events' ),
-			$event_count,
-			$venue_count
-		);
-	}
-
-	return sprintf(
-		/* translators: %d: number of venues */
-		_n( '%d venue', '%d venues', $venue_count, 'extrachill-events' ),
-		$venue_count
-	);
+	// Counts moved to the archive-header stats line; map stands on its own.
+	return '';
 }
 add_filter( 'data_machine_events_map_summary', 'extrachill_events_filter_map_summary', 10, 3 );

--- a/inc/templates/archive.php
+++ b/inc/templates/archive.php
@@ -29,7 +29,9 @@ extrachill_breadcrumbs();
 			<?php if ( ! empty( $term->description ) ) : ?>
 				<div class="taxonomy-description"><?php echo wp_kses_post( wpautop( $term->description ) ); ?></div>
 			<?php endif; ?>
-			
+
+			<?php extrachill_events_render_term_calendar_stats( 'venue', (int) $term->term_id ); ?>
+
 			<?php if ( $formatted_address || ! empty( $venue_data['website'] ) ) : ?>
 				<div class="taxonomy-meta">
 					<?php if ( $formatted_address ) : ?>
@@ -73,18 +75,22 @@ extrachill_breadcrumbs();
 			<?php if ( term_description() ) : ?>
 				<div class="taxonomy-description"><?php echo wp_kses_post( wpautop( term_description() ) ); ?></div>
 			<?php endif; ?>
+			<?php extrachill_events_render_term_calendar_stats( 'location', (int) $term->term_id ); ?>
 		</header>
 		<?php
 		if ( function_exists( 'extrachill_events_render_scope_nav' ) ) {
 			extrachill_events_render_scope_nav( $term, '' );
 		}
 		?>
-	<?php elseif ( is_tax( 'artist' ) ) : ?>
+	<?php elseif ( is_tax( 'artist' ) ) :
+		$term = get_queried_object();
+		?>
 		<header class="taxonomy-archive-header artist-archive-header">
 			<h1 class="page-title"><?php single_term_title(); ?> Tour Dates</h1>
 			<?php if ( term_description() ) : ?>
 				<div class="taxonomy-description"><?php echo wp_kses_post( wpautop( term_description() ) ); ?></div>
 			<?php endif; ?>
+			<?php extrachill_events_render_term_calendar_stats( 'artist', (int) $term->term_id ); ?>
 		</header>
 	<?php elseif ( is_tax() ) : ?>
 		<header class="taxonomy-archive-header">


### PR DESCRIPTION
Closes #107. Depends on (and consumes the new signature from) Extra-Chill/data-machine-events#307 (merged).

## Summary

Renders a stats sentence in the archive header on artist, location, and venue taxonomy archives, matching the homepage stats line pattern.

| Archive | Sentence |
|---|---|
| Artist (`taxonomy: artist`) | `N upcoming events at N venues in N locations` |
| Location (`taxonomy: location`) | `N upcoming events at N venues` |
| Venue (`taxonomy: venue`) | `N upcoming events` |

Hidden entirely when the upcoming-event count is 0. Numbers thousands-separated.

## What changed

### `inc/core/calendar-stats.php` — two new helpers

- `extrachill_events_get_term_calendar_stats( string $taxonomy, int $term_id ): array`
  - Returns `{ events, venues, locations }` (zeroes for axes the archive type doesn't need).
  - Events count via `data_machine_events_query_events()` with `tax_filters` + `fields=count` (verified path in `EventDateQueryAbilities::executeQueryEvents()` — already used by `extrachill_events_get_upcoming_event_count()`).
  - Venue / location counts via `UpcomingCountAbilities::executeGetUpcomingCounts()` with the new `filter_taxonomy` + `filter_term_id` pair from data-machine-events #307.
  - Cached for 6h in a per-term transient (`extrachill_calendar_stats_{taxonomy}_{term_id}`).
  - Graceful degradation: if a sub-count returns `WP_Error`, the corresponding axis returns 0 and the failure is logged via `error_log()`. The render function then drops the affected clause from the sentence rather than rendering "N events at 0 venues."
  - **Not pre-warmed** in `badge-count-warmer.php` — lazy on first request, as the issue spec recommends (artist + location + venue terms are too many for blanket warming).

- `extrachill_events_render_term_calendar_stats( string $taxonomy, int $term_id ): void`
  - Renders `<p class="calendar-stats">…</p>`.
  - Hides itself when events == 0.
  - Drops empty venue/location clauses if the underlying sub-count is 0 (failure path).

The homepage helpers (`extrachill_events_get_calendar_stats()` / `extrachill_events_render_calendar_stats()`) are **unchanged**.

### `inc/templates/archive.php`

Calls the new render function inside each of the three relevant `is_tax()` branches, after `taxonomy-description`. For location archives the line lands inside `<header>` before `extrachill_events_render_scope_nav()`, so the visual order is: title → description → stats line → scope nav → map (via the below-description hook).

### `inc/core/location-map.php` — dedupe the map summary

`extrachill_events_filter_map_summary()` now returns an empty string on location archives. The new top-of-page stats line is the canonical count source; keeping the same number inside the map's summary slot duplicated it on the page. The map itself still renders — only its overlay text is dropped. Choice documented in the function's docblock.

### `assets/css/calendar.css`

- Extended the existing `.page-title + .calendar-stats` negative-margin rule to also match `.taxonomy-description + .calendar-stats` so the line tucks under the description tightly on archive pages.
- Added `.taxonomy-archive-header .calendar-stats { margin-bottom: var(--spacing-md); }` so the line breathes against the scope nav / map below it.

## Live data sanity check

Verified against the live extrachill-events DB on the VPS. The deployed `data-machine-events` plugin is still v0.39.1 (lacks PR #307), so I validated the co-occurrence numbers by running the merged SQL from #307 directly against the same DB:

| Term | Events | Venues | Locations |
|---|---|---|---|
| artist 15008 "Scott" | 490 | 1 | 1 |
| artist 42746 "Sebastian" | 300 | 1 | 1 |
| location 1628 "Austin" | 1,926 | 66 | — |
| location 27055 "Fort Lauderdale" | 1,720 | 12 | — |
| venue 51395 "Elbo Room" | 1,635 | — | — |

Events counts cross-verified against `UpcomingCountAbilities::executeGetUpcomingCounts()` totals (490 / 1926 / 1635 match exactly).

Rendered HTML samples (events-count path only, since deployed ability lacks the filter — these will read the correct co-occurrence numbers once data-machine-events #307 ships and deploys):

```
<p class="calendar-stats">490 upcoming events at 2,645 venues in 186 locations</p>
<p class="calendar-stats">1,926 upcoming events at 2,645 venues</p>
<p class="calendar-stats">1,635 upcoming events</p>
```

(The 2,645 / 186 figures are the inflated global counts the *deployed* ability returns when it ignores the unknown filter args. Post-release these become 1 / 1 / 66 etc. per the table above.)

Empty-state hide path verified — calling the render function with a nonexistent term ID produces no output.

## Caching

- Key: `extrachill_calendar_stats_{taxonomy}_{term_id}` (e.g. `extrachill_calendar_stats_artist_15008`).
- TTL: `6 * HOUR_IN_SECONDS` (same as homepage).
- No invalidation hooks on event publish/update in this PR (v1 ships TTL-only per the issue spec).
- Not pre-warmed.

## Out of scope (intentional per the issue)

- Venue archive distinct-artists count — follow-up.
- Real-time transient invalidation on event publish/update.
- Other taxonomy archives (festival, promoter).
- Touching homepage helpers.
- Modifying data-machine-events code (already done in #307).

cc @chubes <@532385681268408341>