### PR TITLE
fix: suppress duplicate "My Shows" theme H1 on /my-shows/

### DIFF
--- a/inc/core/my-shows.php
+++ b/inc/core/my-shows.php
@@ -45,3 +45,33 @@ function ec_events_my_shows_nav_item( $items ) {
 	return $items;
 }
 add_filter( 'extrachill_secondary_header_items', 'ec_events_my_shows_nav_item' );
+
+/**
+ * Suppress the theme page H1 on /my-shows/.
+ *
+ * The page embeds the extrachill/concert-stats block, which renders its own
+ * contextual header (`isOwn ? 'My Shows' : 'Concert History'`) via
+ * BlockShellHeader. The static theme H1 "My Shows" duplicates that chrome, so
+ * we opt out of the theme title via the sanctioned `extrachill_show_page_title`
+ * filter — mirroring extrachill-studio and extrachill-artist-platform.
+ *
+ * `is_page( 'my-shows' )` covers all three render states (logged-in owner,
+ * other-user view, logged-out marketing surface) since the page is always
+ * titled "My Shows".
+ *
+ * @param bool $show    Whether to show the page title.
+ * @param int  $post_id The current page ID.
+ * @return bool
+ */
+function ec_events_hide_my_shows_page_title( $show, $post_id ) {
+	if ( ! ec_is_events_site() ) {
+		return $show;
+	}
+
+	if ( is_page( 'my-shows' ) ) {
+		return false;
+	}
+
+	return $show;
+}
+add_filter( 'extrachill_show_page_title', 'ec_events_hide_my_shows_page_title', 10, 2 );


### PR DESCRIPTION
## Summary

Closes #133.

On `/my-shows/` (events site) the title **"My Shows" rendered twice** — once from the theme page `<h1>` (`single-page.php`) and once from the `extrachill/concert-stats` React block's own `BlockShellHeader`.

This registers the theme-sanctioned `extrachill_show_page_title` filter in `extrachill-events` to suppress the redundant theme H1, mirroring how `extrachill-studio` and `extrachill-artist-platform` already opt out of the theme title on their block-heavy pages.

## Before / After

- **Before:** theme H1 `<h1>My Shows</h1>` **and** the block header both render.
- **After:** only the block header renders.

## Why the block header is the one to keep

The block header is **contextual** — `isOwn ? 'My Shows' : 'Concert History'` — so it adapts per viewer. The static theme H1 is always "My Shows" and is the redundant one to drop.

## Where the change lives

Extended `inc/core/my-shows.php` — it already owns My Shows nav integration, is already loaded via the plugin's explicit `require_once` loader (`extrachill-events.php:233`), and already uses the `ec_is_events_site()` guard. Adding the filter here keeps all My Shows page concerns in one file rather than introducing a new single-purpose file.

## Implementation notes

- Hook: `add_filter( 'extrachill_show_page_title', 'ec_events_hide_my_shows_page_title', 10, 2 )` (second arg is `$post_id`).
- Returns `false` when `is_page( 'my-shows' )`, else returns `$show` unchanged.
- Guarded by `ec_is_events_site()` so it never leaks to other sites.
- `is_page( 'my-shows' )` covers **all three** render states (logged-in owner, other-user view, logged-out marketing surface) since the page is always titled "My Shows".

## Acceptance criteria

- [x] `extrachill_show_page_title` returns `false` on `is_page( 'my-shows' )`
- [x] No theme `<h1>My Shows</h1>` renders on `/my-shows/` in any of the three states
- [x] The block's `BlockShellHeader` remains the sole title
- [x] Filter is scoped to the events site / my-shows page only — no leakage