### PR TITLE
fix(abilities): remove duplicate `extrachill-events` category registration in PriorityVenueAbilities

### DIFF
--- a/inc/Abilities/PriorityVenueAbilities.php
+++ b/inc/Abilities/PriorityVenueAbilities.php
@@ -25,18 +25,7 @@ class PriorityVenueAbilities {
 	}
 
 	private function registerAbilities(): void {
-		add_action( 'wp_abilities_api_categories_init', array( $this, 'registerCategory' ) );
 		add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
-	}
-
-	public function registerCategory(): void {
-		wp_register_ability_category(
-			'extrachill-events',
-			array(
-				'label'       => __( 'Extra Chill Events', 'extrachill-events' ),
-				'description' => __( 'Event management capabilities', 'extrachill-events' ),
-			)
-		);
 	}
 
 	public function register(): void {


### PR DESCRIPTION
Closes #124.

## Summary

`PriorityVenueAbilities` re-registered the `extrachill-events` ability category that `inc/abilities/register.php` already owns, triggering `_doing_it_wrong` notices on every page load and polluting the production debug log.

## Fix

In `inc/Abilities/PriorityVenueAbilities.php`:

- Removed the `registerCategory()` method
- Removed the `add_action( 'wp_abilities_api_categories_init', array( $this, 'registerCategory' ) );` call in `registerAbilities()`

The category is registered once via `extrachill_events_register_abilities_category()` in `inc/abilities/register.php`. `PriorityVenueAbilities` now only registers its ability (`extrachill/list-priority-venues`) and references the existing category — no functional change to the ability itself.

## Related

Part of the same incident response as:
- Extra-Chill/extrachill-users#56 (silent ec_send_email failures)
- Extra-Chill/data-machine#2287 (abilities load-order on subsites)

## Constraints honoured

- Conventional commit prefix: `fix(abilities):`
- `CHANGELOG.md` untouched
- Version strings untouched
- Branch only; **no release, no deploy**