### PR TITLE
fix(deploy): add artifact_path to block version targets (#4614)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -17,11 +17,13 @@
     },
     {
       "file": "blocks/concert-stats/block.json",
-      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+      "pattern": "\"version\":\\s*\"([0-9.]+)\"",
+      "artifact_path": "build/concert-stats/block.json"
     },
     {
       "file": "blocks/event-submission/block.json",
-      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+      "pattern": "\"version\":\\s*\"([0-9.]+)\"",
+      "artifact_path": "build/event-submission/block.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Pre-emptively unblocks `homeboy deploy` for this plugin against the same failure reported in Extra-Chill/homeboy#4614. `extrachill-events` uses the identical `@wordpress/scripts` layout (bump source `blocks/*/block.json`, ship compiled `build/*/block.json`), so it would hit the same deploy-side artifact verification failure on its next release.

## Change

Adds `artifact_path` to each `blocks/*/block.json` version target so:
- the **version bump** keeps writing the source `blocks/<block>/block.json` (git-tracked)
- **deploy verification** resolves against the compiled `build/<block>/block.json` (what ships)

Targets updated: `concert-stats`, `event-submission` → their `build/<block>/block.json`. Confirmed via `package.json` `copy:block-files`, which copies `block.json` into `build/<block>/`.

## Dependency

Requires the homeboy release containing Extra-Chill/homeboy#4618 (adds the `artifact_path` field). On older homeboy this field is ignored by serde, so it's safe to merge ahead of the homeboy release.