### PR TITLE
fix: stop synthesizing crawlable community search URLs in single-event bridge

### DIFF
--- a/inc/single-event/network-bridge.php
+++ b/inc/single-event/network-bridge.php
@@ -242,18 +242,15 @@ function ec_events_network_bridge_build_cards( $artist_terms, $festival_terms ) 
 		$cards['wire'] = $by_site['wire'];
 	}
 
-	// Slot 3 — a guaranteed community entry point. The artist/festival taxonomy
-	// site map does not include community, so the engine never returns a direct
-	// community match; synthesize a contextual link into the community keyed on
-	// the event's primary artist/festival term.
+	// Slot 3 — a community entry point, but ONLY when the cross-site engine
+	// resolves a real community destination. We deliberately do NOT synthesize a
+	// live community search URL (`/?s=<term>`) as a fallback: those URLs are
+	// crawlable, unbounded, and each one triggers an expensive full-text search.
+	// Emitting them across tens of thousands of event pages turned the community
+	// search endpoint into a crawl/DB-load sink (see extrachill-events#172). No
+	// community card is better than a fake search-result destination.
 	if ( isset( $by_site['community'] ) ) {
 		$cards['community'] = $by_site['community'];
-	} else {
-		$primary_term = ! empty( $artist_terms ) ? reset( $artist_terms ) : reset( $festival_terms );
-		$community    = $primary_term instanceof WP_Term ? ec_events_network_bridge_community_card( $primary_term ) : null;
-		if ( $community ) {
-			$cards['community'] = $community;
-		}
 	}
 
 	// UTM-tag every outbound link so cross-site clicks are measurable.
@@ -313,42 +310,6 @@ function ec_events_network_bridge_collect( &$by_site, $term, $taxonomy ) {
 			);
 		}
 	}
-}
-
-/**
- * Build a contextual community entry-point card for a term.
- *
- * The artist/festival taxonomy site map does not include the community, so the
- * cross-site engine never returns a direct community match. This links the
- * reader into the community's network-wide search scoped to the term name, so
- * there is always a path from a single event into the community discussion.
- *
- * @param WP_Term|null $term Primary term (artist or festival).
- * @return array|null Link array, or null if community is unavailable.
- */
-function ec_events_network_bridge_community_card( $term ) {
-	if ( ! $term || ! function_exists( 'ec_get_site_url' ) ) {
-		return null;
-	}
-
-	$community_url = ec_get_site_url( 'community' );
-	if ( empty( $community_url ) ) {
-		return null;
-	}
-
-	$search_url = add_query_arg(
-		's',
-		rawurlencode( $term->name ),
-		trailingslashit( $community_url )
-	);
-
-	return array(
-		'site_key'  => 'community',
-		'url'       => $search_url,
-		'label'     => __( 'in the Community', 'extrachill-events' ),
-		'term_name' => $term->name,
-		'count'     => 0,
-	);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #172. The single-event network bridge synthesized a **live community search URL** (`community.extrachill.com/?s=<artist>`) as the "in the Community" card on every crawlable event page (~78K events). Bots that ignore `robots.txt` crawled these at scale, each firing an expensive full-text search returning 700–880 rows.

- **~187K bot "search" hits** on community.extrachill.com in ~2 weeks (all `user_id=NULL`, 24/7 even distribution), up from a **17–199/day** baseline. Spiked to **83,456 on 2026-06-01**.
- Offenders ignore the existing `Disallow: /*?s=` robots rule: `meta-externalagent/1.1` (Meta) + spoofed-UA scrapers on Azure IP ranges deep-paginating `/page/N?s=...`.
- The synthesized URLs also **double-encoded ampersands** in artist names (`GOOD & YOU` → `%26amp%3B`).

## Change

- Remove the synthesized `/?s=` community-search fallback card and its helper `ec_events_network_bridge_community_card()`.
- A community card now renders **only** when the cross-site engine resolves a real community destination. In practice the engine never returns one for artist/festival terms (per the file's own comments), so this stops emitting the dead-end search URLs entirely.

> No community card is better than an unbounded, crawlable search-result URL that hammers the community search endpoint.

## Verification

- `php -l` clean on the modified file.
- No dangling references to the removed helper.
- Once merged + deployed, community search event volume should return to pre-2026-05-29 baseline (tens/day, not thousands).

## Follow-ups (separate)

- **extrachill-blog** has the identical `community_card()` pattern (`inc/single/network-bridge.php`) — same fix needed there before blog posts get crawled. Will file/track separately.
- **extrachill-seo#22**: robots-policy side (add `meta-externalagent` to blocklist; server-level blocking for non-compliant bots).