### PR TITLE
fix(my-shows): show tabs in empty state, public marketing page for logged-out (closes #126)

### DIFF
--- a/blocks/concert-stats/render.php
+++ b/blocks/concert-stats/render.php
@@ -34,9 +34,72 @@
 
 $user_id = ! empty( $attributes['userId'] ) ? (int) $attributes['userId'] : get_current_user_id();
 
-// Don't render for logged-out users when no explicit userId is set.
+// #126: when there's no explicit `userId` attribute (the usual case
+// on /my-shows/) and the visitor is logged out, render a public
+// marketing surface instead of nothing. The old behavior — return
+// empty + force-redirect at template_redirect — left anonymous
+// visitors with zero context. The marketing markup is intentionally
+// server-rendered (no React) so search engines and link previews see
+// a real page. Canonical @extrachill/components class names are
+// emitted by hand so the same SCSS that styles the React-side
+// primitives (imported at the top of style.scss) styles this surface
+// for free.
 if ( ! $user_id ) {
 	if ( ! is_user_logged_in() ) {
+		// Signup lives on the community site (canonical registration
+		// surface for the platform). Login lives on the events site
+		// itself when the My Shows page is being viewed; keep the
+		// same `redirect_to=/my-shows/` pattern the deleted
+		// auth-gate used so post-login the user lands back here.
+		$signup_url = function_exists( 'ec_get_site_url' )
+			? trailingslashit( ec_get_site_url( 'community' ) ) . 'register/'
+			: wp_registration_url();
+		$login_url  = function_exists( 'ec_get_site_url' )
+			? trailingslashit( ec_get_site_url( 'events' ) ) . 'login/?redirect_to=' . rawurlencode( home_url( '/my-shows/' ) )
+			: wp_login_url( home_url( '/my-shows/' ) );
+
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class' => 'ec-concert-stats-shell ec-concert-stats-shell--marketing',
+			)
+		);
+		?>
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped via get_block_wrapper_attributes. ?>>
+			<div class="ec-block-shell ec-block-shell--depth-0 ec-mobile-full-width-panel">
+				<div class="ec-block-shell-inner ec-block-shell-inner--narrow">
+					<div class="ec-block-shell-header">
+						<div class="ec-block-shell-header__main">
+							<div class="ec-block-shell-header__title">
+								<?php esc_html_e( 'Your concert history, in one place', 'extrachill-events' ); ?>
+							</div>
+							<div class="ec-block-shell-header__description">
+								<?php esc_html_e( 'My Shows lets you track every concert you\'ve been to and every one you\'re going to.', 'extrachill-events' ); ?>
+							</div>
+						</div>
+					</div>
+					<div class="ec-panel ec-panel--depth-1">
+						<div class="ec-section ec-section--depth-2">
+							<h3><?php esc_html_e( 'What you can do', 'extrachill-events' ); ?></h3>
+							<ul>
+								<li><?php esc_html_e( 'Mark events as \'Going\' or \'I Was There\' — across decades of past shows', 'extrachill-events' ); ?></li>
+								<li><?php esc_html_e( 'See your concert history on a calendar and a map, with chronological tour routes for the artists you\'ve followed', 'extrachill-events' ); ?></li>
+								<li><?php esc_html_e( 'Import your full history from setlist.fm or phish.net', 'extrachill-events' ); ?></li>
+								<li><?php esc_html_e( 'Stats: shows, venues, artists, cities', 'extrachill-events' ); ?></li>
+							</ul>
+						</div>
+						<div class="ec-action-row ec-action-row--center">
+							<a href="<?php echo esc_url( $signup_url ); ?>" class="button-1 button-large">
+								<?php esc_html_e( 'Sign Up', 'extrachill-events' ); ?>
+							</a>
+							<a href="<?php echo esc_url( $login_url ); ?>" class="button-2 button-large">
+								<?php esc_html_e( 'Log In', 'extrachill-events' ); ?>
+							</a>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<?php
 		return;
 	}
 	$user_id = get_current_user_id();

--- a/blocks/concert-stats/src/components/ShowList.js
+++ b/blocks/concert-stats/src/components/ShowList.js
@@ -9,7 +9,7 @@ import { ActionRow, InlineStatus } from '@extrachill/components';
 import ShowCard from './ShowCard';
 import useShows from '../hooks/useShows';
 
-const ShowList = ( { userId, period, year } ) => {
+const ShowList = ( { userId, period, year, eventsUrl } ) => {
 	const [ page, setPage ] = useState( 1 );
 
 	const { shows, total, pages, loading, error } = useShows( userId, {
@@ -24,11 +24,22 @@ const ShowList = ( { userId, period, year } ) => {
 	}
 
 	if ( ! loading && shows.length === 0 ) {
+		if ( period === 'upcoming' ) {
+			return (
+				<InlineStatus tone="info">
+					No upcoming shows you&rsquo;ve marked yet. Find a show on the{ ' ' }
+					{ eventsUrl ? (
+						<a href={ eventsUrl }>events calendar</a>
+					) : (
+						'events calendar'
+					) }{ ' ' }
+					and mark it &lsquo;Going&rsquo;.
+				</InlineStatus>
+			);
+		}
 		return (
 			<InlineStatus tone="info">
-				{ period === 'upcoming'
-					? 'No upcoming shows marked yet. Browse events and mark shows as "Going"!'
-					: 'No past shows tracked yet.' }
+				No past shows tracked yet. Use Add Past Shows to find shows you&rsquo;ve attended, or Import from setlist.fm/phish.net.
 			</InlineStatus>
 		);
 	}

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -198,39 +198,6 @@
 	cursor: pointer;
 }
 
-/* ─── Empty State (no-shows landing) ────────────────────────────────────── */
-
-.ec-concert-stats__empty {
-	text-align: center;
-	padding: var(--spacing-xl, 2rem) var(--spacing-md, 1rem);
-}
-
-.ec-concert-stats__empty-heading {
-	font-size: var(--font-size-lg, 1.25rem);
-	font-weight: 600;
-	margin-bottom: var(--spacing-xs, 0.25rem);
-}
-
-.ec-concert-stats__empty-text {
-	color: var(--muted-text, #6b7280);
-	margin-bottom: var(--spacing-md, 1rem);
-}
-
-.ec-concert-stats__empty-cta {
-	display: inline-block;
-	padding: var(--spacing-xs, 0.25rem) var(--spacing-md, 1rem);
-	background: var(--accent, #53940b);
-	color: #fff;
-	text-decoration: none;
-	border-radius: var(--border-radius-sm, 5px);
-	font-weight: 500;
-	transition: background-color 0.15s ease;
-}
-
-.ec-concert-stats__empty-cta:hover {
-	background: var(--accent-dark, #3d6b08);
-}
-
 /* ─── Loading Skeleton ──────────────────────────────────────────────────── */
 
 .ec-concert-stats__skeleton {

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -30,6 +30,18 @@ const VALID_TAB_IDS = [ 'upcoming', 'past', 'calendar', 'add-past', 'map', 'stat
  * Read the initial active tab from `?tab=` on first render. SSR-safe
  * (no-op when `window` is absent). Falls back to `'upcoming'`.
  *
+ * #126: when `?tab=` is absent we default to `'upcoming'`. A
+ * post-fetch effect inside the app swaps the default to `'add-past'`
+ * for owners whose `stats.total_shows === 0` — that's the empty-state
+ * UX where the search-for-past-shows surface is the most useful
+ * landing tab. Implementation note: we picked JS-side post-fetch over
+ * a server-rendered `data-has-any-shows` attribute for simplicity
+ * (the latter would require either a duplicate DB query in render.php
+ * or threading `total_shows` from the concert-tracking abilities at
+ * server-render time, and the brief upcoming→add-past flip is
+ * acceptable since the loading skeleton covers the very first paint
+ * anyway).
+ *
  * @return {string} Tab ID.
  */
 function readInitialTab() {
@@ -42,11 +54,33 @@ function readInitialTab() {
 }
 
 /**
+ * Whether the current page load arrived with an explicit `?tab=` in
+ * the URL. Used to gate the empty-state default-tab swap so we never
+ * override an intentional deep link.
+ *
+ * @return {boolean}
+ */
+function hasExplicitTabParam() {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+	const params = new URLSearchParams( window.location.search );
+	const requested = params.get( 'tab' );
+	return VALID_TAB_IDS.includes( requested );
+}
+
+/**
  * Main Concert Stats App component.
  */
 function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, containerRef } ) {
 	const [ year, setYear ] = useState( 0 );
 	const [ activeTab, setActiveTab ] = useState( readInitialTab );
+	// #126: tracks whether the user (or a deep link) has chosen a tab.
+	// Until then, the post-stats-fetch effect below is allowed to swap
+	// the default from 'upcoming' → 'add-past' when the owner has zero
+	// tracked shows. Once the user explicitly picks a tab via the tab
+	// strip, this flips to true and the auto-swap stops fighting them.
+	const [ userPickedTab, setUserPickedTab ] = useState( hasExplicitTabParam );
 
 	const { stats, loading: statsLoading } = useStats( userId, { year } );
 
@@ -62,6 +96,31 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 	// page. ImportTab consumes the props directly.
 	const importRunsBag = useImportRuns();
 	const hasImports = isOwn && importRunsBag.sources && importRunsBag.sources.length > 0;
+
+	// #126: empty-state default tab. When the owner has zero tracked
+	// shows and hasn't explicitly picked a tab (no `?tab=` in URL,
+	// hasn't clicked the strip yet), land them on Add Past Shows. The
+	// search-for-past-shows surface is the most useful starting point
+	// for users in this state; the old takeover hid the entire tab
+	// strip behind a Browse-Shows CTA that pointed at the wrong place.
+	useEffect( () => {
+		if ( userPickedTab ) {
+			return;
+		}
+		if ( statsLoading || ! stats ) {
+			return;
+		}
+		if ( stats.total_shows === 0 && isOwn ) {
+			setActiveTab( 'add-past' );
+		}
+	}, [ stats, statsLoading, isOwn, userPickedTab ] );
+
+	const handleTabChange = ( tabId ) => {
+		setUserPickedTab( true );
+		setActiveTab( tabId );
+	};
+
+	const hasAnyShows = !! stats && stats.total_shows > 0;
 
 	// Sync `?tab=` to URL whenever the active tab changes. Use
 	// replaceState to keep the back button useful — switching tabs
@@ -203,36 +262,28 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 			: [] ),
 	];
 
-	// Empty state — no shows at all. Owners see Import alongside the empty CTA.
-	if ( ! statsLoading && stats && stats.total_shows === 0 && ! year ) {
-		return (
-			<BlockShell>
-				<BlockShellInner maxWidth="narrow">
-					<BlockShellHeader title={ isOwn ? 'My Shows' : 'Concert History' } />
-					<Panel>
-						<div className="ec-concert-stats__empty">
-							<p className="ec-concert-stats__empty-heading">
-								Start Tracking Your Shows!
-							</p>
-							<p className="ec-concert-stats__empty-text">
-								Mark events as &ldquo;Going&rdquo; to build your personal concert history.
-							</p>
-							{ eventsUrl && (
-								<a href={ eventsUrl } className="ec-concert-stats__empty-cta">
-									Browse Shows
-								</a>
-							) }
-						</div>
-					</Panel>
-					{ hasImports && (
-						<Panel compact>
-							<ImportTab bag={ importRunsBag } />
-						</Panel>
-					) }
-				</BlockShellInner>
-			</BlockShell>
-		);
-	}
+	// #126: per-tab empty-state messages used when the user has zero
+	// tracked shows overall. Rendered as a plain `<InlineStatus>` so
+	// the surrounding Panel chrome still provides visual continuity
+	// with the rest of the tab strip. ShowList owns its own empty
+	// state for the Upcoming / Past tabs (it already returns
+	// InlineStatus when the period-scoped fetch returns zero rows),
+	// so Upcoming / Past don't need a duplicate empty branch here.
+	const statsEmptyMessage = (
+		<InlineStatus tone="info">
+			Stats will appear here once you&rsquo;ve tracked at least one show.
+		</InlineStatus>
+	);
+	const calendarEmptyMessage = (
+		<InlineStatus tone="info">
+			Your concert calendar will appear here once you&rsquo;ve tracked shows.
+		</InlineStatus>
+	);
+	const mapEmptyMessage = (
+		<InlineStatus tone="info">
+			Your concert map will appear here once you&rsquo;ve tracked shows at venues with coordinates.
+		</InlineStatus>
+	);
 
 	return (
 		<BlockShell>
@@ -240,7 +291,7 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 				<BlockShellHeader
 					title={ isOwn ? 'My Shows' : 'Concert History' }
 					actions={
-						stats && stats.shows_by_year ? (
+						stats && stats.shows_by_year && hasAnyShows ? (
 							<YearFilter
 								showsByYear={ stats.shows_by_year }
 								activeYear={ year }
@@ -255,12 +306,17 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 				<Tabs
 					tabs={ tabs }
 					active={ activeTab }
-					onChange={ setActiveTab }
+					onChange={ handleTabChange }
 				/>
 
 				<Panel compact>
 					{ activeTab === 'upcoming' && (
-						<ShowList userId={ userId } period="upcoming" year={ year } />
+						<ShowList
+							userId={ userId }
+							period="upcoming"
+							year={ year }
+							eventsUrl={ eventsUrl }
+						/>
 					) }
 
 					{ activeTab === 'past' && (
@@ -270,16 +326,22 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 					{ /*
 					   Calendar tab content lives in a sibling DOM node
 					   emitted by render.php (sibling to this React
-					   root). We render nothing in the Panel here; the
-					   useEffect above toggles the sibling's `hidden`
-					   attribute. Keeps the server-rendered calendar
-					   block's own JS (prev/next/today nav, month URL
-					   sync) untouched.
+					   root). We render nothing in the Panel here when
+					   the sibling exists; the useEffect above toggles
+					   its `hidden` attribute. When the user has no
+					   tracked shows yet, the sibling wrapper is still
+					   emitted (render.php only checks owner+is_page),
+					   but the underlying calendar query returns zero
+					   events. Show the per-tab InlineStatus message
+					   instead of an empty grid in that case.
 					 */ }
 					{ activeTab === 'calendar' && ! hasCalendar && (
 						<InlineStatus tone="info">
 							Calendar view is unavailable here.
 						</InlineStatus>
+					) }
+					{ activeTab === 'calendar' && hasCalendar && ! hasAnyShows && ! statsLoading && (
+						calendarEmptyMessage
 					) }
 
 					{ /*
@@ -295,12 +357,23 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 							Map view is unavailable here.
 						</InlineStatus>
 					) }
+					{ activeTab === 'map' && hasMap && ! hasAnyShows && ! statsLoading && (
+						mapEmptyMessage
+					) }
 
 					{ activeTab === 'add-past' && isOwn && (
 						<AddPastShows />
 					) }
 
-					{ activeTab === 'stats' && stats && (
+					{ activeTab === 'stats' && statsLoading && (
+						<InlineStatus tone="info">Loading stats…</InlineStatus>
+					) }
+
+					{ activeTab === 'stats' && ! statsLoading && stats && ! hasAnyShows && (
+						statsEmptyMessage
+					) }
+
+					{ activeTab === 'stats' && ! statsLoading && stats && hasAnyShows && (
 						<div className="ec-concert-stats__leaderboards">
 							<Leaderboard
 								title="Top Artists"

--- a/inc/core/my-shows.php
+++ b/inc/core/my-shows.php
@@ -2,9 +2,16 @@
 /**
  * My Shows — Concert History Page
  *
- * Auth-gating and nav integration for the My Shows page on the events site.
- * The page itself is a standard WordPress page with the extrachill/concert-stats
- * block inserted. This file handles the auth redirect and secondary nav item.
+ * Nav integration for the My Shows page on the events site. The page
+ * itself is a standard WordPress page with the extrachill/concert-stats
+ * block inserted; that block renders the full React app for logged-in
+ * users and a server-rendered public marketing surface for everyone
+ * else (see `blocks/concert-stats/render.php`).
+ *
+ * #126: the old `template_redirect` auth-gate (which force-redirected
+ * anonymous visitors to /login/?redirect_to=/my-shows/ with zero
+ * context) was removed. The marketing surface lives inside the block
+ * itself so /my-shows/ is one URL, two states.
  *
  * @package ExtraChillEvents
  * @since 0.18.0
@@ -13,34 +20,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-
-/**
- * Redirect unauthenticated users to login when visiting /my-shows/.
- *
- * The concert-stats block renders nothing for logged-out users,
- * so redirect them to login with a return URL.
- */
-function ec_events_my_shows_auth_gate() {
-	if ( ! ec_is_events_site() ) {
-		return;
-	}
-
-	if ( is_user_logged_in() ) {
-		return;
-	}
-
-	if ( ! is_page( 'my-shows' ) ) {
-		return;
-	}
-
-	$login_url = function_exists( 'ec_get_site_url' )
-		? ec_get_site_url( 'events' ) . '/login/'
-		: wp_login_url();
-
-	wp_safe_redirect( $login_url . '?redirect_to=' . rawurlencode( home_url( '/my-shows/' ) ) );
-	exit;
-}
-add_action( 'template_redirect', 'ec_events_my_shows_auth_gate' );
 
 /**
  * Add My Shows link to the secondary header nav (logged-in users only).


### PR DESCRIPTION
Closes #126.

## Summary

Two UX fixes scoped to `extrachill-events` only, both inside the concert-stats block + the my-shows page integration. No data-layer changes, no new abilities, no new REST routes.

### Fix 1 — Logged-in empty state

Removes the `total_shows === 0` takeover at `view.js:192-220` that replaced the entire tab strip with a single "Browse Shows" CTA pointing at the upcoming events calendar (wrong destination for a user with zero tracked shows — what they actually need is the search-for-past-shows surface).

- Tab strip stays rendered in the empty state.
- Default tab swaps from `upcoming` → `add-past` for owners when `stats.total_shows === 0` and no `?tab=` was set and the user hasn't manually picked a tab yet. Tracked via a `userPickedTab` flag so deep links and explicit user clicks always win.
- Each tab carries a contextual `<InlineStatus tone="info">` empty message:
  - **Upcoming** (lives in `ShowList`): "No upcoming shows you've marked yet. Find a show on the [events calendar](…) and mark it 'Going'."
  - **Past** (lives in `ShowList`): "No past shows tracked yet. Use Add Past Shows to find shows you've attended, or Import from setlist.fm/phish.net."
  - **Stats / Calendar / Map** (live in `view.js`, gated on `total_shows === 0`): per-spec messages.
- Old `.ec-concert-stats__empty*` SCSS rules deleted.

**Default-tab implementation choice (documented inline in `readInitialTab` JSDoc):** went with JS-side post-fetch over a server-rendered `data-has-any-shows` attribute. Reason: emitting the attribute would mean either a duplicate DB query inside `render.php` or threading `total_shows` from the concert-tracking abilities at server-render time — both more invasive than the post-fetch swap, and the brief `upcoming → add-past` flip is hidden behind the existing loading skeleton anyway.

### Fix 2 — Logged-out public marketing surface

Drops the `template_redirect` auth-gate (`ec_events_my_shows_auth_gate`) from `inc/core/my-shows.php`. Kept the `ec_events_my_shows_nav_item` secondary-nav filter intact, as the issue specified.

`blocks/concert-stats/render.php` now branches on `is_user_logged_in()` when no explicit `userId` attribute is set:
- **Logged in** → React app (unchanged).
- **Logged out** → server-rendered marketing surface composed by hand-emitting the same class names `@extrachill/components` ships at runtime (`ec-block-shell`, `ec-block-shell-inner--narrow`, `ec-block-shell-header`, `ec-panel--depth-1`, `ec-section--depth-2`, `ec-action-row--center`). The SCSS from `@extrachill/components/styles/components.scss` (already imported at the top of `style.scss`) styles the surface for free — no bespoke CSS added.

CTAs use canonical URLs:
- Sign Up → `ec_get_site_url('community') . '/register/'` (fallback `wp_registration_url()`).
- Log In → `ec_get_site_url('events') . '/login/?redirect_to=<my-shows>'` (fallback `wp_login_url( home_url('/my-shows/') )`) — matches the redirect_to pattern the deleted auth-gate used.

**Marketing surface composition choice (documented inline above the branch in `render.php`):** kept everything inside the block (option a from the issue) rather than splitting into a separate template hook. One block, two states, one URL — and `render.php` already inspected `is_user_logged_in()` to set the `is-own` data attribute, so extending it to switch entire render paths was a small change.

## Heads up on collision with #54 companion PR

This PR and the in-flight `#54` companion PR both touch `blocks/concert-stats/src/view.js`, but in different regions:
- `#54` companion: import tab rendering + tabs array Import gating + import-intro copy + `total_events_created` counter.
- This PR (`#126`): empty-state takeover removal + default-tab swap + per-tab `InlineStatus` empty messages + `handleTabChange`/`userPickedTab` wiring + ShowList empty-message copy.

Whichever lands second can rebase. The conflicts should be navigable.

## What was NOT done (out of scope per issue)

- No new abilities, no REST routes, no schema changes.
- No new design-system primitives — composed canonical `@extrachill/components` only.
- No "Get Started" tab — empty-state messaging lives inside existing tabs.
- `ec_events_my_shows_nav_item` filter preserved.

## Build

`npm install && npm run build` passes locally. `build/` is gitignored; homeboy rebuilds on release.

mention @chubes