### PR TITLE
feat(my-shows): calendar view tab embedding data-machine-events/calendar in month-grid mode (closes #110)

### DIFF
--- a/blocks/concert-stats/render.php
+++ b/blocks/concert-stats/render.php
@@ -6,6 +6,20 @@
  * Passes user context via data attributes.
  * Shows a loading skeleton while JS initializes.
  *
+ * #110: When the block is rendering on /my-shows/ for a logged-in
+ * owner, also emit a server-rendered data-machine-events calendar
+ * block (month-grid mode) inside a sibling wrapper. The React app
+ * toggles the sibling's `hidden` attribute when the Calendar tab is
+ * active — no client-side calendar fetch required, the
+ * `data_machine_events_calendar_query_args` filter callback in
+ * `inc/core/my-shows-calendar-filter.php` scopes the underlying
+ * WP_Query to events the user has marked attended.
+ *
+ * The embedded calendar is rendered as a *sibling* (not a child) of
+ * the React root so React's hydration / unmount cycles don't wipe it.
+ * Both nodes live inside a `<div class="ec-concert-stats-shell">`
+ * outer container that the block wrapper attributes attach to.
+ *
  * @package ExtraChillEvents
  * @since 0.18.0
  */
@@ -20,29 +34,63 @@ if ( ! $user_id ) {
 	$user_id = get_current_user_id();
 }
 
-$blog_id  = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : get_current_blog_id();
+$blog_id    = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : get_current_blog_id();
 $events_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'events' ) : home_url();
+$is_own     = is_user_logged_in() && get_current_user_id() === $user_id;
+
+// #110: Calendar tab is owner-only, and the server-side filter callback
+// only activates on /my-shows/. Match both conditions before emitting
+// the embedded calendar block so we don't ship dead markup elsewhere.
+$render_embedded_calendar = $is_own
+	&& function_exists( 'is_page' )
+	&& is_page( 'my-shows' );
 
 $wrapper_attributes = get_block_wrapper_attributes(
 	array(
-		'class'            => 'ec-concert-stats',
-		'data-user-id'     => esc_attr( $user_id ),
-		'data-blog-id'     => esc_attr( $blog_id ),
-		'data-events-url'  => esc_attr( $events_url ),
-		'data-is-own'      => esc_attr( is_user_logged_in() && get_current_user_id() === $user_id ? '1' : '0' ),
+		'class'             => 'ec-concert-stats-shell',
+		'data-has-calendar' => esc_attr( $render_embedded_calendar ? '1' : '0' ),
 	)
 );
 ?>
 <div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped via get_block_wrapper_attributes. ?>>
-	<div class="ec-concert-stats__loading">
-		<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--header"></div>
-		<div class="ec-concert-stats__skeleton-row">
-			<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--stat"></div>
-			<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--stat"></div>
-			<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--stat"></div>
-			<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--stat"></div>
+	<div
+		class="ec-concert-stats"
+		data-user-id="<?php echo esc_attr( $user_id ); ?>"
+		data-blog-id="<?php echo esc_attr( $blog_id ); ?>"
+		data-events-url="<?php echo esc_attr( $events_url ); ?>"
+		data-is-own="<?php echo esc_attr( $is_own ? '1' : '0' ); ?>"
+		data-has-calendar="<?php echo esc_attr( $render_embedded_calendar ? '1' : '0' ); ?>"
+	>
+		<div class="ec-concert-stats__loading">
+			<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--header"></div>
+			<div class="ec-concert-stats__skeleton-row">
+				<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--stat"></div>
+				<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--stat"></div>
+				<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--stat"></div>
+				<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--stat"></div>
+			</div>
+			<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--tabs"></div>
+			<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--list"></div>
 		</div>
-		<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--tabs"></div>
-		<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--list"></div>
 	</div>
+
+	<?php if ( $render_embedded_calendar ) : ?>
+		<div class="ec-concert-stats__embedded-calendar" data-tab="calendar" hidden>
+			<?php
+			// The filter in inc/core/my-shows-calendar-filter.php
+			// auto-gates on is_page('my-shows'), so we don't need to
+			// manage filter add/remove around this do_blocks() call —
+			// the gate prevents leaking the My-Shows constraint into
+			// any other calendar instance that might (theoretically)
+			// also render on this same page.
+			//
+			// showFilters / showSearch / showDateFilter disabled — the
+			// concert-stats block already owns the surrounding chrome
+			// (year filter in the header, tabs); a second filter bar
+			// would be redundant. The calendar block's own
+			// prev/next/today nav still renders.
+			echo do_blocks( '<!-- wp:data-machine-events/calendar {"displayMode":"month-grid","showFilters":false,"showSearch":false,"showDateFilter":false} /-->' );
+			?>
+		</div>
+	<?php endif; ?>
 </div>

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -704,3 +704,19 @@
 .ec-concert-stats__import-run-note--error {
 	color: #991b1b;
 }
+
+/* ─── Embedded Calendar (#110, My Shows Calendar tab) ───────────────────── */
+
+/*
+ * Wrapper for the server-rendered data-machine-events/calendar block
+ * emitted as a sibling to the React root in render.php. Visual weight
+ * comes from the calendar block's own styles — we intentionally don't
+ * override them here. This rule just provides a small top spacer so
+ * the calendar isn't flush against the tab strip when revealed.
+ *
+ * `hidden` is honored natively by the browser; this margin only
+ * applies when the tab is active.
+ */
+.ec-concert-stats__embedded-calendar {
+	margin-top: var(--spacing-md, 1rem);
+}

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -7,7 +7,7 @@
  * @package ExtraChillEvents
  */
 
-import { createRoot, useState } from '@wordpress/element';
+import { createRoot, useState, useEffect, useRef } from '@wordpress/element';
 import { BlockShell, BlockShellInner, BlockShellHeader, Tabs, Panel } from '@extrachill/components';
 import StatsBar from './components/StatsBar';
 import ShowList from './components/ShowList';
@@ -18,19 +18,96 @@ import ImportTab from './components/ImportTab';
 import useStats from './hooks/useStats';
 
 /**
+ * Whitelist of tab IDs that may appear in `?tab=` URL state. Anything
+ * else falls back to the default ("upcoming"). Owner-only tabs are
+ * still gated by `isOwn` inside the render — the whitelist just guards
+ * against arbitrary strings becoming React state.
+ */
+const VALID_TAB_IDS = [ 'upcoming', 'past', 'calendar', 'add-past', 'stats', 'import' ];
+
+/**
+ * Read the initial active tab from `?tab=` on first render. SSR-safe
+ * (no-op when `window` is absent). Falls back to `'upcoming'`.
+ *
+ * @return {string} Tab ID.
+ */
+function readInitialTab() {
+	if ( typeof window === 'undefined' ) {
+		return 'upcoming';
+	}
+	const params = new URLSearchParams( window.location.search );
+	const requested = params.get( 'tab' );
+	return VALID_TAB_IDS.includes( requested ) ? requested : 'upcoming';
+}
+
+/**
  * Main Concert Stats App component.
  */
-function ConcertStatsApp( { userId, eventsUrl, isOwn } ) {
+function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, containerRef } ) {
 	const [ year, setYear ] = useState( 0 );
-	const [ activeTab, setActiveTab ] = useState( 'upcoming' );
+	const [ activeTab, setActiveTab ] = useState( readInitialTab );
 
 	const { stats, loading: statsLoading } = useStats( userId, { year } );
 
+	// Sync `?tab=` to URL whenever the active tab changes. Use
+	// replaceState to keep the back button useful — switching tabs
+	// shouldn't pollute browser history. Strip `tab=` when the user is
+	// on the default tab so /my-shows/ stays a clean canonical URL.
+	useEffect( () => {
+		if ( typeof window === 'undefined' ) {
+			return;
+		}
+		const url = new URL( window.location.href );
+		if ( activeTab === 'upcoming' ) {
+			url.searchParams.delete( 'tab' );
+		} else {
+			url.searchParams.set( 'tab', activeTab );
+		}
+		// Clear `?month=` whenever we leave the calendar tab — the
+		// data-machine-events calendar block manages that param itself
+		// when it's the active surface, but a stale `month` shouldn't
+		// follow the user back to the list tabs.
+		if ( activeTab !== 'calendar' ) {
+			url.searchParams.delete( 'month' );
+		}
+		const next = url.pathname + ( url.search ? url.search : '' );
+		window.history.replaceState( {}, '', next );
+	}, [ activeTab ] );
+
+	// Toggle the server-rendered calendar wrapper based on the active
+	// tab. The wrapper is rendered once at server-render time (see
+	// render.php) as a *sibling* of the React mount node (both live
+	// inside the .ec-concert-stats-shell parent). Toggle rather than
+	// re-mount so the calendar block's own JS keeps owning
+	// prev/next/today + URL month state across tab switches. We scope
+	// the lookup to the shell so multiple concert-stats instances on
+	// the same page (unlikely, but possible) don't fight over each
+	// other's calendars.
+	useEffect( () => {
+		if ( ! hasCalendar || ! containerRef.current ) {
+			return;
+		}
+		const shell = containerRef.current.closest( '.ec-concert-stats-shell' )
+			|| containerRef.current.parentElement;
+		if ( ! shell ) {
+			return;
+		}
+		const calendar = shell.querySelector(
+			'.ec-concert-stats__embedded-calendar'
+		);
+		if ( calendar ) {
+			calendar.hidden = activeTab !== 'calendar';
+		}
+	}, [ activeTab, hasCalendar, containerRef ] );
+
 	const upcomingCount = stats ? ( stats.total_shows - Object.values( stats.shows_by_year || {} ).reduce( ( a, b ) => a + b, 0 ) + stats.total_shows ) : 0;
 
-	// Tab order: Upcoming → Past → Add Past Shows (owner, #109) → Stats →
-	// Import (owner, #112). Owner-only tabs let the user grow their history;
-	// non-owners only see the read-only Upcoming/Past/Stats axes.
+	// Tab order: Upcoming → Past → Calendar (owner, #110) → Add Past
+	// Shows (owner, #109) → Stats → Import (owner, #112). Calendar
+	// sits between the read-only history axes (Upcoming/Past) and the
+	// owner-only growth tabs (Add Past Shows, Import) because it's a
+	// read-only view of the same history but visualized differently.
+	// Owner-only because the underlying tracking table is per-user.
 	const tabs = [
 		{
 			id: 'upcoming',
@@ -40,6 +117,14 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn } ) {
 			id: 'past',
 			label: 'Past',
 		},
+		...( isOwn && hasCalendar
+			? [
+					{
+						id: 'calendar',
+						label: 'Calendar',
+					},
+			  ]
+			: [] ),
 		...( isOwn
 			? [
 					{
@@ -126,6 +211,21 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn } ) {
 						<ShowList userId={ userId } period="past" year={ year } />
 					) }
 
+					{ /*
+					   Calendar tab content lives in a sibling DOM node
+					   emitted by render.php (sibling to this React
+					   root). We render nothing in the Panel here; the
+					   useEffect above toggles the sibling's `hidden`
+					   attribute. Keeps the server-rendered calendar
+					   block's own JS (prev/next/today nav, month URL
+					   sync) untouched.
+					 */ }
+					{ activeTab === 'calendar' && ! hasCalendar && (
+						<div className="ec-concert-stats__empty-tab">
+							Calendar view is unavailable here.
+						</div>
+					) }
+
 					{ activeTab === 'add-past' && isOwn && (
 						<AddPastShows />
 					) }
@@ -163,20 +263,52 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn } ) {
 }
 
 /**
+ * Wrapper that gives the app a stable ref to the React mount container
+ * so the Calendar-tab useEffect can walk up to the shared
+ * .ec-concert-stats-shell parent and locate the sibling embedded
+ * calendar wrapper emitted at server-render time.
+ */
+function ConcertStatsAppWithRef( props ) {
+	const { mountNode, ...rest } = props;
+	const containerRef = useRef( mountNode );
+	return <ConcertStatsApp { ...rest } containerRef={ containerRef } />;
+}
+
+/**
  * Initialize all concert-stats blocks on the page.
+ *
+ * DOM contract (see render.php):
+ *
+ *   <div class="ec-concert-stats-shell">
+ *     <div class="ec-concert-stats" data-…>     ← React root here
+ *       <div class="ec-concert-stats__loading">…</div>
+ *     </div>
+ *     <div class="ec-concert-stats__embedded-calendar" hidden>
+ *       (server-rendered data-machine-events/calendar block)
+ *     </div>
+ *   </div>
+ *
+ * React mounts on `.ec-concert-stats` (unchanged from before #110) and
+ * replaces its loading-skeleton child during initial render. The
+ * embedded calendar sibling is outside the React root and survives
+ * hydration; the Calendar tab's useEffect toggles its `hidden`
+ * attribute on tab change.
  */
 function init() {
 	document.querySelectorAll( '.ec-concert-stats' ).forEach( ( container ) => {
-		const userId = parseInt( container.dataset.userId, 10 );
-		const eventsUrl = container.dataset.eventsUrl || '';
-		const isOwn = container.dataset.isOwn === '1';
+		const userId      = parseInt( container.dataset.userId, 10 );
+		const eventsUrl   = container.dataset.eventsUrl || '';
+		const isOwn       = container.dataset.isOwn === '1';
+		const hasCalendar = container.dataset.hasCalendar === '1';
 
 		const root = createRoot( container );
 		root.render(
-			<ConcertStatsApp
+			<ConcertStatsAppWithRef
 				userId={ userId }
 				eventsUrl={ eventsUrl }
 				isOwn={ isOwn }
+				hasCalendar={ hasCalendar }
+				mountNode={ container }
 			/>
 		);
 	} );

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -231,6 +231,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/home/actions.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/concert-tracking-integration.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows-calendar-filter.php';
 	}
 
 	public function init_data_machine_handlers() {

--- a/inc/core/my-shows-calendar-filter.php
+++ b/inc/core/my-shows-calendar-filter.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * My Shows — Calendar query filter.
+ *
+ * Wires the personal-calendar tab on `/my-shows/` to the
+ * data-machine-events calendar block by injecting a `post__in`
+ * constraint into the WP_Query the calendar runs.
+ *
+ * Layer purity: data-machine-events stays generic (no knowledge of
+ * `c8c_ec_concert_tracking`). Extrachill-events provides the
+ * integration glue via the documented extension point.
+ *
+ * Hook contract (data-machine-events#325):
+ *
+ *     apply_filters(
+ *         'data_machine_events_calendar_query_args',
+ *         array $query_args, // WP_Query args about to be executed.
+ *         array $input       // Raw ability input (scope, tax_filters, search, …).
+ *     );
+ *
+ * `$input` does not carry a user_id — the filter callback resolves it
+ * from request context (path b in the issue body: read the current user
+ * + verify we're rendering on /my-shows/). This avoids a hard
+ * dependency on a new block attribute / param key inside
+ * data-machine-events.
+ *
+ * @package ExtraChillEvents
+ * @since 0.27.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Inject a `post__in` constraint so the calendar block only renders
+ * events the current logged-in user has marked attended.
+ *
+ * Active only when:
+ *   - request is rendering the `/my-shows/` page
+ *   - a logged-in user is present
+ *
+ * When the user has zero tracked events we force `post__in = array( 0 )`
+ * — `0` is never a valid post ID, so the query yields an empty result
+ * set without throwing. WP_Query treats an empty `post__in` as "no
+ * constraint", so we cannot pass `array()`; sentinel `[0]` is the
+ * documented way to express "match nothing".
+ *
+ * @param array $query_args WP_Query args about to be executed.
+ * @param array $input      Raw ability input (unused here; kept for signature compat).
+ * @return array Modified $query_args.
+ */
+function ec_events_my_shows_filter_calendar_query( $query_args, $input = array() ) {
+	unset( $input ); // Signature compatibility; we read from request context instead.
+
+	if ( ! function_exists( 'is_page' ) || ! is_page( 'my-shows' ) ) {
+		return $query_args;
+	}
+
+	$user_id = get_current_user_id();
+	if ( $user_id < 1 ) {
+		return $query_args;
+	}
+
+	$tracked = ec_events_my_shows_get_tracked_post_ids( $user_id );
+
+	if ( empty( $tracked ) ) {
+		// Force-empty result. `[0]` is the canonical "match nothing"
+		// sentinel for post__in — passing an empty array would be a
+		// no-op (WP_Query would skip the constraint entirely and the
+		// user would see EVERY event on the site).
+		$query_args['post__in'] = array( 0 );
+		return $query_args;
+	}
+
+	// If the calendar already has a post__in constraint (defensive — no
+	// known path sets it today, but the filter is generic), intersect
+	// rather than overwrite so we don't silently widen another
+	// consumer's narrowing.
+	if ( ! empty( $query_args['post__in'] ) && is_array( $query_args['post__in'] ) ) {
+		$existing = array_map( 'intval', $query_args['post__in'] );
+		$tracked  = array_values( array_intersect( $tracked, $existing ) );
+		if ( empty( $tracked ) ) {
+			$query_args['post__in'] = array( 0 );
+			return $query_args;
+		}
+	}
+
+	$query_args['post__in'] = $tracked;
+	return $query_args;
+}
+add_filter( 'data_machine_events_calendar_query_args', 'ec_events_my_shows_filter_calendar_query', 10, 2 );
+
+/**
+ * Resolve the list of event post IDs a given user has marked attended
+ * on the events subsite.
+ *
+ * Queries the network-scoped `{$wpdb->base_prefix}ec_concert_tracking`
+ * table directly (the table is owned by extrachill-users, but a
+ * read-only select against a stable schema is acceptable cross-plugin
+ * coupling for this integration). All event IDs are scoped to the
+ * events blog (default blog_id=7, the documented default in the
+ * tracking table schema).
+ *
+ * @param int $user_id User to look up.
+ * @return int[] Event post IDs the user has marked attended (may be empty).
+ */
+function ec_events_my_shows_get_tracked_post_ids( $user_id ) {
+	global $wpdb;
+
+	$user_id = (int) $user_id;
+	if ( $user_id < 1 ) {
+		return array();
+	}
+
+	$events_blog_id = function_exists( 'ec_get_blog_id' )
+		? (int) ec_get_blog_id( 'events' )
+		: 7;
+
+	$table = $wpdb->base_prefix . 'ec_concert_tracking';
+
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT event_id FROM {$table} WHERE user_id = %d AND blog_id = %d",
+			$user_id,
+			$events_blog_id
+		)
+	);
+	// phpcs:enable
+
+	if ( empty( $ids ) ) {
+		return array();
+	}
+
+	return array_values( array_filter( array_map( 'intval', $ids ) ) );
+}


### PR DESCRIPTION
## Summary

Adds a **Calendar** tab to the `extrachill/concert-stats` block on `/my-shows/`. The tab embeds the `data-machine-events/calendar` block in **month-grid display mode** (#318 in data-machine-events), scoped to events the current user has marked attended via the network-scoped `c8c_ec_concert_tracking` table.

Closes #110.

## Dependency

**Depends on** Extra-Chill/data-machine-events#325 (merged). The existing `data_machine_events_calendar_query_args` filter only fired in the deprecated `EventQueryBuilder` code path; the active `EventDateQueryAbilities::executeQueryEvents` path had no extension point. PR #325 added the filter to the active path with the same name and contract (`$query_args`, `$input`).

This PR will not function correctly without #325 deployed.

## Architecture

### New filter callback — `inc/core/my-shows-calendar-filter.php`

Registers `ec_events_my_shows_filter_calendar_query` on `data_machine_events_calendar_query_args`. The callback:

- Gates on `is_page('my-shows')` + `get_current_user_id() > 0` so it cannot leak into any other calendar instance on any other page.
- Injects `post__in` from a direct `SELECT event_id FROM {$wpdb->base_prefix}ec_concert_tracking WHERE user_id = %d AND blog_id = %d`.
- For zero tracked events: forces `post__in = [ 0 ]` (canonical "match nothing" sentinel — passing `[]` would be a no-op and leak every event to the user).
- For an existing `post__in` (defensive — no live path sets one today): intersects rather than overwrites so a future consumer's narrowing isn't silently widened.

### Server-side calendar embed — `blocks/concert-stats/render.php`

Restructured to wrap the React root inside an outer `.ec-concert-stats-shell` div with the embedded calendar as a **sibling** of the React root:

```
<div class="ec-concert-stats-shell">
  <div class="ec-concert-stats" data-…>     ← React root mounts here
    <div class="ec-concert-stats__loading">…</div>
  </div>
  <div class="ec-concert-stats__embedded-calendar" hidden>
    (server-rendered data-machine-events/calendar in month-grid mode)
  </div>
</div>
```

The embedded calendar is rendered only when `is_own && is_page('my-shows')`. It's emitted with `showFilters / showSearch / showDateFilter = false` because the concert-stats block already owns the surrounding chrome (year filter in header, tabs). Calendar block's own prev/next/today nav stays intact.

### Tab + URL state — `blocks/concert-stats/src/view.js`

- New **Calendar** tab positioned between Past and Add Past Shows (owner-only, gated on `hasCalendar` data attribute).
- New `useEffect` walks up to `.ec-concert-stats-shell` and toggles the sibling's `hidden` attribute on tab change — no re-mount, no re-fetch, so the calendar block's own JS retains ownership of `?month=YYYY-MM` URL state across tab switches.
- New `useEffect` syncs `?tab=` to URL via `replaceState` (whitelist-gated to known tab IDs; clears `tab=` on the default `upcoming` tab so canonical `/my-shows/` stays clean; clears stale `?month=` when leaving the Calendar tab).
- New `readInitialTab()` honors `?tab=calendar` on first paint so bookmarked / shared Calendar links land on the Calendar tab directly.

### CSS — `blocks/concert-stats/src/style.scss`

One small rule for `.ec-concert-stats__embedded-calendar` adding top spacing under the tab strip. All visual weight comes from the calendar block's own styles — intentionally not overridden.

## Filter-callback design choice — path **b** from the issue body

The issue body offered two paths for threading user identity to the calendar block:

- **(a)** Add a `myShowsUserId` block attribute that threads through to the calendar's query params.
- **(b)** Read user_id from request context (`get_current_user_id()` + `is_page('my-shows')` gate) inside the filter callback.

**Picked (b).** Reasons:

- **Smaller blast radius.** Path (a) requires extending the calendar block schema + ability input + REST surface in data-machine-events to thread a platform-specific concept (user-scoped calendar) into the generic primitive. That's a layer-purity violation regardless of where the constraint physically lives.
- **Same effective behavior.** The constraint only ever needs to fire on `/my-shows/`, which is already a strong enough gate to avoid cross-page leakage.
- **One fewer round-trip PR.** Path (a) would have required a second DME dep PR for the new attribute (on top of #325).

Documented in the filter file's docblock.

## Acceptance criteria

- [x] Logged-in user on `/my-shows/` clicks Calendar tab → month grid renders with only their attended shows.
- [x] Past + future combined; past dimmer per #318 styling (inherited from calendar block).
- [x] User navigates months freely (prev/next/today buttons from #318, owned by calendar block JS).
- [x] Mobile falls back to list view (per #318 CSS, inherited).
- [x] URL: `?tab=calendar` (concert-stats) + `?month=YYYY-MM` (calendar block) preserved across reload + share. `readInitialTab()` honors `?tab=calendar` on first paint.
- [x] Empty state: handled by two layers — (1) users with `total_shows === 0` hit the pre-existing 'Start tracking' empty CTA and never see the Calendar tab; (2) for users with shows but zero in the visible month, the calendar renders an empty grid with today highlighted; (3) the filter callback's `post__in=[0]` sentinel covers the literal zero-tracked-events case as a fail-safe so removing the empty-CTA short-circuit in the future doesn't silently leak every event.

## What I did NOT do (per locked scope)

- No custom mini-calendar inside concert-stats. Reused `data-machine-events/calendar` in `displayMode=month-grid`.
- No reference to `c8c_ec_concert_tracking` from inside `data-machine-events`. Constraint lives in the extrachill-events filter callback only.
- No year-overview / multi-month view.
- No iCal export of attended shows.
- No storage-table changes.

## Build

```bash
cd /var/lib/datamachine/workspace/extrachill-events@feat-110-my-shows-calendar
npm install && npm run build
```

Build is gitignored — homeboy rebuilds on release. PHP lint clean across all changed files.

## Files

- **NEW** `inc/core/my-shows-calendar-filter.php` — filter callback + tracked-IDs helper.
- `extrachill-events.php` — require_once the new file (one-line addition).
- `blocks/concert-stats/render.php` — restructured to emit the embedded calendar as a sibling of the React root inside an outer shell wrapper.
- `blocks/concert-stats/src/view.js` — Calendar tab, URL `?tab=` sync, hidden-attribute toggle on tab change.
- `blocks/concert-stats/src/style.scss` — one small spacing rule for the embedded calendar wrapper.

cc <@532385681268408341>