### PR TITLE
fix(discovery): stop stranding Load More above re-injected pagination

### DIFF
--- a/assets/js/discovery.js
+++ b/assets/js/discovery.js
@@ -203,6 +203,23 @@
 					// Swap events content.
 					content.innerHTML = data.html;
 
+					// A prior Load More hydration (data-machine-events
+					// issue #314) may have converted the numbered
+					// `.data-machine-events-pagination` nav into a
+					// `.data-machine-events-load-more-nav`. Remove that
+					// stale button before re-injecting fresh pagination
+					// so the calendar's own `initLoadMore` can
+					// re-hydrate it on the `content-updated` event we
+					// dispatch below. Without this, a scope-tab switch
+					// stacks a Load More button above re-injected
+					// numbered pagination on location archive pages.
+					var loadMoreNav = calendar.querySelector(
+						'.data-machine-events-load-more-nav'
+					);
+					if ( loadMoreNav ) {
+						loadMoreNav.remove();
+					}
+
 					// Update pagination.
 					var paginationEl = calendar.querySelector(
 						'.data-machine-events-pagination'


### PR DESCRIPTION
## Summary

Companion to **Extra-Chill/data-machine-events#331**. Fixes the **double pagination on location archive pages** for the scope-tab switcher path.

## Root cause

`discovery.js` swaps calendar content via REST on scope-tab clicks (Tonight / This Weekend / This Week / All Shows) and re-injects the server-rendered numbered pagination HTML — the same pattern as the data-machine-events `api-client.ts` path.

After data-machine-events #314 hydrates the initial pagination nav into a Load More button (`.data-machine-events-load-more-nav`), this code did **not** clear that converted nav before re-injecting fresh numbered pagination. The selector `.data-machine-events-pagination` missed the renamed nav, so a scope-tab switch stacked a Load More button above fresh numbered pagination on archive pages.

## Fix

Clear any stale `.data-machine-events-load-more-nav` before re-injecting pagination. The calendar's own `initLoadMore` (data-machine-events #331) re-hydrates the fresh nav on the `data-machine-calendar-content-updated` event this code already dispatches.

## Verification

- Traced the scope-tab flow end to end: content swap → stale load-more-nav removed → fresh pagination injected → `content-updated` dispatched → calendar re-hydrates into a single Load More button.
- Pure JS change; no build step (asset is enqueued directly).

## Dependency

Requires **Extra-Chill/data-machine-events#331** for the re-hydration half of the contract. Merge that first (or together).