### PR TITLE
build: pin ajv ^8 to fix wp-scripts webpack build on Node 25

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 	},
 	"devDependencies": {
 		"@wordpress/scripts": "^27.1.0",
+		"ajv": "^8.20.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1"
 	},


### PR DESCRIPTION
## Summary

Pins `ajv` to `^8.20.0` as a devDependency to fix a silent `@wordpress/scripts` webpack build failure on Node 25.

## The bug (reproduced on this worktree)

`@wordpress/scripts` pulls in `ajv-keywords@5.x`, which requires **ajv v8** (`ajv/dist/compile/codegen`). On the live VPS (Node 25), npm hoists **ajv v6.15.0** to top-level `node_modules/ajv`, so `ajv-keywords` cannot resolve the module and the webpack build fails:

```
[webpack-cli] Error: Cannot find module 'ajv/dist/compile/codegen'
```

The universal build script downgrades this to a **non-fatal warning** and ships a **PHP-only artifact with no JS/CSS**, silently stripping the plugin's blocks (`event-submission`, `concert-stats`).

Reproduction in this worktree before the fix:
- `npm install --legacy-peer-deps` → top-level `node_modules/ajv` = **6.15.0**
- `npm run build` → `[webpack-cli] Error: Cannot find module 'ajv/dist/compile/codegen'`

## The fix

Add `"ajv": "^8.20.0"` to `devDependencies`, forcing ajv v8 at the top level.

After the fix:
- top-level `node_modules/ajv` = **8.20.0**
- `node -e "require.resolve('ajv/dist/compile/codegen')"` resolves
- `npm run build` → `webpack 5.107.2 compiled successfully` (both blocks)
- JS/CSS artifacts emitted for `build/event-submission/` and `build/concert-stats/`

## Files changed

- `package.json` — single line: add `"ajv": "^8.20.0"` to `devDependencies`

(`package-lock.json` is not tracked in this repo, so it is not committed.)

Part of Extra-Chill/extrachill-community#126