### PR TITLE
feat(event-submission): URL field for artist tour import (closes #320 EC-events side)

### DIFF
--- a/blocks/event-submission/render.php
+++ b/blocks/event-submission/render.php
@@ -24,6 +24,9 @@ $success_message = $attributes['successMessage'] ?? '';
 $button_label    = $attributes['buttonLabel'] ? $attributes['buttonLabel'] : __( 'Send Submission', 'data-machine-events' );
 $system_prompt   = $attributes['systemPrompt'] ?? '';
 $endpoint        = esc_url( rest_url( 'extrachill/v1/event-submissions' ) );
+$preview_endpoint = esc_url( rest_url( 'datamachine/v1/artist-url/preview' ) );
+$submit_endpoint  = esc_url( rest_url( 'datamachine/v1/artist-url/submit' ) );
+$rest_nonce       = wp_create_nonce( 'wp_rest' );
 $form_id         = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'ec-event-form-' ) : 'ec-event-form-' . uniqid();
 
 if ( function_exists( 'ec_enqueue_turnstile_script' ) ) {
@@ -36,6 +39,9 @@ $success_attr = esc_attr( $success_message ? wp_strip_all_tags( $success_message
 <div
 	class="ec-event-submission"
 	data-endpoint="<?php echo esc_url( $endpoint ); ?>"
+	data-artist-url-preview="<?php echo esc_url( $preview_endpoint ); ?>"
+	data-artist-url-submit="<?php echo esc_url( $submit_endpoint ); ?>"
+	data-rest-nonce="<?php echo esc_attr( $rest_nonce ); ?>"
 	data-success-message="<?php echo $success_attr; ?>"
 	data-system-prompt="<?php echo esc_attr( $system_prompt ); ?>"
 >
@@ -48,6 +54,44 @@ $success_attr = esc_attr( $success_message ? wp_strip_all_tags( $success_message
 			<div class="ec-event-submission__description"><?php echo wp_kses_post( wpautop( $description ) ); ?></div>
 		<?php endif; ?>
 
+		<?php if ( is_user_logged_in() ) : ?>
+		<div class="ec-event-submission__url-import" data-state="idle">
+			<div class="ec-event-submission__url-import-intro">
+				<label for="<?php echo esc_attr( $form_id ); ?>-artist-url">
+					<strong><?php esc_html_e( 'Have an artist tour page?', 'data-machine-events' ); ?></strong>
+				</label>
+				<p class="ec-event-submission__url-import-hint">
+					<?php esc_html_e( "Paste the URL and we'll import all their events automatically. Leave blank to submit a single event manually below.", 'data-machine-events' ); ?>
+				</p>
+				<div class="ec-event-submission__url-import-row">
+					<input
+						type="url"
+						id="<?php echo esc_attr( $form_id ); ?>-artist-url"
+						class="ec-event-submission__url-import-input"
+						placeholder="https://"
+						autocomplete="off"
+					/>
+					<button type="button" class="button button-secondary ec-event-submission__url-import-try">
+						<?php esc_html_e( 'Try URL', 'data-machine-events' ); ?>
+					</button>
+				</div>
+				<div class="ec-event-submission__url-import-status" aria-live="polite"></div>
+			</div>
+
+			<div class="ec-event-submission__url-import-confirm" hidden>
+				<p class="ec-event-submission__url-import-summary"></p>
+				<ul class="ec-event-submission__url-import-events"></ul>
+				<div class="ec-event-submission__url-import-actions">
+					<button type="button" class="button-1 ec-event-submission__url-import-submit">
+						<?php esc_html_e( 'Submit for review', 'data-machine-events' ); ?>
+					</button>
+					<button type="button" class="button button-link ec-event-submission__url-import-cancel">
+						<?php esc_html_e( 'Cancel and use manual form', 'data-machine-events' ); ?>
+					</button>
+				</div>
+			</div>
+		</div>
+		<?php endif; ?>
 
 		<form
 			id="<?php echo esc_attr( $form_id ); ?>"

--- a/blocks/event-submission/style.css
+++ b/blocks/event-submission/style.css
@@ -142,3 +142,84 @@
 .ec-event-submission-editor__field--half {
 	grid-column: auto;
 }
+
+/* Artist URL import (extrachill-events#320) */
+.ec-event-submission__url-import {
+	margin-bottom: 24px;
+	padding: 16px;
+	border: 1px dashed var(--border-color);
+	border-radius: 8px;
+	background: var(--background-color);
+}
+
+.ec-event-submission__url-import-hint {
+	margin: 4px 0 12px;
+	font-size: var(--font-size-sm);
+	color: var(--text-muted, var(--text-color));
+}
+
+.ec-event-submission__url-import-row {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+	align-items: center;
+}
+
+.ec-event-submission__url-import-input {
+	flex: 1 1 240px;
+	padding: 8px 10px;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: var(--card-background);
+	color: var(--text-color);
+	font: inherit;
+}
+
+.ec-event-submission__url-import-try {
+	flex: 0 0 auto;
+}
+
+.ec-event-submission__url-import-status {
+	margin-top: 8px;
+	min-height: 1.2em;
+	font-size: var(--font-size-sm);
+}
+
+.ec-event-submission__url-import-status.is-error {
+	color: var(--color-danger, #b32d2e);
+}
+
+.ec-event-submission__url-import[data-state="loading"] .ec-event-submission__url-import-try {
+	opacity: 0.6;
+	cursor: progress;
+}
+
+.ec-event-submission__url-import-confirm {
+	margin-top: 14px;
+	padding: 14px;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: var(--card-background);
+}
+
+.ec-event-submission__url-import-summary {
+	margin: 0 0 10px;
+	font-weight: 600;
+}
+
+.ec-event-submission__url-import-events {
+	margin: 0 0 12px;
+	padding-left: 18px;
+	font-size: var(--font-size-sm);
+}
+
+.ec-event-submission__url-import-events li {
+	margin-bottom: 4px;
+}
+
+.ec-event-submission__url-import-actions {
+	display: flex;
+	gap: 12px;
+	align-items: center;
+	flex-wrap: wrap;
+}

--- a/blocks/event-submission/view.js
+++ b/blocks/event-submission/view.js
@@ -90,6 +90,220 @@
 		}
 	};
 
+	// ────────────────────────────────────────────────────────────────────
+	// Artist URL import (extrachill-events#320)
+	//
+	// Sits on top of the manual form. When the user types a URL into the
+	// import field, we probe it via `datamachine/v1/artist-url/preview`
+	// and, on success, swap the manual form for a confirmation panel
+	// (events found + Submit for review). The manual form keeps working
+	// byte-identically when no URL is provided.
+	// ────────────────────────────────────────────────────────────────────
+
+	const urlImportTimeoutMs = 8000;
+
+	const fetchJson = async (url, body, nonce) => {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), urlImportTimeoutMs);
+		try {
+			const response = await fetch(url, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Requested-With': 'XMLHttpRequest',
+					'X-WP-Nonce': nonce,
+				},
+				credentials: 'same-origin',
+				body: JSON.stringify(body || {}),
+				signal: controller.signal,
+			});
+			const payload = await response.json().catch(() => ({}));
+			return { ok: response.ok, status: response.status, payload };
+		} finally {
+			clearTimeout(timer);
+		}
+	};
+
+	const renderConfirmationEvents = (listEl, events) => {
+		listEl.innerHTML = '';
+		(events || []).slice(0, 5).forEach((evt) => {
+			const li = document.createElement('li');
+			const date = evt.startDate || '';
+			const time = evt.startTime ? ` · ${evt.startTime}` : '';
+			const venue = evt.venue ? ` @ ${evt.venue}` : '';
+			li.textContent = `${date}${time}${venue} — ${evt.title || ''}`.trim();
+			listEl.appendChild(li);
+		});
+	};
+
+	const showManualForm = (container) => {
+		const form = container.querySelector('form.ec-event-submission__form');
+		if (form) {
+			form.hidden = false;
+		}
+	};
+
+	const hideManualForm = (container) => {
+		const form = container.querySelector('form.ec-event-submission__form');
+		if (form) {
+			form.hidden = true;
+		}
+	};
+
+	const initUrlImport = (container) => {
+		const wrap = container.querySelector('.ec-event-submission__url-import');
+		if (!wrap) {
+			return; // anonymous user, no URL import block rendered
+		}
+
+		const input = wrap.querySelector('.ec-event-submission__url-import-input');
+		const tryBtn = wrap.querySelector('.ec-event-submission__url-import-try');
+		const statusEl = wrap.querySelector('.ec-event-submission__url-import-status');
+		const confirmPanel = wrap.querySelector('.ec-event-submission__url-import-confirm');
+		const summaryEl = confirmPanel.querySelector('.ec-event-submission__url-import-summary');
+		const eventsListEl = confirmPanel.querySelector('.ec-event-submission__url-import-events');
+		const submitBtn = confirmPanel.querySelector('.ec-event-submission__url-import-submit');
+		const cancelBtn = confirmPanel.querySelector('.ec-event-submission__url-import-cancel');
+
+		const previewUrl = container.dataset.artistUrlPreview;
+		const submitUrl = container.dataset.artistUrlSubmit;
+		const nonce = container.dataset.restNonce;
+
+		let currentPreview = null;
+
+		const setState = (state) => {
+			wrap.dataset.state = state;
+		};
+
+		const setUrlStatus = (msg, isError = false) => {
+			statusEl.textContent = msg || '';
+			statusEl.classList.toggle('is-error', Boolean(isError));
+		};
+
+		const resetConfirmation = () => {
+			confirmPanel.hidden = true;
+			summaryEl.textContent = '';
+			eventsListEl.innerHTML = '';
+			currentPreview = null;
+		};
+
+		const runPreview = async () => {
+			const url = (input.value || '').trim();
+			if (!url) {
+				setUrlStatus('Enter a URL to try.', true);
+				return;
+			}
+
+			setState('loading');
+			setUrlStatus('Checking that URL…');
+			resetConfirmation();
+			tryBtn.disabled = true;
+
+			try {
+				const { ok, payload } = await fetchJson(previewUrl, { url }, nonce);
+				if (!ok) {
+					const code = payload?.code || 'preview_failed';
+					const message = payload?.message || 'We could not check that URL.';
+					if (code === 'url_already_tracked') {
+						setUrlStatus('This URL is already being tracked. Use the manual form below if you want to submit a single event.', true);
+						setState('error');
+						showManualForm(container);
+						return;
+					}
+					if (code === 'no_events_found') {
+						setUrlStatus("We couldn't extract events from that page. Try the manual form below.", true);
+						setState('error');
+						showManualForm(container);
+						return;
+					}
+					setUrlStatus(message, true);
+					setState('error');
+					showManualForm(container);
+					return;
+				}
+
+				currentPreview = payload;
+				const count = Number(payload?.events_found || 0);
+				const artist = payload?.suggested_artist_name || 'this artist';
+				summaryEl.textContent = `Found ${count} event${count === 1 ? '' : 's'} from ${artist}. Submit for review?`;
+				renderConfirmationEvents(eventsListEl, payload?.events_preview || []);
+				confirmPanel.hidden = false;
+				setUrlStatus('');
+				setState('preview');
+				hideManualForm(container);
+			} catch (err) {
+				if (err && err.name === 'AbortError') {
+					setUrlStatus('That URL took too long to respond. Try again or use the manual form below.', true);
+				} else {
+					setUrlStatus('Something went wrong checking that URL. Try the manual form below.', true);
+				}
+				setState('error');
+				showManualForm(container);
+			} finally {
+				tryBtn.disabled = false;
+			}
+		};
+
+		const runSubmit = async () => {
+			const url = (input.value || '').trim();
+			if (!url) {
+				return;
+			}
+			submitBtn.disabled = true;
+			setUrlStatus('Submitting…');
+
+			try {
+				const { ok, payload } = await fetchJson(submitUrl, { url }, nonce);
+				if (!ok || !payload?.success) {
+					const code = payload?.code || 'submit_failed';
+					if (code === 'url_already_tracked') {
+						setUrlStatus('This URL is already being tracked.', true);
+					} else {
+						setUrlStatus(payload?.message || 'Submission failed. Try the manual form below.', true);
+					}
+					setState('error');
+					showManualForm(container);
+					return;
+				}
+				setUrlStatus(payload?.message || "Submitted for review. We'll set up automatic imports if approved.", false);
+				setState('submitted');
+				confirmPanel.hidden = true;
+				input.disabled = true;
+				tryBtn.disabled = true;
+			} catch (err) {
+				setUrlStatus('Something went wrong submitting that URL. Try the manual form below.', true);
+				setState('error');
+				showManualForm(container);
+			} finally {
+				submitBtn.disabled = false;
+			}
+		};
+
+		const cancelImport = () => {
+			resetConfirmation();
+			setState('idle');
+			setUrlStatus('');
+			showManualForm(container);
+		};
+
+		tryBtn.addEventListener('click', runPreview);
+		input.addEventListener('blur', () => {
+			// Only auto-probe if there's a value and we haven't already
+			// previewed/submitted.
+			if (wrap.dataset.state === 'idle' && input.value.trim() !== '') {
+				runPreview();
+			}
+		});
+		input.addEventListener('keydown', (e) => {
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				runPreview();
+			}
+		});
+		submitBtn.addEventListener('click', runSubmit);
+		cancelBtn.addEventListener('click', cancelImport);
+	};
+
 	const initForm = (container) => {
 		const form = container.querySelector('form');
 		if (!form || form.dataset.ecSubmissionBound === 'true') {
@@ -101,7 +315,10 @@
 	};
 
 	const init = () => {
-		document.querySelectorAll(SELECTOR).forEach(initForm);
+		document.querySelectorAll(SELECTOR).forEach((container) => {
+			initForm(container);
+			initUrlImport(container);
+		});
 	};
 
 	if (document.readyState === 'loading') {


### PR DESCRIPTION
Closes the EC-events side of #320. Depends on (and consumes the abilities from) Extra-Chill/data-machine-events PR #322 (merged).

## Summary

Adds a logged-in-user-only URL import field at the top of the event-submission block. When the user pastes a tour page URL and tabs away (or clicks 'Try URL' / hits Enter), the block calls the `data-machine-events/preview-artist-url` REST ability and renders a confirmation panel showing the events count, suggested artist, and the first few extracted events. On confirm, the block calls `data-machine-events/submit-artist-url` to queue the URL for admin moderation.

## Behavior

- On preview success: manual form is hidden, confirmation panel appears with 'Found N events from [artist]. Submit for review?'.
- On `url_already_tracked`: clear message + reveal manual form so the user can submit a single-event instead.
- On `no_events_found` or any other error: error message + reveal manual form.
- Cancel button restores the idle state and shows the manual form.
- 8s client-side timeout on probe; AbortController-based.
- Anonymous users never see the URL block (the DME ability rejects them anyway).
- The existing manual single-event submission path is unchanged — when the user doesn't touch the URL field, the form behaves byte-identically to before.
- No admin-ajax, no jQuery; uses `fetch` + REST nonce.
- REST endpoints + nonce are passed via `data-*` attributes on the container so `view.js` stays static.

## Files

- `blocks/event-submission/render.php` — emits the URL block + manual-form wrapper, passes endpoints/nonce via data attributes.
- `blocks/event-submission/view.js` — probe + confirm orchestration, AbortController timeout, error rendering.
- `blocks/event-submission/style.css` — minimal styling for URL block, confirmation panel, error state.

## Verification once deployed

1. Visit a page with the event-submission block while logged in.
2. Paste a tour URL → tab away → confirmation panel appears within 8s.
3. Click confirm → success message; submission appears in the wp-admin Artist URL Imports queue.
4. Re-submit the same URL → 'already tracked' message + manual form reveals.
5. Paste a URL with no parseable events → error message + manual form reveals.
6. Don't touch URL field → manual form works exactly as before.