### PR TITLE
feat(concert-stats): responsive tabs + tab badges + interactive stat tiles + softer zero-state

### DIFF
--- a/blocks/concert-stats/src/components/StatsBar.js
+++ b/blocks/concert-stats/src/components/StatsBar.js
@@ -1,37 +1,89 @@
 /**
  * StatsBar — Four-stat summary row.
  *
- * Wrapped in `<Section depth={1}>` for chrome consistency with the rest
- * of the platform. The individual stat tiles remain bespoke local
- * markup — `@extrachill/components` doesn't have a stat-tile primitive
- * yet. If/when one lands, swap the `.ec-concert-stats__stat` items.
+ * Consumes the canonical `StatTile` / `StatGroup` primitives from
+ * `@extrachill/components`. Each tile is interactive: it renders as a
+ * link to the most relevant tab's canonical `?tab=` URL (Shows → past
+ * list, the rest → Stats leaderboards), so the summary row doubles as
+ * navigation rather than a dead readout. The link uses the same
+ * `?tab=` contract view.js reads on load, so it deep-links correctly.
  *
- * @package ExtraChillEvents
+ * MERGE-ORDER DEPENDENCY: `StatTile` / `StatGroup` are added to
+ * `@extrachill/components` in a parallel PR (Minion A). Until that PR
+ * merges and this plugin's dependency is bumped, this import will not
+ * resolve at build time. See the PR description for the required merge
+ * order.
+ *
+ * @package
  */
 
-import { Section } from '@extrachill/components';
+import { StatTile, StatGroup } from '@extrachill/components';
+
+/**
+ * Build a canonical `?tab=` URL for a given tab id, preserving the
+ * current path. Mirrors the URL contract maintained by view.js
+ * (`upcoming` is the default tab and carries no `tab` param).
+ *
+ * @param {string} tabId
+ * @return {string} Relative URL.
+ */
+function tabHref( tabId ) {
+	if ( typeof window === 'undefined' ) {
+		return `?tab=${ tabId }`;
+	}
+	const url = new URL( window.location.href );
+	if ( tabId === 'upcoming' ) {
+		url.searchParams.delete( 'tab' );
+	} else {
+		url.searchParams.set( 'tab', tabId );
+	}
+	return url.pathname + ( url.search ? url.search : '' );
+}
 
 const StatsBar = ( { stats } ) => {
 	if ( ! stats ) {
 		return null;
 	}
 
+	// Each tile maps to the tab that best explains the number. Shows
+	// jumps to the Past list (the tracked-history surface); the
+	// venue/artist/city aggregates jump to the Stats leaderboards
+	// where those breakdowns live.
 	const items = [
-		{ value: stats.total_shows, label: stats.total_shows === 1 ? 'Show' : 'Shows' },
-		{ value: stats.unique_venues, label: stats.unique_venues === 1 ? 'Venue' : 'Venues' },
-		{ value: stats.unique_artists, label: stats.unique_artists === 1 ? 'Artist' : 'Artists' },
-		{ value: stats.unique_cities, label: stats.unique_cities === 1 ? 'City' : 'Cities' },
+		{
+			value: stats.total_shows,
+			label: stats.total_shows === 1 ? 'Show' : 'Shows',
+			tab: 'past',
+		},
+		{
+			value: stats.unique_venues,
+			label: stats.unique_venues === 1 ? 'Venue' : 'Venues',
+			tab: 'stats',
+		},
+		{
+			value: stats.unique_artists,
+			label: stats.unique_artists === 1 ? 'Artist' : 'Artists',
+			tab: 'stats',
+		},
+		{
+			value: stats.unique_cities,
+			label: stats.unique_cities === 1 ? 'City' : 'Cities',
+			tab: 'stats',
+		},
 	];
 
 	return (
-		<Section depth={ 1 } className="ec-concert-stats__stats-bar">
+		<StatGroup className="ec-concert-stats__stats-bar">
 			{ items.map( ( item ) => (
-				<div key={ item.label } className="ec-concert-stats__stat">
-					<span className="ec-concert-stats__stat-value">{ item.value }</span>
-					<span className="ec-concert-stats__stat-label">{ item.label }</span>
-				</div>
+				<StatTile
+					key={ item.label }
+					value={ item.value }
+					label={ item.label }
+					href={ tabHref( item.tab ) }
+					className="ec-concert-stats__stat"
+				/>
 			) ) }
-		</Section>
+		</StatGroup>
 	);
 };
 

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -27,13 +27,16 @@
 	justify-content: center;
 }
 
-/* ─── Stats Bar (bespoke tiles inside Section) ──────────────────────────── */
+/* ─── Stats Bar (canonical StatGroup / StatTile primitives) ─────────────── */
 
 /*
- * The outer `<Section>` chrome comes from @extrachill/components; the
- * stat tiles themselves stay bespoke because there's no canonical
- * stat-tile primitive yet. Override Section's default block layout to
- * a flex row for this specific use.
+ * The stat tiles now consume the canonical `StatGroup` / `StatTile`
+ * primitives from @extrachill/components (which ship their own base
+ * `.ec-stat-group` / `.ec-stat-tile` chrome). These local
+ * `.ec-concert-stats__stats-bar` / `__stat` selectors are passed in as
+ * `className` overrides for the concert-stats summary row: a tight
+ * flex row of equally-weighted tiles with a divider beneath, plus the
+ * interactive (link) tile affordance so the row doubles as navigation.
  */
 .ec-concert-stats__stats-bar {
 	display: flex;
@@ -44,25 +47,52 @@
 	flex-wrap: wrap;
 }
 
+/*
+ * Override the primitive's tile chrome for the summary-row context:
+ * centered column, compact min-width. When the tile is a link
+ * (`.ec-stat-tile--link`, set by StatTile when an `href` is present)
+ * give it a clear interactive affordance — pointer cursor, a subtle
+ * hover lift, and a visible focus ring for keyboard users — so the
+ * "stat → tab" navigation reads as clickable.
+ */
 .ec-concert-stats__stat {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	min-width: 60px;
+	text-decoration: none;
+	border-radius: var(--border-radius-sm, 4px);
+	transition: background-color 0.15s ease, transform 0.15s ease;
+
+	.ec-stat-tile__value {
+		font-size: var(--font-size-2xl, 1.5rem);
+		font-weight: 700;
+		line-height: 1.2;
+		color: var(--text-color, #1f2937);
+	}
+
+	.ec-stat-tile__label {
+		font-size: var(--font-size-xs, 0.625rem);
+		color: var(--muted-text, #6b7280);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
 }
 
-.ec-concert-stats__stat-value {
-	font-size: var(--font-size-2xl, 1.5rem);
-	font-weight: 700;
-	line-height: 1.2;
-	color: var(--text-color, #1f2937);
-}
+a.ec-concert-stats__stat {
+	cursor: pointer;
+	padding: var(--spacing-xs, 0.25rem) var(--spacing-sm, 0.5rem);
+	margin: calc(-1 * var(--spacing-xs, 0.25rem)) calc(-1 * var(--spacing-sm, 0.5rem));
 
-.ec-concert-stats__stat-label {
-	font-size: var(--font-size-xs, 0.625rem);
-	color: var(--muted-text, #6b7280);
-	text-transform: uppercase;
-	letter-spacing: 0.05em;
+	&:hover {
+		background-color: var(--surface-hover, rgba(0, 0, 0, 0.04));
+		transform: translateY(-1px);
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--accent-color, #2563eb);
+		outline-offset: 2px;
+	}
 }
 
 /* ─── Show Cards ────────────────────────────────────────────────────────── */

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -4,11 +4,17 @@
  * Hydrates the server-rendered container with a React app.
  * Uses @extrachill/components for layout primitives.
  *
- * @package ExtraChillEvents
+ * @package
  */
 
 import { createRoot, useState, useEffect, useRef } from '@wordpress/element';
-import { BlockShell, BlockShellInner, BlockShellHeader, InlineStatus, Tabs, Panel } from '@extrachill/components';
+import {
+	BlockShell,
+	BlockShellInner,
+	BlockShellHeader,
+	InlineStatus,
+	ResponsiveTabs,
+} from '@extrachill/components';
 import StatsBar from './components/StatsBar';
 import ShowList from './components/ShowList';
 import Leaderboard from './components/Leaderboard';
@@ -16,6 +22,7 @@ import YearFilter from './components/YearFilter';
 import AddPastShows from './components/AddPastShows';
 import ImportTab from './components/ImportTab';
 import useStats from './hooks/useStats';
+import useShows from './hooks/useShows';
 import useImportRuns from './hooks/useImportRuns';
 
 /**
@@ -24,7 +31,15 @@ import useImportRuns from './hooks/useImportRuns';
  * still gated by `isOwn` inside the render — the whitelist just guards
  * against arbitrary strings becoming React state.
  */
-const VALID_TAB_IDS = [ 'upcoming', 'past', 'calendar', 'add-past', 'map', 'stats', 'import' ];
+const VALID_TAB_IDS = [
+	'upcoming',
+	'past',
+	'calendar',
+	'add-past',
+	'map',
+	'stats',
+	'import',
+];
 
 /**
  * Read the initial active tab from `?tab=` on first render. SSR-safe
@@ -72,7 +87,14 @@ function hasExplicitTabParam() {
 /**
  * Main Concert Stats App component.
  */
-function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, containerRef } ) {
+function ConcertStatsApp( {
+	userId,
+	eventsUrl,
+	isOwn,
+	hasCalendar,
+	hasMap,
+	containerRef,
+} ) {
 	const [ year, setYear ] = useState( 0 );
 	const [ activeTab, setActiveTab ] = useState( readInitialTab );
 	// #126: tracks whether the user (or a deep link) has chosen a tab.
@@ -83,6 +105,25 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 	const [ userPickedTab, setUserPickedTab ] = useState( hasExplicitTabParam );
 
 	const { stats, loading: statsLoading } = useStats( userId, { year } );
+
+	// Badge counts for the Upcoming / Past tabs. The aggregate stats
+	// payload doesn't split tracked shows by period, so we read the
+	// accurate per-period `total` from the same paginated shows
+	// endpoint ShowList uses, but with `perPage: 1` so it's a cheap
+	// count probe rather than a full list fetch. Year-scoped so the
+	// badges track the active YearFilter selection.
+	const { total: upcomingCount } = useShows( userId, {
+		period: 'upcoming',
+		year,
+		page: 1,
+		perPage: 1,
+	} );
+	const { total: pastCount } = useShows( userId, {
+		period: 'past',
+		year,
+		page: 1,
+		perPage: 1,
+	} );
 
 	// Pull the configured source list at the parent level so the Import tab
 	// only renders when at least one source is actually available to this
@@ -95,7 +136,8 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 	// so we don't double-fetch from two `useImportRuns()` sites on the same
 	// page. ImportTab consumes the props directly.
 	const importRunsBag = useImportRuns();
-	const hasImports = isOwn && importRunsBag.sources && importRunsBag.sources.length > 0;
+	const hasImports =
+		isOwn && importRunsBag.sources && importRunsBag.sources.length > 0;
 
 	// #126: empty-state default tab. When the owner has zero tracked
 	// shows and hasn't explicitly picked a tab (no `?tab=` in URL,
@@ -160,8 +202,9 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 		if ( ! hasCalendar || ! containerRef.current ) {
 			return;
 		}
-		const shell = containerRef.current.closest( '.ec-concert-stats-shell' )
-			|| containerRef.current.parentElement;
+		const shell =
+			containerRef.current.closest( '.ec-concert-stats-shell' ) ||
+			containerRef.current.parentElement;
 		if ( ! shell ) {
 			return;
 		}
@@ -185,8 +228,9 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 		if ( ! hasMap || ! containerRef.current ) {
 			return;
 		}
-		const shell = containerRef.current.closest( '.ec-concert-stats-shell' )
-			|| containerRef.current.parentElement;
+		const shell =
+			containerRef.current.closest( '.ec-concert-stats-shell' ) ||
+			containerRef.current.parentElement;
 		if ( ! shell ) {
 			return;
 		}
@@ -217,10 +261,12 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 		{
 			id: 'upcoming',
 			label: 'Upcoming',
+			badge: upcomingCount,
 		},
 		{
 			id: 'past',
 			label: 'Past',
+			badge: pastCount,
 		},
 		...( isOwn && hasCalendar
 			? [
@@ -262,8 +308,8 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 
 	// #126: per-tab empty-state messages used when the user has zero
 	// tracked shows overall. Rendered as a plain `<InlineStatus>` so
-	// the surrounding Panel chrome still provides visual continuity
-	// with the rest of the tab strip. ShowList owns its own empty
+	// the surrounding ResponsiveTabs panel chrome still provides
+	// visual continuity with the tab strip. ShowList owns its own empty
 	// state for the Upcoming / Past tabs (it already returns
 	// InlineStatus when the period-scoped fetch returns zero rows),
 	// so Upcoming / Past don't need a duplicate empty branch here.
@@ -274,14 +320,122 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 	);
 	const calendarEmptyMessage = (
 		<InlineStatus tone="info">
-			Your concert calendar will appear here once you&rsquo;ve tracked shows.
+			Your concert calendar will appear here once you&rsquo;ve tracked
+			shows.
 		</InlineStatus>
 	);
 	const mapEmptyMessage = (
 		<InlineStatus tone="info">
-			Your concert map will appear here once you&rsquo;ve tracked shows at venues with coordinates.
+			Your concert map will appear here once you&rsquo;ve tracked shows at
+			venues with coordinates.
 		</InlineStatus>
 	);
+
+	// Panel renderer for ResponsiveTabs. On desktop this is called for
+	// the active tab; on mobile (accordion) it's called for whichever
+	// item is expanded. The calendar/map cases render only the
+	// fallback / empty-state messaging — their live content lives in
+	// sibling DOM nodes toggled by the useEffects above, so the Panel
+	// body stays empty when the embedded surface is present and
+	// populated.
+	const renderPanel = ( tabId ) => {
+		switch ( tabId ) {
+			case 'upcoming':
+				return (
+					<ShowList
+						userId={ userId }
+						period="upcoming"
+						year={ year }
+						eventsUrl={ eventsUrl }
+					/>
+				);
+
+			case 'past':
+				return (
+					<ShowList userId={ userId } period="past" year={ year } />
+				);
+
+			case 'calendar':
+				/*
+				 * Calendar tab content lives in a sibling DOM node
+				 * emitted by render.php (sibling to this React root);
+				 * the useEffect above toggles its `hidden` attribute.
+				 * When the user has no tracked shows yet, the sibling
+				 * wrapper is still emitted but the calendar query is
+				 * empty, so show the per-tab InlineStatus message
+				 * instead of an empty grid.
+				 */
+				if ( ! hasCalendar ) {
+					return (
+						<InlineStatus tone="info">
+							Calendar view is unavailable here.
+						</InlineStatus>
+					);
+				}
+				if ( ! hasAnyShows && ! statsLoading ) {
+					return calendarEmptyMessage;
+				}
+				return null;
+
+			case 'map':
+				/*
+				 * Map tab content lives in a sibling DOM node emitted
+				 * by render.php. Same pattern as Calendar — the
+				 * useEffect above toggles the sibling's `hidden`
+				 * attribute, preserving Leaflet's internal state
+				 * across tab switches.
+				 */
+				if ( ! hasMap ) {
+					return (
+						<InlineStatus tone="info">
+							Map view is unavailable here.
+						</InlineStatus>
+					);
+				}
+				if ( ! hasAnyShows && ! statsLoading ) {
+					return mapEmptyMessage;
+				}
+				return null;
+
+			case 'add-past':
+				return isOwn ? <AddPastShows /> : null;
+
+			case 'stats':
+				if ( statsLoading ) {
+					return (
+						<InlineStatus tone="info">Loading stats…</InlineStatus>
+					);
+				}
+				if ( stats && ! hasAnyShows ) {
+					return statsEmptyMessage;
+				}
+				if ( stats && hasAnyShows ) {
+					return (
+						<div className="ec-concert-stats__leaderboards">
+							<Leaderboard
+								title="Top Artists"
+								items={ stats.top_artists }
+							/>
+							<Leaderboard
+								title="Top Venues"
+								items={ stats.top_venues }
+							/>
+							<Leaderboard
+								title="Top Cities"
+								items={ stats.top_cities }
+							/>
+						</div>
+					);
+				}
+				return null;
+
+			case 'import':
+				return hasImports ? <ImportTab bag={ importRunsBag } /> : null;
+
+			default:
+				return null;
+		}
+	};
 
 	return (
 		<BlockShell>
@@ -299,99 +453,29 @@ function ConcertStatsApp( { userId, eventsUrl, isOwn, hasCalendar, hasMap, conta
 					}
 				/>
 
-				<StatsBar stats={ stats } />
+				{ /*
+				   #126 zero-state softening: don't greet a brand-new
+				   owner with four "0" stat tiles — that reads as a
+				   dead app. When the owner has zero tracked shows the
+				   inviting Add-Past-Shows tab is the active landing
+				   (see the default-tab effect above), and the
+				   StatsBar is suppressed so the first impression is
+				   the prompt, not the zeros. Once they have any show,
+				   the bar appears. Non-owners and still-loading states
+				   keep prior behavior.
+				 */ }
+				{ ( ! isOwn || statsLoading || hasAnyShows ) && (
+					<StatsBar stats={ stats } />
+				) }
 
-				<Tabs
+				<ResponsiveTabs
 					tabs={ tabs }
 					active={ activeTab }
 					onChange={ handleTabChange }
+					renderPanel={ renderPanel }
+					tabsClassPrefix="ec-tabs"
+					mobileBreakpoint={ 480 }
 				/>
-
-				<Panel compact>
-					{ activeTab === 'upcoming' && (
-						<ShowList
-							userId={ userId }
-							period="upcoming"
-							year={ year }
-							eventsUrl={ eventsUrl }
-						/>
-					) }
-
-					{ activeTab === 'past' && (
-						<ShowList userId={ userId } period="past" year={ year } />
-					) }
-
-					{ /*
-					   Calendar tab content lives in a sibling DOM node
-					   emitted by render.php (sibling to this React
-					   root). We render nothing in the Panel here when
-					   the sibling exists; the useEffect above toggles
-					   its `hidden` attribute. When the user has no
-					   tracked shows yet, the sibling wrapper is still
-					   emitted (render.php only checks owner+is_page),
-					   but the underlying calendar query returns zero
-					   events. Show the per-tab InlineStatus message
-					   instead of an empty grid in that case.
-					 */ }
-					{ activeTab === 'calendar' && ! hasCalendar && (
-						<InlineStatus tone="info">
-							Calendar view is unavailable here.
-						</InlineStatus>
-					) }
-					{ activeTab === 'calendar' && hasCalendar && ! hasAnyShows && ! statsLoading && (
-						calendarEmptyMessage
-					) }
-
-					{ /*
-					   Map tab content lives in a sibling DOM node
-					   emitted by render.php (sibling to this React
-					   root). Same pattern as Calendar — the useEffect
-					   above toggles the sibling's `hidden` attribute,
-					   preserving Leaflet's internal state (zoom,
-					   polyline, marker cluster) across tab switches.
-					 */ }
-					{ activeTab === 'map' && ! hasMap && (
-						<InlineStatus tone="info">
-							Map view is unavailable here.
-						</InlineStatus>
-					) }
-					{ activeTab === 'map' && hasMap && ! hasAnyShows && ! statsLoading && (
-						mapEmptyMessage
-					) }
-
-					{ activeTab === 'add-past' && isOwn && (
-						<AddPastShows />
-					) }
-
-					{ activeTab === 'stats' && statsLoading && (
-						<InlineStatus tone="info">Loading stats…</InlineStatus>
-					) }
-
-					{ activeTab === 'stats' && ! statsLoading && stats && ! hasAnyShows && (
-						statsEmptyMessage
-					) }
-
-					{ activeTab === 'stats' && ! statsLoading && stats && hasAnyShows && (
-						<div className="ec-concert-stats__leaderboards">
-							<Leaderboard
-								title="Top Artists"
-								items={ stats.top_artists }
-							/>
-							<Leaderboard
-								title="Top Venues"
-								items={ stats.top_venues }
-							/>
-							<Leaderboard
-								title="Top Cities"
-								items={ stats.top_cities }
-							/>
-						</div>
-					) }
-
-					{ activeTab === 'import' && hasImports && (
-						<ImportTab bag={ importRunsBag } />
-					) }
-				</Panel>
 			</BlockShellInner>
 		</BlockShell>
 	);
@@ -434,11 +518,11 @@ function ConcertStatsAppWithRef( props ) {
  */
 function init() {
 	document.querySelectorAll( '.ec-concert-stats' ).forEach( ( container ) => {
-		const userId      = parseInt( container.dataset.userId, 10 );
-		const eventsUrl   = container.dataset.eventsUrl || '';
-		const isOwn       = container.dataset.isOwn === '1';
+		const userId = parseInt( container.dataset.userId, 10 );
+		const eventsUrl = container.dataset.eventsUrl || '';
+		const isOwn = container.dataset.isOwn === '1';
 		const hasCalendar = container.dataset.hasCalendar === '1';
-		const hasMap      = container.dataset.hasMap === '1';
+		const hasMap = container.dataset.hasMap === '1';
 
 		const root = createRoot( container );
 		root.render(

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
 		"react-dom": "^18.3.1"
 	},
 	"dependencies": {
-		"@extrachill/components": "^0.5.2"
+		"@extrachill/components": "^0.6.0"
 	}
 }


### PR DESCRIPTION
## Summary

Improves the My Shows / concert-stats block UX. Scoped to `view.js`, `components/StatsBar.js`, and the stat-tile/responsive-tab portions of `style.scss` only.

## IA / UX changes

- **Responsive tabs.** Swapped the flat `Tabs` component for `ResponsiveTabs` (from `@extrachill/components`). The 7-tab strip (Upcoming, Past, Calendar, Add Past Shows, Map, Stats, Import) previously **wrapped badly on mobile**; it now collapses to an accordion below the 480px breakpoint. Panel bodies are rendered via the `renderPanel(id)` callback (one `switch`), preserving every existing per-tab branch including the calendar/map sibling-toggle empty states.
- **Tab badge counts.** Added live badge counts to the **Upcoming** and **Past** tabs using the `TabItem.badge` affordance the shipped library already supports. The aggregate stats payload doesn't split tracked shows by period, so the counts come from cheap `perPage: 1` count probes against the same `/concert-tracking/user/{id}/shows` endpoint `ShowList` uses (reads the accurate `total`, fetches one row). Year-scoped so the badges track the active `YearFilter`.
- **Softer zero-state.** The `StatsBar` is now **suppressed for brand-new owners** (`isOwn && total_shows === 0`) so the first impression is the inviting Add-Past-Shows prompt (already the empty-state default tab via the #126 effect), not four deflating `0` tiles. Non-owners and the loading state keep prior behavior.
- **Interactive stat tiles.** `StatsBar` now consumes the canonical **`StatTile` / `StatGroup`** primitives. Each tile is an interactive deep link to its most relevant tab (Shows → Past list, Venues/Artists/Cities → Stats leaderboards) using the **same `?tab=` URL contract** `view.js` reads on load — so the summary row doubles as navigation and degrades gracefully with JS off.

## URL sync preserved

The existing `?tab=` **query-param** sync (`replaceState`, strips `tab=` on the default Upcoming tab, clears stale `month=`) is unchanged. `ResponsiveTabs`' `syncWithHash` is intentionally **left off** to avoid a competing `#tab-` hash mutation — `ResponsiveTabs` just calls `onChange={handleTabChange}` exactly as `Tabs` did.

## ⚠️ Dependency / merge order

This PR depends on **`StatTile` / `StatGroup` / `ProgressBar` being added to `@extrachill/components`** (parallel work — already **merged to `extrachill-components` main** in #13, but **not yet released** to a new npm version; published `0.5.2` lacks them).

**Required merge order:**
1. `@extrachill/components` cuts a release that includes StatTile/StatGroup (main already has the code).
2. This plugin bumps its `@extrachill/components` dependency to that release.
3. Merge this PR.

`ResponsiveTabs` and the `Tabs` badge affordance already ship in `0.5.2`, so **those parts build cleanly today**.

## Verification

- `npm install && npm run build:concert-stats` → compiles; the **only** two webpack warnings are the documented unresolved `StatTile` / `StatGroup` imports. Verified a **fully clean build (0 warnings)** by linking a local build of `extrachill-components` main (which has StatTile) into `node_modules` and rebuilding.
- `?tab=` query-param sync confirmed intact (state + effect untouched; no hash sync enabled).
- `npx wp-scripts lint-js` on the changed files: the edited lines are prettier-clean; remaining errors are **pre-existing baseline JSDoc issues** on untouched function signatures (base had 55 lint errors; this branch reduced the count on these files).
- `build/` is gitignored — not committed.