### PR TITLE
feat(concert-stats): consolidate 'Add Past Shows' into the Past tab (#159)

### DIFF
--- a/blocks/concert-stats/src/components/AddPastShows.js
+++ b/blocks/concert-stats/src/components/AddPastShows.js
@@ -1,7 +1,10 @@
 /**
- * AddPastShows — "Add Past Shows" tab content for the concert-stats block.
+ * AddPastShows — owner-only "add a past show" affordance.
  *
  * Lets a logged-in user retroactively mark past events they attended.
+ * As of #159 this is no longer a standalone tab — it renders inline at
+ * the top of the "Past" tab (see PastTab.js), above the read-only
+ * tracked-shows list.
  *
  * Behavior:
  *   - Search input (committed on Enter / Search button via SearchBox).
@@ -9,21 +12,38 @@
  *     Backend short-circuits and returns no results. See extrachill-events#130.
  *   - Results list with "+ Mark Attended" per row, optimistic state flip.
  *   - "Load more" pagination, 20 per page (handled in useEventSearch).
+ *   - `onMarked` (optional): invoked after a successful mark so the
+ *     parent (PastTab) can refetch the Past list and surface the newly
+ *     added show without a full page reload (#159).
  *
- * @package ExtraChillEvents
+ * @package
  */
 
-import { useState } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 import { ActionRow, InlineStatus, Section } from '@extrachill/components';
 import EventSearchInput from './EventSearchInput';
 import EventSearchResult from './EventSearchResult';
 import useEventSearch from '../hooks/useEventSearch';
 
-const AddPastShows = () => {
+const AddPastShows = ( { onMarked } ) => {
 	const [ query, setQuery ] = useState( '' );
 
 	const { events, total, pages, page, loading, error, loadMore, setMarked } =
 		useEventSearch( query );
+
+	// Wrap the search-result optimistic flip so a successful mark also
+	// bubbles up to the parent Past list. The local `setMarked` keeps the
+	// search row in its "✓ Tracked" state; `onMarked` lets PastTab refetch
+	// the tracked-shows list so the new show appears below (#159).
+	const handleMarked = useCallback(
+		( postId, marked ) => {
+			setMarked( postId, marked );
+			if ( marked && typeof onMarked === 'function' ) {
+				onMarked( postId );
+			}
+		},
+		[ setMarked, onMarked ]
+	);
 
 	const isEmptyQuery = query.trim() === '';
 
@@ -33,17 +53,17 @@ const AddPastShows = () => {
 
 			{ isEmptyQuery && (
 				<InlineStatus tone="info">
-					Start typing the name of an artist, venue, or show you&rsquo;ve attended.
+					Start typing the name of an artist, venue, or show
+					you&rsquo;ve attended.
 				</InlineStatus>
 			) }
 
-			{ error && (
-				<InlineStatus tone="error">{ error }</InlineStatus>
-			) }
+			{ error && <InlineStatus tone="error">{ error }</InlineStatus> }
 
 			{ ! loading && ! error && events.length === 0 && ! isEmptyQuery && (
 				<InlineStatus tone="info">
-					No matches for &ldquo;{ query }&rdquo;. Try a different artist, venue, or city.
+					No matches for &ldquo;{ query }&rdquo;. Try a different
+					artist, venue, or city.
 				</InlineStatus>
 			) }
 
@@ -53,15 +73,13 @@ const AddPastShows = () => {
 						<EventSearchResult
 							key={ ev.post_id }
 							event={ ev }
-							onMarkedChange={ setMarked }
+							onMarkedChange={ handleMarked }
 						/>
 					) ) }
 				</Section>
 			) }
 
-			{ loading && (
-				<InlineStatus tone="info">Searching…</InlineStatus>
-			) }
+			{ loading && <InlineStatus tone="info">Searching…</InlineStatus> }
 
 			{ ! loading && page < pages && (
 				<ActionRow align="center">

--- a/blocks/concert-stats/src/components/EventSearchResult.js
+++ b/blocks/concert-stats/src/components/EventSearchResult.js
@@ -1,5 +1,6 @@
 /**
- * EventSearchResult — Single past-event row in the Add Past Shows tab.
+ * EventSearchResult — Single past-event row in the Past tab's add-a-show
+ * search results (#159; formerly the standalone "Add Past Shows" tab).
  *
  * Renders date / venue / primary artist / city and a "+ Mark Attended" button
  * (or a disabled "✓ Tracked" label for events already in the user's history).

--- a/blocks/concert-stats/src/components/PastTab.js
+++ b/blocks/concert-stats/src/components/PastTab.js
@@ -1,0 +1,48 @@
+/**
+ * PastTab — combined "Past" tab content for the concert-stats block.
+ *
+ * As of #159 the standalone "Add Past Shows" tab is folded into the
+ * "Past" tab. This component composes:
+ *   - (owner only) the AddPastShows search-and-mark affordance, so a
+ *     user can find and mark past shows they attended from the same
+ *     surface where they review their tracked history.
+ *   - the read-only ShowList of tracked past shows.
+ *
+ * Owner-only gating: non-owners viewing someone's Past tab see only the
+ * read-only list — the add affordance is omitted entirely.
+ *
+ * Newly-added shows: marking a show in AddPastShows triggers a refetch
+ * of the Past list via a bumped `refreshKey`, so the new show appears
+ * below without a full page reload (#159). ShowList re-runs its fetch
+ * whenever its `key` changes.
+ *
+ * @package
+ */
+
+import { useState, useCallback } from '@wordpress/element';
+import AddPastShows from './AddPastShows';
+import ShowList from './ShowList';
+
+const PastTab = ( { userId, year, isOwn } ) => {
+	// Bumping this remounts ShowList, forcing a fresh fetch so a
+	// just-marked show shows up in the tracked-past list.
+	const [ refreshKey, setRefreshKey ] = useState( 0 );
+
+	const handleMarked = useCallback( () => {
+		setRefreshKey( ( k ) => k + 1 );
+	}, [] );
+
+	return (
+		<div className="ec-concert-stats__past-tab">
+			{ isOwn && <AddPastShows onMarked={ handleMarked } /> }
+			<ShowList
+				key={ refreshKey }
+				userId={ userId }
+				period="past"
+				year={ year }
+			/>
+		</div>
+	);
+};
+
+export default PastTab;

--- a/blocks/concert-stats/src/components/ShowList.js
+++ b/blocks/concert-stats/src/components/ShowList.js
@@ -1,7 +1,7 @@
 /**
  * ShowList — Paginated list of show cards with load-more.
  *
- * @package ExtraChillEvents
+ * @package
  */
 
 import { useState } from '@wordpress/element';
@@ -27,7 +27,8 @@ const ShowList = ( { userId, period, year, eventsUrl } ) => {
 		if ( period === 'upcoming' ) {
 			return (
 				<InlineStatus tone="info">
-					No upcoming shows you&rsquo;ve marked yet. Find a show on the{ ' ' }
+					No upcoming shows you&rsquo;ve marked yet. Find a show on
+					the{ ' ' }
 					{ eventsUrl ? (
 						<a href={ eventsUrl }>events calendar</a>
 					) : (
@@ -39,7 +40,8 @@ const ShowList = ( { userId, period, year, eventsUrl } ) => {
 		}
 		return (
 			<InlineStatus tone="info">
-				No past shows tracked yet. Use Add Past Shows to find shows you&rsquo;ve attended, or Import from setlist.fm/phish.net.
+				No past shows tracked yet. Use the search above to find shows
+				you&rsquo;ve attended, or Import from setlist.fm/phish.net.
 			</InlineStatus>
 		);
 	}
@@ -50,9 +52,7 @@ const ShowList = ( { userId, period, year, eventsUrl } ) => {
 				<ShowCard key={ show.event_id } show={ show } />
 			) ) }
 
-			{ loading && (
-				<InlineStatus tone="info">Loading...</InlineStatus>
-			) }
+			{ loading && <InlineStatus tone="info">Loading...</InlineStatus> }
 
 			{ ! loading && page < pages && (
 				<ActionRow align="center">

--- a/blocks/concert-stats/src/hooks/useEventSearch.js
+++ b/blocks/concert-stats/src/hooks/useEventSearch.js
@@ -1,7 +1,8 @@
 /**
  * useEventSearch — Debounced REST search of past events for marking.
  *
- * Drives the "Add Past Shows" tab in the concert-stats block.
+ * Drives the owner-only "add a past show" affordance folded into the
+ * "Past" tab of the concert-stats block (#159).
  *
  * Behavior:
  *   - Debounces query changes by 300ms before firing a request.
@@ -10,7 +11,7 @@
  *   - Resets accumulated results whenever the query changes.
  *   - Empty query is allowed — backend returns recent past events as suggestions.
  *
- * @package ExtraChillEvents
+ * @package
  */
 
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
@@ -56,7 +57,9 @@ export default function useEventSearch( query ) {
 					return;
 				}
 				const incoming = response.events || [];
-				setEvents( ( prev ) => ( p === 1 ? incoming : [ ...prev, ...incoming ] ) );
+				setEvents( ( prev ) =>
+					p === 1 ? incoming : [ ...prev, ...incoming ]
+				);
 				setTotal( response.total || 0 );
 				setPages( response.pages || 0 );
 				setLoading( false );
@@ -65,7 +68,9 @@ export default function useEventSearch( query ) {
 				if ( err && err.name === 'AbortError' ) {
 					return;
 				}
-				setError( ( err && err.message ) || 'Failed to search events.' );
+				setError(
+					( err && err.message ) || 'Failed to search events.'
+				);
 				setLoading( false );
 			} );
 	}, [] );
@@ -103,8 +108,8 @@ export default function useEventSearch( query ) {
 	 * Mark a single event as locally-tracked without a refetch.
 	 * Used for optimistic UI updates.
 	 *
-	 * @param {number} postId   Event post ID.
-	 * @param {boolean} marked  New is_marked state.
+	 * @param {number}  postId Event post ID.
+	 * @param {boolean} marked New is_marked state.
 	 */
 	const setMarked = useCallback( ( postId, marked ) => {
 		setEvents( ( prev ) =>

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -326,6 +326,33 @@ a.ec-concert-stats__stat {
 	100% { background-position: -200% 0; }
 }
 
+/* ─── Past Tab — combined add-affordance + tracked list (#159) ──────────── */
+
+/*
+ * #159 folded the standalone "Add Past Shows" tab into the "Past" tab.
+ * PastTab stacks the owner-only AddPastShows search affordance above the
+ * read-only ShowList of tracked past shows. The gap keeps the search
+ * surface visually distinct from the list below; the divider under the
+ * add block reinforces "search up here / your history down there" so the
+ * two surfaces don't read as one undifferentiated stream.
+ */
+.ec-concert-stats__past-tab {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-md, 1rem);
+}
+
+/*
+ * When the AddPastShows block is present (owner view) give it a bottom
+ * divider so it separates cleanly from the tracked-shows list. Non-owner
+ * views omit AddPastShows entirely, so the list sits flush — no empty
+ * divider is rendered.
+ */
+.ec-concert-stats__past-tab .ec-concert-stats__add-past {
+	padding-bottom: var(--spacing-md, 1rem);
+	border-bottom: 1px solid var(--border-color, #e5e7eb);
+}
+
 /* ─── Search Result inner layout (inside ActionRow) ─────────────────────── */
 
 .ec-concert-stats__search-result-link {

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -17,9 +17,9 @@ import {
 } from '@extrachill/components';
 import StatsBar from './components/StatsBar';
 import ShowList from './components/ShowList';
+import PastTab from './components/PastTab';
 import Leaderboard from './components/Leaderboard';
 import YearFilter from './components/YearFilter';
-import AddPastShows from './components/AddPastShows';
 import ImportTab from './components/ImportTab';
 import useStats from './hooks/useStats';
 import useShows from './hooks/useShows';
@@ -35,27 +35,61 @@ const VALID_TAB_IDS = [
 	'upcoming',
 	'past',
 	'calendar',
-	'add-past',
 	'map',
 	'stats',
 	'import',
 ];
 
 /**
+ * Back-compat alias map for retired tab IDs.
+ *
+ * #159: the standalone `add-past` tab was folded into the `past` tab.
+ * Any shared link or bookmark that still carries `?tab=add-past` should
+ * resolve to `past` instead of silently falling back to the default
+ * `upcoming` tab. `resolveTabId()` maps a raw `?tab=` value through this
+ * table before whitelist validation.
+ */
+const TAB_ALIASES = {
+	'add-past': 'past',
+};
+
+/**
+ * Resolve a raw `?tab=` value to a valid, current tab ID.
+ *
+ * Applies the {@link TAB_ALIASES} back-compat mapping first (so retired
+ * IDs like `add-past` resolve to their replacement), then validates
+ * against {@link VALID_TAB_IDS}. Returns `null` when the value isn't a
+ * recognized (or aliased) tab so callers can apply their own default.
+ *
+ * @param {?string} requested Raw `tab` query param value.
+ * @return {?string} A valid tab ID, or null when unrecognized.
+ */
+function resolveTabId( requested ) {
+	if ( ! requested ) {
+		return null;
+	}
+	const aliased = TAB_ALIASES[ requested ] || requested;
+	return VALID_TAB_IDS.includes( aliased ) ? aliased : null;
+}
+
+/**
  * Read the initial active tab from `?tab=` on first render. SSR-safe
  * (no-op when `window` is absent). Falls back to `'upcoming'`.
  *
  * #126: when `?tab=` is absent we default to `'upcoming'`. A
- * post-fetch effect inside the app swaps the default to `'add-past'`
+ * post-fetch effect inside the app swaps the default to `'past'`
  * for owners whose `stats.total_shows === 0` — that's the empty-state
- * UX where the search-for-past-shows surface is the most useful
- * landing tab. Implementation note: we picked JS-side post-fetch over
- * a server-rendered `data-has-any-shows` attribute for simplicity
- * (the latter would require either a duplicate DB query in render.php
- * or threading `total_shows` from the concert-tracking abilities at
- * server-render time, and the brief upcoming→add-past flip is
- * acceptable since the loading skeleton covers the very first paint
- * anyway).
+ * UX where the search-for-past-shows affordance (folded into the Past
+ * tab as of #159) is the most useful landing tab. Implementation note:
+ * we picked JS-side post-fetch over a server-rendered
+ * `data-has-any-shows` attribute for simplicity (the latter would
+ * require either a duplicate DB query in render.php or threading
+ * `total_shows` from the concert-tracking abilities at server-render
+ * time, and the brief upcoming→past flip is acceptable since the
+ * loading skeleton covers the very first paint anyway).
+ *
+ * #159: a legacy `?tab=add-past` deep link resolves to `'past'` via
+ * resolveTabId()'s alias table.
  *
  * @return {string} Tab ID.
  */
@@ -64,14 +98,15 @@ function readInitialTab() {
 		return 'upcoming';
 	}
 	const params = new URLSearchParams( window.location.search );
-	const requested = params.get( 'tab' );
-	return VALID_TAB_IDS.includes( requested ) ? requested : 'upcoming';
+	return resolveTabId( params.get( 'tab' ) ) || 'upcoming';
 }
 
 /**
- * Whether the current page load arrived with an explicit `?tab=` in
- * the URL. Used to gate the empty-state default-tab swap so we never
- * override an intentional deep link.
+ * Whether the current page load arrived with an explicit (recognized
+ * or aliased) `?tab=` in the URL. Used to gate the empty-state
+ * default-tab swap so we never override an intentional deep link —
+ * including a legacy `?tab=add-past` link, which resolveTabId() maps to
+ * `past` (#159).
  *
  * @return {boolean}
  */
@@ -80,8 +115,7 @@ function hasExplicitTabParam() {
 		return false;
 	}
 	const params = new URLSearchParams( window.location.search );
-	const requested = params.get( 'tab' );
-	return VALID_TAB_IDS.includes( requested );
+	return resolveTabId( params.get( 'tab' ) ) !== null;
 }
 
 /**
@@ -99,7 +133,7 @@ function ConcertStatsApp( {
 	const [ activeTab, setActiveTab ] = useState( readInitialTab );
 	// #126: tracks whether the user (or a deep link) has chosen a tab.
 	// Until then, the post-stats-fetch effect below is allowed to swap
-	// the default from 'upcoming' → 'add-past' when the owner has zero
+	// the default from 'upcoming' → 'past' when the owner has zero
 	// tracked shows. Once the user explicitly picks a tab via the tab
 	// strip, this flips to true and the auto-swap stops fighting them.
 	const [ userPickedTab, setUserPickedTab ] = useState( hasExplicitTabParam );
@@ -139,12 +173,15 @@ function ConcertStatsApp( {
 	const hasImports =
 		isOwn && importRunsBag.sources && importRunsBag.sources.length > 0;
 
-	// #126: empty-state default tab. When the owner has zero tracked
-	// shows and hasn't explicitly picked a tab (no `?tab=` in URL,
-	// hasn't clicked the strip yet), land them on Add Past Shows. The
-	// search-for-past-shows surface is the most useful starting point
-	// for users in this state; the old takeover hid the entire tab
-	// strip behind a Browse-Shows CTA that pointed at the wrong place.
+	// #126/#159: empty-state default tab. When the owner has zero
+	// tracked shows and hasn't explicitly picked a tab (no `?tab=` in
+	// URL, hasn't clicked the strip yet), land them on the Past tab —
+	// which now hosts the search-for-past-shows affordance inline above
+	// the (empty) tracked-shows list (#159 folded the old standalone
+	// "Add Past Shows" tab into Past). That search surface is the most
+	// useful starting point for users in this state; the old takeover
+	// hid the entire tab strip behind a Browse-Shows CTA that pointed
+	// at the wrong place.
 	useEffect( () => {
 		if ( userPickedTab ) {
 			return;
@@ -153,7 +190,7 @@ function ConcertStatsApp( {
 			return;
 		}
 		if ( stats.total_shows === 0 && isOwn ) {
-			setActiveTab( 'add-past' );
+			setActiveTab( 'past' );
 		}
 	}, [ stats, statsLoading, isOwn, userPickedTab ] );
 
@@ -250,13 +287,15 @@ function ConcertStatsApp( {
 		}
 	}, [ activeTab, hasMap, containerRef ] );
 
-	// Tab order: Upcoming → Past → Calendar (owner, #110) → Add Past
-	// Shows (owner, #109) → Map (owner, #111) → Stats → Import
-	// (owner, #112). Visualization tabs (Calendar, Map) sit alongside
-	// the history axes (Upcoming, Past) and the growth tabs (Add Past
-	// Shows, Import); Stats stays second-to-last as the summary
-	// surface. Owner-only because the underlying tracking table is
-	// per-user.
+	// Tab order: Upcoming → Past → Calendar (owner, #110) → Map
+	// (owner, #111) → Stats → Import (owner, #112). The Past tab now
+	// also hosts the owner-only "add a past show" search affordance
+	// (#159 folded the old standalone "Add Past Shows" tab into Past),
+	// so there's no separate growth tab in the strip anymore.
+	// Visualization tabs (Calendar, Map) sit alongside the history axes
+	// (Upcoming, Past); Stats stays second-to-last as the summary
+	// surface; Import is the remaining growth tab. Owner-only tabs exist
+	// because the underlying tracking table is per-user.
 	const tabs = [
 		{
 			id: 'upcoming',
@@ -273,14 +312,6 @@ function ConcertStatsApp( {
 					{
 						id: 'calendar',
 						label: 'Calendar',
-					},
-			  ]
-			: [] ),
-		...( isOwn
-			? [
-					{
-						id: 'add-past',
-						label: 'Add Past Shows',
 					},
 			  ]
 			: [] ),
@@ -351,8 +382,14 @@ function ConcertStatsApp( {
 				);
 
 			case 'past':
+				// #159: the Past tab hosts both the read-only tracked
+				// past-shows list and (for the owner) the inline
+				// search-and-mark affordance that used to live in the
+				// removed standalone "Add Past Shows" tab. PastTab
+				// composes the two and refetches the list when a show
+				// is marked so additions appear without a reload.
 				return (
-					<ShowList userId={ userId } period="past" year={ year } />
+					<PastTab userId={ userId } year={ year } isOwn={ isOwn } />
 				);
 
 			case 'calendar':
@@ -396,9 +433,6 @@ function ConcertStatsApp( {
 					return mapEmptyMessage;
 				}
 				return null;
-
-			case 'add-past':
-				return isOwn ? <AddPastShows /> : null;
 
 			case 'stats':
 				if ( statsLoading ) {


### PR DESCRIPTION
Closes #159.

On the My Shows page (`/my-shows/`, events.extrachill.com) the standalone owner-only **"Add Past Shows"** tab is folded into the existing **"Past"** tab, so adding past shows and reviewing tracked past shows live in one place.

## What moved

- New `PastTab` component (`blocks/concert-stats/src/components/PastTab.js`) composes:
  - **(owner only)** the `AddPastShows` search-and-mark affordance, rendered inline **above**
  - the read-only `ShowList period="past"` of tracked past shows.
- `view.js`:
  - Removed `add-past` from `VALID_TAB_IDS` and from the tab strip (the old owner-only `add-past` tab entry is gone).
  - The `past` render case now returns `<PastTab>` instead of a bare `<ShowList>`.
  - Dropped the `add-past` render case and the `AddPastShows` import (now imported by `PastTab`).
- `ShowList` empty-state copy for the past period updated ("Use the search above…" instead of "Use Add Past Shows…").

## Back-compat for `?tab=add-past`

- Added a `TAB_ALIASES = { 'add-past': 'past' }` map and a `resolveTabId()` helper.
- `resolveTabId()` applies the alias **before** whitelist validation, so any shared/bookmarked `?tab=add-past` link resolves to the **Past** tab instead of silently falling back to the default `upcoming` tab.
- `readInitialTab()` and `hasExplicitTabParam()` both route through `resolveTabId()`, so a legacy deep link is honored as an explicit tab choice (it won't get overridden by the empty-state auto-switch).
- Empty-state auto-switch (#126): owners with `stats.total_shows === 0` now land on `past` (which hosts the search affordance) instead of the removed `add-past` tab.

## Owner-only gating confirmed

- `PastTab` only renders `<AddPastShows>` when `isOwn` is true. Non-owners viewing someone's Past tab see **only** the read-only `ShowList` — no search input, no "+ Mark Attended" affordance.
- This preserves the prior gating exactly (the old `add-past` tab and its empty-state landing were already `isOwn`-gated).

## How newly-added shows appear in the list

- `AddPastShows` gained an optional `onMarked` callback. Its existing optimistic flip (`useEventSearch.setMarked` + the `EventSearchResult` "+ Mark Attended" toggle) is preserved so the search row immediately shows "✓ Tracked".
- On a successful mark, `AddPastShows` also calls `onMarked`. `PastTab` handles that by bumping a `refreshKey` passed as the `ShowList` `key`, which remounts `ShowList` and triggers a fresh fetch — so the just-marked show appears in the tracked-past list below **without a full page reload**.

## Build / verification

- `npm install && npm run build` — webpack compiles successfully. (`build/` is gitignored in this repo, so no built assets are committed.)
- `wp-scripts lint-js` on the changed files introduces **zero new errors** — the only remaining lint errors (`jsdoc/require-param` on `ConcertStatsApp`/`ConcertStatsAppWithRef`, `jsdoc/require-returns-description`) are pre-existing on `main` and untouched by this change.
- Did **not** run prettier `--fix` across the repo (it reformatted unrelated files); those collateral reformats were reverted so this PR contains only the #159 change.

## Acceptance checklist
- [x] "Add Past Shows" tab no longer appears in the tab strip.
- [x] "Past" tab shows the tracked past-shows list AND (owner) an inline search-and-mark affordance.
- [x] Newly marked shows appear in the Past list without a full reload.
- [x] Non-owners viewing a Past tab see only the read-only list.
- [x] `?tab=add-past` links resolve to the Past tab (no 404/break).
- [x] Empty-state auto-switch (#126) lands on Past, not a removed tab.