### PR TITLE
fix(abilities): remove duplicate category registration (closes #124)

### DIFF
--- a/inc/Abilities/PriorityVenueAbilities.php
+++ b/inc/Abilities/PriorityVenueAbilities.php
@@ -25,18 +25,7 @@ class PriorityVenueAbilities {
 	}
 
 	private function registerAbilities(): void {
-		add_action( 'wp_abilities_api_categories_init', array( $this, 'registerCategory' ) );
 		add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
-	}
-
-	public function registerCategory(): void {
-		wp_register_ability_category(
-			'extrachill-events',
-			array(
-				'label'       => __( 'Extra Chill Events', 'extrachill-events' ),
-				'description' => __( 'Event management capabilities', 'extrachill-events' ),
-			)
-		);
 	}
 
 	public function register(): void {


### PR DESCRIPTION
## Summary

Removes the duplicate `extrachill-events` ability category registration from `PriorityVenueAbilities`. The category is already registered in `inc/abilities/register.php` via `extrachill_events_register_abilities_category()` on the `wp_abilities_api_categories_init` hook.

The duplicate registration was emitting `_doing_it_wrong` notices on every page load and polluting the production debug log.

## Changes

- Removed `registerCategory()` method from `inc/Abilities/PriorityVenueAbilities.php`
- Removed `add_action( 'wp_abilities_api_categories_init', ... )` from `registerAbilities()`
- The `extrachill/list-priority-venues` and `extrachill/set-priority-venue` abilities still reference `'category' => 'extrachill-events'`, which is registered once in `inc/abilities/register.php`

## Verification

- `php -l` clean
- Diff confined to the duplicate registration; ability registrations untouched
- Category still registered exactly once via `inc/abilities/register.php`

Closes #124

Sibling issues from the same incident: Extra-Chill/extrachill-users#56, Extra-Chill/data-machine#2287