### PR TITLE
fix: migrate @extrachill/components from file: link to published ^0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
 		"react-dom": "^18.3.1"
 	},
 	"dependencies": {
-		"@extrachill/components": "file:../extrachill-components"
+		"@extrachill/components": "^0.5.2"
 	}
 }


### PR DESCRIPTION
## Summary

Migrates `extrachill-events` from the divergent local `file:` link to the published npm registry version of the shared component library, matching every other consumer in the network. This also lands the **My Shows block centering fix** that shipped in `@extrachill/components@0.5.2`.

Closes #138

## What changed

```diff
- "@extrachill/components": "file:../extrachill-components"
+ "@extrachill/components": "^0.5.2"
```

- **Before:** `file:../extrachill-components` — builds against whatever unreleased local source happens to be on disk in the sibling workspace directory. Not reproducible from a clean checkout; path-dependent; the lone outlier in the network.
- **After:** `^0.5.2` — published registry range, reproducible builds, consistent with the rest of the stack.

> Note: `package-lock.json` and `build/` are both gitignored in this repo, so the only tracked change is `package.json`. `npm install` cleanly resolved `@extrachill/components@0.5.2` from the registry.

## My Shows centering fix

`@extrachill/components@0.5.2` contains the `BlockShellInner` centering fix (`margin-inline:auto` on `.ec-block-shell-inner--narrow`) that fixes the My Shows block pinning left with a phantom right-side gap.

Verified the fix is present in the rebuilt concert-stats CSS:

```
$ grep -oh "ec-block-shell-inner--narrow[^}]*margin-inline:auto" build/concert-stats/style-index.css
ec-block-shell-inner--narrow{margin-inline:auto
```

This PR is what lands the visible **/my-shows/** centering fix once deployed.

## Verification

- ✅ `npm install` resolved `@extrachill/components@0.5.2` from the registry
- ✅ `npm run build` compiled successfully (event-submission + concert-stats)
- ✅ `margin-inline:auto` on `.ec-block-shell-inner--narrow` confirmed present in rebuilt `build/concert-stats/style-index.css`
- ✅ `homeboy lint` reports 734 findings — all pre-existing PHPCS violations tracked in #137; this one-line dependency change adds none