### PR TITLE
Register event taxonomy relationship caches as non-persistent (fix ~642K-key Redis leak on blog 7)

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -212,6 +212,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/PlatformDetector.php';
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/data-machine-events/init.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/cache-groups.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/nav.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/priority-venue-ordering.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/priority-event-ordering.php';

--- a/inc/core/cache-groups.php
+++ b/inc/core/cache-groups.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Object-Cache Group Tuning
+ *
+ * Registers high-cardinality, low-cross-request-reuse object-cache groups as
+ * NON-PERSISTENT on the events site (blog 7) so they live in per-request
+ * memory instead of being written to the persistent Redis backend forever.
+ *
+ * Background (extrachill-events#167): blog 7 holds ~79K published events across
+ * many taxonomies. WordPress caches per-object term-relationship lists in the
+ * `{$taxonomy}_relationships` groups with NO TTL, so the Redis keyspace grew to
+ * ~2.34M persistent keys, pinned the object cache at its memory ceiling, and
+ * triggered LRU thrashing that caused a network-wide login outage on
+ * 2026-06-02. No event data is deleted — this only changes WHERE these cheap,
+ * easily-recomputed lookups are stored.
+ *
+ * Why `{$taxonomy}_relationships` is safe to make non-persistent:
+ *   - Each entry is just the list of term IDs attached to one object for one
+ *     taxonomy (see get_object_term_cache() / update_object_term_cache() in
+ *     wp-includes/taxonomy.php). Recomputing is a single, batched
+ *     (wp_cache_get_multiple) term-relationship query.
+ *   - Within a single request the WP_Object_Cache in-memory array still serves
+ *     repeat reads, so the_loop on an archive page incurs at most one query per
+ *     taxonomy, not one per post.
+ *   - These groups are the dominant share of the blog-7 keyspace and the lowest
+ *     risk to move off the persistent backend.
+ *
+ * Scoped to the events site only so the other network sites keep WordPress's
+ * default persistent caching behavior.
+ *
+ * @package ExtraChillEvents
+ * @since 0.30.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register non-persistent object-cache groups for the events site.
+ *
+ * Runs on `init` at a late priority so every taxonomy (WordPress core defaults,
+ * data-machine-events, and the extrachill platform taxonomies) is registered
+ * before we derive the group list. Term-relationship caches are only read
+ * during query/loop execution (after `init`), so this timing is early enough to
+ * intercept every persistent write for the request.
+ *
+ * @return void
+ */
+function extrachill_events_register_non_persistent_cache_groups() {
+	if ( ! ec_is_events_site() ) {
+		return;
+	}
+
+	if ( ! function_exists( 'wp_cache_add_non_persistent_groups' ) ) {
+		return;
+	}
+
+	$groups = array();
+
+	// Every registered taxonomy gets a `{$taxonomy}_relationships` object-cache
+	// group. Derive the list dynamically so newly added taxonomies are covered
+	// automatically and removed ones simply drop out.
+	foreach ( get_taxonomies( array(), 'names' ) as $taxonomy ) {
+		$groups[] = $taxonomy . '_relationships';
+	}
+
+	/**
+	 * Filter the object-cache groups registered as non-persistent on the
+	 * events site. Operators can add or remove groups without forking the
+	 * plugin.
+	 *
+	 * @param array $groups Cache group names to mark non-persistent.
+	 */
+	$groups = apply_filters( 'extrachill_events_non_persistent_cache_groups', $groups );
+
+	if ( empty( $groups ) ) {
+		return;
+	}
+
+	wp_cache_add_non_persistent_groups( array_values( array_unique( $groups ) ) );
+}
+add_action( 'init', 'extrachill_events_register_non_persistent_cache_groups', 99 );


### PR DESCRIPTION
## Summary

Fixes the root cause of the 2026-06-02 network-wide login outage: the events site (blog 7) was generating **~2.34M persistent (no-TTL) Redis keys**, pinning the object cache at its memory ceiling and causing LRU thrashing + dropped connections.

**No event data is deleted.** All 79K+ events, terms, and relationships are retained (My Shows concert-tracking depends on past events). The fix is purely at the caching layer.

Closes #167.

## Root cause

WordPress caches per-object term-relationship lists in the `{$taxonomy}_relationships` object-cache groups **with no TTL**. With ~79K events across ~14 taxonomies on blog 7, these groups alone account for **~642K persistent Redis keys** (~26% of the entire 2.34M keyspace) that never age out.

## The fix

A new `inc/core/cache-groups.php` registers every registered taxonomy's `{$taxonomy}_relationships` group as **non-persistent** via `wp_cache_add_non_persistent_groups()`, so these lookups live in per-request memory instead of being written to Redis forever.

- **Group list is derived dynamically** from `get_taxonomies()` — covers current taxonomies (`category`, `post_tag`, `post_format`, `location`, `festival`, `artist`, `venue`, `promoter`, plus the rest) and is future-proof for added/removed taxonomies. Also stops orphaned persistent keys from deregistered taxonomies (e.g. stale `topic-tag_relationships` / `author_relationships` seen in the keyspace).
- **Exposed via the `extrachill_events_non_persistent_cache_groups` filter** so operators can tune without forking.
- **Scoped to the events site only** (`ec_is_events_site()` guard) — the other 8 network sites keep WordPress's default persistent caching.
- **Registered on `init` priority 99** — after all taxonomies register (default priority 10) and before any `WP_Query`/loop reads the relationship cache (which happens during template rendering, well after `init`).

### Which groups, and why each is safe to make non-persistent

Only the `{$taxonomy}_relationships` groups. Each entry is just the list of term IDs attached to one object for one taxonomy (`get_object_term_cache()` / `update_object_term_cache()` in `wp-includes/taxonomy.php`):

- Recomputing is a single, **batched** (`wp_cache_get_multiple`) term-relationship query.
- Within a single request, the in-memory `WP_Object_Cache` array still serves repeat reads, so an archive loop incurs at most one query per taxonomy, not one per post.
- These are the dominant share of the blog-7 keyspace and the lowest risk to move off the persistent backend.

`posts`, `post_meta`, `terms`, `term_meta` are **deliberately left persistent** (conservative — those have higher cross-request reuse value and recompute cost).

## Before / after (measured on production blog 7)

| Metric | Value |
|---|---|
| Total Redis keys (db0) before | **2,436,734** |
| Blog-7 `*_relationships` keys (exact SCAN count) | **642,294** |
| dbsize after flushing only the `_relationships` cache | **1,795,578** (−641,156, ~26%) |
| Same 300-event archive render, **baseline** (no fix) | re-persisted **2,421** relationship keys to Redis |
| Same 300-event archive render, **with fix** | **0** relationship keys persisted (in-memory only) |

At full scale the baseline render path re-grows back to ~642K+ persistent keys; with the fix those writes never reach Redis.

## Regression checks

- **Term resolution is byte-identical** with and without persistence (verified per-taxonomy on a real event: `location`, `festival`, `artist`, `venue`, `promoter` all returned identical term IDs).
- `php -l` clean on both changed files.
- **PHPStan: passed.** PHPCS: one pre-existing `Universal.Files.SeparateFunctionsFromOO.Mixed` warning on `extrachill-events.php` (the main file already mixes the `ExtraChillEvents` class with procedural functions on `origin/main` — unrelated to this change; only surfaces because the file is now "changed").
- **Tests: 96 passed / 28 failed — identical to clean `main`.** The 28 failures are a pre-existing SQLite test-harness issue in `QualifyRecheckHandlerTest` (`no such table: wptests_datamachine_flows`), unrelated to caching. `--changed-since main` reports zero impacted tests for this change.

## Notes

- Did **not** release or deploy — PR only.
- Conventional commit; did not touch CHANGELOG.md or version strings.