### PR TITLE
fix: stop per-term calendar stats from warming Redis on empty term archives (#168)

### DIFF
--- a/inc/core/calendar-stats.php
+++ b/inc/core/calendar-stats.php
@@ -127,10 +127,21 @@ function extrachill_events_render_calendar_stats(): void {
  * zeros for the missing axes. The render function will then drop the
  * affected clause from the sentence.
  *
- * Cached for 6h in a per-term transient
+ * Cached for 1h in a per-term transient
  * (`extrachill_calendar_stats_{taxonomy}_{term_id}`). Lazy on first
  * request — NOT pre-warmed (the cross-product of artist+location+venue
  * terms is too large for blanket warming).
+ *
+ * Cache-bloat guard (extrachill-events#168): the events site has ~51k
+ * artist terms walkable via core sitemaps. Computing + caching stats on
+ * every long-tail archive pageview warmed up to one
+ * `extrachill_calendar_stats_artist_N` transient per term, a major
+ * contributor to the Redis keyspace bloat behind the 2026-06-02 login
+ * outage. The render-side gate in
+ * `extrachill_events_render_term_calendar_stats()` now skips terms with
+ * no published events, and this helper's TTL was cut from 6h to 1h so
+ * any keys that do get created for sparse terms expire 6x faster instead
+ * of lingering in the keyspace.
  *
  * @param string $taxonomy 'artist'|'location'|'venue'.
  * @param int    $term_id  Term ID.
@@ -238,7 +249,7 @@ function extrachill_events_get_term_calendar_stats( string $taxonomy, int $term_
 		'locations' => $locations,
 	);
 
-	set_transient( $cache_key, $stats, 6 * HOUR_IN_SECONDS );
+	set_transient( $cache_key, $stats, HOUR_IN_SECONDS );
 
 	return $stats;
 }
@@ -256,11 +267,31 @@ function extrachill_events_get_term_calendar_stats( string $taxonomy, int $term_
  * provides useful information rather than reading "N events at 0
  * venues."
  *
+ * Cache-bloat guard (extrachill-events#168): bail BEFORE computing or
+ * caching anything when the queried term has no published events. Terms
+ * with `count === 0` have no upcoming events either, so the stats line
+ * would be hidden anyway after a full count query — but skipping here
+ * avoids warming a per-term `extrachill_calendar_stats_*` transient for
+ * the long tail of empty terms (~51k artist terms are walkable via core
+ * sitemaps). This is the same sparseness threshold Extra Chill SEO uses
+ * to noindex term archives with fewer than 2 posts.
+ *
  * @param string $taxonomy 'artist'|'location'|'venue'.
  * @param int    $term_id  Term ID.
  */
 function extrachill_events_render_term_calendar_stats( string $taxonomy, int $term_id ): void {
 	if ( ! in_array( $taxonomy, array( 'artist', 'location', 'venue' ), true ) ) {
+		return;
+	}
+
+	// Skip empty terms before touching the cache. A term with zero
+	// published events cannot have upcoming events, so the stats line
+	// renders nothing — but computing that would still warm (and persist)
+	// a transient key. With tens of thousands of long-tail terms behind
+	// core sitemaps, that cache warming is the dominant keyspace-bloat
+	// source this guard exists to stop.
+	$term = get_term( $term_id, $taxonomy );
+	if ( ! $term instanceof WP_Term || (int) $term->count < 1 ) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

Investigation + fix for the full-catalog/unbounded-query cache-bloat hunt in #168. The events site (blog 7) has ~80k published events and ~56k terms. The Redis keyspace bloat report (2.34M keys, behind the 2026-06-02 login outage — #166, #167) showed a `7:transient:extrachill_calendar_stats_artist_N` key family. This PR fixes the source of that key family.

## Root cause

`extrachill_events_render_term_calendar_stats()` (inc/core/calendar-stats.php) is called on **every** artist / venue / location term archive pageview (inc/templates/archive.php:33, 78, 94). On a cache miss it:

1. runs `data_machine_events_query_events(scope=upcoming, fields=count)` (a lightweight COUNT — fine),
2. for artist/location, runs up to two `UpcomingCountAbilities::executeGetUpcomingCounts()` co-occurrence SQL queries, then
3. **writes a per-term transient** `extrachill_calendar_stats_{tax}_{term_id}` with a **6h TTL**.

With ~51k artist terms exposed across core's paginated `wp-sitemap-taxonomies-artist-N.xml` sub-sitemaps, crawlers walk every archive → each pageview persists one stats transient. On a Redis-backed object cache that is up to ~51k+ long-lived keys (artist) plus venue/location — a primary contributor to the keyspace bloat.

## Changes (inc/core/calendar-stats.php)

| Path | Before | After |
|------|--------|-------|
| `extrachill_events_render_term_calendar_stats()` (render gate, ~L283) | Always computed + cached stats, even for empty terms | **Bails before touching the cache** when the queried term has `count < 1`. Empty terms have no upcoming events, so the stats line renders nothing anyway — this skips cache warming for the long tail of sparse terms. Same `< 1`/sparse threshold Extra Chill SEO uses to noindex term archives. |
| `extrachill_events_get_term_calendar_stats()` TTL (L252) | `set_transient( ..., 6 * HOUR_IN_SECONDS )` | `set_transient( ..., HOUR_IN_SECONDS )` — keys that do get created for terms with events expire **6x faster**. |

The empty-term check uses `get_term( $term_id, $taxonomy )`, which on an archive request is a cache hit (the term is already the queried object), so it adds no DB query; it *avoids* the much heavier count + co-occurrence SQL + transient write for empty terms.

## Catalog of query paths reviewed (full findings posted on #168)

- **`EventQueryBuilder::build_query_args()` `posts_per_page => -1`** (data-machine-events) — **DEPRECATED & unused** in live render; the live calendar uses `EventDateQueryAbilities::executeQueryEvents` which is paginated (`per_page`) and `count` mode is bounded (`posts_per_page => 1`, fields=ids). Not a live hot path.
- **`PriorityEventAbilities::listPriorityEvents()` `posts_per_page => -1`** (extrachill-events) — bounded by `post__in => $priority_ids` (small admin-curated option); admin ability, not user-facing. Safe.
- **`get_terms()` in discovery-pages / near-me / location-meta / location-normalizer** (extrachill-events) — all scoped to the `location` taxonomy (88 terms) or bounded by `parent` / `number`. Not bloat sources.
- **No artist-taxonomy `get_terms()`/`WP_Query` scan exists in extrachill-events**; the 51k-artist sitemap is core's, not a plugin scan.

## Follow-ups left on the issue (not fixed here — read-only dme scope or ambiguous)

- **dme: `UpcomingCountAbilities::executeGetUpcomingCounts()` returns the full term list and calls `get_term_link()` per row**, but `extrachill_events_get_term_calendar_stats()` only uses `count()` of it — for a popular artist this warms term-link caches for every co-occurring venue/location needlessly. Recommend a `fields=count` mode on that ability.
- **dme: the calendar full-response cache is keyed per `archive_term_id`** (`data-machine_cal_full_*`, 1h/24h TTL) — by design (#246 DOS mitigation) but is part of the same per-archive key cardinality. Worth a separate look at whether sparse/noindexed archives should skip the full-response cache too.

## Regression checks

- `php -l inc/core/calendar-stats.php` — clean.
- `homeboy lint --changed-since main` — PHPStan passes; the 2 `error_log()` PHPCS warnings (L207/L232) are a **pre-existing baseline** in the venue/location error handlers, not in this diff (`git diff | grep error_log` → none). The hard failure was a stale `data-machine` dependency checkout (2 commits behind origin/main) — a CI-parity guard unrelated to this change.
- **No event data touched.** My Shows concert tracking, calendar rendering, and taxonomy archives for terms *with* events render identically (the stats line only changes for empty terms, where it was already hidden).

Closes #168