### PR TITLE
fix(my-shows): canonical CTA classes + InlineStatus error + empty-search prompt (closes #130, EC-events side)

### DIFF
--- a/blocks/concert-stats/src/components/AddPastShows.js
+++ b/blocks/concert-stats/src/components/AddPastShows.js
@@ -5,7 +5,8 @@
  *
  * Behavior:
  *   - Search input (committed on Enter / Search button via SearchBox).
- *   - Empty query: backend returns the ~most-recent past events as suggestions.
+ *   - Empty query: renders an InlineStatus prompt asking the user to search.
+ *     Backend short-circuits and returns no results. See extrachill-events#130.
  *   - Results list with "+ Mark Attended" per row, optimistic state flip.
  *   - "Load more" pagination, 20 per page (handled in useEventSearch).
  *
@@ -31,9 +32,9 @@ const AddPastShows = () => {
 			<EventSearchInput value={ query } onChange={ setQuery } />
 
 			{ isEmptyQuery && (
-				<p className="ec-concert-stats__search-hint">
-					Search for shows you&rsquo;ve attended to add them to your history.
-				</p>
+				<InlineStatus tone="info">
+					Start typing the name of an artist, venue, or show you&rsquo;ve attended.
+				</InlineStatus>
 			) }
 
 			{ error && (
@@ -42,17 +43,12 @@ const AddPastShows = () => {
 
 			{ ! loading && ! error && events.length === 0 && ! isEmptyQuery && (
 				<InlineStatus tone="info">
-					No past shows match &ldquo;{ query }&rdquo;. Try a different artist or venue name.
+					No matches for &ldquo;{ query }&rdquo;. Try a different artist, venue, or city.
 				</InlineStatus>
 			) }
 
 			{ events.length > 0 && (
 				<Section className="ec-concert-stats__search-results">
-					{ isEmptyQuery && (
-						<p className="ec-concert-stats__search-results-label">
-							Recent past shows
-						</p>
-					) }
 					{ events.map( ( ev ) => (
 						<EventSearchResult
 							key={ ev.post_id }

--- a/blocks/concert-stats/src/components/EventSearchResult.js
+++ b/blocks/concert-stats/src/components/EventSearchResult.js
@@ -11,7 +11,7 @@
 
 import { useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
-import { ActionRow } from '@extrachill/components';
+import { ActionRow, InlineStatus } from '@extrachill/components';
 
 const MONTHS = [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ];
 
@@ -105,16 +105,18 @@ const EventSearchResult = ( { event, onMarkedChange } ) => {
 
 			<div className="ec-concert-stats__search-result-action">
 				{ isMarked ? (
-					<span
-						className="ec-concert-stats__mark-btn ec-concert-stats__mark-btn--tracked"
+					<button
+						type="button"
+						className="button-2 button-medium"
+						disabled
 						aria-label="Already tracked"
 					>
 						✓ Tracked
-					</span>
+					</button>
 				) : (
 					<button
 						type="button"
-						className="ec-concert-stats__mark-btn ec-concert-stats__mark-btn--add"
+						className="button-1 button-medium"
 						onClick={ handleMark }
 						disabled={ submitting }
 					>
@@ -122,9 +124,7 @@ const EventSearchResult = ( { event, onMarkedChange } ) => {
 					</button>
 				) }
 				{ error && (
-					<span className="ec-concert-stats__search-result-error" role="alert">
-						{ error }
-					</span>
+					<InlineStatus tone="error">{ error }</InlineStatus>
 				) }
 			</div>
 		</ActionRow>

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -240,23 +240,6 @@
 	100% { background-position: -200% 0; }
 }
 
-/* ─── Add Past Shows Tab — inner content ────────────────────────────────── */
-
-.ec-concert-stats__search-hint {
-	margin: 0;
-	color: var(--muted-text, #6b7280);
-	font-size: var(--font-size-sm, 0.875rem);
-}
-
-.ec-concert-stats__search-results-label {
-	margin: 0 0 var(--spacing-xs, 0.25rem);
-	font-size: var(--font-size-xs, 0.625rem);
-	font-weight: 600;
-	text-transform: uppercase;
-	letter-spacing: 0.05em;
-	color: var(--muted-text, #6b7280);
-}
-
 /* ─── Search Result inner layout (inside ActionRow) ─────────────────────── */
 
 .ec-concert-stats__search-result-link {
@@ -303,54 +286,18 @@
 	white-space: nowrap;
 }
 
+/*
+ * Action area inside the search-result row. The canonical button-1 /
+ * button-2 classes own the button visuals; InlineStatus owns the error
+ * pill. This rule only provides the column-stack layout (button on top,
+ * error below, right-aligned) the ActionRow's right side needs.
+ */
 .ec-concert-stats__search-result-action {
 	flex-shrink: 0;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-end;
 	gap: 2px;
-}
-
-.ec-concert-stats__mark-btn {
-	display: inline-block;
-	padding: var(--spacing-xs, 0.25rem) var(--spacing-sm, 0.5rem);
-	border-radius: var(--border-radius-sm, 5px);
-	font-size: var(--font-size-sm, 0.875rem);
-	font-weight: 500;
-	line-height: 1.2;
-	white-space: nowrap;
-}
-
-.ec-concert-stats__mark-btn--add {
-	background: var(--accent, #53940b);
-	color: #fff;
-	border: 1px solid var(--accent, #53940b);
-	cursor: pointer;
-	transition: background-color 0.15s ease;
-}
-
-.ec-concert-stats__mark-btn--add:hover:not(:disabled) {
-	background: var(--accent-dark, #3d6b08);
-	border-color: var(--accent-dark, #3d6b08);
-}
-
-.ec-concert-stats__mark-btn--add:disabled {
-	opacity: 0.6;
-	cursor: not-allowed;
-}
-
-.ec-concert-stats__mark-btn--tracked {
-	background: transparent;
-	color: var(--muted-text, #6b7280);
-	border: 1px solid var(--border-color, #d1d5db);
-	cursor: default;
-}
-
-.ec-concert-stats__search-result-error {
-	font-size: var(--font-size-xs, 0.625rem);
-	color: var(--error-color, #dc2626);
-	max-width: 160px;
-	text-align: right;
 }
 
 /* ─── Mobile ────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Three coordinated fixes inside the concert-stats block, all on the
'Add Past Shows' surface of /my-shows/.

### 1. EventSearchResult — canonical button classes + InlineStatus

Replaced the hand-rolled `.ec-concert-stats__mark-btn` variants with the
platform's canonical CTA classes:

- `+ Mark Attended` → `<button className=\"button-1 button-medium\">`
  (primary action, matches `blocks/concert-stats/render.php`'s Sign Up CTA).
- `✓ Tracked` → `<button className=\"button-2 button-medium\" disabled>`
  (secondary, disabled variant). No more bespoke `--tracked` modifier.
- Inline error `<span>` → `<InlineStatus tone=\"error\">` per the
  canonical-primitives discipline established in #120/#121.

### 2. AddPastShows — empty-input prompt

When the search input is empty, the tab now renders:

```jsx
<InlineStatus tone=\"info\">
  Start typing the name of an artist, venue, or show you've attended.
</InlineStatus>
```

Paired with the `extrachill-users` backend change that returns empty
results for empty queries. The 'No matches' state for real searches that
return zero results stays the same (copy refreshed to match).

Removed the dead 'Recent past shows' label block — there are no
recent-past-shows results to label anymore.

### 3. SCSS cleanup

Deleted the rules that are no longer referenced:

- `.ec-concert-stats__mark-btn` and `--add` / `--tracked` variants.
- `.ec-concert-stats__search-result-error`.
- `.ec-concert-stats__search-hint`, `.ec-concert-stats__search-results-label`.

Kept `.ec-concert-stats__search-result-action` — it still does the
column-stack layout (button on top, error below, right-aligned) that
the canonical primitives don't cover. Updated its comment to reflect
that scope.

Verified with:

```
grep -nE '\\.ec-concert-stats__mark-btn|search-result-error|search-hint|search-results-label' \\
  blocks/concert-stats/src/style.scss
```

Only the kept layout rule remains.

## Acceptance

- `+ Mark Attended` and `✓ Tracked` buttons render with platform CTA styling.
- Inline error renders as an `<InlineStatus tone=\"error\">` pill.
- Empty search input renders an info prompt; non-empty zero-result state
  renders 'No matches for \"...\"'; non-empty with results renders the list.
- No bespoke `.ec-concert-stats__mark-btn*` rules ship in the built CSS.

## Sequencing

Independent of the theme PR. Pairs with the `extrachill-users` empty-query
backend change for the new prompt to be reachable cleanly — that PR should
land first or simultaneously.

Closes #130 — events side. Companion PRs in `extrachill` (theme grid) and
`extrachill-users` (empty-query backend).