### PR TITLE
refactor(events): stop tooling from stamping universal policy into pipeline/flow prompts

### DIFF
--- a/inc/Abilities/CityAbilities.php
+++ b/inc/Abilities/CityAbilities.php
@@ -631,9 +631,7 @@ class CityAbilities {
 					self::DEFAULT_AI_PROVIDER => array( 'model' => self::DEFAULT_AI_MODEL ),
 				);
 				$step['system_prompt'] = sprintf(
-					'You run the Extra Chill events feed for %s. Process the event and prepare it for update to the calendar, assigning the appropriate details to the event based on the available information.
-
-The festival taxonomy should only be used if the event in question is a festival; otherwise ignore it.',
+					'You run the Extra Chill events feed for %s.',
 					$city_label
 				);
 				$step['enabled_tools'] = array();
@@ -691,13 +689,9 @@ The festival taxonomy should only be used if the event in question is a festival
 							'taxonomy_artist_selection'   => 'ai_decides',
 							'taxonomy_promoter_selection' => 'skip',
 						),
-						'user_message'   => "IMPORTANT SYSTEM-WIDE RULE: Do not assign WordPress Categories or Tags for events. Always set:\n- taxonomy_category_selection = \"skip\"\n- taxonomy_post_tag_selection = \"skip\"\nIf any source includes categories/tags, ignore them.",
 					),
 					'ai'           => array(
-						'user_message' => sprintf(
-							'Process this Ticketmaster music event for the %s events calendar',
-							$city_full
-						),
+						'user_message' => '',
 					),
 				),
 			)
@@ -725,7 +719,7 @@ The festival taxonomy should only be used if the event in question is a festival
 					'exclude_keywords'    => '',
 				),
 				$location_term,
-				sprintf( 'Process this Ticketmaster music event for the %s events calendar', $city_full )
+				''
 			);
 		}
 
@@ -783,7 +777,7 @@ The festival taxonomy should only be used if the event in question is a festival
 					'exclude_keywords' => '',
 				),
 				$location_term,
-				sprintf( 'Process this Dice.fm event for the %s events calendar.', $city_full )
+				''
 			);
 		}
 
@@ -806,7 +800,10 @@ The festival taxonomy should only be used if the event in question is a festival
 	 * @param string $import_handler Handler slug for the event_import step.
 	 * @param array  $import_config  Handler config for the event_import step.
 	 * @param string $location_term  Location taxonomy term for the update step.
-	 * @param string $ai_message     User message for the AI step.
+	 * @param string $ai_message     Source-delta prompt for the AI step. Empty for
+	 *                               bulk sources whose identity is carried structurally
+	 *                               (flow name + location taxonomy + handler config);
+	 *                               universal processing policy lives in the agent SOUL.
 	 */
 	private function patchFlowSteps( int $flow_id, string $import_handler, array $import_config, string $location_term, string $ai_message ): void {
 		global $wpdb;
@@ -851,7 +848,6 @@ The festival taxonomy should only be used if the event in question is a festival
 						'taxonomy_promoter_selection' => 'skip',
 					),
 				);
-				$step['user_message']    = "IMPORTANT SYSTEM-WIDE RULE: Do not assign WordPress Categories or Tags for events. Always set:\n- taxonomy_category_selection = \"skip\"\n- taxonomy_post_tag_selection = \"skip\"\nIf any source includes categories/tags, ignore them.";
 				$step['enabled']         = true;
 			}
 

--- a/inc/Abilities/VenueAddAbilities.php
+++ b/inc/Abilities/VenueAddAbilities.php
@@ -373,15 +373,16 @@ class VenueAddAbilities {
 						'taxonomy_promoter_selection' => 'skip',
 					),
 				);
-				$step['user_message']    = 'IMPORTANT SYSTEM-WIDE RULE: Do not assign WordPress Categories or Tags for events.';
 				$step['enabled']         = true;
 			}
 
 			if ( 'ai' === $step_type ) {
-				$step['user_message'] = sprintf(
-					'Process this event from %s for the events calendar.',
-					$venue_name
-				);
+				// Prompt-layer purity: venue flows start with an empty AI prompt.
+				// The venue identity is carried structurally (flow name + location
+				// taxonomy + scraper handler config); universal processing policy
+				// lives in the agent SOUL. A human only adds a prompt here when the
+				// venue has a genuine quirk worth a per-flow delta.
+				$step['user_message'] = '';
 			}
 		}
 		unset( $step );


### PR DESCRIPTION
## The layering rule (the point of this fix)

The events-bot agent has three prompt layers, each owning ONE job:

1. **SOUL.md** — agent identity + UNIVERSAL policy (applies to every city/venue).
2. **Pipeline `system_prompt`** — CITY identity ONLY: `You run the Extra Chill events feed for {City}.`
3. **Flow prompt** — VENUE/SOURCE deltas ONLY (quirks unique to one venue/source).

The tooling was actively **stamping universal boilerplate** into every new pipeline/flow, so any data cleanup would drift back the next time someone ran `add city` / `venues add`. This PR fixes the tooling so newly-created pipelines/flows are prompt-layer-pure **by construction**.

## Root cause (verified by reading the code on prod)

- **`inc/Abilities/CityAbilities.php` ~L633** — city pipeline `system_prompt` was stamped with the universal "Process the event and prepare it for update to the calendar…" sentence **and** the festival-taxonomy rule.
- **`inc/Abilities/VenueAddAbilities.php` ~L381** — venue flow AI `user_message` was stamped with `Process this event from {venue} for the events calendar.` — the agent's whole job, already in SOUL.

Also addressed (per task): the Ticketmaster/Dice.fm bulk flows in `CityAbilities` (`createTicketmasterFlow`/`createDiceFmFlow` + `patchFlowSteps`) stamped the same boilerplate `ai_message` plus a free-text `IMPORTANT SYSTEM-WIDE RULE: Do not assign Categories/Tags` `user_message`.

## Before / after

**Pipeline `system_prompt`:**
```
- You run the Extra Chill events feed for {City}. Process the event and prepare it
- for update to the calendar, assigning the appropriate details to the event based
- on the available information.
-
- The festival taxonomy should only be used if the event in question is a festival;
- otherwise ignore it.
+ You run the Extra Chill events feed for {City}.
```

**Venue flow AI prompt:**
```
- Process this event from {Venue Name} for the events calendar.
+ (empty)
```

**Ticketmaster / Dice.fm bulk flow AI prompt:**
```
- Process this Ticketmaster music event for the {City} events calendar
- Process this Dice.fm event for the {City} events calendar.
+ (empty)
```

## Decision: venue/bulk flow prompt — empty (not bare source line)

I chose **empty** `user_message` over a bare `Source: {name}.` line. Rationale: the source/venue identity is already carried **structurally** — the flow name is the venue/source name, the `taxonomy_location_selection` is set to the city's location term, and the import handler config (`universal_web_scraper` URL, `ticketmaster` coordinates, `dice_fm` city) names the source. A bare source line would just restate data the flow already holds structurally and re-introduce a per-flow string the cleanup would have to police. Empty is the cleanest layer-pure default: a human adds a prompt here only when a venue has a genuine quirk worth a per-flow delta.

## Decision: "Do not assign Categories/Tags" message — removed (moved to SOUL)

The `IMPORTANT SYSTEM-WIDE RULE: Do not assign Categories/Tags` strings were **free-text `user_message` prompts on the `update` step**, duplicating universal policy — **not** structured config. The load-bearing mechanism is the structured `upsert_event` handler config in the same step, which I left untouched:

```php
'taxonomy_category_selection' => 'skip',
'taxonomy_post_tag_selection' => 'skip',
```

Since the structured fields already enforce the rule deterministically and the prose merely restated universal policy verbatim, the `user_message` was a pure prompt-layer leak and was removed. The universal rule belongs in SOUL (handled in the paired PR).

## What was NOT touched

- Frontend event-submission prompt (different surface).
- Structured `step_config` taxonomy fields (`taxonomy_location_selection`, `taxonomy_festival_selection=ai_decides`, etc.).
- `FlowLocationGuard` / extrachill-events#98 location-coercion logic.
- The actual festival/category policy — not deleting policy, only stopping the tooling from duplicating universal policy into per-pipeline/per-flow prompts.

## Pairs with

This pairs with the **extrachill-event-bundles data-cleanup PR** that cleans the existing 192 pipelines / 671 flows and adds the universal "use festival taxonomy only when the event is a festival" rule to SOUL.md. Both are needed for the layering to hold: that PR fixes the existing data + SOUL; this PR stops the tooling from re-drifting on the next `add city` / `venues add`.

## Verification

- `php -l` clean on both changed files.
- Full test suite green: **132 tests, 263 assertions, OK** (`vendor/bin/phpunit`). No tests asserted the old prompt strings, so none needed updating.
- phpcs finding count identical before/after the change (81 → 81) — **zero new findings**; remaining findings are pre-existing house-style baseline on untouched lines.
- grep confirms **no remaining tooling path** stamps `Process the event` / `Process this event from` / the festival-taxonomy sentence / `IMPORTANT SYSTEM-WIDE RULE` into a prompt.