### PR TITLE
feat(concert-stats): link leaderboard terms to cross-site profiles/archives

### DIFF
--- a/blocks/concert-stats/src/components/Leaderboard.js
+++ b/blocks/concert-stats/src/components/Leaderboard.js
@@ -20,9 +20,18 @@ const Leaderboard = ( { title, items, maxItems = 5 } ) => {
 			<ol className="ec-concert-stats__leaderboard-list">
 				{ items.slice( 0, maxItems ).map( ( item ) => (
 					<li key={ item.slug } className="ec-concert-stats__leaderboard-item">
-						<span className="ec-concert-stats__leaderboard-name">
-							{ item.name }
-						</span>
+						{ item.url ? (
+							<a
+								className="ec-concert-stats__leaderboard-name ec-concert-stats__leaderboard-link"
+								href={ item.url }
+							>
+								{ item.name }
+							</a>
+						) : (
+							<span className="ec-concert-stats__leaderboard-name">
+								{ item.name }
+							</span>
+						) }
 						<span className="ec-concert-stats__leaderboard-count">
 							{ item.count }
 						</span>

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -181,6 +181,17 @@
 	color: var(--text-color, #1f2937);
 }
 
+.ec-concert-stats__leaderboard-link {
+	text-decoration: none;
+	color: var(--link-color, var(--text-color, #1f2937));
+
+	&:hover,
+	&:focus {
+		text-decoration: underline;
+		color: var(--link-hover-color, var(--accent-color, #53940b));
+	}
+}
+
 .ec-concert-stats__leaderboard-count {
 	color: var(--muted-text, #6b7280);
 	font-weight: 500;


### PR DESCRIPTION
## Summary

Renders the My Shows leaderboards (top artists/venues/cities) as **links** into the network, turning a dead-end stats list into a launchpad for cross-site journeys — the platform's network-density goal.

When the stats payload carries a `url` per item (added server-side in Extra-Chill/extrachill-users via the canonical cross-site linker), `Leaderboard` renders the term name as an `<a>`:
- artist → artist profile (artist.extrachill.com)
- venue / city → events-site archives

Falls back to plain text when `url` is empty (no resolvable target). Adds a theme-variable-based link style.

## Validation
- Block compiles (`wp-scripts build`). `build/` is a gitignored deploy artifact.
- `lint-js` clean relative to baseline (remaining `@package`/prettier notes are pre-existing, untouched).

## Companion PR
- Extra-Chill/extrachill-users (adds the `url` to the stats payload).

Conventional commit; no version/changelog hand-edits.