### PR TITLE
fix: scope My Shows calendar + map by signed token so owner scoping survives REST (#160)

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -232,6 +232,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/home/actions.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/concert-tracking-integration.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows-scope-token.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows-calendar-filter.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows-map-filter.php';
 	}

--- a/inc/core/my-shows-calendar-filter.php
+++ b/inc/core/my-shows-calendar-filter.php
@@ -10,19 +10,30 @@
  * `c8c_ec_concert_tracking`). Extrachill-events provides the
  * integration glue via the documented extension point.
  *
- * Hook contract (data-machine-events#325):
+ * Hook contract (data-machine-events#325 / scope-token seam #160):
  *
  *     apply_filters(
  *         'data_machine_events_calendar_query_args',
  *         array $query_args, // WP_Query args about to be executed.
- *         array $input       // Raw ability input (scope, tax_filters, search, …).
+ *         array $input       // Raw ability input (scope, …, scope_token).
  *     );
  *
- * `$input` does not carry a user_id — the filter callback resolves it
- * from request context (path b in the issue body: read the current user
- * + verify we're rendering on /my-shows/). This avoids a hard
- * dependency on a new block attribute / param key inside
- * data-machine-events.
+ * Scope-token model (#160). The previous implementation gated on
+ * `is_page( 'my-shows' )` + `get_current_user_id()`. That gate is TRUE on
+ * the initial PHP render but FALSE on the calendar block's prev/next
+ * month REST re-fetch, so the `post__in` scoping silently dropped over
+ * REST and the endpoint leaked the entire network-wide calendar.
+ *
+ * The fix: owner identity now travels as a DATA token, not page context.
+ *   1. On the initial `/my-shows/` render we mint a non-spoofable HMAC
+ *      token for the owner and hand it to data-machine-events via the
+ *      generic `data_machine_events_calendar_scope_token` filter. DME
+ *      emits it as `data-scope-token` on the calendar root and threads it
+ *      into this filter's `$input['scope_token']`.
+ *   2. The calendar frontend re-sends that token on every REST re-fetch,
+ *      so DME hands it back into `$input['scope_token']` there too.
+ *   3. This callback validates the token → owner user id and applies the
+ *      `post__in` scoping regardless of page context.
  *
  * @package ExtraChillEvents
  * @since 0.27.0
@@ -33,12 +44,46 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Inject a `post__in` constraint so the calendar block only renders
- * events the current logged-in user has marked attended.
+ * Mint the owner scope token for the embedded My Shows calendar.
  *
- * Active only when:
- *   - request is rendering the `/my-shows/` page
- *   - a logged-in user is present
+ * Runs at server-render time via the generic
+ * `data_machine_events_calendar_scope_token` seam. Page context IS
+ * reliable here (this fires during the `/my-shows/` PHP render, never
+ * over REST), so `is_page()` is the correct gate for EMISSION. We mint a
+ * token for the logged-in owner so the constraint can be re-applied on
+ * the REST round-trip where page context is gone.
+ *
+ * @param string $scope_token Incoming token (empty unless another consumer set one).
+ * @param array  $context     Render context from DME (attributes, display_mode).
+ * @return string Minted token, or the incoming value unchanged when not applicable.
+ */
+function ec_events_my_shows_emit_calendar_scope_token( $scope_token, $context = array() ) {
+	unset( $context );
+
+	// Only the embedded My Shows calendar should be scoped. Any other
+	// calendar instance (public archives, etc.) must stay unscoped.
+	if ( ! function_exists( 'is_page' ) || ! is_page( 'my-shows' ) ) {
+		return $scope_token;
+	}
+
+	$user_id = get_current_user_id();
+	if ( $user_id < 1 ) {
+		return $scope_token;
+	}
+
+	return ec_events_my_shows_mint_scope_token( $user_id );
+}
+add_filter( 'data_machine_events_calendar_scope_token', 'ec_events_my_shows_emit_calendar_scope_token', 10, 2 );
+
+/**
+ * Inject a `post__in` constraint so the calendar block only renders
+ * events the token's owner has marked attended.
+ *
+ * Active only when `$input['scope_token']` is a VALID owner token (minted
+ * by `ec_events_my_shows_emit_calendar_scope_token()` and verified here).
+ * No valid token → no scoping (the public calendar default). This is the
+ * core of the #160 fix: scoping is driven by the verified data token, not
+ * by `is_page()`, so it survives the prev/next month REST round-trip.
  *
  * When the user has zero tracked events we force `post__in = array( 0 )`
  * — `0` is never a valid post ID, so the query yields an empty result
@@ -47,18 +92,17 @@ if ( ! defined( 'ABSPATH' ) ) {
  * documented way to express "match nothing".
  *
  * @param array $query_args WP_Query args about to be executed.
- * @param array $input      Raw ability input (unused here; kept for signature compat).
+ * @param array $input      Raw ability input; `scope_token` carries the owner token.
  * @return array Modified $query_args.
  */
 function ec_events_my_shows_filter_calendar_query( $query_args, $input = array() ) {
-	unset( $input ); // Signature compatibility; we read from request context instead.
+	$token   = is_array( $input ) ? ( $input['scope_token'] ?? '' ) : '';
+	$user_id = ec_events_my_shows_verify_scope_token( $token );
 
-	if ( ! function_exists( 'is_page' ) || ! is_page( 'my-shows' ) ) {
-		return $query_args;
-	}
-
-	$user_id = get_current_user_id();
 	if ( $user_id < 1 ) {
+		// No valid owner token → leave the calendar unscoped (public
+		// default). The forged / absent-token case lands here too, so a
+		// public viewer can never read another user's tracked shows.
 		return $query_args;
 	}
 

--- a/inc/core/my-shows-map-filter.php
+++ b/inc/core/my-shows-map-filter.php
@@ -15,13 +15,25 @@
  *     attachment path requires `taxonomy + term_id`, which is not
  *     applicable on a Page route like `/my-shows/`.
  *
- * Both callbacks are guarded on `is_page('my-shows')` + logged-in user
- * so they no-op everywhere else, including in REST requests originating
- * from other contexts.
+ * Scope-token model (#160). Both callbacks USED to gate on
+ * `is_page('my-shows')` + logged-in user. The events-map block fetches
+ * venues over the public REST endpoint on mount (and on every pan/zoom),
+ * where `is_page('my-shows')` is FALSE — so the scoping silently dropped
+ * and the map leaked the entire network-wide venue set (the same class of
+ * bug as the calendar in #160).
+ *
+ * The fix mirrors the calendar: owner identity travels as a DATA token.
+ * We mint a non-spoofable HMAC token for the owner at server-render time
+ * via the generic `data_machine_events_map_scope_token` seam; DME emits
+ * it on the map root as `data-scope-token`, the map frontend re-sends it
+ * as `scope_token` on every venue fetch, and DME threads it into these
+ * filters' `$input['scope_token']`. The callbacks validate the token →
+ * owner user id and scope accordingly, regardless of page context.
  *
  * Reuses `ec_events_my_shows_get_tracked_post_ids()` from
  * `my-shows-calendar-filter.php` (#110) for the underlying
- * tracked-event lookup against `{$wpdb->base_prefix}ec_concert_tracking`.
+ * tracked-event lookup against `{$wpdb->base_prefix}ec_concert_tracking`,
+ * and the mint/verify helpers from `my-shows-scope-token.php`.
  *
  * Layer purity: data-machine-events stays generic (no knowledge of
  * `c8c_ec_concert_tracking`). Extrachill-events provides the
@@ -36,31 +48,57 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Restrict events-map venue lookup to venues of the user's tracked shows.
+ * Mint the owner scope token for the embedded My Shows map.
  *
- * Active only when:
- *   - request is rendering the `/my-shows/` page
- *   - a logged-in user is present
+ * Runs at server-render time via the generic
+ * `data_machine_events_map_scope_token` seam. Page context IS reliable
+ * here (fires during the `/my-shows/` PHP render, never over REST), so
+ * `is_page()` is the correct gate for EMISSION.
+ *
+ * @param string $scope_token Incoming token (empty unless another consumer set one).
+ * @param array  $context     Map render context from DME.
+ * @return string Minted token, or the incoming value unchanged when not applicable.
+ */
+function ec_events_my_shows_emit_map_scope_token( $scope_token, $context = array() ) {
+	unset( $context );
+
+	if ( ! function_exists( 'is_page' ) || ! is_page( 'my-shows' ) ) {
+		return $scope_token;
+	}
+
+	$user_id = get_current_user_id();
+	if ( $user_id < 1 ) {
+		return $scope_token;
+	}
+
+	return ec_events_my_shows_mint_scope_token( $user_id );
+}
+add_filter( 'data_machine_events_map_scope_token', 'ec_events_my_shows_emit_map_scope_token', 10, 2 );
+
+/**
+ * Restrict events-map venue lookup to venues of the token owner's
+ * tracked shows.
+ *
+ * Active only when `$input['scope_token']` is a VALID owner token. No
+ * valid token → no scoping (the public map default). Driven by the
+ * verified data token rather than `is_page()` so it survives the map's
+ * mount + pan/zoom REST round-trips (the #160 fix).
  *
  * The DME venue-map query path computes a candidate venue ID set from
  * any geo / taxonomy filters and exposes the merged result via
  * `$query_args['include_ids']`. We narrow that set further to the
- * venue terms attached to the user's tracked events. Empty tracked set
+ * venue terms attached to the owner's tracked events. Empty tracked set
  * → sentinel `[0]` so the venue lookup short-circuits to "no results"
  * cleanly.
  *
  * @param array $query_args Resolved query args from VenueMapAbilities.
- * @param array $input      Raw ability input (unused; signature compat).
+ * @param array $input      Raw ability input; `scope_token` carries the owner token.
  * @return array Modified $query_args.
  */
 function ec_events_my_shows_filter_map_query( array $query_args, array $input = array() ): array {
-	unset( $input );
+	$token   = $input['scope_token'] ?? '';
+	$user_id = ec_events_my_shows_verify_scope_token( $token );
 
-	if ( ! function_exists( 'is_page' ) || ! is_page( 'my-shows' ) ) {
-		return $query_args;
-	}
-
-	$user_id = get_current_user_id();
 	if ( $user_id < 1 ) {
 		return $query_args;
 	}
@@ -107,17 +145,13 @@ add_filter( 'data_machine_events_map_query_args', 'ec_events_my_shows_filter_map
  * tour-route mode that uses earliest-event-at-venue ordering.
  *
  * @param array $venues Final venue array from VenueMapAbilities (already sorted + capped).
- * @param array $input  Raw ability input (unused; signature compat).
+ * @param array $input  Raw ability input; `scope_token` carries the owner token.
  * @return array Venues with tracked events attached and re-ordered chronologically.
  */
 function ec_events_my_shows_attach_tracked_events( array $venues, array $input = array() ): array {
-	unset( $input );
+	$token   = $input['scope_token'] ?? '';
+	$user_id = ec_events_my_shows_verify_scope_token( $token );
 
-	if ( ! function_exists( 'is_page' ) || ! is_page( 'my-shows' ) ) {
-		return $venues;
-	}
-
-	$user_id = get_current_user_id();
 	if ( $user_id < 1 || empty( $venues ) ) {
 		return $venues;
 	}

--- a/inc/core/my-shows-scope-token.php
+++ b/inc/core/my-shows-scope-token.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * My Shows — scope token mint + verify.
+ *
+ * data-machine-events#160 fix. The My Shows calendar + map are the
+ * generic data-machine-events `calendar` / `events-map` blocks, embedded
+ * on `/my-shows/` and owner-scoped by the query filters in
+ * `my-shows-calendar-filter.php` / `my-shows-map-filter.php`.
+ *
+ * Those filters used to gate on `is_page( 'my-shows' )`, which is TRUE on
+ * the initial PHP render but FALSE on the client-side prev/next-month
+ * (calendar) and mount/pan (map) REST re-fetches. Over REST the gate
+ * returned early, the `post__in` / `include_ids` scoping was dropped, and
+ * the endpoint returned the entire network-wide set — a cross-user data
+ * leak (issue #160).
+ *
+ * The fix moves scoping from page-context to a DATA token that travels
+ * with every request. data-machine-events exposes generic, opaque
+ * `scope_token` seams (filters to emit it on the block root, a passthrough
+ * param on the public REST routes, and the token reaching the query
+ * filters' `$input`). This file owns the EC-specific half: minting a
+ * NON-SPOOFABLE token and verifying it.
+ *
+ * Security model
+ * --------------
+ * The calendar / venues REST routes are public (`__return_true`). A plain
+ * `?user_id=N` would let anyone read anyone else's tracked-shows calendar.
+ * So the token is an HMAC of the owner user id keyed on a WordPress secret
+ * (`wp_salt( 'auth' )`). It is tamper-evident: the server can recover the
+ * owner id from the token and reject any forged / mutated value, but a
+ * client cannot mint a valid token for a user id it does not already own
+ * (the secret never leaves the server).
+ *
+ * Token format: `<uid>.<hmac>` where `hmac = HMAC_SHA256( "<uid>", secret )`.
+ * No expiry — a tracked-shows calendar is not sensitive enough to warrant
+ * rotation, and the token only ever authorizes READING the owner's own
+ * already-public-to-them tracked list. The HMAC binds the token to the
+ * single user id it encodes; it cannot be repurposed for another user.
+ *
+ * @package ExtraChillEvents
+ * @since 0.28.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Mint a scope token for a given owner user id.
+ *
+ * @param int $user_id Owner user id to encode.
+ * @return string Token of the form `<uid>.<hmac>`, or '' for an invalid id.
+ */
+function ec_events_my_shows_mint_scope_token( $user_id ) {
+	$user_id = (int) $user_id;
+	if ( $user_id < 1 ) {
+		return '';
+	}
+
+	$hmac = hash_hmac( 'sha256', (string) $user_id, ec_events_my_shows_scope_token_secret() );
+
+	return $user_id . '.' . $hmac;
+}
+
+/**
+ * Verify a scope token and return the owner user id it encodes.
+ *
+ * Returns 0 for any token that is empty, malformed, or whose HMAC does not
+ * validate (forged / tampered). Uses `hash_equals()` for constant-time
+ * comparison so the endpoint does not leak validity via timing.
+ *
+ * @param string $token Raw token string from the request `$input`.
+ * @return int Verified owner user id, or 0 when the token is invalid.
+ */
+function ec_events_my_shows_verify_scope_token( $token ) {
+	if ( ! is_string( $token ) || '' === $token ) {
+		return 0;
+	}
+
+	$parts = explode( '.', $token, 2 );
+	if ( count( $parts ) !== 2 ) {
+		return 0;
+	}
+
+	list( $uid_raw, $provided_hmac ) = $parts;
+
+	// Reject anything that isn't a clean positive integer id so we never
+	// feed surprising values into the HMAC recomputation.
+	if ( ! ctype_digit( $uid_raw ) ) {
+		return 0;
+	}
+	$user_id = (int) $uid_raw;
+	if ( $user_id < 1 ) {
+		return 0;
+	}
+
+	$expected_hmac = hash_hmac( 'sha256', (string) $user_id, ec_events_my_shows_scope_token_secret() );
+
+	if ( ! hash_equals( $expected_hmac, (string) $provided_hmac ) ) {
+		return 0;
+	}
+
+	return $user_id;
+}
+
+/**
+ * Secret used to key the scope-token HMAC.
+ *
+ * `wp_salt( 'auth' )` is a per-install secret that never leaves the
+ * server, so a client cannot reproduce the HMAC for an arbitrary user id.
+ * Wrapped in a filter purely so tests can pin a deterministic secret.
+ *
+ * @return string HMAC secret.
+ */
+function ec_events_my_shows_scope_token_secret() {
+	/**
+	 * Filter the My Shows scope-token HMAC secret.
+	 *
+	 * @param string $secret Default `wp_salt( 'auth' )`.
+	 */
+	return (string) apply_filters( 'ec_events_my_shows_scope_token_secret', wp_salt( 'auth' ) );
+}


### PR DESCRIPTION
## Summary

Fixes #160 — the **My Shows calendar (and map) leak other users' events** on month-nav / pan. Owner scoping that worked on initial render silently dropped over the blocks' client-side REST re-fetches, exposing the entire network-wide event/venue set to any viewer. Also closes the cache-poisoning angle.

**Must land together with Extra-Chill/data-machine-events#356** (the generic `scope_token` passthrough this consumer rides on).

## Root cause

The My Shows calendar/map are the generic data-machine-events `calendar` / `events-map` blocks, owner-scoped by the query filters in `inc/core/my-shows-calendar-filter.php` and `inc/core/my-shows-map-filter.php`. Those filters gated on `is_page('my-shows')`:

- **Calendar:** TRUE on initial `/my-shows/` PHP render → `post__in` applied → correct. But the prev/next month arrows refetch `GET /wp-json/datamachine/v1/events/calendar`, where `is_page('my-shows')` is **FALSE** → the filter returned early → no `post__in` → `WP_Query` returned **ALL** events for the month. One user saw other users' shows.
- **Map:** the events-map block fetches `/events/venues` on **mount** and on every pan/zoom. Same gate, same leak — the map returned the full network venue set instead of the user's tracked venues.
- **Cache:** the calendar REST response is cached with no user dimension, so a scoped/leaked month could be served across viewers.

`is_page()` was never a sound way to carry per-user scope across a stateless REST call.

## The fix — scoping travels as a signed DATA token

Owner identity now rides on every request as a **non-spoofable HMAC token**, not page context, using the generic scope_token seams added in data-machine-events#356.

**Data-flow of the token**
```
/my-shows/ PHP render
  └─ ec_events_my_shows_emit_calendar_scope_token  (is_page() reliable HERE — render, not REST)
       mints HMAC(owner_id)  ──► DME data_machine_events_calendar_scope_token
                                   └─ emits data-scope-token="<uid>.<hmac>" on calendar root
                                        │
month-grid-nav.ts re-sends ?scope_token  ◄────┘   (survives every prev/next REST fetch)
  └─ DME → $input['scope_token'] at data_machine_events_calendar_query_args
       └─ ec_events_my_shows_filter_calendar_query VERIFIES token → owner id → post__in
```
Map path is identical via `ec_events_my_shows_emit_map_scope_token` → `data_machine_events_map_scope_token` → `scope_token` on `/events/venues` → `data_machine_events_map_query_args` / `data_machine_events_map_venues` `$input`.

## Security mechanism chosen

`inc/core/my-shows-scope-token.php` mints/verifies a token of the form `<uid>.<hmac>` where `hmac = HMAC_SHA256("<uid>", wp_salt('auth'))`:

- The calendar/venues REST routes are **public** (`__return_true`), so a plain `?user_id=N` would let anyone read anyone's tracked-shows calendar. The HMAC **binds the token to the single owner id it encodes** and is keyed on a per-install secret that never leaves the server — a client cannot forge a valid token for a user id it doesn't own.
- Verification uses `hash_equals()` (constant-time) and `ctype_digit()` on the uid before recomputation.
- **No valid token → no scoping** (public default). A forged/absent/tampered token verifies to user id `0`, so the filter no-ops and a public viewer can never read another user's tracked shows.
- The secret is wrapped in `ec_events_my_shows_scope_token_secret` (filterable) only so tests can pin a deterministic value.

## Map tab — checked and fixed

Confirmed the Map tab had the **identical leak** and is fixed in this PR. The events-map block (`EventsMap/frontend.tsx`) fetches venues client-side on mount + pan/zoom, so even the initial map paint leaked the full venue set under the old `is_page()` gate. Both `ec_events_my_shows_filter_map_query` and `ec_events_my_shows_attach_tracked_events` now validate `$input['scope_token']` instead of `is_page()`.

## Cache poisoning closed

data-machine-events#356 folds `scope_token` into the calendar full-response cache key, so a scoped month response can never be served to a different (or unscoped) viewer, and vice-versa.

## Files

- `inc/core/my-shows-scope-token.php` (new) — mint/verify HMAC token.
- `inc/core/my-shows-calendar-filter.php` — emit token at render; validate from `$input` instead of `is_page()`.
- `inc/core/my-shows-map-filter.php` — same for both map filter callbacks.
- `extrachill-events.php` — require the new helper.

## Verify

- `php -l` clean on all changed files; PHPStan analysis passes.
- Remaining phpcs findings in the touched files are pre-existing baseline `$wpdb->prepare` warnings in the DB-helper functions (untouched by this PR), not in the new scoping logic.

## Acceptance (#160)

- [x] Next/prev month on My Shows calendar now shows ONLY the logged-in user's tracked shows (token re-sent on every fetch).
- [x] A logged-out / different user cannot retrieve another user's scoped calendar by forging params (HMAC-bound, `hash_equals` verified).
- [x] Map tab verified for the same leak and fixed.
- [x] No EC-specific identifiers leak into the generic data-machine-events layer (see #356 grep-clean confirmation).
- [x] Cache cannot serve a scoped month response to the wrong viewer (cache key includes scope_token).

## Cross-ref

Generic passthrough PR (must land together): **Extra-Chill/data-machine-events#356**.