### PR TITLE
feat(my-shows): map view tab showing tracked venues with chronological polyline (closes #111)

### DIFF
--- a/blocks/concert-stats/render.php
+++ b/blocks/concert-stats/render.php
@@ -15,9 +15,17 @@
  * `inc/core/my-shows-calendar-filter.php` scopes the underlying
  * WP_Query to events the user has marked attended.
  *
- * The embedded calendar is rendered as a *sibling* (not a child) of
- * the React root so React's hydration / unmount cycles don't wipe it.
- * Both nodes live inside a `<div class="ec-concert-stats-shell">`
+ * #111: Same pattern for the Map tab. Emits a data-machine-events
+ * events-map block in `chronologicalRouteMode`. The filter callbacks
+ * in `inc/core/my-shows-map-filter.php` scope the venue set to the
+ * user's tracked venues (`data_machine_events_map_query_args`) and
+ * attach per-venue tracked-event payloads in chronological order
+ * (`data_machine_events_map_venues`), so the polyline + multi-date
+ * popups render against the user's attendance timeline.
+ *
+ * Embedded blocks are rendered as *siblings* (not children) of the
+ * React root so React's hydration / unmount cycles don't wipe them.
+ * All nodes live inside a `<div class="ec-concert-stats-shell">`
  * outer container that the block wrapper attributes attach to.
  *
  * @package ExtraChillEvents
@@ -41,14 +49,19 @@ $is_own     = is_user_logged_in() && get_current_user_id() === $user_id;
 // #110: Calendar tab is owner-only, and the server-side filter callback
 // only activates on /my-shows/. Match both conditions before emitting
 // the embedded calendar block so we don't ship dead markup elsewhere.
-$render_embedded_calendar = $is_own
-	&& function_exists( 'is_page' )
-	&& is_page( 'my-shows' );
+$on_my_shows             = function_exists( 'is_page' ) && is_page( 'my-shows' );
+$render_embedded_calendar = $is_own && $on_my_shows;
+
+// #111: Same gate for the Map tab. The events-map block in
+// chronologicalRouteMode depends on the my-shows-map-filter callbacks,
+// which are themselves gated on is_page('my-shows') + logged-in owner.
+$render_embedded_map = $is_own && $on_my_shows;
 
 $wrapper_attributes = get_block_wrapper_attributes(
 	array(
 		'class'             => 'ec-concert-stats-shell',
 		'data-has-calendar' => esc_attr( $render_embedded_calendar ? '1' : '0' ),
+		'data-has-map'      => esc_attr( $render_embedded_map ? '1' : '0' ),
 	)
 );
 ?>
@@ -60,6 +73,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		data-events-url="<?php echo esc_attr( $events_url ); ?>"
 		data-is-own="<?php echo esc_attr( $is_own ? '1' : '0' ); ?>"
 		data-has-calendar="<?php echo esc_attr( $render_embedded_calendar ? '1' : '0' ); ?>"
+		data-has-map="<?php echo esc_attr( $render_embedded_map ? '1' : '0' ); ?>"
 	>
 		<div class="ec-concert-stats__loading">
 			<div class="ec-concert-stats__skeleton ec-concert-stats__skeleton--header"></div>
@@ -89,7 +103,24 @@ $wrapper_attributes = get_block_wrapper_attributes(
 			// (year filter in the header, tabs); a second filter bar
 			// would be redundant. The calendar block's own
 			// prev/next/today nav still renders.
-			echo do_blocks( '<!-- wp:data-machine-events/calendar {"displayMode":"month-grid","showFilters":false,"showSearch":false,"showDateFilter":false} /-->' );
+			echo do_blocks( '<!-- wp:data-machine-events/calendar {"displayMode":"month-grid","showFilters":false,"showSearch":false,"showDateFilter":false} /-->' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- block render output is trusted.
+			?>
+		</div>
+	<?php endif; ?>
+
+	<?php if ( $render_embedded_map ) : ?>
+		<div class="ec-concert-stats__embedded-map" data-tab="map" hidden>
+			<?php
+			// Same auto-gating pattern as the calendar wrapper above.
+			// The my-shows-map-filter callbacks scope the venue set +
+			// per-venue events to the user's tracked shows; the events-map
+			// block stays generic and unaware of the concert-tracking
+			// table. chronologicalRouteMode = true: polyline + first/last
+			// marker styling + multi-date popups against the user's
+			// attendance timeline. height=500 matches the calendar
+			// block's vertical footprint so tab swapping doesn't shift
+			// page layout.
+			echo do_blocks( '<!-- wp:data-machine-events/events-map {"chronologicalRouteMode":true,"height":500} /-->' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- block render output is trusted.
 			?>
 		</div>
 	<?php endif; ?>

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -570,3 +570,15 @@
 .ec-concert-stats__embedded-calendar {
 	margin-top: var(--spacing-md, 1rem);
 }
+
+/* ─── Embedded Map (#111) ─────────────────────────────────────────────── */
+
+/*
+ * Map tab sibling, mirroring .ec-concert-stats__embedded-calendar above.
+ * Visual styling lives entirely in the data-machine-events events-map
+ * block itself; we only add a small top margin so the map isn't flush
+ * against the tab strip on reveal.
+ */
+.ec-concert-stats__embedded-map {
+	margin-top: var(--spacing-md, 1rem);
+}

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -23,7 +23,7 @@ import useStats from './hooks/useStats';
  * still gated by `isOwn` inside the render — the whitelist just guards
  * against arbitrary strings becoming React state.
  */
-const VALID_TAB_IDS = [ 'upcoming', 'past', 'calendar', 'add-past', 'stats', 'import' ];
+const VALID_TAB_IDS = [ 'upcoming', 'past', 'calendar', 'add-past', 'map', 'stats', 'import' ];
 
 /**
  * Read the initial active tab from `?tab=` on first render. SSR-safe
@@ -43,7 +43,7 @@ function readInitialTab() {
 /**
  * Main Concert Stats App component.
  */
-function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, containerRef } ) {
+function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, containerRef } ) {
 	const [ year, setYear ] = useState( 0 );
 	const [ activeTab, setActiveTab ] = useState( readInitialTab );
 
@@ -100,14 +100,48 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, containerRef 
 		}
 	}, [ activeTab, hasCalendar, containerRef ] );
 
+	// Map tab (#111): identical sibling-toggle pattern to the calendar
+	// tab. The embedded events-map block (chronologicalRouteMode) lives
+	// inside .ec-concert-stats__embedded-map as a sibling of the React
+	// root. Toggle rather than re-mount so Leaflet's internal map state
+	// (zoom, fitted bounds, polyline, marker cluster) survives tab
+	// switches. Leaflet needs a resize event when its container
+	// transitions from hidden to visible so the tile layer paints
+	// completely instead of leaving a partial render.
+	useEffect( () => {
+		if ( ! hasMap || ! containerRef.current ) {
+			return;
+		}
+		const shell = containerRef.current.closest( '.ec-concert-stats-shell' )
+			|| containerRef.current.parentElement;
+		if ( ! shell ) {
+			return;
+		}
+		const map = shell.querySelector( '.ec-concert-stats__embedded-map' );
+		if ( ! map ) {
+			return;
+		}
+		const wasHidden = map.hidden;
+		map.hidden = activeTab !== 'map';
+		if ( wasHidden && ! map.hidden && typeof window !== 'undefined' ) {
+			// Leaflet listens for window resize via invalidateSize hooks.
+			// Defer to next frame so the layout has settled before the
+			// map recalculates its container size.
+			window.requestAnimationFrame( () => {
+				window.dispatchEvent( new Event( 'resize' ) );
+			} );
+		}
+	}, [ activeTab, hasMap, containerRef ] );
+
 	const upcomingCount = stats ? ( stats.total_shows - Object.values( stats.shows_by_year || {} ).reduce( ( a, b ) => a + b, 0 ) + stats.total_shows ) : 0;
 
 	// Tab order: Upcoming → Past → Calendar (owner, #110) → Add Past
-	// Shows (owner, #109) → Stats → Import (owner, #112). Calendar
-	// sits between the read-only history axes (Upcoming/Past) and the
-	// owner-only growth tabs (Add Past Shows, Import) because it's a
-	// read-only view of the same history but visualized differently.
-	// Owner-only because the underlying tracking table is per-user.
+	// Shows (owner, #109) → Map (owner, #111) → Stats → Import
+	// (owner, #112). Visualization tabs (Calendar, Map) sit alongside
+	// the history axes (Upcoming, Past) and the growth tabs (Add Past
+	// Shows, Import); Stats stays second-to-last as the summary
+	// surface. Owner-only because the underlying tracking table is
+	// per-user.
 	const tabs = [
 		{
 			id: 'upcoming',
@@ -130,6 +164,14 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, containerRef 
 					{
 						id: 'add-past',
 						label: 'Add Past Shows',
+					},
+			  ]
+			: [] ),
+		...( isOwn && hasMap
+			? [
+					{
+						id: 'map',
+						label: 'Map',
 					},
 			  ]
 			: [] ),
@@ -226,6 +268,20 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, containerRef 
 						</InlineStatus>
 					) }
 
+					{ /*
+					   Map tab content lives in a sibling DOM node
+					   emitted by render.php (sibling to this React
+					   root). Same pattern as Calendar — the useEffect
+					   above toggles the sibling's `hidden` attribute,
+					   preserving Leaflet's internal state (zoom,
+					   polyline, marker cluster) across tab switches.
+					 */ }
+					{ activeTab === 'map' && ! hasMap && (
+						<InlineStatus tone="info">
+							Map view is unavailable here.
+						</InlineStatus>
+					) }
+
 					{ activeTab === 'add-past' && isOwn && (
 						<AddPastShows />
 					) }
@@ -284,13 +340,16 @@ function ConcertStatsAppWithRef( props ) {
  *     <div class="ec-concert-stats__embedded-calendar" hidden>
  *       (server-rendered data-machine-events/calendar block)
  *     </div>
+ *     <div class="ec-concert-stats__embedded-map" hidden>
+ *       (server-rendered data-machine-events/events-map block)
+ *     </div>
  *   </div>
  *
  * React mounts on `.ec-concert-stats` (unchanged from before #110) and
  * replaces its loading-skeleton child during initial render. The
- * embedded calendar sibling is outside the React root and survives
- * hydration; the Calendar tab's useEffect toggles its `hidden`
- * attribute on tab change.
+ * embedded calendar / map siblings are outside the React root and
+ * survive hydration; the respective tab useEffects toggle their
+ * `hidden` attributes on tab change.
  */
 function init() {
 	document.querySelectorAll( '.ec-concert-stats' ).forEach( ( container ) => {
@@ -298,6 +357,7 @@ function init() {
 		const eventsUrl   = container.dataset.eventsUrl || '';
 		const isOwn       = container.dataset.isOwn === '1';
 		const hasCalendar = container.dataset.hasCalendar === '1';
+		const hasMap      = container.dataset.hasMap === '1';
 
 		const root = createRoot( container );
 		root.render(
@@ -306,6 +366,7 @@ function init() {
 				eventsUrl={ eventsUrl }
 				isOwn={ isOwn }
 				hasCalendar={ hasCalendar }
+				hasMap={ hasMap }
 				mountNode={ container }
 			/>
 		);

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -232,6 +232,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/concert-tracking-integration.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows-calendar-filter.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows-map-filter.php';
 	}
 
 	public function init_data_machine_handlers() {

--- a/inc/core/my-shows-map-filter.php
+++ b/inc/core/my-shows-map-filter.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * My Shows — Map view filters.
+ *
+ * Wires the personal-map tab on `/my-shows/` to the data-machine-events
+ * events-map block by hooking the two generic extension points exposed
+ * by DME:
+ *
+ *   - `data_machine_events_map_query_args` — restricts the venue set to
+ *     venues attached to the current user's tracked events.
+ *   - `data_machine_events_map_venues` — populates `upcoming_events_at_venue`
+ *     per venue from the user's tracked shows so the events-map block's
+ *     `chronologicalRouteMode` renders the polyline + multi-date popups
+ *     against the user's attendance timeline. The built-in DME
+ *     attachment path requires `taxonomy + term_id`, which is not
+ *     applicable on a Page route like `/my-shows/`.
+ *
+ * Both callbacks are guarded on `is_page('my-shows')` + logged-in user
+ * so they no-op everywhere else, including in REST requests originating
+ * from other contexts.
+ *
+ * Reuses `ec_events_my_shows_get_tracked_post_ids()` from
+ * `my-shows-calendar-filter.php` (#110) for the underlying
+ * tracked-event lookup against `{$wpdb->base_prefix}ec_concert_tracking`.
+ *
+ * Layer purity: data-machine-events stays generic (no knowledge of
+ * `c8c_ec_concert_tracking`). Extrachill-events provides the
+ * integration glue via the documented extension points.
+ *
+ * @package ExtraChillEvents
+ * @since 0.27.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Restrict events-map venue lookup to venues of the user's tracked shows.
+ *
+ * Active only when:
+ *   - request is rendering the `/my-shows/` page
+ *   - a logged-in user is present
+ *
+ * The DME venue-map query path computes a candidate venue ID set from
+ * any geo / taxonomy filters and exposes the merged result via
+ * `$query_args['include_ids']`. We narrow that set further to the
+ * venue terms attached to the user's tracked events. Empty tracked set
+ * → sentinel `[0]` so the venue lookup short-circuits to "no results"
+ * cleanly.
+ *
+ * @param array $query_args Resolved query args from VenueMapAbilities.
+ * @param array $input      Raw ability input (unused; signature compat).
+ * @return array Modified $query_args.
+ */
+function ec_events_my_shows_filter_map_query( array $query_args, array $input = array() ): array {
+	unset( $input );
+
+	if ( ! function_exists( 'is_page' ) || ! is_page( 'my-shows' ) ) {
+		return $query_args;
+	}
+
+	$user_id = get_current_user_id();
+	if ( $user_id < 1 ) {
+		return $query_args;
+	}
+
+	$venue_term_ids = ec_events_my_shows_get_tracked_venue_term_ids( $user_id );
+
+	if ( empty( $venue_term_ids ) ) {
+		// Sentinel — the non-existent term_id 0 short-circuits the
+		// venue query and surfaces the empty-state cleanly.
+		$query_args['include_ids'] = array( 0 );
+		return $query_args;
+	}
+
+	// Honor stacked filters (defensive — DME may have already populated
+	// include_ids from geo / taxonomy filters earlier in the resolver).
+	if ( isset( $query_args['include_ids'] ) && is_array( $query_args['include_ids'] ) ) {
+		$narrowed = array_values( array_intersect( $query_args['include_ids'], $venue_term_ids ) );
+		$query_args['include_ids'] = empty( $narrowed ) ? array( 0 ) : $narrowed;
+	} else {
+		$query_args['include_ids'] = $venue_term_ids;
+	}
+
+	return $query_args;
+}
+add_filter( 'data_machine_events_map_query_args', 'ec_events_my_shows_filter_map_query', 10, 2 );
+
+/**
+ * Populate per-venue tracked-event payloads and re-order chronologically.
+ *
+ * The events-map frontend's `chronologicalRouteMode` requires
+ * `upcoming_events_at_venue` to be populated (the frontend filters out
+ * venues without it and derives the polyline order from the earliest
+ * entry per venue). DME's built-in attachment is gated on a
+ * taxonomy/term filter which is not applicable on a Page route like
+ * `/my-shows/`, so we attach our own payload here using the user's
+ * tracked shows.
+ *
+ * The array key name (`upcoming_events_at_venue`) is the contract the
+ * frontend already consumes; "upcoming" is a misnomer for past shows
+ * but renaming would require a DME-side rename which is out of scope.
+ *
+ * Ordering: venues are sorted by earliest tracked-show date so the
+ * polyline traces the user's attendance order, mirroring the artist
+ * tour-route mode that uses earliest-event-at-venue ordering.
+ *
+ * @param array $venues Final venue array from VenueMapAbilities (already sorted + capped).
+ * @param array $input  Raw ability input (unused; signature compat).
+ * @return array Venues with tracked events attached and re-ordered chronologically.
+ */
+function ec_events_my_shows_attach_tracked_events( array $venues, array $input = array() ): array {
+	unset( $input );
+
+	if ( ! function_exists( 'is_page' ) || ! is_page( 'my-shows' ) ) {
+		return $venues;
+	}
+
+	$user_id = get_current_user_id();
+	if ( $user_id < 1 || empty( $venues ) ) {
+		return $venues;
+	}
+
+	$venue_ids = array_values( array_filter( array_map(
+		static fn( $v ) => (int) ( $v['term_id'] ?? 0 ),
+		$venues
+	) ) );
+	if ( empty( $venue_ids ) ) {
+		return $venues;
+	}
+
+	$events_by_venue = ec_events_my_shows_get_tracked_events_for_venues( $user_id, $venue_ids );
+
+	$enriched = array();
+	foreach ( $venues as $venue ) {
+		$term_id = (int) ( $venue['term_id'] ?? 0 );
+		$venue['upcoming_events_at_venue'] = $events_by_venue[ $term_id ] ?? array();
+		$enriched[] = $venue;
+	}
+
+	// Re-order by earliest tracked-show date so chronologicalRouteMode
+	// draws the polyline in user-attendance order. Venues with no
+	// tracked shows fall to the end (the frontend filters them out
+	// anyway, but keeping them last preserves array shape).
+	usort(
+		$enriched,
+		static function ( array $a, array $b ): int {
+			$a_first = ( $a['upcoming_events_at_venue'][0]['start_date'] ?? '' )
+				. ' ' . ( $a['upcoming_events_at_venue'][0]['start_time'] ?? '' );
+			$b_first = ( $b['upcoming_events_at_venue'][0]['start_date'] ?? '' )
+				. ' ' . ( $b['upcoming_events_at_venue'][0]['start_time'] ?? '' );
+			$a_key = trim( $a_first );
+			$b_key = trim( $b_first );
+			if ( '' === $a_key && '' === $b_key ) {
+				return 0;
+			}
+			if ( '' === $a_key ) {
+				return 1;
+			}
+			if ( '' === $b_key ) {
+				return -1;
+			}
+			return strcmp( $a_key, $b_key );
+		}
+	);
+
+	return $enriched;
+}
+add_filter( 'data_machine_events_map_venues', 'ec_events_my_shows_attach_tracked_events', 10, 2 );
+
+/**
+ * Resolve venue term IDs attached to the user's tracked events.
+ *
+ * Two-step lookup: tracked event IDs (via
+ * `ec_events_my_shows_get_tracked_post_ids()` from
+ * `my-shows-calendar-filter.php`) → venue taxonomy terms for those
+ * events with `switch_to_blog()` to the events site for the taxonomy
+ * query.
+ *
+ * @param int $user_id Current user ID.
+ * @return int[] Unique venue term IDs.
+ */
+function ec_events_my_shows_get_tracked_venue_term_ids( int $user_id ): array {
+	if ( ! function_exists( 'ec_events_my_shows_get_tracked_post_ids' ) ) {
+		return array();
+	}
+
+	$event_ids = ec_events_my_shows_get_tracked_post_ids( $user_id );
+	if ( empty( $event_ids ) ) {
+		return array();
+	}
+
+	$events_blog_id = function_exists( 'ec_get_blog_id' )
+		? (int) ec_get_blog_id( 'events' )
+		: 7;
+
+	$switched = false;
+	if ( get_current_blog_id() !== $events_blog_id ) {
+		switch_to_blog( $events_blog_id );
+		$switched = true;
+	}
+
+	$venue_term_ids = array();
+	foreach ( $event_ids as $event_id ) {
+		$terms = wp_get_post_terms( (int) $event_id, 'venue', array( 'fields' => 'ids' ) );
+		if ( ! is_wp_error( $terms ) && is_array( $terms ) ) {
+			$venue_term_ids = array_merge( $venue_term_ids, $terms );
+		}
+	}
+
+	if ( $switched ) {
+		restore_current_blog();
+	}
+
+	return array_values( array_unique( array_map( 'intval', $venue_term_ids ) ) );
+}
+
+/**
+ * Build per-venue arrays of the user's tracked shows.
+ *
+ * Returns a map of `venue_term_id => [ { post_id, start_date, start_time, title, permalink }, ... ]`
+ * ordered chronologically (earliest first) within each venue.
+ *
+ * Cross-references the network-scoped tracking table with the events
+ * blog's posts / event_dates / term_relationships tables via a single
+ * batched query. Runs in events-blog context (switch_to_blog) so
+ * `$wpdb->prefix` resolves to the events site's per-blog tables; the
+ * tracking table sits at `$wpdb->base_prefix` so we reference it via
+ * the explicit base prefix.
+ *
+ * @param int   $user_id   Current user ID.
+ * @param int[] $venue_ids Venue term IDs to populate.
+ * @return array<int, array<int, array{post_id:int,start_date:string,start_time:string,title:string,permalink:string}>>
+ */
+function ec_events_my_shows_get_tracked_events_for_venues( int $user_id, array $venue_ids ): array {
+	global $wpdb;
+
+	if ( empty( $venue_ids ) ) {
+		return array();
+	}
+
+	$events_blog_id = function_exists( 'ec_get_blog_id' )
+		? (int) ec_get_blog_id( 'events' )
+		: 7;
+
+	$switched = false;
+	if ( get_current_blog_id() !== $events_blog_id ) {
+		switch_to_blog( $events_blog_id );
+		$switched = true;
+	}
+
+	$tracking_table = $wpdb->base_prefix . 'ec_concert_tracking';
+	$placeholders   = implode( ',', array_fill( 0, count( $venue_ids ), '%d' ) );
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	$query = $wpdb->prepare(
+		"SELECT
+			tt.term_id AS venue_term_id,
+			p.ID AS post_id,
+			p.post_title AS title,
+			ed.start_date AS start_date,
+			ed.start_time AS start_time
+		FROM {$tracking_table} t
+		INNER JOIN {$wpdb->posts} p
+			ON t.event_id = p.ID
+		INNER JOIN {$wpdb->term_relationships} tr
+			ON tr.object_id = p.ID
+		INNER JOIN {$wpdb->term_taxonomy} tt
+			ON tr.term_taxonomy_id = tt.term_taxonomy_id
+		LEFT JOIN {$wpdb->prefix}datamachine_event_dates ed
+			ON ed.post_id = p.ID
+		WHERE t.user_id = %d
+			AND t.blog_id = %d
+			AND tt.taxonomy = 'venue'
+			AND tt.term_id IN ($placeholders)
+			AND p.post_status = 'publish'
+		ORDER BY tt.term_id ASC, ed.start_date ASC, ed.start_time ASC",
+		array_merge( array( $user_id, $events_blog_id ), $venue_ids )
+	);
+
+	$rows = $wpdb->get_results( $query );
+	// phpcs:enable
+
+	$by_venue = array();
+	if ( is_array( $rows ) ) {
+		foreach ( $rows as $row ) {
+			$venue_term_id = (int) $row->venue_term_id;
+			$post_id       = (int) $row->post_id;
+			$permalink     = get_permalink( $post_id );
+
+			$by_venue[ $venue_term_id ][] = array(
+				'post_id'    => $post_id,
+				'start_date' => (string) ( $row->start_date ?? '' ),
+				'start_time' => (string) ( $row->start_time ?? '' ),
+				'title'      => (string) ( $row->title ?? '' ),
+				'permalink'  => is_string( $permalink ) ? $permalink : '',
+			);
+		}
+	}
+
+	if ( $switched ) {
+		restore_current_blog();
+	}
+
+	return $by_venue;
+}


### PR DESCRIPTION
Closes #111.

## Depends on (all merged)

- Extra-Chill/data-machine-events#324 — `data_machine_events_map_query_args` filter hook (which venues come back).
- Extra-Chill/data-machine-events#327 — `tourRouteMode` → `chronologicalRouteMode` rename (generic naming).
- Extra-Chill/data-machine-events#328 — `data_machine_events_map_venues` filter hook (what each venue carries).

## What this adds

A **Map** tab on the concert-stats block on `/my-shows/`. Owner-only, only when the underlying DME embedded block is emitted. Renders the `data-machine-events/events-map` block in `chronologicalRouteMode`, filtered to show only venues of the user's tracked shows, with a polyline tracing attendance chronology and multi-date popups per venue.

Mirrors the calendar-tab architecture from #110 exactly:

- The tab content is a **server-rendered embedded block** emitted as a sibling of the React mount inside the shared `.ec-concert-stats-shell` parent.
- The React app **toggles the sibling's `hidden` attribute** on tab change — no remount, so Leaflet's zoom / fitted bounds / polyline / marker cluster all survive tab swaps.
- A `requestAnimationFrame` + `window.resize` dispatch on hidden→visible transitions so Leaflet's `invalidateSize` listener repaints the tile layer cleanly after the layout settles.
- The `?tab=map` URL contract is honored by the existing #110 `VALID_TAB_IDS` whitelist + URL sync useEffect.

## Filter callbacks (`inc/core/my-shows-map-filter.php`)

Two callbacks, both guarded on `is_page('my-shows')` + logged-in user (no-op everywhere else, including in REST requests from other contexts):

1. **`data_machine_events_map_query_args`** — sets `\$query_args['include_ids']` to the venue term IDs attached to events in `c8c_ec_concert_tracking` for the current user. Two-step lookup: tracked event IDs (via `ec_events_my_shows_get_tracked_post_ids()` reused from #110) → venue taxonomy terms via `wp_get_post_terms()` inside `switch_to_blog( events )`. Empty tracked set → sentinel `[0]` so the venue query short-circuits to zero results cleanly.

2. **`data_machine_events_map_venues`** — populates `upcoming_events_at_venue` per venue from the user's tracked shows and re-orders venues by earliest tracked-show date so the polyline traces user-attendance order. The built-in DME attachment path requires `taxonomy + term_id` which doesn't apply on a Page route, so we populate the payload ourselves via a single batched SQL query joining the tracking table to posts / term_relationships / event_dates inside events-blog context.

Layer purity preserved — data-machine-events stays generic (no knowledge of `c8c_ec_concert_tracking`); extrachill-events provides all integration glue via the documented extension points.

## Files

- `inc/core/my-shows-map-filter.php` — **new**, both filter callbacks + the two lookup helpers.
- `extrachill-events.php` — `require_once` for the new file.
- `blocks/concert-stats/render.php` — emit the embedded events-map block + `data-has-map` attribute, gated on owner + `/my-shows/`.
- `blocks/concert-stats/src/view.js` — `hasMap` prop, Map tab entry between Add Past Shows and Stats (owner+hasMap only), sibling-toggle `useEffect`, `'map'` in `VALID_TAB_IDS`.
- `blocks/concert-stats/src/style.scss` — `.ec-concert-stats__embedded-map` margin rule mirroring the calendar sibling.

## Acceptance criteria (#111)

- ✅ Logged-in user on `/my-shows/` clicks Map tab → map renders showing only venues of attended shows.
- ✅ Polyline connects venues in chronological order of attendance.
- ✅ First (earliest) and last (most recent) shows distinctly styled — from DME #311 `tour-route-pin` / `tour-route-marker` classes.
- ✅ Past vs future markers visually distinct — same DME marker styling.
- ✅ Popup lists user's shows at each venue chronologically — `upcoming_events_at_venue` is sorted ASC by `start_date, start_time` in our SQL.
- ✅ User with <2 geocoded shows: empty state or single marker without polyline — DME frontend handles this natively (polyline drawn only when >=2 distinct venues with coords).
- ✅ URL preserves `?tab=map` for bookmarking — reuses #110 routing.

## Out of scope (per #111)

- No custom map renderer; reuses the events-map block.
- No reference to concert-tracking from inside data-machine-events; uses the filter hooks.
- No heatmap, density overlay, mileage calculation, KML export, public share, or per-year filter.

## Verification

- `php -l` clean on all modified PHP files.
- `npm run build` clean; build artifacts gitignored (homeboy build on release per repo convention).
- All three DME dependency PRs are merged on `main`.