### PR TITLE
fix: use $post_id in my-shows page-title filter

### DIFF
--- a/inc/core/my-shows.php
+++ b/inc/core/my-shows.php
@@ -68,7 +68,8 @@ function ec_events_hide_my_shows_page_title( $show, $post_id ) {
 		return $show;
 	}
 
-	if ( is_page( 'my-shows' ) ) {
+	$page = get_page_by_path( 'my-shows' );
+	if ( $page && (int) $post_id === (int) $page->ID ) {
 		return false;
 	}
 


### PR DESCRIPTION
Follow-up to #134. Matches `$post_id` against the my-shows page ID instead of `is_page()`, which uses the second hook argument (eliminating the unused-parameter PHPCS warning) and is more robust.