### PR TITLE
feat(my-shows): concert history import framework + setlist.fm + phish.net adapters (closes #112)

### DIFF
--- a/blocks/concert-stats/src/components/ImportRunProgress.js
+++ b/blocks/concert-stats/src/components/ImportRunProgress.js
@@ -1,0 +1,89 @@
+/**
+ * ImportRunProgress — Live progress indicator for a single import run.
+ *
+ * @package ExtraChillEvents
+ */
+
+const STATUS_LABEL = {
+	pending: 'Queued',
+	running: 'Running',
+	paused: 'Paused (rate-limited — resuming soon)',
+	complete: 'Complete',
+	failed: 'Failed',
+};
+
+function formatPercent( run ) {
+	if ( ! run.total_pages || run.total_pages < 1 ) {
+		return null;
+	}
+	const current = Math.min( run.total_pages, Math.max( 0, ( run.next_page || 1 ) - 1 ) );
+	const pct = Math.round( ( current / run.total_pages ) * 100 );
+	return Math.min( 100, Math.max( 0, pct ) );
+}
+
+const ImportRunProgress = ( { run } ) => {
+	const isActive = [ 'pending', 'running', 'paused' ].includes( run.status );
+	const isDone = run.status === 'complete';
+	const isFailed = run.status === 'failed';
+	const pct = formatPercent( run );
+
+	return (
+		<div className="ec-concert-stats__import-run">
+			<div className="ec-concert-stats__import-run-header">
+				<span className="ec-concert-stats__import-run-status">
+					{ STATUS_LABEL[ run.status ] || run.status }
+				</span>
+				{ pct !== null && isActive && (
+					<span className="ec-concert-stats__import-run-pct">
+						{ pct }%
+					</span>
+				) }
+			</div>
+
+			{ pct !== null && (
+				<div className="ec-concert-stats__import-run-bar">
+					<div
+						className="ec-concert-stats__import-run-bar-fill"
+						style={ { width: pct + '%' } }
+					/>
+				</div>
+			) }
+
+			<div className="ec-concert-stats__import-run-counts">
+				<span>
+					<strong>{ run.total_events_matched }</strong> matched
+				</span>
+				<span>
+					<strong>{ run.total_events_unmatched }</strong> unmatched
+				</span>
+				<span>
+					<strong>{ run.total_events_seen }</strong> seen
+				</span>
+			</div>
+
+			{ run.status === 'paused' && run.next_attempt_at && (
+				<div className="ec-concert-stats__import-run-note">
+					Resumes at { run.next_attempt_at } UTC
+				</div>
+			) }
+
+			{ isDone && (
+				<div className="ec-concert-stats__import-run-note ec-concert-stats__import-run-note--success">
+					{ run.total_events_matched } show
+					{ run.total_events_matched === 1 ? '' : 's' } added to your history.
+					{ run.total_events_unmatched > 0 && (
+						<> { run.total_events_unmatched } not found in our database (skipped).</>
+					) }
+				</div>
+			) }
+
+			{ isFailed && run.error_message && (
+				<div className="ec-concert-stats__import-run-note ec-concert-stats__import-run-note--error">
+					{ run.error_message }
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default ImportRunProgress;

--- a/blocks/concert-stats/src/components/ImportSourceCard.js
+++ b/blocks/concert-stats/src/components/ImportSourceCard.js
@@ -1,0 +1,159 @@
+/**
+ * ImportSourceCard — Per-source connect card + recent runs.
+ *
+ * Flow:
+ *  1. Username field + "Preview" button.
+ *  2. Preview returns total event count → confirmation dialog.
+ *  3. User confirms → start import → progress polled by parent.
+ *
+ * @package ExtraChillEvents
+ */
+
+import { useState, useMemo } from '@wordpress/element';
+import ImportRunProgress from './ImportRunProgress';
+
+const ACTIVE_STATUSES = [ 'pending', 'running', 'paused' ];
+
+const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
+	const [ username, setUsername ] = useState( source.username || '' );
+	const [ previewState, setPreviewState ] = useState( null ); // { total, username }
+	const [ previewing, setPreviewing ] = useState( false );
+	const [ starting, setStarting ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	const sourceRuns = useMemo(
+		() => runs.filter( ( r ) => r.source_slug === source.slug ),
+		[ runs, source.slug ]
+	);
+	const activeRun = sourceRuns.find( ( r ) => ACTIVE_STATUSES.includes( r.status ) ) || null;
+	const recentRuns = sourceRuns.filter( ( r ) => ! ACTIVE_STATUSES.includes( r.status ) ).slice( 0, 3 );
+
+	const handlePreview = ( e ) => {
+		e.preventDefault();
+		setError( null );
+		setPreviewState( null );
+		setPreviewing( true );
+
+		onPreview( source.slug, username )
+			.then( ( res ) => {
+				setPreviewState( res );
+			} )
+			.catch( ( err ) => {
+				setError( err.message || 'Failed to verify username.' );
+			} )
+			.finally( () => setPreviewing( false ) );
+	};
+
+	const handleStart = () => {
+		setError( null );
+		setStarting( true );
+		onStart( source.slug, username )
+			.then( () => {
+				setPreviewState( null );
+			} )
+			.catch( ( err ) => {
+				setError( err.message || 'Failed to start import.' );
+			} )
+			.finally( () => setStarting( false ) );
+	};
+
+	const handleCancelPreview = () => {
+		setPreviewState( null );
+	};
+
+	return (
+		<div className="ec-concert-stats__import-card">
+			<div className="ec-concert-stats__import-card-header">
+				<h3 className="ec-concert-stats__import-card-title">{ source.label }</h3>
+				{ source.rate_limit && source.rate_limit.requests_per_day > 0 && (
+					<span className="ec-concert-stats__import-card-meta">
+						{ source.rate_limit.requests_per_day } reqs/day
+					</span>
+				) }
+			</div>
+
+			{ ! source.configured && (
+				<p className="ec-concert-stats__import-card-disabled">
+					Not yet available — { source.label } API key has not been configured on this platform.
+				</p>
+			) }
+
+			{ source.configured && activeRun && (
+				<ImportRunProgress run={ activeRun } />
+			) }
+
+			{ source.configured && ! activeRun && ! previewState && (
+				<form className="ec-concert-stats__import-card-form" onSubmit={ handlePreview }>
+					<label className="ec-concert-stats__import-card-label">
+						Your { source.label } username
+					</label>
+					<div className="ec-concert-stats__import-card-row">
+						<input
+							type="text"
+							className="ec-concert-stats__import-card-input"
+							value={ username }
+							onChange={ ( e ) => setUsername( e.target.value ) }
+							placeholder="username"
+							disabled={ previewing }
+							required
+						/>
+						<button
+							type="submit"
+							className="ec-concert-stats__import-card-btn"
+							disabled={ previewing || ! username.trim() }
+						>
+							{ previewing ? 'Checking…' : 'Connect' }
+						</button>
+					</div>
+				</form>
+			) }
+
+			{ source.configured && previewState && (
+				<div className="ec-concert-stats__import-card-confirm">
+					<p>
+						Import <strong>~{ previewState.total }</strong> show
+						{ previewState.total === 1 ? '' : 's' } from { source.label } user{' '}
+						<strong>{ previewState.username }</strong>?
+					</p>
+					<p className="ec-concert-stats__import-card-hint">
+						We&rsquo;ll match each show to events in our database. Shows we can&rsquo;t find will be skipped.
+						Large imports may take several days to complete due to { source.label } rate limits — we&rsquo;ll resume automatically.
+					</p>
+					<div className="ec-concert-stats__import-card-row">
+						<button
+							type="button"
+							className="ec-concert-stats__import-card-btn ec-concert-stats__import-card-btn--primary"
+							onClick={ handleStart }
+							disabled={ starting }
+						>
+							{ starting ? 'Starting…' : 'Yes, import' }
+						</button>
+						<button
+							type="button"
+							className="ec-concert-stats__import-card-btn-link"
+							onClick={ handleCancelPreview }
+							disabled={ starting }
+						>
+							Cancel
+						</button>
+					</div>
+				</div>
+			) }
+
+			{ error && (
+				<div className="ec-concert-stats__import-card-error">{ error }</div>
+			) }
+
+			{ recentRuns.length > 0 && (
+				<div className="ec-concert-stats__import-card-history">
+					<h4 className="ec-concert-stats__import-card-history-title">Recent imports</h4>
+					{ recentRuns.map( ( run ) => (
+						<ImportRunProgress key={ run.id } run={ run } />
+					) ) }
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default ImportSourceCard;

--- a/blocks/concert-stats/src/components/ImportTab.js
+++ b/blocks/concert-stats/src/components/ImportTab.js
@@ -1,0 +1,57 @@
+/**
+ * ImportTab — Container for the Import tab in the concert-stats block.
+ *
+ * Lists every registered import source as a card and shows the current
+ * user's run history below.
+ *
+ * @package ExtraChillEvents
+ */
+
+import ImportSourceCard from './ImportSourceCard';
+import useImportRuns from '../hooks/useImportRuns';
+
+const ImportTab = () => {
+	const { sources, runs, loading, error, preview, start } = useImportRuns();
+
+	if ( loading ) {
+		return (
+			<div className="ec-concert-stats__loading-more">Loading import sources…</div>
+		);
+	}
+
+	if ( error ) {
+		return <div className="ec-concert-stats__error">{ error }</div>;
+	}
+
+	if ( ! sources.length ) {
+		return (
+			<div className="ec-concert-stats__empty-tab">
+				No import sources are available yet.
+			</div>
+		);
+	}
+
+	return (
+		<div className="ec-concert-stats__import-tab">
+			<p className="ec-concert-stats__import-intro">
+				Already tracking your shows on another site? Pull your history into Extra Chill.
+				We&rsquo;ll match each show to events in our database and mark you as attended.
+				Shows we can&rsquo;t find will be skipped.
+			</p>
+
+			<div className="ec-concert-stats__import-cards">
+				{ sources.map( ( source ) => (
+					<ImportSourceCard
+						key={ source.slug }
+						source={ source }
+						runs={ runs }
+						onPreview={ preview }
+						onStart={ start }
+					/>
+				) ) }
+			</div>
+		</div>
+	);
+};
+
+export default ImportTab;

--- a/blocks/concert-stats/src/hooks/useImportRuns.js
+++ b/blocks/concert-stats/src/hooks/useImportRuns.js
@@ -1,0 +1,113 @@
+/**
+ * useImportRuns — Manage concert import sources, runs, and actions.
+ *
+ * Fetches the registered sources and current user's runs, polls while any
+ * run is active, and exposes preview + start actions.
+ *
+ * @package ExtraChillEvents
+ */
+
+import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+const POLL_INTERVAL_MS = 5000;
+const ACTIVE_STATUSES = [ 'pending', 'running', 'paused' ];
+
+/**
+ * Hook returning import sources + runs + actions.
+ */
+export default function useImportRuns() {
+	const [ sources, setSources ] = useState( [] );
+	const [ runs, setRuns ] = useState( [] );
+	const [ loading, setLoading ] = useState( true );
+	const [ error, setError ] = useState( null );
+
+	const pollTimerRef = useRef( null );
+
+	const fetchSources = useCallback( () => {
+		return apiFetch( { path: '/extrachill/v1/concert-import/sources' } )
+			.then( ( response ) => {
+				setSources( response.sources || [] );
+			} )
+			.catch( ( err ) => {
+				setError( err.message || 'Failed to load sources.' );
+			} );
+	}, [] );
+
+	const fetchRuns = useCallback( () => {
+		return apiFetch( { path: '/extrachill/v1/concert-import/status' } )
+			.then( ( response ) => {
+				setRuns( response.runs || [] );
+			} )
+			.catch( ( err ) => {
+				setError( err.message || 'Failed to load runs.' );
+			} );
+	}, [] );
+
+	const refresh = useCallback( () => {
+		setLoading( true );
+		return Promise.all( [ fetchSources(), fetchRuns() ] ).finally( () =>
+			setLoading( false )
+		);
+	}, [ fetchSources, fetchRuns ] );
+
+	// Initial load.
+	useEffect( () => {
+		refresh();
+	}, [ refresh ] );
+
+	// Poll while any run is active.
+	useEffect( () => {
+		const anyActive = runs.some( ( r ) => ACTIVE_STATUSES.includes( r.status ) );
+
+		if ( pollTimerRef.current ) {
+			clearInterval( pollTimerRef.current );
+			pollTimerRef.current = null;
+		}
+
+		if ( anyActive ) {
+			pollTimerRef.current = setInterval( () => {
+				fetchRuns();
+			}, POLL_INTERVAL_MS );
+		}
+
+		return () => {
+			if ( pollTimerRef.current ) {
+				clearInterval( pollTimerRef.current );
+				pollTimerRef.current = null;
+			}
+		};
+	}, [ runs, fetchRuns ] );
+
+	const preview = useCallback( ( source, username ) => {
+		return apiFetch( {
+			path: '/extrachill/v1/concert-import/preview',
+			method: 'POST',
+			data: { source, username },
+		} );
+	}, [] );
+
+	const start = useCallback(
+		( source, username ) => {
+			return apiFetch( {
+				path: '/extrachill/v1/concert-import/start',
+				method: 'POST',
+				data: { source, username },
+			} ).then( ( response ) => {
+				fetchRuns();
+				return response;
+			} );
+		},
+		[ fetchRuns ]
+	);
+
+	return {
+		sources,
+		runs,
+		loading,
+		error,
+		refresh,
+		preview,
+		start,
+	};
+}

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -487,3 +487,220 @@
 		padding-left: calc(80px + var(--spacing-md, 1rem));
 	}
 }
+
+/* ─── Import Tab ────────────────────────────────────────────────────────── */
+
+.ec-concert-stats__import-tab {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-md, 1rem);
+}
+
+.ec-concert-stats__import-intro {
+	margin: 0 0 var(--spacing-sm, 0.5rem) 0;
+	font-size: var(--font-size-sm, 0.875rem);
+	color: var(--muted-text, #6b7280);
+}
+
+.ec-concert-stats__import-cards {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+	gap: var(--spacing-md, 1rem);
+}
+
+.ec-concert-stats__import-card {
+	border: 1px solid var(--border-color, #e5e7eb);
+	border-radius: var(--border-radius, 8px);
+	padding: var(--spacing-md, 1rem);
+	background: var(--card-background, #fff);
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-sm, 0.5rem);
+}
+
+.ec-concert-stats__import-card-header {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: var(--spacing-sm, 0.5rem);
+}
+
+.ec-concert-stats__import-card-title {
+	margin: 0;
+	font-size: var(--font-size-lg, 1.125rem);
+	font-weight: 700;
+	color: var(--text-color, #1f2937);
+}
+
+.ec-concert-stats__import-card-meta {
+	font-size: var(--font-size-xs, 0.75rem);
+	color: var(--muted-text, #6b7280);
+}
+
+.ec-concert-stats__import-card-disabled {
+	margin: 0;
+	padding: var(--spacing-sm, 0.5rem);
+	font-size: var(--font-size-sm, 0.875rem);
+	background: var(--muted-bg, #f3f4f6);
+	color: var(--muted-text, #6b7280);
+	border-radius: var(--border-radius-sm, 5px);
+}
+
+.ec-concert-stats__import-card-form {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-xs, 0.25rem);
+}
+
+.ec-concert-stats__import-card-label {
+	font-size: var(--font-size-sm, 0.875rem);
+	color: var(--muted-text, #6b7280);
+}
+
+.ec-concert-stats__import-card-row {
+	display: flex;
+	gap: var(--spacing-sm, 0.5rem);
+	align-items: center;
+}
+
+.ec-concert-stats__import-card-input {
+	flex: 1;
+	padding: var(--spacing-sm, 0.5rem);
+	border: 1px solid var(--border-color, #e5e7eb);
+	border-radius: var(--border-radius-sm, 5px);
+	font-size: var(--font-size-md, 1rem);
+}
+
+.ec-concert-stats__import-card-btn {
+	padding: var(--spacing-sm, 0.5rem) var(--spacing-md, 1rem);
+	border: 1px solid var(--primary-color, #1f2937);
+	background: var(--card-background, #fff);
+	color: var(--primary-color, #1f2937);
+	border-radius: var(--border-radius-sm, 5px);
+	cursor: pointer;
+	font-weight: 600;
+	font-size: var(--font-size-sm, 0.875rem);
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+}
+
+.ec-concert-stats__import-card-btn--primary {
+	background: var(--primary-color, #1f2937);
+	color: #fff;
+}
+
+.ec-concert-stats__import-card-btn-link {
+	background: transparent;
+	border: none;
+	color: var(--muted-text, #6b7280);
+	cursor: pointer;
+	font-size: var(--font-size-sm, 0.875rem);
+	padding: var(--spacing-sm, 0.5rem);
+	text-decoration: underline;
+}
+
+.ec-concert-stats__import-card-confirm {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-sm, 0.5rem);
+}
+
+.ec-concert-stats__import-card-hint {
+	font-size: var(--font-size-sm, 0.875rem);
+	color: var(--muted-text, #6b7280);
+	margin: 0;
+}
+
+.ec-concert-stats__import-card-error {
+	padding: var(--spacing-sm, 0.5rem);
+	background: #fee2e2;
+	color: #991b1b;
+	border-radius: var(--border-radius-sm, 5px);
+	font-size: var(--font-size-sm, 0.875rem);
+}
+
+.ec-concert-stats__import-card-history {
+	margin-top: var(--spacing-sm, 0.5rem);
+	border-top: 1px solid var(--border-color, #e5e7eb);
+	padding-top: var(--spacing-sm, 0.5rem);
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-sm, 0.5rem);
+}
+
+.ec-concert-stats__import-card-history-title {
+	margin: 0;
+	font-size: var(--font-size-sm, 0.875rem);
+	color: var(--muted-text, #6b7280);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+/* ─── Import Run Progress ────────────────────────────────────────────── */
+
+.ec-concert-stats__import-run {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-xs, 0.25rem);
+	padding: var(--spacing-sm, 0.5rem);
+	background: var(--muted-bg, #f9fafb);
+	border-radius: var(--border-radius-sm, 5px);
+}
+
+.ec-concert-stats__import-run-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	font-size: var(--font-size-sm, 0.875rem);
+	font-weight: 600;
+}
+
+.ec-concert-stats__import-run-status {
+	color: var(--text-color, #1f2937);
+}
+
+.ec-concert-stats__import-run-pct {
+	color: var(--muted-text, #6b7280);
+	font-variant-numeric: tabular-nums;
+}
+
+.ec-concert-stats__import-run-bar {
+	height: 6px;
+	background: var(--border-color, #e5e7eb);
+	border-radius: 999px;
+	overflow: hidden;
+}
+
+.ec-concert-stats__import-run-bar-fill {
+	height: 100%;
+	background: var(--primary-color, #1f2937);
+	transition: width 0.3s ease;
+}
+
+.ec-concert-stats__import-run-counts {
+	display: flex;
+	gap: var(--spacing-md, 1rem);
+	font-size: var(--font-size-xs, 0.75rem);
+	color: var(--muted-text, #6b7280);
+}
+
+.ec-concert-stats__import-run-counts strong {
+	color: var(--text-color, #1f2937);
+	font-weight: 700;
+}
+
+.ec-concert-stats__import-run-note {
+	font-size: var(--font-size-xs, 0.75rem);
+	color: var(--muted-text, #6b7280);
+}
+
+.ec-concert-stats__import-run-note--success {
+	color: #166534;
+}
+
+.ec-concert-stats__import-run-note--error {
+	color: #991b1b;
+}

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -14,6 +14,7 @@ import ShowList from './components/ShowList';
 import Leaderboard from './components/Leaderboard';
 import YearFilter from './components/YearFilter';
 import AddPastShows from './components/AddPastShows';
+import ImportTab from './components/ImportTab';
 import useStats from './hooks/useStats';
 
 /**
@@ -27,6 +28,9 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn } ) {
 
 	const upcomingCount = stats ? ( stats.total_shows - Object.values( stats.shows_by_year || {} ).reduce( ( a, b ) => a + b, 0 ) + stats.total_shows ) : 0;
 
+	// Tab order: Upcoming → Past → Add Past Shows (owner, #109) → Stats →
+	// Import (owner, #112). Owner-only tabs let the user grow their history;
+	// non-owners only see the read-only Upcoming/Past/Stats axes.
 	const tabs = [
 		{
 			id: 'upcoming',
@@ -36,10 +40,6 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn } ) {
 			id: 'past',
 			label: 'Past',
 		},
-		// Only show "Add Past Shows" to the profile owner — anyone else viewing
-		// the profile shouldn't see a tool that would mark events on the owner's
-		// behalf (the toggle endpoint marks for the current user, but the tab is
-		// owner-only by intent per issue #109).
 		...( isOwn
 			? [
 					{
@@ -52,9 +52,17 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn } ) {
 			id: 'stats',
 			label: 'Stats',
 		},
+		...( isOwn
+			? [
+					{
+						id: 'import',
+						label: 'Import',
+					},
+			  ]
+			: [] ),
 	];
 
-	// Empty state — no shows at all.
+	// Empty state — no shows at all. Owners see Import alongside the empty CTA.
 	if ( ! statsLoading && stats && stats.total_shows === 0 && ! year ) {
 		return (
 			<BlockShell>
@@ -75,6 +83,11 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn } ) {
 							) }
 						</div>
 					</Panel>
+					{ isOwn && (
+						<Panel compact>
+							<ImportTab />
+						</Panel>
+					) }
 				</BlockShellInner>
 			</BlockShell>
 		);
@@ -138,6 +151,10 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn } ) {
 						<div className="ec-concert-stats__loading-more">
 							Loading stats...
 						</div>
+					) }
+
+					{ activeTab === 'import' && isOwn && (
+						<ImportTab />
 					) }
 				</Panel>
 			</BlockShellInner>


### PR DESCRIPTION
## Summary

Implements the umbrella concert-history import framework for My Shows, with **setlist.fm** and **phish.net** adapters shipped in v1. Users can pull their existing concert history from external services and have shows automatically marked attended on matching internal events.

Closes #112.

## Companion PRs

This work spans three repos:

| Repo | PR | Scope |
|------|-----|-------|
| Extra-Chill/extrachill-users | [#53](https://github.com/Extra-Chill/extrachill-users/pull/53) | Framework + abilities + adapters + DB table |
| Extra-Chill/extrachill-api | [#62](https://github.com/Extra-Chill/extrachill-api/pull/62) | REST routes wrapping the abilities |
| Extra-Chill/extrachill-events | this PR | Import tab UI in the concert-stats block |

All three branches share the name `feat-112-concert-import-framework` (or `-rest` for the api branch). Merge order: users → api → events.

## What this PR adds

A new **Import tab** in the `extrachill/concert-stats` block (My Shows view, owner only).

### New components

- `ImportTab.js` — shell that lists every registered import source as a card.
- `ImportSourceCard.js` — per-source UI:
  - Connect form (username field + Connect button).
  - Confirmation dialog: shows total event count from the preview probe, asks "Import ~N shows?" before kicking off the full run.
  - Disabled state when the platform API key isn't configured yet ("Not yet available — setlist.fm API key has not been configured on this platform.").
  - Recent runs panel below the active form.
- `ImportRunProgress.js` — live progress block: status label, progress bar (based on `next_page` / `total_pages`), counters (matched / unmatched / seen), plus contextual notes for the paused (rate-limited / resuming-tomorrow) and complete states.

### New hook

- `useImportRuns.js` — wraps the three REST endpoints. Polls `/status` every **5s** while any run is `pending|running|paused`; stops polling once everything is terminal. Exposes `preview` and `start` actions.

### View integration

`view.js`:
- Adds an "Import" tab (owner-only via `isOwn`).
- In the empty-state branch (zero tracked shows yet), the Import surface renders below the empty CTA so brand-new users can bootstrap their entire history from setlist.fm/phish.net before they've manually marked a single show.

### Styles

Adds the `ec-concert-stats__import-*` BEM block to `style.scss`. Uses the same CSS-custom-property + fallback pattern the rest of the block already uses (consumes `--spacing-*`, `--font-size-*`, `--border-radius-*`, etc.).

## How it works end-to-end

```
User clicks Import tab
        ↓
useImportRuns fetches /concert-import/sources + /concert-import/status
        ↓
Renders one ImportSourceCard per source
        ↓
User enters setlist.fm username + clicks Connect
        ↓
POST /concert-import/preview { source, username }
        ↓
Backend hits setlist.fm /user/{username}/attended page=1
Returns { total, username }
        ↓
Card shows "Import ~N shows from setlist.fm user X?"
        ↓
User confirms
        ↓
POST /concert-import/start { source, username }
        ↓
Backend inserts run row + enqueues async AS action
        ↓
ImportRunProgress polls every 5s
        ↓
Backend AS worker processes one page per tick,
matches via EventMatcher (85% threshold),
calls ec_users_mark_event for each match,
schedules next tick (immediate / rate-limit backoff / tomorrow UTC)
        ↓
Run completes → newly-marked shows appear in Past tab
```

## Acceptance criteria (from #112)

- [x] Logged-in user visits `/my-shows/`, clicks Import tab.
- [x] Sees per-source connect cards for setlist.fm and phish.net.
- [x] Connects setlist.fm with their username; import is queued.
- [x] Sees a progress indicator while the import runs in the background.
- [x] On completion, sees a summary: "X shows matched, Y unmatched (skipped)."
- [x] Newly-marked shows appear in the Past tab (via existing `ec_users_mark_event` path).
- [x] Re-running the same import is idempotent (DB UNIQUE KEY + service no-op).
- [x] Errors (invalid username, rate limit, API down) surfaced clearly in run state.
- [x] Sources gated by `is_configured()` — Card shows "Not yet available" until Chris provisions the API keys.

## Scope decisions

The prompt asked whether to split into two PRs (framework + setlist.fm; phish.net later). I kept both adapters in one PR because:

- The phish.net adapter is structurally trivial (~150 LOC) — its one quirk is a non-paginated response, which the framework handles via `total_pages=1` without special-casing.
- The framework is only validated by having two concrete implementations. Building both at once forced the `ImportSource` contract to actually be generic instead of accidentally setlist-fm-shaped.

## Matching threshold

`EventMatcher` uses an **85% combined similarity** threshold (60% venue name + 40% headliner artist, weighted). Documented in detail in the framework PR ([extrachill-users#53](https://github.com/Extra-Chill/extrachill-users/pull/53)). Tunable per-call via constructor arg if we need to tighten/loosen later.

## Rate limit handling

- **setlist.fm:** 2 req/sec, 1440 req/day.
- **phish.net:** 1 req/sec, 300 req/day (conservative — they don't publish a hard cap).

Action Scheduler drives the loop. A power user with 5000+ setlist.fm shows takes multiple days; the run stays `paused` overnight with `next_attempt_at` = next 00:05 UTC. The React UI surfaces this state cleanly ("Paused (rate-limited — resuming soon)").

## Admin API key configuration

API keys live in **network options** with environment-variable overrides:

| Source | Network option | Constant override |
|--------|---------------|-------------------|
| setlist.fm | `ec_concert_import_setlistfm_api_key` | `EC_CONCERT_IMPORT_SETLISTFM_API_KEY` |
| phish.net  | `ec_concert_import_phishnet_api_key`  | `EC_CONCERT_IMPORT_PHISHNET_API_KEY`  |

A proper admin settings UI in extrachill-admin-tools is **tracked as a follow-up** rather than included here to keep this PR focused. Until then, set via WP-CLI:

```bash
wp --allow-root --path=/var/www/extrachill.com network meta update 1 ec_concert_import_setlistfm_api_key 'YOUR_KEY'
wp --allow-root --path=/var/www/extrachill.com network meta update 1 ec_concert_import_phishnet_api_key 'YOUR_KEY'
```

## TODO for Chris

- [ ] Acquire setlist.fm developer API key: https://api.setlist.fm/docs/1.0/index.html
- [ ] Acquire phish.net API key: https://docs.phish.net/
- [ ] File follow-up issue: admin UI for managing the network API keys (extrachill-admin-tools).
- [ ] File follow-up issue: unmatched-events review surface (let users manually match or submit to moderation).

## Build output

This worktree's `build/` directory is committed by convention only at release time via homeboy (`build/` is gitignored in this repo). Run `npm install && npm run build` to regenerate locally.

**Pre-existing build environment note:** the `@extrachill/components` sibling package declares `react` as a peer dependency but isn't currently installed at the workspace root, so `webpack` can't resolve `react/jsx-runtime` when building any concert-stats branch (including `main` and unrelated worktrees like `feat-109`). Local workaround: `cd ../extrachill-components && npm install react@^18.3.1 react-dom@^18.3.1 --no-save`. This bug pre-dates this PR — I'll file it separately so it doesn't block merge.

## Rules respected

- No `wp-content/plugins/` edits.
- No `CHANGELOG.md` edits.
- No version bumps.
- Conventional commit.