### PR TITLE
feat(calendar): enable in-block scope chips on non-location archives, keep SEO scope-nav on location (data-machine-events#373)

### DIFF
--- a/inc/templates/archive.php
+++ b/inc/templates/archive.php
@@ -108,13 +108,25 @@ extrachill_breadcrumbs();
 		// (data-machine-events#373). The nav keeps its crawlable SEO
 		// /location/<city>/tonight/ links and discovery.js swap behaviour —
 		// only WHERE it renders changed (it used to sit above the map).
-		if ( is_tax( 'location' ) && function_exists( 'extrachill_events_render_scope_nav' ) ) {
+		$is_location_archive = is_tax( 'location' );
+		if ( $is_location_archive && function_exists( 'extrachill_events_render_scope_nav' ) ) {
 			$scope_term = get_queried_object();
 			if ( $scope_term instanceof \WP_Term ) {
 				extrachill_events_render_scope_nav( $scope_term, '', 'is-calendar-grouped' );
 			}
 		}
-		echo do_blocks( '<!-- wp:data-machine-events/calendar /-->' );
+
+		// Enable the in-block scope-preset chips (data-machine-events#374)
+		// everywhere EXCEPT location archives. Location archives already render
+		// the crawlable SEO scope-nav above (Tonight / This Weekend / ...), so
+		// adding the in-block chips there would duplicate the control and bury
+		// the SEO /location/<city>/tonight/ links. On every other archive type
+		// (venue, promoter, artist, generic taxonomy) the chips are the only
+		// scope control, so we turn them on.
+		$calendar_block = $is_location_archive
+			? '<!-- wp:data-machine-events/calendar /-->'
+			: '<!-- wp:data-machine-events/calendar {"showScopePresets":true} /-->';
+		echo do_blocks( $calendar_block );
 		?>
 	</div>
 </div>


### PR DESCRIPTION
## Summary

Enables the in-block calendar scope-preset chips (added generically in **data-machine-events#374** via the `showScopePresets` block attribute) on `extrachill-events` archive pages — **everywhere except location archives**.

- **Location archives** keep their existing crawlable SEO scope-nav (`extrachill_events_render_scope_nav` → Tonight / This Weekend / This Week / All Shows, rendering real `/location/<city>/tonight/` links with search value). They do **not** get the in-block chips, so there is no duplicate scope control and the SEO links are preserved.
- **Every other archive type** (venue, promoter, artist, generic `is_tax()`) gets the in-block chips, since those archives previously had **no** scope control at all. Chips re-filter the calendar in place (no navigation).

The net change is a single conditional in `inc/templates/archive.php`: the shared `do_blocks()` calendar call now emits `{"showScopePresets":true}` unless `is_tax('location')`.

## Implementation

`inc/templates/archive.php` (the single shared template serving all taxonomy archive types):

```php
$calendar_block = $is_location_archive
    ? '<!-- wp:data-machine-events/calendar /-->'
    : '<!-- wp:data-machine-events/calendar {"showScopePresets":true} /-->';
echo do_blocks( $calendar_block );
```

There were no other existing block attributes on this call to preserve (verified).

## Other calendar call sites — intentionally left unchanged (with reasoning)

| Call site | Decision | Why |
|---|---|---|
| `inc/templates/discovery.php` (`{"defaultDateRange":"%s"}`) | **No chips** | These ARE the SEO scope-filtered landing pages (`/location/<city>/tonight/` etc). The page itself is already scoped to a date range — adding chips would be redundant/confusing. |
| `blocks/concert-stats/render.php` (`showFilters:false, showSearch:false, showDateFilter:false`) | **No chips** | Minimal stats view with the entire filter bar disabled — there is no filter-bar cluster for chips to group into. (`build/concert-stats/render.php` is a build artifact and was not touched.) |
| Homepage calendar | **Out of scope** | The homepage calendar lives in post content (production data, not this repo). Enabling chips there is a separate content edit, not a code change. |

## Per-page-type scope control matrix (proving no duplication)

| Page type | SEO scope-nav (links) | In-block chips (re-filter) | Duplicate? |
|---|---|---|---|
| Homepage | — | — (separate content edit) | no |
| **Location archive** (`is_tax('location')`) | ✅ rendered | ❌ | **no** |
| Venue archive | ❌ | ✅ | no |
| Artist archive | ❌ | ✅ | no |
| Promoter archive | ❌ | ✅ | no |
| Generic taxonomy archive | ❌ | ✅ | no |
| Discovery / scope landing (`discovery.php`) | page IS the scope | ❌ (intentional) | no |
| Concert-stats block | n/a (no filter bar) | ❌ (intentional) | no |

No page renders two scope controls.

## Verification

- `php -l inc/templates/archive.php` → no syntax errors.
- `phpcs --standard=WordPress` on `archive.php` → only pre-existing baseline findings (4× `$term` global-override + 1× `do_blocks` escaping on the original calendar line). Confirmed identical before/after via stash — **zero new findings introduced** by this change.

## References

- Implements the theme side of **data-machine-events#373**.
- Consumes the generic `showScopePresets` attribute added (and merged) in **data-machine-events#374**.