### PR TITLE
fix: guard ability category registration against double-fire _doing_it_wrong notice

### DIFF
--- a/inc/abilities/register.php
+++ b/inc/abilities/register.php
@@ -20,6 +20,17 @@ add_action( 'wp_abilities_api_categories_init', 'extrachill_events_register_abil
  * Register the events-domain ability category.
  */
 function extrachill_events_register_abilities_category(): void {
+	if ( ! function_exists( 'wp_register_ability_category' ) ) {
+		return;
+	}
+
+	// The wp_abilities_api_categories_init action can fire more than once per
+	// request on multisite; guard against re-registering an already-registered
+	// category to avoid a _doing_it_wrong notice.
+	if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'extrachill-events' ) ) {
+		return;
+	}
+
 	wp_register_ability_category(
 		'extrachill-events',
 		array(


### PR DESCRIPTION
## The notice

```
PHP Notice: Function WP_Ability_Categories_Registry::register was called incorrectly.
Ability category "extrachill-events" is already registered.
in /var/www/extrachill.com/wp-includes/functions.php on line 6170
```

## Root cause

On this multisite, WordPress core's `wp_abilities_api_categories_init` action fires more than once per request. The plugin's `extrachill_events_register_abilities_category()` callback called `wp_register_ability_category( 'extrachill-events', ... )` unconditionally, so the second hook fire re-registered the already-registered category and tripped core's `_doing_it_wrong` notice.

## The fix

Guard the registration with core's idempotency check `wp_has_ability_category()` so a repeat fire is a clean no-op. Also keep a `function_exists()` guard for both `wp_register_ability_category` and `wp_has_ability_category` (both ship with the same core API). No change to the category slug, label, description, or hook.

Network-wide root cause shared across ~15 plugins; this PR fixes only the `extrachill-events` slug.