### PR TITLE
feat(concert-stats): render venue/city as platform taxonomy badges

### DIFF
--- a/blocks/concert-stats/src/components/Leaderboard.js
+++ b/blocks/concert-stats/src/components/Leaderboard.js
@@ -4,12 +4,52 @@
  * Wrapped in a compact `<Panel>` for chrome consistency with the rest
  * of the platform. The inner list markup remains local.
  *
+ * Venue and city names render as platform **taxonomy badges** so they
+ * match the colored pill badges users see across the events calendar and
+ * archives. The class contract mirrors the theme's
+ * `extrachill_display_taxonomy_badges()` helper and the
+ * `inc/core/data-machine-events/badge-styling.php` mapping:
+ *   - base:  `taxonomy-badge`
+ *   - venue: `venue-badge` + `venue-<slug>`
+ *   - city:  `location-badge` + `location-<slug>`
+ * Per-term color classes (`venue-<slug>` / `location-<slug>`) resolve
+ * against the theme's `taxonomy-badges.css`; terms without a custom color
+ * fall back to the base `taxonomy-badge` + `venue-badge`/`location-badge`
+ * styling, so every term still reads as a badge. Artists are intentionally
+ * NOT badged — the artist taxonomy is excluded from the badge system by
+ * design (see `extrachill_events_exclude_taxonomies`).
+ *
  * @package
  */
 
 import { Badge, Panel } from '@extrachill/components';
 
-const Leaderboard = ( { title, items, maxItems = 5 } ) => {
+/**
+ * Build the taxonomy-badge class list for a leaderboard term.
+ *
+ * @param {string} taxonomy Badge taxonomy: `venue` | `location` | undefined.
+ * @param {string} slug     Term slug for the per-term color class.
+ * @return {string|null} Space-joined badge classes, or null when unbadged.
+ */
+const badgeClasses = ( taxonomy, slug ) => {
+	if ( 'venue' === taxonomy ) {
+		return `taxonomy-badge venue-badge venue-${ slug }`;
+	}
+	if ( 'location' === taxonomy ) {
+		return `taxonomy-badge location-badge location-${ slug }`;
+	}
+	return null;
+};
+
+/**
+ * @param {Object}      props          Component props.
+ * @param {string}      props.title    Leaderboard heading.
+ * @param {Array}       props.items    Term rows ({ name, slug, count, url }).
+ * @param {number}      props.maxItems Max rows to render.
+ * @param {string|null} props.taxonomy Badge taxonomy: `venue` | `location`.
+ *                                     Omit for unbadged lists (artists).
+ */
+const Leaderboard = ( { title, items, maxItems = 5, taxonomy = null } ) => {
 	if ( ! items || items.length === 0 ) {
 		return null;
 	}
@@ -18,33 +58,42 @@ const Leaderboard = ( { title, items, maxItems = 5 } ) => {
 		<Panel compact className="ec-concert-stats__leaderboard">
 			<h3 className="ec-concert-stats__leaderboard-title">{ title }</h3>
 			<ol className="ec-concert-stats__leaderboard-list">
-				{ items.slice( 0, maxItems ).map( ( item ) => (
-					<li
-						key={ item.slug }
-						className="ec-concert-stats__leaderboard-item"
-					>
-						{ item.url ? (
-							<a
-								className="ec-concert-stats__leaderboard-name ec-concert-stats__leaderboard-link"
-								href={ item.url }
-							>
-								{ item.name }
-							</a>
-						) : (
-							<span className="ec-concert-stats__leaderboard-name">
-								{ item.name }
-							</span>
-						) }
-						<Badge
-							tone="muted"
-							variant="subtle"
-							size="sm"
-							className="ec-concert-stats__leaderboard-count"
+				{ items.slice( 0, maxItems ).map( ( item ) => {
+					const badge = badgeClasses( taxonomy, item.slug );
+					// Badged terms drop the color-bearing `__leaderboard-link`
+					// class so the local link color does not fight the badge's
+					// own background/color; `__leaderboard-name` (flex sizing
+					// only) is kept for layout. Unbadged terms (artists) keep
+					// the link class for the original plain-link styling.
+					const nameClass = badge
+						? `ec-concert-stats__leaderboard-name ec-concert-stats__leaderboard-badge ${ badge }`
+						: 'ec-concert-stats__leaderboard-name ec-concert-stats__leaderboard-link';
+
+					return (
+						<li
+							key={ item.slug }
+							className="ec-concert-stats__leaderboard-item"
 						>
-							{ item.count }
-						</Badge>
-					</li>
-				) ) }
+							{ item.url ? (
+								<a className={ nameClass } href={ item.url }>
+									{ item.name }
+								</a>
+							) : (
+								<span className={ nameClass }>
+									{ item.name }
+								</span>
+							) }
+							<Badge
+								tone="muted"
+								variant="subtle"
+								size="sm"
+								className="ec-concert-stats__leaderboard-count"
+							>
+								{ item.count }
+							</Badge>
+						</li>
+					);
+				} ) }
 			</ol>
 		</Panel>
 	);

--- a/blocks/concert-stats/src/components/ShowCard.js
+++ b/blocks/concert-stats/src/components/ShowCard.js
@@ -8,6 +8,19 @@
  * This serves the platform's network-density goal — every show becomes
  * several doorways into the network.
  *
+ * Venue + city render as platform **taxonomy badges** (colored pills)
+ * matching the events calendar / archives. The class contract mirrors the
+ * theme's `extrachill_display_taxonomy_badges()` helper and the
+ * `inc/core/data-machine-events/badge-styling.php` mapping:
+ *   - base:  `taxonomy-badge`
+ *   - venue: `venue-badge` + `venue-<slug>`
+ *   - city:  `location-badge` + `location-<slug>`
+ * Terms without a custom per-term color fall back to the base
+ * `taxonomy-badge` + `venue-badge`/`location-badge` styling, so every term
+ * still reads as a badge. Artists are intentionally left as plain links —
+ * the artist taxonomy is excluded from the badge system by design (see
+ * `extrachill_events_exclude_taxonomies`).
+ *
  * Anchors cannot nest, so the card is intentionally NOT a single wrapping
  * <a>. The row is a plain container; the date carries the event-permalink
  * link and each term name is its own sibling link.
@@ -18,28 +31,57 @@
 import { formatShortDate } from '../utils/formatDate';
 
 /**
+ * Build the taxonomy-badge class list for a venue / city term.
+ *
+ * @param {string} taxonomy Badge taxonomy: `venue` | `location`.
+ * @param {string} slug     Term slug for the per-term color class.
+ * @return {string|null} Space-joined badge classes, or null when unbadged.
+ */
+const badgeClasses = ( taxonomy, slug ) => {
+	if ( 'venue' === taxonomy ) {
+		return `taxonomy-badge venue-badge venue-${ slug }`;
+	}
+	if ( 'location' === taxonomy ) {
+		return `taxonomy-badge location-badge location-${ slug }`;
+	}
+	return null;
+};
+
+/**
  * Render a single term (artist / venue / city) as a link when it has a
  * resolvable URL, falling back to plain text otherwise.
  *
- * @param {Object} props           Component props.
- * @param {Object} props.term      Term object with `name` and optional `url`.
- * @param {string} props.className CSS class for the rendered element.
+ * When `taxonomy` is `venue` or `location`, the taxonomy-badge classes are
+ * appended so venue / city terms render as platform badges. Artists pass no
+ * `taxonomy` and stay plain links.
+ *
+ * @param {Object}      props           Component props.
+ * @param {Object}      props.term      Term object with `name`, `slug`, optional `url`.
+ * @param {string}      props.className Base CSS class for the rendered element.
+ * @param {string|null} props.taxonomy  Badge taxonomy: `venue` | `location`.
  * @return {JSX.Element|null} Rendered link/span, or null when nameless.
  */
-const TermLink = ( { term, className } ) => {
+const TermLink = ( { term, className, taxonomy = null } ) => {
 	if ( ! term || ! term.name ) {
 		return null;
 	}
 
+	const badge = badgeClasses( taxonomy, term.slug );
+	// Badged terms drop the color-bearing local link class so its muted
+	// color does not fight the badge's own background/color; the badge
+	// classes fully own the visual. Unbadged terms (artists) keep their
+	// original link class.
+	const finalClass = badge ? badge : className;
+
 	if ( term.url ) {
 		return (
-			<a className={ className } href={ term.url }>
+			<a className={ finalClass } href={ term.url }>
 				{ term.name }
 			</a>
 		);
 	}
 
-	return <span className={ className }>{ term.name }</span>;
+	return <span className={ finalClass }>{ term.name }</span>;
 };
 
 const ShowCard = ( { show } ) => {
@@ -86,6 +128,7 @@ const ShowCard = ( { show } ) => {
 							<TermLink
 								term={ show.venue }
 								className="ec-concert-stats__show-venue-link"
+								taxonomy="venue"
 							/>
 						) }
 						{ hasVenue && hasCity && (
@@ -97,6 +140,7 @@ const ShowCard = ( { show } ) => {
 							<TermLink
 								term={ show.city }
 								className="ec-concert-stats__show-city-link"
+								taxonomy="location"
 							/>
 						) }
 					</span>

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -179,6 +179,23 @@ a.ec-concert-stats__stat {
 	color: var(--muted-text, #6b7280);
 }
 
+/*
+ * Taxonomy-badge glue for the show-card venue / city row.
+ *
+ * Venue + city render as platform taxonomy badges (`.taxonomy-badge` +
+ * `venue-badge`/`location-badge` + per-term slug class) from the theme's
+ * taxonomy-badges.css. We do NOT redefine badge colors here. The row is
+ * laid out as an inline-flex cluster so the pills, with the `·` separator
+ * between them, align vertically and wrap cleanly with a small gap instead
+ * of butting against the baseline text spacing.
+ */
+.ec-concert-stats__show-venue {
+	display: inline-flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--spacing-xs, 0.25rem);
+}
+
 /* ─── Leaderboards (inside Panel) ───────────────────────────────────────── */
 
 .ec-concert-stats__leaderboards {
@@ -238,6 +255,21 @@ a.ec-concert-stats__stat {
 .ec-concert-stats__leaderboard-count {
 	color: var(--muted-text, #6b7280);
 	font-weight: 500;
+}
+
+/*
+ * Taxonomy-badge glue for venue / city leaderboard rows.
+ *
+ * Venue + city names render as platform taxonomy badges (`.taxonomy-badge`
+ * + `venue-badge`/`location-badge` + per-term slug class) defined in the
+ * theme's taxonomy-badges.css. We do NOT redefine badge colors here — this
+ * rule only undoes the `flex: 1` stretch that `__leaderboard-name` applies
+ * (which would balloon the pill to fill the row) so the badge keeps its
+ * intrinsic pill width and stays left-aligned beside the count.
+ */
+.ec-concert-stats__leaderboard-name.ec-concert-stats__leaderboard-badge {
+	flex: 0 1 auto;
+	margin-right: auto;
 }
 
 /* ─── Year Filter (select inside FieldGroup) ────────────────────────────── */

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -419,10 +419,12 @@ function ConcertStatsApp( {
 							<Leaderboard
 								title="Top Venues"
 								items={ stats.top_venues }
+								taxonomy="venue"
 							/>
 							<Leaderboard
 								title="Top Cities"
 								items={ stats.top_cities }
+								taxonomy="location"
 							/>
 						</div>
 					);


### PR DESCRIPTION
## Summary

Wires the **My Shows** concert-stats block to render its venue + city term displays using the platform **taxonomy-badge** styling, so they read as the same colored pill badges users see across the events calendar and archives instead of plain text/links.

## What changed

`blocks/concert-stats/` only:

- **`Leaderboard.js`** — added a `taxonomy` prop. Top Venues apply `taxonomy-badge venue-badge venue-<slug>`; Top Cities apply `taxonomy-badge location-badge location-<slug>`. Top Artists pass no taxonomy and stay unbadged.
- **`ShowCard.js`** — the venue + city `TermLink`s apply the same badge classes (`taxonomy="venue"` / `taxonomy="location"`). The artist links are intentionally left unbadged.
- **`view.js`** — passes `taxonomy="venue"` / `taxonomy="location"` to the Venues / Cities leaderboards.
- **`style.scss`** — minimal glue only (no badge colors redefined): undo the `__leaderboard-name` `flex: 1` stretch on badge pills so they keep their intrinsic pill width, and lay out the show-card venue/city row as an inline-flex cluster so the pills + `·` separator align and wrap cleanly.

## Class contract

Mirrors the theme's `extrachill_display_taxonomy_badges()` helper, the existing `inc/home/location-badges.php` markup, and the `inc/core/data-machine-events/badge-styling.php` mapping:

| Term  | Classes |
|-------|---------|
| Venue | `taxonomy-badge` · `venue-badge` · `venue-<slug>` |
| City  | `taxonomy-badge` · `location-badge` · `location-<slug>` |

Badged terms drop the local color-bearing link class (`__leaderboard-link` / `__show-venue-link`) so the theme badge colors are **reused, never redefined or fought**.

## Artist is intentionally left unbadged

The `artist` taxonomy is excluded from the badge system by design (`extrachill_events_exclude_taxonomies` sets `$excluded[] = 'artist'`). This PR only badges venue + city; artist displays stay as plain links.

## Color resolution / fallback

The theme's `taxonomy-badges.css` loads unconditionally on every events-theme front-end page (`extrachill_enqueue_taxonomy_badges` on `wp_enqueue_scripts`), so it is present on `/my-shows/` and the per-term color classes resolve. Terms without a custom per-term color fall back to the always-present base `.taxonomy-badge` (+ the `venue-badge` default) styling, so every term still renders as a proper badge pill — not unstyled text. (There is no base `.taxonomy-badge.location-badge` default in the theme, so an uncolored city uses the neutral base badge palette; this matches existing platform behavior in `location-badges.php`.)

## Verification

- `npm run build:concert-stats` compiles successfully (`build/` is gitignored — not committed).
- `npx wp-scripts lint-js` on `Leaderboard.js` + `ShowCard.js` is clean. The 9 `view.js` JSDoc errors are **pre-existing on `origin/main`** (confirmed via stash) and out of scope for this change.