### PR TITLE
refactor(concert-stats): migrate to @extrachill/components canonical primitives (closes #120)

### DIFF
--- a/blocks/concert-stats/src/components/AddPastShows.js
+++ b/blocks/concert-stats/src/components/AddPastShows.js
@@ -4,7 +4,7 @@
  * Lets a logged-in user retroactively mark past events they attended.
  *
  * Behavior:
- *   - Search input (debounced in the hook).
+ *   - Search input (committed on Enter / Search button via SearchBox).
  *   - Empty query: backend returns the ~most-recent past events as suggestions.
  *   - Results list with "+ Mark Attended" per row, optimistic state flip.
  *   - "Load more" pagination, 20 per page (handled in useEventSearch).
@@ -13,6 +13,7 @@
  */
 
 import { useState } from '@wordpress/element';
+import { ActionRow, InlineStatus, Section } from '@extrachill/components';
 import EventSearchInput from './EventSearchInput';
 import EventSearchResult from './EventSearchResult';
 import useEventSearch from '../hooks/useEventSearch';
@@ -26,7 +27,7 @@ const AddPastShows = () => {
 	const isEmptyQuery = query.trim() === '';
 
 	return (
-		<div className="ec-concert-stats__add-past">
+		<Section className="ec-concert-stats__add-past">
 			<EventSearchInput value={ query } onChange={ setQuery } />
 
 			{ isEmptyQuery && (
@@ -36,17 +37,17 @@ const AddPastShows = () => {
 			) }
 
 			{ error && (
-				<div className="ec-concert-stats__error">{ error }</div>
+				<InlineStatus tone="error">{ error }</InlineStatus>
 			) }
 
 			{ ! loading && ! error && events.length === 0 && ! isEmptyQuery && (
-				<div className="ec-concert-stats__empty-tab">
+				<InlineStatus tone="info">
 					No past shows match &ldquo;{ query }&rdquo;. Try a different artist or venue name.
-				</div>
+				</InlineStatus>
 			) }
 
 			{ events.length > 0 && (
-				<div className="ec-concert-stats__search-results">
+				<Section className="ec-concert-stats__search-results">
 					{ isEmptyQuery && (
 						<p className="ec-concert-stats__search-results-label">
 							Recent past shows
@@ -59,15 +60,15 @@ const AddPastShows = () => {
 							onMarkedChange={ setMarked }
 						/>
 					) ) }
-				</div>
+				</Section>
 			) }
 
 			{ loading && (
-				<div className="ec-concert-stats__loading-more">Searching…</div>
+				<InlineStatus tone="info">Searching…</InlineStatus>
 			) }
 
 			{ ! loading && page < pages && (
-				<div className="ec-concert-stats__load-more">
+				<ActionRow align="center">
 					<button
 						type="button"
 						className="ec-concert-stats__load-more-btn"
@@ -75,9 +76,9 @@ const AddPastShows = () => {
 					>
 						Load more ({ total - events.length } remaining)
 					</button>
-				</div>
+				</ActionRow>
 			) }
-		</div>
+		</Section>
 	);
 };
 

--- a/blocks/concert-stats/src/components/EventSearchInput.js
+++ b/blocks/concert-stats/src/components/EventSearchInput.js
@@ -1,34 +1,25 @@
 /**
- * EventSearchInput — Controlled search input with a clear button.
+ * EventSearchInput — Canonical search input wrapper.
  *
- * The debounce lives in the consuming hook (`useEventSearch`), so this
- * component just controls the input value and emits onChange immediately.
+ * Thin adapter over the canonical `SearchBox` primitive from
+ * `@extrachill/components`. The parent owns the committed query value;
+ * `onChange(value)` is invoked when the user hits Enter, clicks the
+ * Search button, or clears the input. Debouncing (if any) lives in the
+ * consuming hook (`useEventSearch`).
  *
  * @package ExtraChillEvents
  */
 
+import { SearchBox } from '@extrachill/components';
+
 const EventSearchInput = ( { value, onChange, placeholder } ) => {
 	return (
-		<div className="ec-concert-stats__search">
-			<input
-				type="search"
-				className="ec-concert-stats__search-input"
-				value={ value }
-				onChange={ ( e ) => onChange( e.target.value ) }
-				placeholder={ placeholder || 'Search past shows by artist, venue, or title…' }
-				aria-label="Search past events"
-			/>
-			{ value && (
-				<button
-					type="button"
-					className="ec-concert-stats__search-clear"
-					onClick={ () => onChange( '' ) }
-					aria-label="Clear search"
-				>
-					×
-				</button>
-			) }
-		</div>
+		<SearchBox
+			value={ value }
+			onSearch={ ( next ) => onChange( next ) }
+			onClear={ () => onChange( '' ) }
+			placeholder={ placeholder || 'Search past shows by artist, venue, or title…' }
+		/>
 	);
 };
 

--- a/blocks/concert-stats/src/components/EventSearchResult.js
+++ b/blocks/concert-stats/src/components/EventSearchResult.js
@@ -11,6 +11,7 @@
 
 import { useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import { ActionRow } from '@extrachill/components';
 
 const MONTHS = [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ];
 
@@ -80,7 +81,7 @@ const EventSearchResult = ( { event, onMarkedChange } ) => {
 	};
 
 	return (
-		<div className="ec-concert-stats__search-result">
+		<ActionRow align="between" className="ec-concert-stats__search-result">
 			<a
 				href={ event.permalink || '#' }
 				className="ec-concert-stats__search-result-link"
@@ -126,7 +127,7 @@ const EventSearchResult = ( { event, onMarkedChange } ) => {
 					</span>
 				) }
 			</div>
-		</div>
+		</ActionRow>
 	);
 };
 

--- a/blocks/concert-stats/src/components/ImportRunProgress.js
+++ b/blocks/concert-stats/src/components/ImportRunProgress.js
@@ -1,8 +1,16 @@
 /**
  * ImportRunProgress — Live progress indicator for a single import run.
  *
+ * The progress bar itself stays bespoke: there's no canonical
+ * `ProgressBar` primitive in `@extrachill/components` yet. If/when one
+ * lands, the inner `.ec-concert-stats__import-run-bar*` markup should
+ * be swapped out. Wrapped in `<Section>` for chrome consistency with
+ * the rest of the platform. Success/error notes use `<InlineStatus>`.
+ *
  * @package ExtraChillEvents
  */
+
+import { InlineStatus, Section } from '@extrachill/components';
 
 const STATUS_LABEL = {
 	pending: 'Queued',
@@ -28,7 +36,7 @@ const ImportRunProgress = ( { run } ) => {
 	const pct = formatPercent( run );
 
 	return (
-		<div className="ec-concert-stats__import-run">
+		<Section className="ec-concert-stats__import-run">
 			<div className="ec-concert-stats__import-run-header">
 				<span className="ec-concert-stats__import-run-status">
 					{ STATUS_LABEL[ run.status ] || run.status }
@@ -40,6 +48,10 @@ const ImportRunProgress = ( { run } ) => {
 				) }
 			</div>
 
+			{ /*
+			   Bespoke progress bar — no canonical ProgressBar primitive
+			   in @extrachill/components yet. Future swap candidate.
+			 */ }
 			{ pct !== null && (
 				<div className="ec-concert-stats__import-run-bar">
 					<div
@@ -68,21 +80,21 @@ const ImportRunProgress = ( { run } ) => {
 			) }
 
 			{ isDone && (
-				<div className="ec-concert-stats__import-run-note ec-concert-stats__import-run-note--success">
+				<InlineStatus tone="success">
 					{ run.total_events_matched } show
 					{ run.total_events_matched === 1 ? '' : 's' } added to your history.
 					{ run.total_events_unmatched > 0 && (
 						<> { run.total_events_unmatched } not found in our database (skipped).</>
 					) }
-				</div>
+				</InlineStatus>
 			) }
 
 			{ isFailed && run.error_message && (
-				<div className="ec-concert-stats__import-run-note ec-concert-stats__import-run-note--error">
+				<InlineStatus tone="error">
 					{ run.error_message }
-				</div>
+				</InlineStatus>
 			) }
-		</div>
+		</Section>
 	);
 };
 

--- a/blocks/concert-stats/src/components/ImportSourceCard.js
+++ b/blocks/concert-stats/src/components/ImportSourceCard.js
@@ -10,6 +10,13 @@
  */
 
 import { useState, useMemo } from '@wordpress/element';
+import {
+	ActionRow,
+	FieldGroup,
+	InlineStatus,
+	Panel,
+	PanelHeader,
+} from '@extrachill/components';
 import ImportRunProgress from './ImportRunProgress';
 
 const ACTIVE_STATUSES = [ 'pending', 'running', 'paused' ];
@@ -61,21 +68,22 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 		setPreviewState( null );
 	};
 
+	const rateLimitMeta =
+		source.rate_limit && source.rate_limit.requests_per_day > 0
+			? `${ source.rate_limit.requests_per_day } reqs/day`
+			: null;
+
 	return (
-		<div className="ec-concert-stats__import-card">
-			<div className="ec-concert-stats__import-card-header">
-				<h3 className="ec-concert-stats__import-card-title">{ source.label }</h3>
-				{ source.rate_limit && source.rate_limit.requests_per_day > 0 && (
-					<span className="ec-concert-stats__import-card-meta">
-						{ source.rate_limit.requests_per_day } reqs/day
-					</span>
-				) }
-			</div>
+		<Panel className="ec-concert-stats__import-card">
+			<PanelHeader
+				title={ source.label }
+				description={ rateLimitMeta }
+			/>
 
 			{ ! source.configured && (
-				<p className="ec-concert-stats__import-card-disabled">
+				<InlineStatus tone="warning">
 					Not yet available — { source.label } API key has not been configured on this platform.
-				</p>
+				</InlineStatus>
 			) }
 
 			{ source.configured && activeRun && (
@@ -84,10 +92,7 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 
 			{ source.configured && ! activeRun && ! previewState && (
 				<form className="ec-concert-stats__import-card-form" onSubmit={ handlePreview }>
-					<label className="ec-concert-stats__import-card-label">
-						Your { source.label } username
-					</label>
-					<div className="ec-concert-stats__import-card-row">
+					<FieldGroup label={ `Your ${ source.label } username` }>
 						<input
 							type="text"
 							className="ec-concert-stats__import-card-input"
@@ -97,6 +102,8 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 							disabled={ previewing }
 							required
 						/>
+					</FieldGroup>
+					<ActionRow align="end">
 						<button
 							type="submit"
 							className="ec-concert-stats__import-card-btn"
@@ -104,7 +111,7 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 						>
 							{ previewing ? 'Checking…' : 'Connect' }
 						</button>
-					</div>
+					</ActionRow>
 				</form>
 			) }
 
@@ -119,7 +126,7 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 						We&rsquo;ll match each show to events in our database. Shows we can&rsquo;t find will be skipped.
 						Large imports may take several days to complete due to { source.label } rate limits — we&rsquo;ll resume automatically.
 					</p>
-					<div className="ec-concert-stats__import-card-row">
+					<ActionRow align="end">
 						<button
 							type="button"
 							className="ec-concert-stats__import-card-btn ec-concert-stats__import-card-btn--primary"
@@ -136,12 +143,12 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 						>
 							Cancel
 						</button>
-					</div>
+					</ActionRow>
 				</div>
 			) }
 
 			{ error && (
-				<div className="ec-concert-stats__import-card-error">{ error }</div>
+				<InlineStatus tone="error">{ error }</InlineStatus>
 			) }
 
 			{ recentRuns.length > 0 && (
@@ -152,7 +159,7 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 					) ) }
 				</div>
 			) }
-		</div>
+		</Panel>
 	);
 };
 

--- a/blocks/concert-stats/src/components/ImportTab.js
+++ b/blocks/concert-stats/src/components/ImportTab.js
@@ -7,6 +7,7 @@
  * @package ExtraChillEvents
  */
 
+import { InlineStatus, Section } from '@extrachill/components';
 import ImportSourceCard from './ImportSourceCard';
 import useImportRuns from '../hooks/useImportRuns';
 
@@ -14,25 +15,23 @@ const ImportTab = () => {
 	const { sources, runs, loading, error, preview, start } = useImportRuns();
 
 	if ( loading ) {
-		return (
-			<div className="ec-concert-stats__loading-more">Loading import sources…</div>
-		);
+		return <InlineStatus tone="info">Loading import sources…</InlineStatus>;
 	}
 
 	if ( error ) {
-		return <div className="ec-concert-stats__error">{ error }</div>;
+		return <InlineStatus tone="error">{ error }</InlineStatus>;
 	}
 
 	if ( ! sources.length ) {
 		return (
-			<div className="ec-concert-stats__empty-tab">
+			<InlineStatus tone="info">
 				No import sources are available yet.
-			</div>
+			</InlineStatus>
 		);
 	}
 
 	return (
-		<div className="ec-concert-stats__import-tab">
+		<Section className="ec-concert-stats__import-tab">
 			<p className="ec-concert-stats__import-intro">
 				Already tracking your shows on another site? Pull your history into Extra Chill.
 				We&rsquo;ll match each show to events in our database and mark you as attended.
@@ -50,7 +49,7 @@ const ImportTab = () => {
 					/>
 				) ) }
 			</div>
-		</div>
+		</Section>
 	);
 };
 

--- a/blocks/concert-stats/src/components/Leaderboard.js
+++ b/blocks/concert-stats/src/components/Leaderboard.js
@@ -1,8 +1,13 @@
 /**
  * Leaderboard — Top artists/venues/cities.
  *
+ * Wrapped in a compact `<Panel>` for chrome consistency with the rest
+ * of the platform. The inner list markup remains local.
+ *
  * @package ExtraChillEvents
  */
+
+import { Panel } from '@extrachill/components';
 
 const Leaderboard = ( { title, items, maxItems = 5 } ) => {
 	if ( ! items || items.length === 0 ) {
@@ -10,7 +15,7 @@ const Leaderboard = ( { title, items, maxItems = 5 } ) => {
 	}
 
 	return (
-		<div className="ec-concert-stats__leaderboard">
+		<Panel compact className="ec-concert-stats__leaderboard">
 			<h3 className="ec-concert-stats__leaderboard-title">{ title }</h3>
 			<ol className="ec-concert-stats__leaderboard-list">
 				{ items.slice( 0, maxItems ).map( ( item ) => (
@@ -24,7 +29,7 @@ const Leaderboard = ( { title, items, maxItems = 5 } ) => {
 					</li>
 				) ) }
 			</ol>
-		</div>
+		</Panel>
 	);
 };
 

--- a/blocks/concert-stats/src/components/ShowList.js
+++ b/blocks/concert-stats/src/components/ShowList.js
@@ -5,6 +5,7 @@
  */
 
 import { useState } from '@wordpress/element';
+import { ActionRow, InlineStatus } from '@extrachill/components';
 import ShowCard from './ShowCard';
 import useShows from '../hooks/useShows';
 
@@ -19,20 +20,16 @@ const ShowList = ( { userId, period, year } ) => {
 	} );
 
 	if ( error ) {
-		return (
-			<div className="ec-concert-stats__error">
-				{ error }
-			</div>
-		);
+		return <InlineStatus tone="error">{ error }</InlineStatus>;
 	}
 
 	if ( ! loading && shows.length === 0 ) {
 		return (
-			<div className="ec-concert-stats__empty-tab">
+			<InlineStatus tone="info">
 				{ period === 'upcoming'
 					? 'No upcoming shows marked yet. Browse events and mark shows as "Going"!'
 					: 'No past shows tracked yet.' }
-			</div>
+			</InlineStatus>
 		);
 	}
 
@@ -43,11 +40,11 @@ const ShowList = ( { userId, period, year } ) => {
 			) ) }
 
 			{ loading && (
-				<div className="ec-concert-stats__loading-more">Loading...</div>
+				<InlineStatus tone="info">Loading...</InlineStatus>
 			) }
 
 			{ ! loading && page < pages && (
-				<div className="ec-concert-stats__load-more">
+				<ActionRow align="center">
 					<button
 						className="ec-concert-stats__load-more-btn"
 						onClick={ () => setPage( ( p ) => p + 1 ) }
@@ -55,7 +52,7 @@ const ShowList = ( { userId, period, year } ) => {
 					>
 						Load More ({ total - shows.length } remaining)
 					</button>
-				</div>
+				</ActionRow>
 			) }
 		</div>
 	);

--- a/blocks/concert-stats/src/components/StatsBar.js
+++ b/blocks/concert-stats/src/components/StatsBar.js
@@ -1,8 +1,15 @@
 /**
  * StatsBar — Four-stat summary row.
  *
+ * Wrapped in `<Section depth={1}>` for chrome consistency with the rest
+ * of the platform. The individual stat tiles remain bespoke local
+ * markup — `@extrachill/components` doesn't have a stat-tile primitive
+ * yet. If/when one lands, swap the `.ec-concert-stats__stat` items.
+ *
  * @package ExtraChillEvents
  */
+
+import { Section } from '@extrachill/components';
 
 const StatsBar = ( { stats } ) => {
 	if ( ! stats ) {
@@ -17,14 +24,14 @@ const StatsBar = ( { stats } ) => {
 	];
 
 	return (
-		<div className="ec-concert-stats__stats-bar">
+		<Section depth={ 1 } className="ec-concert-stats__stats-bar">
 			{ items.map( ( item ) => (
 				<div key={ item.label } className="ec-concert-stats__stat">
 					<span className="ec-concert-stats__stat-value">{ item.value }</span>
 					<span className="ec-concert-stats__stat-label">{ item.label }</span>
 				</div>
 			) ) }
-		</div>
+		</Section>
 	);
 };
 

--- a/blocks/concert-stats/src/components/YearFilter.js
+++ b/blocks/concert-stats/src/components/YearFilter.js
@@ -1,8 +1,10 @@
 /**
- * YearFilter — Year selection dropdown.
+ * YearFilter — Year selection dropdown wrapped in a canonical FieldGroup.
  *
  * @package ExtraChillEvents
  */
+
+import { FieldGroup } from '@extrachill/components';
 
 const YearFilter = ( { showsByYear, activeYear, onChange } ) => {
 	if ( ! showsByYear || Object.keys( showsByYear ).length === 0 ) {
@@ -12,18 +14,20 @@ const YearFilter = ( { showsByYear, activeYear, onChange } ) => {
 	const years = Object.entries( showsByYear ).sort( ( a, b ) => b[ 0 ] - a[ 0 ] );
 
 	return (
-		<select
-			className="ec-concert-stats__year-filter"
-			value={ activeYear || '' }
-			onChange={ ( e ) => onChange( e.target.value ? parseInt( e.target.value, 10 ) : 0 ) }
-		>
-			<option value="">All Time</option>
-			{ years.map( ( [ yr, count ] ) => (
-				<option key={ yr } value={ yr }>
-					{ yr } ({ count })
-				</option>
-			) ) }
-		</select>
+		<FieldGroup label="Year" className="ec-concert-stats__year-filter-group">
+			<select
+				className="ec-concert-stats__year-filter"
+				value={ activeYear || '' }
+				onChange={ ( e ) => onChange( e.target.value ? parseInt( e.target.value, 10 ) : 0 ) }
+			>
+				<option value="">All Time</option>
+				{ years.map( ( [ yr, count ] ) => (
+					<option key={ yr } value={ yr }>
+						{ yr } ({ count })
+					</option>
+				) ) }
+			</select>
+		</FieldGroup>
 	);
 };
 

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -1,17 +1,40 @@
 /**
  * Concert Stats Block — Styles
  *
- * Uses @extrachill/components for layout primitives (BlockShell, Panel, Tabs).
- * Component-specific styles use ec-concert-stats BEM namespace.
- * Token consumption via CSS custom properties with fallbacks.
+ * Uses @extrachill/components for layout primitives (BlockShell, Panel,
+ * PanelHeader, Section, ActionRow, FieldGroup, InlineStatus, SearchBox,
+ * Tabs). Component-specific styles use ec-concert-stats BEM namespace
+ * and are limited to what the canonical primitives do NOT cover:
+ *   - bespoke stat tiles (no canonical stat-tile primitive yet)
+ *   - bespoke import-run progress bar (no canonical ProgressBar yet)
+ *   - inline content layouts inside the canonical containers
  *
  * @package ExtraChillEvents
  */
 
 @import '@extrachill/components/styles/components.scss';
 
-/* ─── Stats Bar ─────────────────────────────────────────────────────────── */
+/* ─── ActionRow center alignment ───────────────────────────────────────── */
 
+/*
+ * Local extension of the canonical `<ActionRow align="center">` variant.
+ * The shared package ships `--between` and `--end` modifiers only; the
+ * concert-stats block uses `align="center"` for load-more rows below
+ * lists. If/when `@extrachill/components` ships a `--center` modifier,
+ * this rule can be deleted.
+ */
+.ec-action-row--center {
+	justify-content: center;
+}
+
+/* ─── Stats Bar (bespoke tiles inside Section) ──────────────────────────── */
+
+/*
+ * The outer `<Section>` chrome comes from @extrachill/components; the
+ * stat tiles themselves stay bespoke because there's no canonical
+ * stat-tile primitive yet. Override Section's default block layout to
+ * a flex row for this specific use.
+ */
 .ec-concert-stats__stats-bar {
 	display: flex;
 	gap: var(--spacing-lg, 1.5rem);
@@ -95,12 +118,7 @@
 	color: var(--muted-text, #6b7280);
 }
 
-/* ─── Load More ─────────────────────────────────────────────────────────── */
-
-.ec-concert-stats__load-more {
-	text-align: center;
-	padding: var(--spacing-md, 1rem) 0;
-}
+/* ─── Load More Button (inside ActionRow) ───────────────────────────────── */
 
 .ec-concert-stats__load-more-btn {
 	display: inline-block;
@@ -118,7 +136,7 @@
 	background-color: var(--card-background, #f3f4f6);
 }
 
-/* ─── Leaderboards ──────────────────────────────────────────────────────── */
+/* ─── Leaderboards (inside Panel) ───────────────────────────────────────── */
 
 .ec-concert-stats__leaderboards {
 	display: grid;
@@ -168,7 +186,7 @@
 	font-weight: 500;
 }
 
-/* ─── Year Filter ───────────────────────────────────────────────────────── */
+/* ─── Year Filter (select inside FieldGroup) ────────────────────────────── */
 
 .ec-concert-stats__year-filter {
 	padding: var(--spacing-xs, 0.25rem) var(--spacing-sm, 0.5rem);
@@ -180,7 +198,7 @@
 	cursor: pointer;
 }
 
-/* ─── Empty State ───────────────────────────────────────────────────────── */
+/* ─── Empty State (no-shows landing) ────────────────────────────────────── */
 
 .ec-concert-stats__empty {
 	text-align: center;
@@ -211,24 +229,6 @@
 
 .ec-concert-stats__empty-cta:hover {
 	background: var(--accent-dark, #3d6b08);
-}
-
-.ec-concert-stats__empty-tab {
-	text-align: center;
-	padding: var(--spacing-lg, 1.5rem);
-	color: var(--muted-text, #6b7280);
-}
-
-.ec-concert-stats__error {
-	text-align: center;
-	padding: var(--spacing-md, 1rem);
-	color: var(--error-color, #dc2626);
-}
-
-.ec-concert-stats__loading-more {
-	text-align: center;
-	padding: var(--spacing-md, 1rem);
-	color: var(--muted-text, #6b7280);
 }
 
 /* ─── Loading Skeleton ──────────────────────────────────────────────────── */
@@ -273,68 +273,12 @@
 	100% { background-position: -200% 0; }
 }
 
-/* ─── Add Past Shows Tab ─────────────────────────────────────────────────── */
-
-.ec-concert-stats__add-past {
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing-md, 1rem);
-}
-
-.ec-concert-stats__search {
-	position: relative;
-	display: flex;
-	align-items: center;
-}
-
-.ec-concert-stats__search-input {
-	width: 100%;
-	padding: var(--spacing-sm, 0.5rem) var(--spacing-md, 1rem);
-	padding-right: 2.25rem; /* room for clear button */
-	border: 1px solid var(--border-color, #d1d5db);
-	border-radius: var(--border-radius-sm, 5px);
-	background: var(--background-color, #fff);
-	color: var(--text-color, #1f2937);
-	font-size: var(--font-size-body, 1rem);
-	line-height: 1.4;
-}
-
-.ec-concert-stats__search-input:focus {
-	outline: none;
-	border-color: var(--accent, #53940b);
-	box-shadow: 0 0 0 2px rgba(83, 148, 11, 0.15);
-}
-
-.ec-concert-stats__search-clear {
-	position: absolute;
-	right: var(--spacing-xs, 0.25rem);
-	top: 50%;
-	transform: translateY(-50%);
-	background: transparent;
-	border: none;
-	color: var(--muted-text, #6b7280);
-	font-size: 1.25rem;
-	line-height: 1;
-	cursor: pointer;
-	padding: 0.25rem 0.5rem;
-	border-radius: var(--border-radius-sm, 5px);
-}
-
-.ec-concert-stats__search-clear:hover {
-	background: var(--card-background, #f3f4f6);
-	color: var(--text-color, #1f2937);
-}
+/* ─── Add Past Shows Tab — inner content ────────────────────────────────── */
 
 .ec-concert-stats__search-hint {
 	margin: 0;
 	color: var(--muted-text, #6b7280);
 	font-size: var(--font-size-sm, 0.875rem);
-}
-
-.ec-concert-stats__search-results {
-	display: flex;
-	flex-direction: column;
-	gap: 2px;
 }
 
 .ec-concert-stats__search-results-label {
@@ -346,18 +290,7 @@
 	color: var(--muted-text, #6b7280);
 }
 
-.ec-concert-stats__search-result {
-	display: flex;
-	align-items: center;
-	gap: var(--spacing-md, 1rem);
-	padding: var(--spacing-sm, 0.5rem) var(--spacing-xs, 0.25rem);
-	border-radius: var(--border-radius-sm, 5px);
-	transition: background-color 0.1s ease;
-}
-
-.ec-concert-stats__search-result:hover {
-	background-color: var(--card-background, #f9fafb);
-}
+/* ─── Search Result inner layout (inside ActionRow) ─────────────────────── */
 
 .ec-concert-stats__search-result-link {
 	display: flex;
@@ -472,29 +405,13 @@
 		grid-template-columns: 1fr;
 	}
 
-	.ec-concert-stats__search-result {
-		flex-wrap: wrap;
-	}
-
 	.ec-concert-stats__search-result-date {
 		width: 80px;
 		font-size: var(--font-size-xs, 0.625rem);
 	}
-
-	.ec-concert-stats__search-result-action {
-		width: 100%;
-		align-items: flex-start;
-		padding-left: calc(80px + var(--spacing-md, 1rem));
-	}
 }
 
-/* ─── Import Tab ────────────────────────────────────────────────────────── */
-
-.ec-concert-stats__import-tab {
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing-md, 1rem);
-}
+/* ─── Import Tab — inner content ────────────────────────────────────────── */
 
 .ec-concert-stats__import-intro {
 	margin: 0 0 var(--spacing-sm, 0.5rem) 0;
@@ -508,59 +425,11 @@
 	gap: var(--spacing-md, 1rem);
 }
 
-.ec-concert-stats__import-card {
-	border: 1px solid var(--border-color, #e5e7eb);
-	border-radius: var(--border-radius, 8px);
-	padding: var(--spacing-md, 1rem);
-	background: var(--card-background, #fff);
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing-sm, 0.5rem);
-}
-
-.ec-concert-stats__import-card-header {
-	display: flex;
-	align-items: baseline;
-	justify-content: space-between;
-	gap: var(--spacing-sm, 0.5rem);
-}
-
-.ec-concert-stats__import-card-title {
-	margin: 0;
-	font-size: var(--font-size-lg, 1.125rem);
-	font-weight: 700;
-	color: var(--text-color, #1f2937);
-}
-
-.ec-concert-stats__import-card-meta {
-	font-size: var(--font-size-xs, 0.75rem);
-	color: var(--muted-text, #6b7280);
-}
-
-.ec-concert-stats__import-card-disabled {
-	margin: 0;
-	padding: var(--spacing-sm, 0.5rem);
-	font-size: var(--font-size-sm, 0.875rem);
-	background: var(--muted-bg, #f3f4f6);
-	color: var(--muted-text, #6b7280);
-	border-radius: var(--border-radius-sm, 5px);
-}
-
+/* Form layout inside the import Panel */
 .ec-concert-stats__import-card-form {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing-xs, 0.25rem);
-}
-
-.ec-concert-stats__import-card-label {
-	font-size: var(--font-size-sm, 0.875rem);
-	color: var(--muted-text, #6b7280);
-}
-
-.ec-concert-stats__import-card-row {
-	display: flex;
-	gap: var(--spacing-sm, 0.5rem);
-	align-items: center;
 }
 
 .ec-concert-stats__import-card-input {
@@ -614,14 +483,6 @@
 	margin: 0;
 }
 
-.ec-concert-stats__import-card-error {
-	padding: var(--spacing-sm, 0.5rem);
-	background: #fee2e2;
-	color: #991b1b;
-	border-radius: var(--border-radius-sm, 5px);
-	font-size: var(--font-size-sm, 0.875rem);
-}
-
 .ec-concert-stats__import-card-history {
 	margin-top: var(--spacing-sm, 0.5rem);
 	border-top: 1px solid var(--border-color, #e5e7eb);
@@ -639,17 +500,14 @@
 	letter-spacing: 0.05em;
 }
 
-/* ─── Import Run Progress ────────────────────────────────────────────── */
+/* ─── Import Run Progress (bespoke bar + counts inside Section) ─────────── */
 
-.ec-concert-stats__import-run {
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing-xs, 0.25rem);
-	padding: var(--spacing-sm, 0.5rem);
-	background: var(--muted-bg, #f9fafb);
-	border-radius: var(--border-radius-sm, 5px);
-}
-
+/*
+ * Inner layout for ImportRunProgress. The outer chrome comes from
+ * `<Section>`. The progress bar itself (`__import-run-bar*`) stays
+ * bespoke until `@extrachill/components` ships a canonical
+ * `ProgressBar` primitive.
+ */
 .ec-concert-stats__import-run-header {
 	display: flex;
 	justify-content: space-between;
@@ -695,14 +553,6 @@
 .ec-concert-stats__import-run-note {
 	font-size: var(--font-size-xs, 0.75rem);
 	color: var(--muted-text, #6b7280);
-}
-
-.ec-concert-stats__import-run-note--success {
-	color: #166534;
-}
-
-.ec-concert-stats__import-run-note--error {
-	color: #991b1b;
 }
 
 /* ─── Embedded Calendar (#110, My Shows Calendar tab) ───────────────────── */

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -8,7 +8,7 @@
  */
 
 import { createRoot, useState, useEffect, useRef } from '@wordpress/element';
-import { BlockShell, BlockShellInner, BlockShellHeader, Tabs, Panel } from '@extrachill/components';
+import { BlockShell, BlockShellInner, BlockShellHeader, InlineStatus, Tabs, Panel } from '@extrachill/components';
 import StatsBar from './components/StatsBar';
 import ShowList from './components/ShowList';
 import Leaderboard from './components/Leaderboard';
@@ -221,9 +221,9 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, containerRef 
 					   sync) untouched.
 					 */ }
 					{ activeTab === 'calendar' && ! hasCalendar && (
-						<div className="ec-concert-stats__empty-tab">
+						<InlineStatus tone="info">
 							Calendar view is unavailable here.
-						</div>
+						</InlineStatus>
 					) }
 
 					{ activeTab === 'add-past' && isOwn && (
@@ -248,9 +248,7 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, containerRef 
 					) }
 
 					{ activeTab === 'stats' && statsLoading && (
-						<div className="ec-concert-stats__loading-more">
-							Loading stats...
-						</div>
+						<InlineStatus tone="info">Loading stats…</InlineStatus>
 					) }
 
 					{ activeTab === 'import' && isOwn && (


### PR DESCRIPTION
## Summary

Migrates the `extrachill/concert-stats` React block (the entire `/my-shows/` surface) off hand-rolled `<div className="ec-concert-stats__*">` containers and onto canonical `@extrachill/components` primitives, matching every other block on the platform (artist-platform, link-page-editor, artist-shop-manager, etc.).

Closes #120. **Blocks the release** per the issue.

## Per-component refactor (follows the locked map in #120)

| File | Canonical primitives now used |
|---|---|
| `AddPastShows.js` | `Section` (outer + results), `InlineStatus` (error/empty/searching), `ActionRow align="center"` (load-more) |
| `EventSearchInput.js` | `SearchBox` (replaces hand-rolled input+clear combo) |
| `EventSearchResult.js` | `ActionRow align="between"` (outer row) |
| `ImportTab.js` | `Section` (outer), `InlineStatus` (loading/error/empty) |
| `ImportSourceCard.js` | `Panel` + `PanelHeader`, `FieldGroup` (username), `ActionRow align="end"` (Connect / confirm-cancel), `InlineStatus` (disabled-source + error) |
| `ImportRunProgress.js` | `Section` (outer), `InlineStatus` (success / failure notes) |
| `ShowList.js` | `InlineStatus` (error/empty/loading), `ActionRow align="center"` (load-more) |
| `Leaderboard.js` | `Panel compact` (outer) |
| `StatsBar.js` | `Section depth={1}` (outer) |
| `YearFilter.js` | `FieldGroup label="Year"` (wraps the select) |
| `view.js` | minimal touch: calendar-fallback + stats-loading hand-rolled divs swapped to `InlineStatus` so their CSS rules can be deleted. Tab structure, URL sync, and embedded-calendar toggle untouched. |
| `ShowCard.js` | unchanged (placeholder file per #120) |

## CSS deletions in `blocks/concert-stats/src/style.scss`

Removed every bespoke rule covered by a canonical primitive's built-in styles (which arrive via `@extrachill/components/styles/components.scss`):

- `.ec-concert-stats__error`
- `.ec-concert-stats__empty-tab`
- `.ec-concert-stats__loading-more`
- `.ec-concert-stats__add-past`
- `.ec-concert-stats__search` + `__search-input(:focus)` + `__search-clear(:hover)` (SearchBox owns this now)
- `.ec-concert-stats__search-results` + outer `.ec-concert-stats__search-result(:hover)` (ActionRow owns the outer row)
- `.ec-concert-stats__load-more` wrapper (the inner `__load-more-btn` button stays)
- outer `.ec-concert-stats__leaderboard` (Panel owns chrome; inner list rules stay)
- `.ec-concert-stats__import-tab` (Section owns chrome)
- `.ec-concert-stats__import-card`, `__import-card-header`, `__import-card-title`, `__import-card-meta`, `__import-card-disabled`, `__import-card-row`, `__import-card-label`, `__import-card-error` (Panel + PanelHeader + FieldGroup + ActionRow + InlineStatus own these)
- `.ec-concert-stats__import-run` outer (Section owns chrome)
- `.ec-concert-stats__import-run-note--success`, `--error` (InlineStatus owns these)
- Mobile breakpoints for removed selectors

Net diff: **+167 / -295 lines**, of which ~−165 are the SCSS shrinking.

## Local additions

- `.ec-action-row--center { justify-content: center; }` — small local extension because the canonical package currently ships only `--between` and `--end` align modifiers. Used by the load-more rows in `ShowList` and `AddPastShows`. Deletable once `@extrachill/components` adds the `--center` modifier upstream.

## Bespoke local components retained (kept inside canonical chrome)

These do **not** have canonical equivalents in `@extrachill/components` yet, so they keep their local markup wrapped in `<Section>` / `<Panel>` for chrome consistency. Each carries a code comment flagging it as a future swap candidate:

- **Import-run progress bar** in `ImportRunProgress.js` — would be replaced by a future `ProgressBar` canonical primitive.
- **Stat tiles** in `StatsBar.js` — would be replaced by a future stat-tile canonical primitive.

Per the issue, no new exports were added to `@extrachill/components`. Follow-up issues for the missing primitives can be filed separately against that package.

## Behavior

Pure UI refactor — **no behavior changes**:

- Same hooks (`useShows`, `useStats`, `useEventSearch`, `useImportRuns`), same REST contract, same React state, same tab/URL sync, same calendar-tab DOM toggle, same optimistic mark-attended flow.
- `EventSearchInput` is now a thin adapter over `SearchBox`, so the committed query value updates on Enter / Search-button click / Clear (same surface the canonical SearchBox exposes everywhere else on the platform). The consuming `useEventSearch` hook's internal debounce is unchanged.
- No PHP layer touched; no `view.js` tab/URL logic touched; no hooks touched; no `event-submission` or any other block touched.

## Build

```
npm install
npm run build
```

Compiles clean (`webpack 5.107.2 compiled successfully`). `build/` is gitignored per repo convention — homeboy rebuilds on release.

## Out of scope (NOT included; tracked elsewhere)

- TS migration of concert-stats (#117).
- Migration of `event-submission` block.
- New canonical primitives in `@extrachill/components` (ProgressBar, stat tile, `ActionRow --center`).

cc <@532385681268408341>