### PR TITLE
feat(artist-map): chronological tour-route map on artist archives (#310)

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -218,6 +218,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-meta.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-map.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/venue-map.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/artist-map.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-seo.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/near-me.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/discovery-pages.php';

--- a/inc/core/artist-map.php
+++ b/inc/core/artist-map.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Artist Map
+ *
+ * Renders the data-machine-events/events-map block on artist taxonomy
+ * archive pages in chronological-route mode — a date-ordered polyline
+ * connecting the artist's upcoming-tour venues so a fan can see the
+ * tour footprint at a glance.
+ *
+ * Mirrors `location-map.php` / `venue-map.php`: the extrachill layer
+ * only decides *whether* and *in what mode* to render the block on this
+ * archive context. All map logic, venue fetching, polyline drawing,
+ * residency collapsing, first/last marker styling, and empty-route
+ * hiding live in the generic data-machine-events events-map block.
+ *
+ * Backend wiring is automatic: on an artist archive the block's
+ * render.php seeds `taxonomy=artist` + `term_id` from the queried
+ * object, and chronological-route mode makes the frontend request the
+ * opt-in `include=events` payload. VenueMapAbilities then attaches
+ * `upcoming_events_at_venue` per venue (chronological ascending) because
+ * taxonomy + term_id + include_events are all present. No EC-side
+ * query_args / venues filter is needed for the artist archive — unlike
+ * the `/my-shows/` page, which has no taxonomy/term context and must
+ * supply its own payload.
+ *
+ * @package ExtraChillEvents
+ * @since 0.28.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Render the events-map block in chronological-route mode on artist archives.
+ *
+ * Gating:
+ *   - Only on `is_tax( 'artist' )`.
+ *   - Only when the artist has at least 2 distinct upcoming venues — a
+ *     route needs at least two stops. Uses the transient-cached
+ *     `extrachill_events_get_term_calendar_stats()` (already computed for
+ *     the stats line rendered just above this hook) so the gate adds no
+ *     extra query. The block applies a second, stricter guard
+ *     client-side (>= 2 venues that actually have coordinates) and hides
+ *     itself when that is not met, so venues missing geo never produce a
+ *     broken single-point map.
+ *
+ * @hook extrachill_archive_below_description
+ */
+function extrachill_events_render_artist_map() {
+	if ( ! is_tax( 'artist' ) ) {
+		return;
+	}
+
+	$term = get_queried_object();
+	if ( ! $term || ! isset( $term->term_id ) ) {
+		return;
+	}
+
+	// Cheap gate: need >= 2 upcoming venues to draw a route. The block's
+	// own coordinate-aware guard handles the final hide when venues lack
+	// geo, but this avoids emitting the block markup + booting Leaflet for
+	// artists with a single (or zero) upcoming venue.
+	if ( function_exists( 'extrachill_events_get_term_calendar_stats' ) ) {
+		$stats = extrachill_events_get_term_calendar_stats( 'artist', (int) $term->term_id );
+		if ( (int) ( $stats['venues'] ?? 0 ) < 2 ) {
+			return;
+		}
+	}
+
+	// Render the block in chronological-route mode. The block reads
+	// taxonomy/term_id from its own render context (is_tax + queried
+	// object) and auto-fits to the route's bounding box.
+	echo do_blocks( '<!-- wp:data-machine-events/events-map {"chronologicalRouteMode":true} /-->' );
+}
+add_action( 'extrachill_archive_below_description', 'extrachill_events_render_artist_map' );
+
+/**
+ * Suppress the map summary on artist archives.
+ *
+ * The archive header already renders a canonical upcoming-events stats
+ * line ("N upcoming events at N venues in N locations") via
+ * `extrachill_events_render_term_calendar_stats()`. Showing the same
+ * counts inside the map's summary slot would duplicate the number on the
+ * page, so return an empty string. The map itself still renders — only
+ * its overlay summary text is dropped. Mirrors the location/venue
+ * archive treatment.
+ *
+ * @hook data_machine_events_map_summary
+ * @param string $summary Current summary.
+ * @param array  $venues  Venue data array (empty — dynamic mode).
+ * @param array  $context Map context.
+ * @return string Summary text. Empty on artist archives.
+ */
+function extrachill_events_filter_artist_map_summary( string $summary, array $venues, array $context ): string {
+	if ( ! ( $context['is_taxonomy'] ?? false ) || 'artist' !== ( $context['taxonomy'] ?? '' ) ) {
+		return $summary;
+	}
+
+	// Counts live in the archive-header stats line; the map stands alone.
+	return '';
+}
+add_filter( 'data_machine_events_map_summary', 'extrachill_events_filter_artist_map_summary', 10, 3 );


### PR DESCRIPTION
## Summary

Implements the artist tour-route line map for **Extra-Chill/data-machine-events#310** — the "missing line map" the founder (via Chris Gardner) flagged on artist taxonomy archive pages (e.g. https://events.extrachill.com/artist/theo-katzman/).

Adds **`inc/core/artist-map.php`** hooking `extrachill_archive_below_description` on `is_tax('artist')` to render the generic `data-machine-events/events-map` block in **`chronologicalRouteMode`** — a date-ordered polyline through the artist's upcoming-tour venues, placed **below the stats line / above the calendar**, mirroring `location-map.php` and `venue-map.php`.

## Why this is the only change needed

The line-map **capability already shipped** in data-machine-events v0.40.5. The branch `feat-310-artist-tour-map` in data-machine-events has **zero diff vs main** — the block, REST opt-in param, abilities payload, polyline/residency/marker logic, empty-route hide, and CSS are all already on `main`. **No data-machine-events PR is needed.** This PR is purely the EC-side archive wiring (the gap identified in the #310 green-light comment).

## What `artist-map.php` does

- **Render hook:** `extrachill_archive_below_description` → gated to `is_tax('artist')` → `echo do_blocks('<!-- wp:data-machine-events/events-map {"chronologicalRouteMode":true} /-->')`. Matches the bare `echo do_blocks()` convention used by the shipped `location-map.php` / `venue-map.php` siblings.
- **Backend wiring is automatic.** On an artist archive the block's `render.php` seeds `taxonomy=artist` + `term_id` from the queried object. `chronologicalRouteMode` makes the frontend request the opt-in payload, and `VenueMapAbilities::executeListVenues()` attaches per-venue `upcoming_events_at_venue` because `taxonomy + term_id + include_events` are all present. **No EC-side `data_machine_events_map_query_args` / `data_machine_events_map_venues` filter is needed** — unlike `/my-shows/`, the artist archive *has* a taxonomy/term context, so DME's built-in attachment path handles it.
- **Summary suppression filter** on `data_machine_events_map_summary` for the artist context, so the map's overlay summary doesn't duplicate the archive-header stats line. Mirrors location/venue.

## Venue-endpoint opt-in param (already shipped in DME — documented here for the contract)

The events-map frontend requests the per-venue event list via the venues endpoint's **opt-in param**:

- `GET /wp-json/datamachine/v1/events/venues?taxonomy=artist&term_id=N&include=events`
- Boolean shortcut: `&with_events=1` (equivalent to `include=events`).

**Back-compat:** absence of the param keeps the venue response **byte-identical** to today's shape, so the location-archive / venue-archive maps (which don't need per-venue events) stay on the legacy lean response. The per-venue array is only attached when `include_events=true` **AND** a `taxonomy + term_id` filter is in play.

## Polyline / residency / empty-route behavior (in the shipped DME block)

- **Polyline:** straight `L.polyline()` between consecutive venues ordered by each venue's earliest upcoming show date. Drawn **before** the marker cluster group so markers paint on top.
- **Residencies (same venue, multiple dates):** one marker; consecutive same-`term_id` stops are collapsed so the line does **not** self-loop. The marker popup lists every upcoming show date for that venue chronologically.
- **First/last styling:** first = green (`#22c55e`), last = red (`#ef4444`), middle = slate — the simple default per #310 (iterate after live feedback).
- **Empty-route hide:** the block hides itself when fewer than 2 venues with valid coordinates are in the route. This PR adds a **second, cheaper server-side gate**: `extrachill_events_get_term_calendar_stats('artist', $term_id)['venues'] >= 2` (transient-cached, already computed for the stats line above) so the block + Leaflet only boot when a route can exist.

## Layer purity — grep-clean confirmation

`data-machine-events` receives **no changes** in this PR and stays generic/taxonomy-agnostic. Grep of the events-map + venues surface (`inc/Blocks/EventsMap/`, `VenueMapAbilities.php`, `VenueMap.php`, `Api/Routes.php`) for `extrachill|my-shows|concert-tracking|c8c_`:

- The only matches are **docblock prose** — issue cross-references (`extrachill-events#88`, `#320`) and a hypothetical `/my-shows/` page named as an *example* consumer of a generic filter. No EC names in field names, schema keys, params, or logic. This is the "cosmetic prose" exception under the site layer-purity rule.

All EC-specific wiring lives here in `extrachill-events`.

## Lint note

`homeboy lint` reports two PHPCS errors that are **pre-existing baseline**, not introduced by this PR:
- `artist-map.php:74` `do_blocks` not escaped — **identical to the shipped `location-map.php:46` and `venue-map.php:90`**; matching the established repo convention rather than diverging with an inconsistent ignore.
- `extrachill-events.php:360` mixed functions/OO — pre-existing on `main`; this PR only adds a one-line `require_once`. PHPStan passes.

## Out of scope (tracked fast-follows per #310)

- Single-event page map ("this artist's other tour stops").
- Tabbed routing (use the `@extrachill/components` `Tabs` + `?tab=` pattern, **not** DME extensibility — explicitly rejected in the #310 comment).
- Past-tour toggle, animated draw, tour-stat overlays, numbered residency badges.

Refs Extra-Chill/data-machine-events#310