### PR TITLE
fix(concert-stats): hide unconfigured import sources from end users + show created-events counter (companion to extrachill-users#54)

### DIFF
--- a/blocks/concert-stats/src/components/ImportRunProgress.js
+++ b/blocks/concert-stats/src/components/ImportRunProgress.js
@@ -66,7 +66,7 @@ const ImportRunProgress = ( { run } ) => {
 					<strong>{ run.total_events_matched }</strong> matched
 				</span>
 				<span>
-					<strong>{ run.total_events_unmatched }</strong> unmatched
+					<strong>{ run.total_events_created || 0 }</strong> created
 				</span>
 				<span>
 					<strong>{ run.total_events_seen }</strong> seen
@@ -81,11 +81,23 @@ const ImportRunProgress = ( { run } ) => {
 
 			{ isDone && (
 				<InlineStatus tone="success">
-					{ run.total_events_matched } show
-					{ run.total_events_matched === 1 ? '' : 's' } added to your history.
-					{ run.total_events_unmatched > 0 && (
-						<> { run.total_events_unmatched } not found in our database (skipped).</>
-					) }
+					{ ( () => {
+						const matched = run.total_events_matched || 0;
+						const created = run.total_events_created || 0;
+						const total = matched + created;
+						const parts = [];
+						parts.push(
+							`${ total } show${ total === 1 ? '' : 's' } added to your history`
+						);
+						if ( created > 0 && matched > 0 ) {
+							parts.push(
+								` (${ matched } matched existing event${ matched === 1 ? '' : 's' }, ${ created } newly created)`
+							);
+						} else if ( created > 0 ) {
+							parts.push( ` (${ created } newly created)` );
+						}
+						return parts.join( '' ) + '.';
+					} )() }
 				</InlineStatus>
 			) }
 

--- a/blocks/concert-stats/src/components/ImportSourceCard.js
+++ b/blocks/concert-stats/src/components/ImportSourceCard.js
@@ -80,17 +80,17 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 				description={ rateLimitMeta }
 			/>
 
-			{ ! source.configured && (
-				<InlineStatus tone="warning">
-					Not yet available — { source.label } API key has not been configured on this platform.
-				</InlineStatus>
-			) }
-
-			{ source.configured && activeRun && (
+			{ /*
+			   The server-side ability filters unconfigured sources out for end
+			   users (#54), so any source that reaches this component is
+			   actionable. No `source.configured === false` branch — that path
+			   should never be exposed to end users.
+			 */ }
+			{ activeRun && (
 				<ImportRunProgress run={ activeRun } />
 			) }
 
-			{ source.configured && ! activeRun && ! previewState && (
+			{ ! activeRun && ! previewState && (
 				<form className="ec-concert-stats__import-card-form" onSubmit={ handlePreview }>
 					<FieldGroup label={ `Your ${ source.label } username` }>
 						<input
@@ -115,7 +115,7 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 				</form>
 			) }
 
-			{ source.configured && previewState && (
+			{ previewState && (
 				<div className="ec-concert-stats__import-card-confirm">
 					<p>
 						Import <strong>~{ previewState.total }</strong> show
@@ -123,7 +123,7 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 						<strong>{ previewState.username }</strong>?
 					</p>
 					<p className="ec-concert-stats__import-card-hint">
-						We&rsquo;ll match each show to events in our database. Shows we can&rsquo;t find will be skipped.
+						We&rsquo;ll match each show to events in our database. Shows we don&rsquo;t already have we&rsquo;ll add for you.
 						Large imports may take several days to complete due to { source.label } rate limits — we&rsquo;ll resume automatically.
 					</p>
 					<ActionRow align="end">

--- a/blocks/concert-stats/src/components/ImportTab.js
+++ b/blocks/concert-stats/src/components/ImportTab.js
@@ -1,18 +1,26 @@
 /**
  * ImportTab — Container for the Import tab in the concert-stats block.
  *
- * Lists every registered import source as a card and shows the current
- * user's run history below.
+ * Lists every CONFIGURED import source as a card and shows the current
+ * user's run history below. End users never see "not yet configured"
+ * plumbing — the underlying ability filters unconfigured sources out
+ * server-side. By the time the source list reaches this component, every
+ * entry is actionable.
  *
  * @package ExtraChillEvents
  */
 
 import { InlineStatus, Section } from '@extrachill/components';
 import ImportSourceCard from './ImportSourceCard';
-import useImportRuns from '../hooks/useImportRuns';
 
-const ImportTab = () => {
-	const { sources, runs, loading, error, preview, start } = useImportRuns();
+/**
+ * The parent (`view.js`) hoists the `useImportRuns` hook and passes the bag
+ * down so the Import tab visibility check (`hasImports`) shares the same
+ * fetch as the tab body. This component is a pure renderer — it does not
+ * fetch on its own. `bag` is the return value of `useImportRuns()`.
+ */
+const ImportTab = ( { bag } ) => {
+	const { sources, runs, loading, error, preview, start } = bag;
 
 	if ( loading ) {
 		return <InlineStatus tone="info">Loading import sources…</InlineStatus>;
@@ -22,12 +30,12 @@ const ImportTab = () => {
 		return <InlineStatus tone="error">{ error }</InlineStatus>;
 	}
 
+	// The parent view gates rendering on `sources.length > 0`, so reaching
+	// this component with an empty list means the source list mutated after
+	// initial mount (provider deconfigured mid-session). Leave a quiet
+	// fallback rather than rendering the heading.
 	if ( ! sources.length ) {
-		return (
-			<InlineStatus tone="info">
-				No import sources are available yet.
-			</InlineStatus>
-		);
+		return null;
 	}
 
 	return (
@@ -35,7 +43,7 @@ const ImportTab = () => {
 			<p className="ec-concert-stats__import-intro">
 				Already tracking your shows on another site? Pull your history into Extra Chill.
 				We&rsquo;ll match each show to events in our database and mark you as attended.
-				Shows we can&rsquo;t find will be skipped.
+				Shows we don&rsquo;t already have we&rsquo;ll add for you so your full history comes in.
 			</p>
 
 			<div className="ec-concert-stats__import-cards">

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -16,6 +16,7 @@ import YearFilter from './components/YearFilter';
 import AddPastShows from './components/AddPastShows';
 import ImportTab from './components/ImportTab';
 import useStats from './hooks/useStats';
+import useImportRuns from './hooks/useImportRuns';
 
 /**
  * Whitelist of tab IDs that may appear in `?tab=` URL state. Anything
@@ -48,6 +49,19 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 	const [ activeTab, setActiveTab ] = useState( readInitialTab );
 
 	const { stats, loading: statsLoading } = useStats( userId, { year } );
+
+	// Pull the configured source list at the parent level so the Import tab
+	// only renders when at least one source is actually available to this
+	// user. Mirrors the hasMap / hasCalendar gating pattern — the difference
+	// is that source availability is driven by server-side ability filtering
+	// (admins provision API keys via Data Machine auth), so we read it
+	// dynamically rather than from a server-emitted dataset attribute.
+	//
+	// We hoist the hook to the parent and pass the full bag down to ImportTab
+	// so we don't double-fetch from two `useImportRuns()` sites on the same
+	// page. ImportTab consumes the props directly.
+	const importRunsBag = useImportRuns();
+	const hasImports = isOwn && importRunsBag.sources && importRunsBag.sources.length > 0;
 
 	// Sync `?tab=` to URL whenever the active tab changes. Use
 	// replaceState to keep the back button useful — switching tabs
@@ -179,7 +193,7 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 			id: 'stats',
 			label: 'Stats',
 		},
-		...( isOwn
+		...( hasImports
 			? [
 					{
 						id: 'import',
@@ -210,9 +224,9 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 							) }
 						</div>
 					</Panel>
-					{ isOwn && (
+					{ hasImports && (
 						<Panel compact>
-							<ImportTab />
+							<ImportTab bag={ importRunsBag } />
 						</Panel>
 					) }
 				</BlockShellInner>
@@ -307,8 +321,8 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 						<InlineStatus tone="info">Loading stats…</InlineStatus>
 					) }
 
-					{ activeTab === 'import' && isOwn && (
-						<ImportTab />
+					{ activeTab === 'import' && hasImports && (
+						<ImportTab bag={ importRunsBag } />
 					) }
 				</Panel>
 			</BlockShellInner>


### PR DESCRIPTION
## Summary

Companion UI changes for Extra-Chill/extrachill-users#54. The primary PR (extrachill-users) lands first so the ability behavior is live before the frontend depends on it.

### What changed

- **`view.js`** — hoists `useImportRuns` to the parent (`ConcertStatsApp`) and gates the Import tab on `hasImports = isOwn && sources.length > 0`. Mirrors the existing `hasMap` / `hasCalendar` gating pattern; source availability is driven by server-side ability filtering rather than a `render.php` dataset attribute. The hook bag is threaded down to `ImportTab` via a `bag` prop so the tab body shares the same fetch as the gating check (no double-fetch).

- **`ImportTab.js`** — now a pure renderer that consumes the `bag` prop. Drops its own `useImportRuns` call. The "no sources available" info-status fallback is replaced with `return null` because the parent gates rendering on `hasImports`; reaching the component with an empty list means a transient post-mount mutation, not the no-config-at-all state. Intro copy rewritten from "Shows we can't find will be skipped" to "Shows we don't already have we'll add for you so your full history comes in."

- **`ImportSourceCard.js`** — removes the disabled-source warning and all `source.configured ===` guards. By the time a source reaches this component it's actionable. Confirmation-dialog copy also rewritten to match the new "we'll add what we don't have" framing.

- **`ImportRunProgress.js`** — surfaces the new `total_events_created` counter alongside `total_events_matched`. Completion message reads honestly: `"X shows added to your history (Y matched existing events, Z newly created)."` instead of framing unmatched as a loss. The `unmatched` counter drops out of the live display since the new orchestrator path eliminates unmatched as a user-facing outcome.

### Acceptance criteria

- End user on `/my-shows/` with no API keys provisioned: Import tab is absent from the tabs row. No "not yet available" cards. No empty-state CTAs that aren't real.
- End user with at least one configured source: Import tab appears alongside the existing tabs and lists only configured sources.
- Run-completion summary shows `matched + created` totals honestly.

### Build

`npm install && npm run build` runs clean. Bundle compiled at commit time. `build/` is gitignored as expected.

### Files

- `blocks/concert-stats/src/view.js`
- `blocks/concert-stats/src/components/ImportTab.js`
- `blocks/concert-stats/src/components/ImportSourceCard.js`
- `blocks/concert-stats/src/components/ImportRunProgress.js`

mention @chubes when ready for review.