### PR TITLE
refactor(concert-stats): unify My Shows buttons on theme classes

### DIFF
--- a/blocks/concert-stats/src/components/AddPastShows.js
+++ b/blocks/concert-stats/src/components/AddPastShows.js
@@ -67,7 +67,7 @@ const AddPastShows = () => {
 				<ActionRow align="center">
 					<button
 						type="button"
-						className="ec-concert-stats__load-more-btn"
+						className="button-2 button-medium"
 						onClick={ loadMore }
 					>
 						Load more ({ total - events.length } remaining)

--- a/blocks/concert-stats/src/components/ImportSourceCard.js
+++ b/blocks/concert-stats/src/components/ImportSourceCard.js
@@ -106,7 +106,7 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 					<ActionRow align="end">
 						<button
 							type="submit"
-							className="ec-concert-stats__import-card-btn"
+							className="button-1 button-medium"
 							disabled={ previewing || ! username.trim() }
 						>
 							{ previewing ? 'Checking…' : 'Connect' }
@@ -129,7 +129,7 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 					<ActionRow align="end">
 						<button
 							type="button"
-							className="ec-concert-stats__import-card-btn ec-concert-stats__import-card-btn--primary"
+							className="button-1 button-medium"
 							onClick={ handleStart }
 							disabled={ starting }
 						>
@@ -137,7 +137,7 @@ const ImportSourceCard = ( { source, runs, onPreview, onStart } ) => {
 						</button>
 						<button
 							type="button"
-							className="ec-concert-stats__import-card-btn-link"
+							className="button-2 button-medium"
 							onClick={ handleCancelPreview }
 							disabled={ starting }
 						>

--- a/blocks/concert-stats/src/components/ShowList.js
+++ b/blocks/concert-stats/src/components/ShowList.js
@@ -57,7 +57,7 @@ const ShowList = ( { userId, period, year, eventsUrl } ) => {
 			{ ! loading && page < pages && (
 				<ActionRow align="center">
 					<button
-						className="ec-concert-stats__load-more-btn"
+						className="button-2 button-medium"
 						onClick={ () => setPage( ( p ) => p + 1 ) }
 						type="button"
 					>

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -118,24 +118,6 @@
 	color: var(--muted-text, #6b7280);
 }
 
-/* ─── Load More Button (inside ActionRow) ───────────────────────────────── */
-
-.ec-concert-stats__load-more-btn {
-	display: inline-block;
-	padding: var(--spacing-xs, 0.25rem) var(--spacing-md, 1rem);
-	border: 1px solid var(--border-color, #d1d5db);
-	border-radius: var(--border-radius-sm, 5px);
-	background: transparent;
-	color: var(--text-color, #1f2937);
-	font-size: var(--font-size-sm, 0.875rem);
-	cursor: pointer;
-	transition: background-color 0.15s ease;
-}
-
-.ec-concert-stats__load-more-btn:hover {
-	background-color: var(--card-background, #f3f4f6);
-}
-
 /* ─── Leaderboards (inside Panel) ───────────────────────────────────────── */
 
 .ec-concert-stats__leaderboards {
@@ -363,37 +345,6 @@
 	border: 1px solid var(--border-color, #e5e7eb);
 	border-radius: var(--border-radius-sm, 5px);
 	font-size: var(--font-size-md, 1rem);
-}
-
-.ec-concert-stats__import-card-btn {
-	padding: var(--spacing-sm, 0.5rem) var(--spacing-md, 1rem);
-	border: 1px solid var(--primary-color, #1f2937);
-	background: var(--card-background, #fff);
-	color: var(--primary-color, #1f2937);
-	border-radius: var(--border-radius-sm, 5px);
-	cursor: pointer;
-	font-weight: 600;
-	font-size: var(--font-size-sm, 0.875rem);
-
-	&:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-}
-
-.ec-concert-stats__import-card-btn--primary {
-	background: var(--primary-color, #1f2937);
-	color: #fff;
-}
-
-.ec-concert-stats__import-card-btn-link {
-	background: transparent;
-	border: none;
-	color: var(--muted-text, #6b7280);
-	cursor: pointer;
-	font-size: var(--font-size-sm, 0.875rem);
-	padding: var(--spacing-sm, 0.5rem);
-	text-decoration: underline;
 }
 
 .ec-concert-stats__import-card-confirm {


### PR DESCRIPTION
## Summary

The concert-stats block ("My Shows") shipped **three divergent button styles** — one canonical, two bespoke. This unifies all of them onto the theme button classes (`button-1`/`button-2` + `button-medium`) already used correctly by `EventSearchResult.js` and the logged-out CTA in `render.php` (`button-1`/`button-2 button-large`).

## Button surfaces unified

| Surface | Before | After |
|---|---|---|
| `ShowList.js` Load More | `ec-concert-stats__load-more-btn` | `button-2 button-medium` |
| `AddPastShows.js` Load more | `ec-concert-stats__load-more-btn` | `button-2 button-medium` |
| `ImportSourceCard.js` Connect | `ec-concert-stats__import-card-btn` | `button-1 button-medium` |
| `ImportSourceCard.js` Yes, import | `__import-card-btn --primary` | `button-1 button-medium` |
| `ImportSourceCard.js` Cancel | `__import-card-btn-link` | `button-2 button-medium` |

Primary actions (Connect, Yes import) -> `button-1`; neutral/secondary actions (Load More, Cancel) -> `button-2`. Matches the canonical `EventSearchResult.js` convention (`button-1 button-medium` primary, `button-2 button-medium` neutral).

## Dead CSS removed (`src/style.scss`)

- `.ec-concert-stats__load-more-btn` (+ `:hover`)
- `.ec-concert-stats__import-card-btn` (+ `--primary` modifier, `-btn-link` variant)

Only these now-orphaned button selectors were removed. Stat tiles, leaderboard, show-card, year-filter, tabs, progress-bar, and import-card form/layout selectors are untouched.

## Verification

- `npm run build:concert-stats` compiles successfully.
- `npx wp-scripts lint-js` on the three changed components reports the **same 20 pre-existing errors** as the unmodified baseline (verified via `git stash`) — these className-only swaps introduce **zero new lint errors**. Pre-existing prettier/jsdoc debt is out of scope.
- `build/` is gitignored and not committed.

cc <@532385681268408341>