### PR TITLE
feat(events): collapsible/less-dominant archive map + scope nav grouped with calendar filters

### DIFF
--- a/assets/css/archive-map.css
+++ b/assets/css/archive-map.css
@@ -1,0 +1,83 @@
+/**
+ * Archive Map Collapse + Scope Nav Grouping
+ *
+ * Two related presentation fixes for Gardner's calendar feedback
+ * (data-machine-events#373):
+ *
+ *   1. The events-map on location / venue / artist archives is now a
+ *      collapsible, height-reduced panel (defaults collapsed) so the event
+ *      list is the dominant element, not the map.
+ *
+ *   2. The Tonight / This Weekend / This Week scope nav now sits directly with
+ *      the calendar block's search + date-range + filter controls as one
+ *      visual cluster, instead of being stranded above the map.
+ *
+ * Uses theme CSS custom properties — no hard-coded colors, no !important.
+ *
+ * @package ExtraChillEvents
+ * @since 0.30.0
+ */
+
+/* --- Collapsible Archive Map --- */
+
+.extrachill-events-archive-map {
+	margin-bottom: var(--spacing-lg);
+}
+
+.extrachill-events-archive-map__toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--spacing-xs);
+	padding: var(--spacing-xs) var(--spacing-md);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	background: var(--card-background);
+	color: var(--text-color);
+	font-size: var(--font-size-sm);
+	font-weight: 500;
+	cursor: pointer;
+	transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.extrachill-events-archive-map__toggle:hover,
+.extrachill-events-archive-map__toggle:focus-visible {
+	border-color: var(--text-color);
+}
+
+.extrachill-events-archive-map__toggle-icon {
+	font-size: var(--font-size-md, 1rem);
+	line-height: 1;
+}
+
+/* Panel spacing once revealed. The map block manages its own height via the
+   block's `height` attribute (reduced to 280px on archives). */
+.extrachill-events-archive-map.is-expanded .extrachill-events-archive-map__panel {
+	margin-top: var(--spacing-sm);
+}
+
+/* --- Scope Nav grouped with the calendar filter bar --- */
+
+/*
+ * The scope nav now renders immediately before the calendar block. Pull it
+ * visually flush with the block's filter bar so the chips + search + date +
+ * filter read as a single control cluster. The calendar block owns the
+ * .data-machine-events-filter-bar DOM; we only join to it from here.
+ */
+.discovery-scope-nav.is-calendar-grouped {
+	margin-bottom: var(--spacing-sm);
+}
+
+/* Tighten the gap between the grouped scope nav and the block's own filter
+   bar so they read as one unit. The calendar block's filter bar has its own
+   top margin via .data-machine-events-calendar { margin: 2rem 0 }, so pull it
+   up when it directly follows our grouped nav. */
+.discovery-scope-nav.is-calendar-grouped + .data-machine-events-calendar {
+	margin-top: 0;
+}
+
+@media (max-width: 480px) {
+	.extrachill-events-archive-map__toggle {
+		width: 100%;
+		justify-content: center;
+	}
+}

--- a/assets/js/archive-map.js
+++ b/assets/js/archive-map.js
@@ -1,0 +1,80 @@
+/**
+ * Archive Map Collapse Toggle
+ *
+ * Toggles the collapsible events-map wrapper on taxonomy archives
+ * (location / venue / artist). The map defaults collapsed so the event
+ * list — not the map — is the dominant element (data-machine-events#373).
+ *
+ * Leaflet caveat: the events-map block only calls invalidateSize() once at
+ * mount. When the panel starts hidden the map boots with a zero-size box, so
+ * the first time we reveal it we dispatch a synthetic window `resize` event.
+ * Leaflet's Map registers a window-resize handler by default (trackResize),
+ * which calls invalidateSize() for us — no dependency on block internals.
+ *
+ * Plain vanilla JS, no jQuery / React — matches assets/js/discovery.js style.
+ *
+ * @package ExtraChillEvents
+ * @since 0.30.0
+ */
+
+( function () {
+	'use strict';
+
+	document.addEventListener( 'DOMContentLoaded', init );
+
+	function init() {
+		var wrappers = document.querySelectorAll( '[data-collapsible-map]' );
+		if ( ! wrappers.length ) {
+			return;
+		}
+
+		for ( var i = 0; i < wrappers.length; i++ ) {
+			setupWrapper( wrappers[ i ] );
+		}
+	}
+
+	function setupWrapper( wrapper ) {
+		var toggle = wrapper.querySelector(
+			'.extrachill-events-archive-map__toggle'
+		);
+		var panel = wrapper.querySelector(
+			'.extrachill-events-archive-map__panel'
+		);
+		if ( ! toggle || ! panel ) {
+			return;
+		}
+
+		toggle.addEventListener( 'click', function () {
+			var expanded =
+				toggle.getAttribute( 'aria-expanded' ) === 'true';
+			setExpanded( wrapper, toggle, panel, ! expanded );
+		} );
+	}
+
+	function setExpanded( wrapper, toggle, panel, expand ) {
+		toggle.setAttribute( 'aria-expanded', expand ? 'true' : 'false' );
+		wrapper.classList.toggle( 'is-expanded', expand );
+
+		var label = toggle.querySelector(
+			'.extrachill-events-archive-map__toggle-label'
+		);
+
+		if ( expand ) {
+			panel.hidden = false;
+			if ( label ) {
+				label.textContent = 'Hide map';
+			}
+			// Nudge Leaflet to recompute tile layout now that the panel
+			// has a real size. Defer to the next frame so the panel has
+			// laid out before the resize fires.
+			requestAnimationFrame( function () {
+				window.dispatchEvent( new Event( 'resize' ) );
+			} );
+		} else {
+			panel.hidden = true;
+			if ( label ) {
+				label.textContent = 'Show map';
+			}
+		}
+	}
+} )();

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -217,6 +217,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/priority-venue-ordering.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/priority-event-ordering.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-meta.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/archive-map.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-map.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/venue-map.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/artist-map.php';

--- a/inc/core/archive-map.php
+++ b/inc/core/archive-map.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Archive Map Collapsible Wrapper
+ *
+ * Shared presentation layer for the events-map block when it appears on
+ * taxonomy archive pages (location / venue / artist). Gardner's calendar
+ * feedback (data-machine-events#373) was that the 400px map dominated the
+ * Charleston location archive and pushed the actual event list far down the
+ * page. This helper wraps the block markup in a collapsible, height-reduced
+ * container so the map is available but no longer the dominant element.
+ *
+ * The wrapper:
+ *   - Renders a real <button aria-expanded> toggle ("Show map" / "Hide map").
+ *   - Defaults COLLAPSED — the list is the priority, the map is opt-in.
+ *   - Collapses with max-height + overflow (NOT display:none) so Leaflet keeps
+ *     a layout box and never boots zero-sized. On first expand a synthetic
+ *     window `resize` event is dispatched so Leaflet's built-in resize handler
+ *     calls invalidateSize() and the tiles paint correctly.
+ *   - Passes a reduced height (280px) to the events-map block so even when
+ *     expanded the map reads as a secondary element, not the page hero.
+ *
+ * EC-side only: the events-map block itself is unchanged — we only pass its
+ * existing `height` attribute and wrap its output. No data-machine-events or
+ * theme changes are required.
+ *
+ * @package ExtraChillEvents
+ * @since 0.30.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Reduced map height (px) used for archive maps.
+ *
+ * The events-map block defaults to 400px. Archives pass this smaller value so
+ * the map is non-dominant even when expanded.
+ *
+ * @return int Height in pixels.
+ */
+function extrachill_events_archive_map_height(): int {
+	/**
+	 * Filter the archive map height.
+	 *
+	 * @param int $height Height in pixels. Default 280.
+	 */
+	return (int) apply_filters( 'extrachill_events_archive_map_height', 280 );
+}
+
+/**
+ * Wrap events-map block markup in a collapsible, height-reduced container.
+ *
+ * Callers pass the rendered block HTML (already produced via do_blocks()).
+ * This keeps each archive map renderer in control of WHICH block attributes
+ * it sets (zoom, chronologicalRouteMode, etc.) while sharing the collapse UI.
+ *
+ * @param string $map_html  Rendered events-map block markup.
+ * @param string $archive   Archive context slug (location|venue|artist) for styling hooks.
+ * @return string Wrapped markup, or empty string if no map HTML was provided.
+ */
+function extrachill_events_render_collapsible_map( string $map_html, string $archive = '' ): string {
+	$map_html = trim( $map_html );
+	if ( '' === $map_html ) {
+		return '';
+	}
+
+	$panel_id    = 'extrachill-events-archive-map-' . ( $archive ? sanitize_html_class( $archive ) : 'panel' );
+	$context_cls = $archive ? ' is-' . sanitize_html_class( $archive ) : '';
+
+	ob_start();
+	?>
+	<div class="extrachill-events-archive-map<?php echo esc_attr( $context_cls ); ?>" data-collapsible-map>
+		<button type="button"
+				class="extrachill-events-archive-map__toggle"
+				aria-expanded="false"
+				aria-controls="<?php echo esc_attr( $panel_id ); ?>">
+			<span class="extrachill-events-archive-map__toggle-label"><?php esc_html_e( 'Show map', 'extrachill-events' ); ?></span>
+			<span class="extrachill-events-archive-map__toggle-icon dashicons dashicons-location-alt" aria-hidden="true"></span>
+		</button>
+		<div id="<?php echo esc_attr( $panel_id ); ?>" class="extrachill-events-archive-map__panel" hidden>
+			<?php echo $map_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Trusted block markup from do_blocks(). ?>
+		</div>
+	</div>
+	<?php
+	return (string) ob_get_clean();
+}
+
+/**
+ * Enqueue the archive-map collapse assets.
+ *
+ * Loads on any taxonomy archive where one of the map renderers may output a
+ * map (location / venue / artist). The toggle script + styles are tiny and
+ * self-contained; they no-op when no collapsible map is present on the page.
+ *
+ * @hook wp_enqueue_scripts
+ */
+function extrachill_events_archive_map_assets() {
+	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : 7;
+	if ( (int) get_current_blog_id() !== $events_blog_id ) {
+		return;
+	}
+
+	if ( ! is_tax( 'location' ) && ! is_tax( 'venue' ) && ! is_tax( 'artist' ) ) {
+		return;
+	}
+
+	$css_path = EXTRACHILL_EVENTS_PLUGIN_DIR . 'assets/css/archive-map.css';
+	$js_path  = EXTRACHILL_EVENTS_PLUGIN_DIR . 'assets/js/archive-map.js';
+
+	wp_enqueue_style(
+		'extrachill-events-archive-map',
+		EXTRACHILL_EVENTS_PLUGIN_URL . 'assets/css/archive-map.css',
+		array(),
+		file_exists( $css_path ) ? (string) filemtime( $css_path ) : EXTRACHILL_EVENTS_VERSION
+	);
+
+	wp_enqueue_script(
+		'extrachill-events-archive-map',
+		EXTRACHILL_EVENTS_PLUGIN_URL . 'assets/js/archive-map.js',
+		array(),
+		file_exists( $js_path ) ? (string) filemtime( $js_path ) : EXTRACHILL_EVENTS_VERSION,
+		true
+	);
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_events_archive_map_assets' );

--- a/inc/core/artist-map.php
+++ b/inc/core/artist-map.php
@@ -70,8 +70,13 @@ function extrachill_events_render_artist_map() {
 
 	// Render the block in chronological-route mode. The block reads
 	// taxonomy/term_id from its own render context (is_tax + queried
-	// object) and auto-fits to the route's bounding box.
-	echo do_blocks( '<!-- wp:data-machine-events/events-map {"chronologicalRouteMode":true} /-->' );
+	// object) and auto-fits to the route's bounding box. Wrapped in the
+	// shared collapsible, height-reduced container so the route map stays
+	// secondary to the tour-date list (data-machine-events#373) and is
+	// consistent with the location/venue archives.
+	$height    = extrachill_events_archive_map_height();
+	$map_block = sprintf( '<!-- wp:data-machine-events/events-map {"chronologicalRouteMode":true,"height":%d} /-->', $height );
+	echo extrachill_events_render_collapsible_map( do_blocks( $map_block ), 'artist' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Wrapper escapes its own chrome; inner markup is trusted block output.
 }
 add_action( 'extrachill_archive_below_description', 'extrachill_events_render_artist_map' );
 

--- a/inc/core/discovery-pages.php
+++ b/inc/core/discovery-pages.php
@@ -401,10 +401,13 @@ add_action( 'wp_enqueue_scripts', 'extrachill_events_discovery_scripts' );
  * Highlights the current scope. Links to sibling scopes and the
  * base location archive.
  *
- * @param \WP_Term $term    Location term object.
- * @param string   $current Current scope slug.
+ * @param \WP_Term $term        Location term object.
+ * @param string   $current     Current scope slug.
+ * @param string   $extra_class Optional extra class(es) for the <nav> wrapper.
+ *                              Used to visually group the nav with the
+ *                              calendar block's filter bar on archives.
  */
-function extrachill_events_render_scope_nav( \WP_Term $term, string $current ) {
+function extrachill_events_render_scope_nav( \WP_Term $term, string $current, string $extra_class = '' ) {
 	$term_link = get_term_link( $term );
 	if ( is_wp_error( $term_link ) ) {
 		return;
@@ -417,8 +420,14 @@ function extrachill_events_render_scope_nav( \WP_Term $term, string $current ) {
 		''             => 'All Shows',
 	);
 
+	$nav_class = 'discovery-scope-nav';
+	if ( '' !== trim( $extra_class ) ) {
+		$nav_class .= ' ' . trim( $extra_class );
+	}
+
 	printf(
-		'<nav class="discovery-scope-nav" aria-label="Time scope navigation" data-term-id="%d" data-term-name="%s" data-term-link="%s">',
+		'<nav class="%s" aria-label="Time scope navigation" data-term-id="%d" data-term-name="%s" data-term-link="%s">',
+		esc_attr( $nav_class ),
 		$term->term_id,
 		esc_attr( $term->name ),
 		esc_url( $term_link )

--- a/inc/core/location-map.php
+++ b/inc/core/location-map.php
@@ -42,8 +42,12 @@ function extrachill_events_render_location_map() {
 		return;
 	}
 
-	// Render the block — filters below provide center and summary.
-	echo do_blocks( '<!-- wp:data-machine-events/events-map /-->' );
+	// Render the block — filters below provide center and summary. The map is
+	// wrapped in a collapsible, height-reduced container so it no longer
+	// dominates the archive (data-machine-events#373).
+	$height    = extrachill_events_archive_map_height();
+	$map_block = sprintf( '<!-- wp:data-machine-events/events-map {"height":%d} /-->', $height );
+	echo extrachill_events_render_collapsible_map( do_blocks( $map_block ), 'location' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Wrapper escapes its own chrome; inner markup is trusted block output.
 }
 add_action( 'extrachill_archive_below_description', 'extrachill_events_render_location_map' );
 

--- a/inc/core/venue-map.php
+++ b/inc/core/venue-map.php
@@ -87,7 +87,11 @@ function extrachill_events_render_venue_map() {
 		return;
 	}
 
-	echo do_blocks( '<!-- wp:data-machine-events/events-map {"zoom":14} /-->' );
+	// Collapsible, height-reduced map so it stays secondary to the event list
+	// (data-machine-events#373). Mirrors the location archive treatment.
+	$height    = extrachill_events_archive_map_height();
+	$map_block = sprintf( '<!-- wp:data-machine-events/events-map {"zoom":14,"height":%d} /-->', $height );
+	echo extrachill_events_render_collapsible_map( do_blocks( $map_block ), 'venue' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Wrapper escapes its own chrome; inner markup is trusted block output.
 }
 add_action( 'extrachill_archive_below_description', 'extrachill_events_render_venue_map' );
 

--- a/inc/templates/archive.php
+++ b/inc/templates/archive.php
@@ -78,11 +78,6 @@ extrachill_breadcrumbs();
 			<?php extrachill_events_render_term_calendar_stats( 'location', (int) $term->term_id ); ?>
 		</header>
 		<?php
-		if ( function_exists( 'extrachill_events_render_scope_nav' ) ) {
-			extrachill_events_render_scope_nav( $term, '' );
-		}
-		?>
-		<?php
 	elseif ( is_tax( 'artist' ) ) :
 		$term = get_queried_object();
 		?>
@@ -106,7 +101,21 @@ extrachill_breadcrumbs();
 	</div>
 
 	<div class="page-content">
-		<?php echo do_blocks( '<!-- wp:data-machine-events/calendar /-->' ); ?>
+		<?php
+		// Render the location scope nav (Tonight / This Weekend / This Week /
+		// All Shows) directly with the calendar block's filter bar so the
+		// scope chips and the search/date controls read as one cluster
+		// (data-machine-events#373). The nav keeps its crawlable SEO
+		// /location/<city>/tonight/ links and discovery.js swap behaviour —
+		// only WHERE it renders changed (it used to sit above the map).
+		if ( is_tax( 'location' ) && function_exists( 'extrachill_events_render_scope_nav' ) ) {
+			$scope_term = get_queried_object();
+			if ( $scope_term instanceof \WP_Term ) {
+				extrachill_events_render_scope_nav( $scope_term, '', 'is-calendar-grouped' );
+			}
+		}
+		echo do_blocks( '<!-- wp:data-machine-events/calendar /-->' );
+		?>
 	</div>
 </div>
 


### PR DESCRIPTION
Implements the Extra Chill side of Gardner's calendar feedback (Extra-Chill/data-machine-events#373): make the events-map non-dominant on archives, and group the Tonight/This-Weekend scope buttons with the calendar's search/date controls.

## Before / after page order (location archive, e.g. Charleston)

**Before:** H1 + stats → **400px MAP** → `[scope buttons]` → calendar `[Search][Date range][Filter]` → events list. The map dominated and the scope buttons were stranded above it, split from the search/date controls.

**After:** H1 + stats → **collapsible "Show map" toggle (collapsed by default; 280px when expanded)** → `[scope chips + Search + Date range + Filter]` as one cluster → events list.

## Part A — collapsible / less-dominant map

**Approach: height reduction (280px) + a collapsible wrapper, defaulting collapsed.** Both, because either alone is half a fix — a 280px map still pushes the list down on mobile, and a collapsible 400px map still dominates when opened. New shared helper `inc/core/archive-map.php`:

- `extrachill_events_render_collapsible_map( $map_html, $archive )` wraps the rendered block in a real `<button aria-expanded>` toggle ("Show map" / "Hide map") + an `aria-controls`'d panel that starts `hidden`.
- `extrachill_events_archive_map_height()` returns `280` (filterable via `extrachill_events_archive_map_height`); each renderer passes it as the block's existing `height` attribute.
- Applied consistently across **location**, **venue**, and **artist** map renderers (all three call the shared wrapper).

**Leaflet resize caveat + how it's avoided:** the events-map block only calls `invalidateSize()` once, at mount. With the panel starting `hidden`, the map boots with a zero-size box. Rather than fight that with `display`-vs-`max-height` gymnastics, `assets/js/archive-map.js` dispatches a synthetic `window` `resize` event on first expand (deferred via `requestAnimationFrame` so the panel has laid out). Leaflet's `Map` registers a window-resize handler by default (`trackResize`), so it calls `invalidateSize()` itself and the tiles paint correctly — **no dependency on block internals**. Vanilla JS, no jQuery/React, matches `assets/js/discovery.js` style.

## Part B — group scope nav with the calendar filter bar

- Stopped rendering `extrachill_events_render_scope_nav()` at the top of `archive.php` (it used to sit above the map).
- It now renders **immediately before the calendar block** with a new `is-calendar-grouped` class. CSS visually joins `.discovery-scope-nav.is-calendar-grouped` to the block's `.data-machine-events-calendar` / `.data-machine-events-filter-bar` (pulls the block's top margin to 0 so chips + search/date/filter read as one cluster).
- `extrachill_events_render_scope_nav()` gained an optional 3rd `$extra_class` param (backward compatible) so the nav can carry the grouping class.
- **The SEO `<a href>` links (`/location/<city>/tonight/` etc.) and `discovery.js` REST-swap behaviour are fully preserved** — only *where* the nav renders changed.

## Scope / notes

- **EC-side only.** No `data-machine-events` changes, no theme changes. Plain PHP + CSS + vanilla JS, theme CSS custom properties only (no hard-coded colors, no `!important`), `filemtime` cache-busting, no build step (assets live in `assets/`, not `blocks/`).
- Accessibility: toggle is a real `<button>` with `aria-expanded` + `aria-controls`; existing `aria-label` on the scope nav is untouched.
- **Future, not this PR:** a parallel PR adds an optional `showScopePresets` attribute to the calendar block that renders generic in-block scope chips. This PR deliberately keeps EC's existing SEO-link scope nav (the generic chips don't produce crawlable `/location/<city>/tonight/` pages). Once that attribute lands, EC could optionally revisit adopting the in-block chips vs. keeping the SEO-link nav — a future decision.

## Verification

- `php -l` clean on all changed PHP; `node --check` clean on the new JS.
- `homeboy lint` / phpcs: the new files add **zero** new findings. Baseline error counts on `discovery-pages.php` (3) and `archive.php` (6) are identical pre/post change (pre-existing house-style escaping + `$term = get_queried_object()` template patterns); the `SeparateFunctionsFromOO` error in `extrachill-events.php` is a pre-existing baseline finding (line 362→363, shifted only by the one added `require_once`).

Refs Extra-Chill/data-machine-events#373.