### PR TITLE
fix(calendar): use in-block toolbar scope chips on location archives too (data-machine-events#373)

### DIFF
--- a/inc/templates/archive.php
+++ b/inc/templates/archive.php
@@ -102,31 +102,21 @@ extrachill_breadcrumbs();
 
 	<div class="page-content">
 		<?php
-		// Render the location scope nav (Tonight / This Weekend / This Week /
-		// All Shows) directly with the calendar block's filter bar so the
-		// scope chips and the search/date controls read as one cluster
-		// (data-machine-events#373). The nav keeps its crawlable SEO
-		// /location/<city>/tonight/ links and discovery.js swap behaviour —
-		// only WHERE it renders changed (it used to sit above the map).
-		$is_location_archive = is_tax( 'location' );
-		if ( $is_location_archive && function_exists( 'extrachill_events_render_scope_nav' ) ) {
-			$scope_term = get_queried_object();
-			if ( $scope_term instanceof \WP_Term ) {
-				extrachill_events_render_scope_nav( $scope_term, '', 'is-calendar-grouped' );
-			}
-		}
-
-		// Enable the in-block scope-preset chips (data-machine-events#374)
-		// everywhere EXCEPT location archives. Location archives already render
-		// the crawlable SEO scope-nav above (Tonight / This Weekend / ...), so
-		// adding the in-block chips there would duplicate the control and bury
-		// the SEO /location/<city>/tonight/ links. On every other archive type
-		// (venue, promoter, artist, generic taxonomy) the chips are the only
-		// scope control, so we turn them on.
-		$calendar_block = $is_location_archive
-			? '<!-- wp:data-machine-events/calendar /-->'
-			: '<!-- wp:data-machine-events/calendar {"showScopePresets":true} /-->';
-		echo do_blocks( $calendar_block );
+		// Render the in-block scope-preset chips (data-machine-events#374) in
+		// the calendar's filter-bar toolbar on EVERY archive type — venue,
+		// promoter, artist, location, and generic taxonomy. Keeping the scope
+		// control in the same DM toolbar everywhere is what makes the UI
+		// consistent (data-machine-events#373).
+		//
+		// Location archives previously rendered a separate
+		// discovery-scope-nav element (crawlable /location/<city>/tonight/
+		// links) above the calendar, which placed the control differently from
+		// every other archive type and looked inconsistent. That nav is
+		// dropped here in favour of the toolbar chips; the crawlable SEO scope
+		// URLs still live on the dedicated discovery landing pages rendered by
+		// discovery.php (extrachill_events_render_scope_nav with real links),
+		// which is their canonical home.
+		echo do_blocks( '<!-- wp:data-machine-events/calendar {"showScopePresets":true} /-->' );
 		?>
 	</div>
 </div>


### PR DESCRIPTION
## Why a second PR

PR #180 was squash-merged at its **first commit only** (`f3108d4`), before the consistency follow-up (`91840d2`) was pushed to its branch. As a result, `main` shipped the half-finished version: every archive type shows the in-block toolbar scope chips **except location archives**, which still render a separate `discovery-scope-nav` element above the calendar. That places the scope control differently on location vs. everywhere else — the inconsistent, visually-broken state observed on the live site (and already in v0.31.0 / v0.31.1).

The dangling `enable-scope-chips` branch still holds that follow-up commit, but it can't merge cleanly post-squash. This PR re-applies the fix on top of current `main`.

## Change

`inc/templates/archive.php`: drop the location-only `discovery-scope-nav` and always emit the in-block chips:

```php
echo do_blocks( '<!-- wp:data-machine-events/calendar {"showScopePresets":true} /-->' );
```

Location archives now match venue / artist / promoter / generic archives — the scope control lives in the calendar's filter-bar toolbar everywhere.

## SEO links preserved

The crawlable `/location/<city>/tonight/` scope URLs still render on the dedicated discovery landing pages via `discovery.php` (`extrachill_events_render_scope_nav` with real `<a href>` links), their canonical home. The function remains in use — only the `archive.php` call site is removed (no dead code).

## Scope-control matrix after this PR

| Page type | Scope control | Where |
|---|---|---|
| Venue / Artist / Promoter / **Location** / generic archive | toolbar chips | calendar filter bar (consistent) |
| Discovery / scope landing (`discovery.php`) | SEO scope-nav (links) | page already scoped; chips off |
| Concert-stats block | none | filter bar disabled; chips off |

## Verification

- `php -l inc/templates/archive.php` → no syntax errors.
- `extrachill_events_render_scope_nav()` still referenced by `discovery.php` (no dead code).

## References

- Completes the theme side of **data-machine-events#373** (the part lost when #180 merged early).
- Consumes the `showScopePresets` attribute from **data-machine-events#374**.