### PR TITLE
feat(concert-stats): link show-card terms and badge leaderboard counts

### DIFF
--- a/blocks/concert-stats/src/components/Leaderboard.js
+++ b/blocks/concert-stats/src/components/Leaderboard.js
@@ -4,10 +4,10 @@
  * Wrapped in a compact `<Panel>` for chrome consistency with the rest
  * of the platform. The inner list markup remains local.
  *
- * @package ExtraChillEvents
+ * @package
  */
 
-import { Panel } from '@extrachill/components';
+import { Badge, Panel } from '@extrachill/components';
 
 const Leaderboard = ( { title, items, maxItems = 5 } ) => {
 	if ( ! items || items.length === 0 ) {
@@ -19,7 +19,10 @@ const Leaderboard = ( { title, items, maxItems = 5 } ) => {
 			<h3 className="ec-concert-stats__leaderboard-title">{ title }</h3>
 			<ol className="ec-concert-stats__leaderboard-list">
 				{ items.slice( 0, maxItems ).map( ( item ) => (
-					<li key={ item.slug } className="ec-concert-stats__leaderboard-item">
+					<li
+						key={ item.slug }
+						className="ec-concert-stats__leaderboard-item"
+					>
 						{ item.url ? (
 							<a
 								className="ec-concert-stats__leaderboard-name ec-concert-stats__leaderboard-link"
@@ -32,9 +35,14 @@ const Leaderboard = ( { title, items, maxItems = 5 } ) => {
 								{ item.name }
 							</span>
 						) }
-						<span className="ec-concert-stats__leaderboard-count">
+						<Badge
+							tone="muted"
+							variant="subtle"
+							size="sm"
+							className="ec-concert-stats__leaderboard-count"
+						>
 							{ item.count }
-						</span>
+						</Badge>
 					</li>
 				) ) }
 			</ol>

--- a/blocks/concert-stats/src/components/ShowCard.js
+++ b/blocks/concert-stats/src/components/ShowCard.js
@@ -1,44 +1,108 @@
 /**
  * ShowCard — Single show entry in the list.
  *
+ * Each card is a cluster of cross-site on-ramps rather than one big link:
+ * the date links to the event permalink, and the artist / venue / city
+ * names are individual links to their respective entity pages (artist
+ * profile on the artist site, venue + location archives on the events site).
+ * This serves the platform's network-density goal — every show becomes
+ * several doorways into the network.
+ *
+ * Anchors cannot nest, so the card is intentionally NOT a single wrapping
+ * <a>. The row is a plain container; the date carries the event-permalink
+ * link and each term name is its own sibling link.
+ *
  * @package
  */
 
 import { formatShortDate } from '../utils/formatDate';
 
-const ShowCard = ( { show } ) => {
-	const artistDisplay =
-		show.artists && show.artists.length
-			? show.artists.map( ( a ) => a.name ).join( ', ' )
-			: show.title || '';
+/**
+ * Render a single term (artist / venue / city) as a link when it has a
+ * resolvable URL, falling back to plain text otherwise.
+ *
+ * @param {Object} props           Component props.
+ * @param {Object} props.term      Term object with `name` and optional `url`.
+ * @param {string} props.className CSS class for the rendered element.
+ * @return {JSX.Element|null} Rendered link/span, or null when nameless.
+ */
+const TermLink = ( { term, className } ) => {
+	if ( ! term || ! term.name ) {
+		return null;
+	}
 
-	const venueParts = [];
-	if ( show.venue && show.venue.name ) {
-		venueParts.push( show.venue.name );
+	if ( term.url ) {
+		return (
+			<a className={ className } href={ term.url }>
+				{ term.name }
+			</a>
+		);
 	}
-	if ( show.city && show.city.name ) {
-		venueParts.push( show.city.name );
-	}
+
+	return <span className={ className }>{ term.name }</span>;
+};
+
+const ShowCard = ( { show } ) => {
+	const artists = show.artists && show.artists.length ? show.artists : null;
+	const hasVenue = show.venue && show.venue.name;
+	const hasCity = show.city && show.city.name;
 
 	return (
-		<a
-			href={ show.permalink || '#' }
-			className="ec-concert-stats__show-card"
-		>
-			<span className="ec-concert-stats__show-date">
+		<div className="ec-concert-stats__show-card">
+			<a
+				className="ec-concert-stats__show-date"
+				href={ show.permalink || '#' }
+			>
 				{ formatShortDate( show.event_date ) }
-			</span>
+			</a>
 			<span className="ec-concert-stats__show-details">
 				<span className="ec-concert-stats__show-artist">
-					{ artistDisplay }
+					{ artists ? (
+						artists.map( ( artist, index ) => (
+							<span key={ artist.slug || index }>
+								{ index > 0 && (
+									<span className="ec-concert-stats__show-sep">
+										{ ', ' }
+									</span>
+								) }
+								<TermLink
+									term={ artist }
+									className="ec-concert-stats__show-artist-link"
+								/>
+							</span>
+						) )
+					) : (
+						<a
+							className="ec-concert-stats__show-artist-link"
+							href={ show.permalink || '#' }
+						>
+							{ show.title || '' }
+						</a>
+					) }
 				</span>
-				{ venueParts.length > 0 && (
+				{ ( hasVenue || hasCity ) && (
 					<span className="ec-concert-stats__show-venue">
-						{ venueParts.join( ' \u00b7 ' ) }
+						{ hasVenue && (
+							<TermLink
+								term={ show.venue }
+								className="ec-concert-stats__show-venue-link"
+							/>
+						) }
+						{ hasVenue && hasCity && (
+							<span className="ec-concert-stats__show-sep">
+								{ ' \u00b7 ' }
+							</span>
+						) }
+						{ hasCity && (
+							<TermLink
+								term={ show.city }
+								className="ec-concert-stats__show-city-link"
+							/>
+						) }
 					</span>
 				) }
 			</span>
-		</a>
+		</div>
 	);
 };
 

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -78,8 +78,6 @@
 	align-items: flex-start;
 	gap: var(--spacing-md, 1rem);
 	padding: var(--spacing-sm, 0.5rem) var(--spacing-xs, 0.25rem);
-	text-decoration: none;
-	color: inherit;
 	border-radius: var(--border-radius-sm, 5px);
 	transition: background-color 0.1s ease;
 }
@@ -95,6 +93,12 @@
 	font-weight: 600;
 	color: var(--muted-text, #6b7280);
 	white-space: nowrap;
+	text-decoration: none;
+
+	&:hover,
+	&:focus {
+		color: var(--link-hover-color, var(--accent-color, #53940b));
+	}
 }
 
 .ec-concert-stats__show-details {
@@ -113,8 +117,35 @@
 	white-space: nowrap;
 }
 
+.ec-concert-stats__show-artist-link {
+	color: var(--text-color, #1f2937);
+	text-decoration: none;
+
+	&:hover,
+	&:focus {
+		text-decoration: underline;
+		color: var(--link-hover-color, var(--accent-color, #53940b));
+	}
+}
+
 .ec-concert-stats__show-venue {
 	font-size: var(--font-size-sm, 0.875rem);
+	color: var(--muted-text, #6b7280);
+}
+
+.ec-concert-stats__show-venue-link,
+.ec-concert-stats__show-city-link {
+	color: var(--muted-text, #6b7280);
+	text-decoration: none;
+
+	&:hover,
+	&:focus {
+		text-decoration: underline;
+		color: var(--link-hover-color, var(--accent-color, #53940b));
+	}
+}
+
+.ec-concert-stats__show-sep {
 	color: var(--muted-text, #6b7280);
 }
 


### PR DESCRIPTION
## Summary

Deepens the interconnection of the **My Shows** concert-stats block so each show card becomes several cross-site on-ramps instead of one link, plus a small leaderboard polish. Serves the platform's network-density / cross-site-journey goal.

## What changed

### 1. ShowCard — individual term links (no nested anchors)
`blocks/concert-stats/src/components/ShowCard.js`

The card row was previously a **single wrapping `<a>`** to the event permalink, with artist/venue/city as plain `<span>` text. Anchors cannot nest, so to link the term names individually the row is restructured:

- The card root is now a plain `<div>` (not an `<a>`).
- The **date** carries the event-permalink link (preserves the "view event" affordance).
- **Artist names** are individual links (comma-separated), each to its entity page.
- **Venue** and **city** names are individual links.
- A small `TermLink` helper renders a term as an `<a>` when it has a `url`, falling back to plain text otherwise — so cards degrade gracefully if the payload lacks urls.

### 2. Leaderboard — Badge counts
`blocks/concert-stats/src/components/Leaderboard.js`

The leaderboard count is now rendered as a `<Badge tone="muted" variant="subtle" size="sm">` from `@extrachill/components` for chrome consistency, keeping the existing linked term name.

### 3. Styles
`blocks/concert-stats/src/style.scss`

Restructured only the `.ec-concert-stats__show-card*` and `.ec-concert-stats__leaderboard*` selector blocks: the card root no longer needs `text-decoration: none`, the date is now a styled link, and new `*-artist-link` / `*-venue-link` / `*-city-link` / `*-sep` selectors style the inline term links with hover/focus underline. No button / stat-tile / tab / progress selectors touched.

## Payload dependency

The new term links read `show.artists[].url`, `show.venue.url`, and `show.city.url`. Those fields are added server-side in **extrachill-users#86** (`concert-shows-term-links`), which enriches `ec_users_build_show_data` via the same linker primitives used by the stats leaderboard. This PR is safe to merge independently — without urls, `TermLink` falls back to plain text — but the links only light up once #86 ships.

## Verify

- `npm install && npm run build:concert-stats` — compiles successfully.
- `npx wp-scripts lint-js` on `ShowCard.js` + `Leaderboard.js` — clean (exit 0).
- `build/` is gitignored — not committed.

## Notes

- No `CHANGELOG.md` edits, no version bumps (homeboy owns both).