### PR TITLE
feat(my-shows): search-and-add past shows tab (closes #109)

### DIFF
--- a/blocks/concert-stats/src/components/AddPastShows.js
+++ b/blocks/concert-stats/src/components/AddPastShows.js
@@ -1,0 +1,84 @@
+/**
+ * AddPastShows — "Add Past Shows" tab content for the concert-stats block.
+ *
+ * Lets a logged-in user retroactively mark past events they attended.
+ *
+ * Behavior:
+ *   - Search input (debounced in the hook).
+ *   - Empty query: backend returns the ~most-recent past events as suggestions.
+ *   - Results list with "+ Mark Attended" per row, optimistic state flip.
+ *   - "Load more" pagination, 20 per page (handled in useEventSearch).
+ *
+ * @package ExtraChillEvents
+ */
+
+import { useState } from '@wordpress/element';
+import EventSearchInput from './EventSearchInput';
+import EventSearchResult from './EventSearchResult';
+import useEventSearch from '../hooks/useEventSearch';
+
+const AddPastShows = () => {
+	const [ query, setQuery ] = useState( '' );
+
+	const { events, total, pages, page, loading, error, loadMore, setMarked } =
+		useEventSearch( query );
+
+	const isEmptyQuery = query.trim() === '';
+
+	return (
+		<div className="ec-concert-stats__add-past">
+			<EventSearchInput value={ query } onChange={ setQuery } />
+
+			{ isEmptyQuery && (
+				<p className="ec-concert-stats__search-hint">
+					Search for shows you&rsquo;ve attended to add them to your history.
+				</p>
+			) }
+
+			{ error && (
+				<div className="ec-concert-stats__error">{ error }</div>
+			) }
+
+			{ ! loading && ! error && events.length === 0 && ! isEmptyQuery && (
+				<div className="ec-concert-stats__empty-tab">
+					No past shows match &ldquo;{ query }&rdquo;. Try a different artist or venue name.
+				</div>
+			) }
+
+			{ events.length > 0 && (
+				<div className="ec-concert-stats__search-results">
+					{ isEmptyQuery && (
+						<p className="ec-concert-stats__search-results-label">
+							Recent past shows
+						</p>
+					) }
+					{ events.map( ( ev ) => (
+						<EventSearchResult
+							key={ ev.post_id }
+							event={ ev }
+							onMarkedChange={ setMarked }
+						/>
+					) ) }
+				</div>
+			) }
+
+			{ loading && (
+				<div className="ec-concert-stats__loading-more">Searching…</div>
+			) }
+
+			{ ! loading && page < pages && (
+				<div className="ec-concert-stats__load-more">
+					<button
+						type="button"
+						className="ec-concert-stats__load-more-btn"
+						onClick={ loadMore }
+					>
+						Load more ({ total - events.length } remaining)
+					</button>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default AddPastShows;

--- a/blocks/concert-stats/src/components/EventSearchInput.js
+++ b/blocks/concert-stats/src/components/EventSearchInput.js
@@ -1,0 +1,35 @@
+/**
+ * EventSearchInput — Controlled search input with a clear button.
+ *
+ * The debounce lives in the consuming hook (`useEventSearch`), so this
+ * component just controls the input value and emits onChange immediately.
+ *
+ * @package ExtraChillEvents
+ */
+
+const EventSearchInput = ( { value, onChange, placeholder } ) => {
+	return (
+		<div className="ec-concert-stats__search">
+			<input
+				type="search"
+				className="ec-concert-stats__search-input"
+				value={ value }
+				onChange={ ( e ) => onChange( e.target.value ) }
+				placeholder={ placeholder || 'Search past shows by artist, venue, or title…' }
+				aria-label="Search past events"
+			/>
+			{ value && (
+				<button
+					type="button"
+					className="ec-concert-stats__search-clear"
+					onClick={ () => onChange( '' ) }
+					aria-label="Clear search"
+				>
+					×
+				</button>
+			) }
+		</div>
+	);
+};
+
+export default EventSearchInput;

--- a/blocks/concert-stats/src/components/EventSearchResult.js
+++ b/blocks/concert-stats/src/components/EventSearchResult.js
@@ -1,0 +1,133 @@
+/**
+ * EventSearchResult — Single past-event row in the Add Past Shows tab.
+ *
+ * Renders date / venue / primary artist / city and a "+ Mark Attended" button
+ * (or a disabled "✓ Tracked" label for events already in the user's history).
+ *
+ * Marking is optimistic: the row flips immediately and reverts on REST error.
+ *
+ * @package ExtraChillEvents
+ */
+
+import { useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+const MONTHS = [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ];
+
+function formatDate( dateString ) {
+	if ( ! dateString ) {
+		return '';
+	}
+	const d = new Date( dateString + 'T00:00:00' );
+	if ( Number.isNaN( d.getTime() ) ) {
+		return '';
+	}
+	return `${ MONTHS[ d.getMonth() ] } ${ d.getDate() }, ${ d.getFullYear() }`;
+}
+
+const EventSearchResult = ( { event, onMarkedChange } ) => {
+	const [ submitting, setSubmitting ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	const isMarked = !! event.is_marked;
+
+	const artistDisplay =
+		event.artists && event.artists.length
+			? event.artists.map( ( a ) => a.name ).join( ', ' )
+			: event.title || '';
+
+	const venueName = event.venue && event.venue.name ? event.venue.name : '';
+	const cityName = event.city && event.city.name ? event.city.name : '';
+
+	const venueParts = [];
+	if ( venueName ) {
+		venueParts.push( venueName );
+	}
+	if ( cityName ) {
+		venueParts.push( cityName );
+	}
+
+	const handleMark = () => {
+		if ( isMarked || submitting ) {
+			return;
+		}
+
+		setSubmitting( true );
+		setError( null );
+
+		// Optimistic flip.
+		onMarkedChange( event.post_id, true );
+
+		apiFetch( {
+			path: '/extrachill/v1/concert-tracking/toggle',
+			method: 'POST',
+			data: { event_id: event.post_id },
+		} )
+			.then( ( response ) => {
+				setSubmitting( false );
+				// If somehow the server reports unmarked (e.g. server-side toggle
+				// of a previously-marked event), reconcile state.
+				if ( response && response.marked === false ) {
+					onMarkedChange( event.post_id, false );
+					setError( 'Could not mark event.' );
+				}
+			} )
+			.catch( ( err ) => {
+				setSubmitting( false );
+				onMarkedChange( event.post_id, false );
+				setError( ( err && err.message ) || 'Failed to mark event.' );
+			} );
+	};
+
+	return (
+		<div className="ec-concert-stats__search-result">
+			<a
+				href={ event.permalink || '#' }
+				className="ec-concert-stats__search-result-link"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				<span className="ec-concert-stats__search-result-date">
+					{ formatDate( event.event_date ) }
+				</span>
+				<span className="ec-concert-stats__search-result-details">
+					<span className="ec-concert-stats__search-result-artist">
+						{ artistDisplay }
+					</span>
+					{ venueParts.length > 0 && (
+						<span className="ec-concert-stats__search-result-venue">
+							{ venueParts.join( ' \u00b7 ' ) }
+						</span>
+					) }
+				</span>
+			</a>
+
+			<div className="ec-concert-stats__search-result-action">
+				{ isMarked ? (
+					<span
+						className="ec-concert-stats__mark-btn ec-concert-stats__mark-btn--tracked"
+						aria-label="Already tracked"
+					>
+						✓ Tracked
+					</span>
+				) : (
+					<button
+						type="button"
+						className="ec-concert-stats__mark-btn ec-concert-stats__mark-btn--add"
+						onClick={ handleMark }
+						disabled={ submitting }
+					>
+						+ Mark Attended
+					</button>
+				) }
+				{ error && (
+					<span className="ec-concert-stats__search-result-error" role="alert">
+						{ error }
+					</span>
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default EventSearchResult;

--- a/blocks/concert-stats/src/hooks/useEventSearch.js
+++ b/blocks/concert-stats/src/hooks/useEventSearch.js
@@ -1,0 +1,127 @@
+/**
+ * useEventSearch — Debounced REST search of past events for marking.
+ *
+ * Drives the "Add Past Shows" tab in the concert-stats block.
+ *
+ * Behavior:
+ *   - Debounces query changes by 300ms before firing a request.
+ *   - Cancels in-flight requests when the query changes (AbortController).
+ *   - Accumulates results across pages on loadMore() (infinite-scroll style).
+ *   - Resets accumulated results whenever the query changes.
+ *   - Empty query is allowed — backend returns recent past events as suggestions.
+ *
+ * @package ExtraChillEvents
+ */
+
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+const PER_PAGE = 20;
+const DEBOUNCE_MS = 300;
+
+export default function useEventSearch( query ) {
+	const [ events, setEvents ] = useState( [] );
+	const [ total, setTotal ] = useState( 0 );
+	const [ pages, setPages ] = useState( 0 );
+	const [ page, setPage ] = useState( 1 );
+	const [ loading, setLoading ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	const abortRef = useRef( null );
+	const debounceRef = useRef( null );
+
+	const runFetch = useCallback( ( q, p ) => {
+		// Cancel any in-flight request.
+		if ( abortRef.current ) {
+			abortRef.current.abort();
+		}
+		const controller = new AbortController();
+		abortRef.current = controller;
+
+		setLoading( true );
+		setError( null );
+
+		const params = new URLSearchParams( {
+			query: q || '',
+			page: String( p ),
+			per_page: String( PER_PAGE ),
+		} );
+
+		apiFetch( {
+			path: `/extrachill/v1/concert-tracking/search?${ params.toString() }`,
+			signal: controller.signal,
+		} )
+			.then( ( response ) => {
+				if ( controller.signal.aborted ) {
+					return;
+				}
+				const incoming = response.events || [];
+				setEvents( ( prev ) => ( p === 1 ? incoming : [ ...prev, ...incoming ] ) );
+				setTotal( response.total || 0 );
+				setPages( response.pages || 0 );
+				setLoading( false );
+			} )
+			.catch( ( err ) => {
+				if ( err && err.name === 'AbortError' ) {
+					return;
+				}
+				setError( ( err && err.message ) || 'Failed to search events.' );
+				setLoading( false );
+			} );
+	}, [] );
+
+	// Debounced query effect: resets to page 1 and refetches.
+	useEffect( () => {
+		if ( debounceRef.current ) {
+			clearTimeout( debounceRef.current );
+		}
+		debounceRef.current = setTimeout( () => {
+			setPage( 1 );
+			runFetch( query, 1 );
+		}, DEBOUNCE_MS );
+
+		return () => {
+			if ( debounceRef.current ) {
+				clearTimeout( debounceRef.current );
+			}
+		};
+	}, [ query, runFetch ] );
+
+	const loadMore = useCallback( () => {
+		if ( loading ) {
+			return;
+		}
+		if ( page >= pages ) {
+			return;
+		}
+		const next = page + 1;
+		setPage( next );
+		runFetch( query, next );
+	}, [ loading, page, pages, query, runFetch ] );
+
+	/**
+	 * Mark a single event as locally-tracked without a refetch.
+	 * Used for optimistic UI updates.
+	 *
+	 * @param {number} postId   Event post ID.
+	 * @param {boolean} marked  New is_marked state.
+	 */
+	const setMarked = useCallback( ( postId, marked ) => {
+		setEvents( ( prev ) =>
+			prev.map( ( ev ) =>
+				ev.post_id === postId ? { ...ev, is_marked: marked } : ev
+			)
+		);
+	}, [] );
+
+	return {
+		events,
+		total,
+		pages,
+		page,
+		loading,
+		error,
+		loadMore,
+		setMarked,
+	};
+}

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -273,6 +273,186 @@
 	100% { background-position: -200% 0; }
 }
 
+/* ─── Add Past Shows Tab ─────────────────────────────────────────────────── */
+
+.ec-concert-stats__add-past {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-md, 1rem);
+}
+
+.ec-concert-stats__search {
+	position: relative;
+	display: flex;
+	align-items: center;
+}
+
+.ec-concert-stats__search-input {
+	width: 100%;
+	padding: var(--spacing-sm, 0.5rem) var(--spacing-md, 1rem);
+	padding-right: 2.25rem; /* room for clear button */
+	border: 1px solid var(--border-color, #d1d5db);
+	border-radius: var(--border-radius-sm, 5px);
+	background: var(--background-color, #fff);
+	color: var(--text-color, #1f2937);
+	font-size: var(--font-size-body, 1rem);
+	line-height: 1.4;
+}
+
+.ec-concert-stats__search-input:focus {
+	outline: none;
+	border-color: var(--accent, #53940b);
+	box-shadow: 0 0 0 2px rgba(83, 148, 11, 0.15);
+}
+
+.ec-concert-stats__search-clear {
+	position: absolute;
+	right: var(--spacing-xs, 0.25rem);
+	top: 50%;
+	transform: translateY(-50%);
+	background: transparent;
+	border: none;
+	color: var(--muted-text, #6b7280);
+	font-size: 1.25rem;
+	line-height: 1;
+	cursor: pointer;
+	padding: 0.25rem 0.5rem;
+	border-radius: var(--border-radius-sm, 5px);
+}
+
+.ec-concert-stats__search-clear:hover {
+	background: var(--card-background, #f3f4f6);
+	color: var(--text-color, #1f2937);
+}
+
+.ec-concert-stats__search-hint {
+	margin: 0;
+	color: var(--muted-text, #6b7280);
+	font-size: var(--font-size-sm, 0.875rem);
+}
+
+.ec-concert-stats__search-results {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.ec-concert-stats__search-results-label {
+	margin: 0 0 var(--spacing-xs, 0.25rem);
+	font-size: var(--font-size-xs, 0.625rem);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--muted-text, #6b7280);
+}
+
+.ec-concert-stats__search-result {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-md, 1rem);
+	padding: var(--spacing-sm, 0.5rem) var(--spacing-xs, 0.25rem);
+	border-radius: var(--border-radius-sm, 5px);
+	transition: background-color 0.1s ease;
+}
+
+.ec-concert-stats__search-result:hover {
+	background-color: var(--card-background, #f9fafb);
+}
+
+.ec-concert-stats__search-result-link {
+	display: flex;
+	flex: 1;
+	min-width: 0;
+	align-items: flex-start;
+	gap: var(--spacing-md, 1rem);
+	text-decoration: none;
+	color: inherit;
+}
+
+.ec-concert-stats__search-result-date {
+	flex-shrink: 0;
+	width: 95px;
+	font-size: var(--font-size-sm, 0.875rem);
+	font-weight: 600;
+	color: var(--muted-text, #6b7280);
+	white-space: nowrap;
+}
+
+.ec-concert-stats__search-result-details {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+	flex: 1;
+}
+
+.ec-concert-stats__search-result-artist {
+	font-weight: 500;
+	font-size: var(--font-size-body, 1rem);
+	color: var(--text-color, #1f2937);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.ec-concert-stats__search-result-venue {
+	font-size: var(--font-size-sm, 0.875rem);
+	color: var(--muted-text, #6b7280);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.ec-concert-stats__search-result-action {
+	flex-shrink: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 2px;
+}
+
+.ec-concert-stats__mark-btn {
+	display: inline-block;
+	padding: var(--spacing-xs, 0.25rem) var(--spacing-sm, 0.5rem);
+	border-radius: var(--border-radius-sm, 5px);
+	font-size: var(--font-size-sm, 0.875rem);
+	font-weight: 500;
+	line-height: 1.2;
+	white-space: nowrap;
+}
+
+.ec-concert-stats__mark-btn--add {
+	background: var(--accent, #53940b);
+	color: #fff;
+	border: 1px solid var(--accent, #53940b);
+	cursor: pointer;
+	transition: background-color 0.15s ease;
+}
+
+.ec-concert-stats__mark-btn--add:hover:not(:disabled) {
+	background: var(--accent-dark, #3d6b08);
+	border-color: var(--accent-dark, #3d6b08);
+}
+
+.ec-concert-stats__mark-btn--add:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.ec-concert-stats__mark-btn--tracked {
+	background: transparent;
+	color: var(--muted-text, #6b7280);
+	border: 1px solid var(--border-color, #d1d5db);
+	cursor: default;
+}
+
+.ec-concert-stats__search-result-error {
+	font-size: var(--font-size-xs, 0.625rem);
+	color: var(--error-color, #dc2626);
+	max-width: 160px;
+	text-align: right;
+}
+
 /* ─── Mobile ────────────────────────────────────────────────────────────── */
 
 @media (max-width: 480px) {
@@ -290,5 +470,20 @@
 
 	.ec-concert-stats__leaderboards {
 		grid-template-columns: 1fr;
+	}
+
+	.ec-concert-stats__search-result {
+		flex-wrap: wrap;
+	}
+
+	.ec-concert-stats__search-result-date {
+		width: 80px;
+		font-size: var(--font-size-xs, 0.625rem);
+	}
+
+	.ec-concert-stats__search-result-action {
+		width: 100%;
+		align-items: flex-start;
+		padding-left: calc(80px + var(--spacing-md, 1rem));
 	}
 }

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -13,6 +13,7 @@ import StatsBar from './components/StatsBar';
 import ShowList from './components/ShowList';
 import Leaderboard from './components/Leaderboard';
 import YearFilter from './components/YearFilter';
+import AddPastShows from './components/AddPastShows';
 import useStats from './hooks/useStats';
 
 /**
@@ -35,6 +36,18 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn } ) {
 			id: 'past',
 			label: 'Past',
 		},
+		// Only show "Add Past Shows" to the profile owner — anyone else viewing
+		// the profile shouldn't see a tool that would mark events on the owner's
+		// behalf (the toggle endpoint marks for the current user, but the tab is
+		// owner-only by intent per issue #109).
+		...( isOwn
+			? [
+					{
+						id: 'add-past',
+						label: 'Add Past Shows',
+					},
+			  ]
+			: [] ),
 		{
 			id: 'stats',
 			label: 'Stats',
@@ -98,6 +111,10 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn } ) {
 
 					{ activeTab === 'past' && (
 						<ShowList userId={ userId } period="past" year={ year } />
+					) }
+
+					{ activeTab === 'add-past' && isOwn && (
+						<AddPastShows />
 					) }
 
 					{ activeTab === 'stats' && stats && (


### PR DESCRIPTION
## Summary

Adds an **"Add Past Shows"** tab to the `extrachill/concert-stats` block on /my-shows/ so logged-in users can retroactively mark past events they attended — the most-requested gap in the My Shows feature per Chris Gardner.

Closes #109.

## Scope (locked per #109)

- ✅ Match existing events only. No event-creation form. No moderation queue.
- ✅ New tab visible only to the profile owner (`isOwn === true`).
- ✅ Search → 300ms-debounced REST call → results list → "+ Mark Attended" per row.
- ✅ Past events only (`start_datetime < NOW`).
- ✅ 20 results per page with "Load more" inside the tab.
- ✅ Empty query shows ~recent past events as suggestions + a one-line tip.
- ✅ Optimistic UI: row flips to "✓ Tracked" immediately; reverts + inline error on REST failure.
- ✅ Already-tracked rows render disabled "✓ Tracked" from the start.

## Implementation

### New files

- `blocks/concert-stats/src/hooks/useEventSearch.js`
  - 300ms debounce, `AbortController` for in-flight cancellation, page accumulation for infinite-scroll-style load-more.
  - Exposes `setMarked(postId, marked)` so result rows can update state without a refetch.
- `blocks/concert-stats/src/components/EventSearchInput.js` — controlled input + clear button.
- `blocks/concert-stats/src/components/EventSearchResult.js` — single row (date / artist / venue + city) with the mark button. Reuses the existing `/concert-tracking/toggle` REST endpoint (same one powering the "Going" button on event singles — no past/future distinction at the storage layer).
- `blocks/concert-stats/src/components/AddPastShows.js` — tab shell composing the input + results + load-more.

### Modified files

- `blocks/concert-stats/src/view.js`
  - Imports `AddPastShows`.
  - Inserts the new tab between **Past** and **Stats**, owner-only.
  - Adds the `activeTab === 'add-past'` render branch.
- `blocks/concert-stats/src/style.scss`
  - Reuses existing `--spacing-*` / `--accent` / `--border-color` / `--muted-text` tokens.
  - No new design primitives introduced.
  - Mobile-responsive variant for narrow viewports.

## Backend dependencies

- **Extra-Chill/extrachill-users#52** — registers the `extrachill/search-events-for-marking` ability.
- **Extra-Chill/extrachill-api#61** — adds `GET /extrachill/v1/concert-tracking/search` REST wrapper.

Both must merge + deploy before this UI works. The frontend gracefully handles missing endpoints (catches REST error and surfaces it inline).

## What's NOT included

- No event-creation form for missing shows (out of scope per #109).
- No moderation queue.
- No DB schema changes.
- No changes to the "Going" button on event singles.
- No admin-ajax or jQuery.

## Build

- `npm install` + `npm run build` complete cleanly.
- `build/` is gitignored per repo convention — homeboy release will rebuild on tag.

## Testing path

1. Merge + deploy Extra-Chill/extrachill-users#52.
2. Merge + deploy Extra-Chill/extrachill-api#61.
3. Merge + deploy this PR.
4. Visit `/my-shows/` while logged in.
5. Click **Add Past Shows** tab → suggestion list appears.
6. Type "phish" → debounce + results appear within ~300ms.
7. Click **+ Mark Attended** on a row → flips to **✓ Tracked** immediately.
8. Click **Past** tab → newly-marked show appears.

## Acceptance criteria from #109

- ✅ Tab "Add Past Shows" appears in concert-stats block for logged-in users (on their own profile).
- ✅ Search input debounces ~300ms.
- ✅ Past events matching the query render with date/venue/artist/city.
- ✅ "+ Mark Attended" button works; row flips to "✓ Tracked" optimistically.
- ✅ Already-tracked rows render with the disabled "✓ Tracked" state.
- ✅ Pagination via "Load more" fetches next 20.
- ✅ Empty search input shows suggestions (~5 recent past events).
- ✅ Marked shows appear in the Past tab on refresh / re-render.

Closes #109