### PR TITLE
feat(home): events homepage router + /cities directory + /all calendar

### DIFF
--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -87,3 +87,30 @@
         padding-right: var(--spacing-md);
     }
 }
+
+/* Homepage router: "Browse all cities" link below the top-N badges. */
+.events-browse-all-cities {
+    margin: var(--spacing-md) 0 0;
+    text-align: center;
+    font-size: var(--font-size-body);
+}
+
+/* Cities directory (/cities): region-grouped badge sections. */
+.cities-directory-intro {
+    color: var(--muted-text);
+    margin-bottom: 0;
+}
+
+.cities-directory .cities-region {
+    margin-bottom: var(--spacing-xl);
+}
+
+.cities-region-title {
+    margin-bottom: var(--spacing-md);
+}
+
+.cities-region-count {
+    color: var(--muted-text);
+    font-weight: normal;
+    font-size: 0.8em;
+}

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -224,6 +224,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-seo.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/near-me.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/discovery-pages.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/router-pages.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-normalizer.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/calendar-stats.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/admin/priority-venues.php';

--- a/inc/abilities/events-upcoming-counts.php
+++ b/inc/abilities/events-upcoming-counts.php
@@ -50,6 +50,11 @@ function extrachill_events_register_upcoming_counts_ability(): void {
 						'default'     => 0,
 						'minimum'     => 0,
 					),
+					'rollup'        => array(
+						'type'        => 'boolean',
+						'description' => 'Roll counts up the hierarchy: each non-leaf term reports the distinct upcoming events across its whole subtree. Only meaningful for hierarchical taxonomies (location). Default false.',
+						'default'     => false,
+					),
 				),
 			),
 			'output_schema'       => array(
@@ -89,6 +94,7 @@ function extrachill_events_ability_upcoming_counts( array $input ): array|\WP_Er
 	$slug          = sanitize_title( $input['slug'] ?? '' );
 	$location_slug = sanitize_title( $input['location_slug'] ?? '' );
 	$limit         = (int) ( $input['limit'] ?? 0 );
+	$rollup        = ! empty( $input['rollup'] );
 
 	$allowed = array( 'venue', 'location', 'artist', 'festival' );
 	if ( empty( $taxonomy ) || ! in_array( $taxonomy, $allowed, true ) ) {
@@ -113,11 +119,17 @@ function extrachill_events_ability_upcoming_counts( array $input ): array|\WP_Er
 		return array( $single );
 	}
 
-	// Bulk query — check transient, run SQL on cold cache.
-	$cache_key = '' !== $location_slug
-		? 'ec_upcoming_counts_' . $taxonomy . '_loc_' . $location_slug
-		: 'ec_upcoming_counts_' . $taxonomy;
-	$cached    = get_transient( $cache_key );
+	// Bulk query — check transient, delegate to the data-machine-events
+	// ability on cold cache. Cache key varies by every parameter that
+	// changes the result set.
+	$cache_key = 'ec_upcoming_counts_' . $taxonomy;
+	if ( '' !== $location_slug ) {
+		$cache_key .= '_loc_' . $location_slug;
+	}
+	if ( $rollup ) {
+		$cache_key .= '_rollup';
+	}
+	$cached = get_transient( $cache_key );
 
 	if ( false !== $cached ) {
 		$results = $cached;
@@ -127,8 +139,11 @@ function extrachill_events_ability_upcoming_counts( array $input ): array|\WP_Er
 		return $results;
 	}
 
-	// Cold cache — run the query.
-	$terms = extrachill_events_query_upcoming_counts( $taxonomy, $location_slug );
+	// Cold cache — delegate to the owning ability.
+	$terms = extrachill_events_query_upcoming_counts( $taxonomy, $location_slug, $rollup );
+	if ( is_wp_error( $terms ) ) {
+		return $terms;
+	}
 
 	set_transient( $cache_key, $terms, 6 * HOUR_IN_SECONDS );
 
@@ -142,92 +157,65 @@ function extrachill_events_ability_upcoming_counts( array $input ): array|\WP_Er
 /**
  * Query upcoming event counts for all terms in a taxonomy.
  *
- * Optionally scopes results to events tagged with a specific location term.
- * Only honored when $taxonomy is 'venue' (see caller for enforcement).
+ * Thin wrapper over the data-machine-events/get-upcoming-counts ability — the
+ * single source of truth for the count query. This function owns only the
+ * EC-specific concerns the generic layer should not: mapping a venue
+ * `location_slug` scope onto the ability's co-occurrence filter, and passing
+ * through the optional hierarchy `rollup` mode. Caching + limit slicing are
+ * handled by the caller.
  *
  * @param string $taxonomy      Taxonomy slug.
- * @param string $location_slug Optional location term slug to scope event counts to.
- *                              When non-empty, only events that also have this location
- *                              term assigned are counted. Empty string disables scoping.
- * @return array Array of term count data.
+ * @param string $location_slug Optional location term slug to scope venue counts to.
+ *                              When non-empty (and taxonomy is venue), only events also
+ *                              tagged with this location term are counted.
+ * @param bool   $rollup        Roll counts up the hierarchy (ancestor subtree totals).
+ * @return array|\WP_Error Array of term count data, or WP_Error on failure.
  */
-function extrachill_events_query_upcoming_counts( string $taxonomy, string $location_slug = '' ): array {
+function extrachill_events_query_upcoming_counts( string $taxonomy, string $location_slug = '', bool $rollup = false ): array|\WP_Error {
 	if ( ! taxonomy_exists( $taxonomy ) ) {
 		return array();
 	}
 
-	global $wpdb;
+	$ability = wp_get_ability( 'data-machine-events/get-upcoming-counts' );
+	if ( ! $ability ) {
+		return new \WP_Error(
+			'ability_unavailable',
+			__( 'data-machine-events/get-upcoming-counts ability is not available.', 'extrachill-events' ),
+			array( 'status' => 500 )
+		);
+	}
 
-	$today         = gmdate( 'Y-m-d 00:00:00' );
-	$exclude_roots = is_taxonomy_hierarchical( $taxonomy );
-	$parent_clause = $exclude_roots ? 'AND tt.parent != 0' : '';
+	$args = array( 'taxonomy' => $taxonomy );
+	if ( $rollup ) {
+		$args['rollup'] = true;
+	}
 
-	// Optional location scope. Adds a second join through term_relationships
-	// onto the same post (p.ID) so only events tagged with the given location
-	// term are counted. Resolved up-front to avoid placeholder gymnastics.
-	$location_join   = '';
-	$location_where  = '';
-	$location_params = array();
-
+	// Map the venue location scope onto the ability's co-occurrence filter:
+	// count distinct venues of upcoming events also tagged with this location.
 	if ( '' !== $location_slug ) {
 		$location_term = get_term_by( 'slug', $location_slug, 'location' );
 		if ( ! $location_term || is_wp_error( $location_term ) ) {
 			// Unknown location — return empty rather than unscoped results.
 			return array();
 		}
-
-		$location_join   = "INNER JOIN {$wpdb->term_relationships} tr_loc ON tr_loc.object_id = p.ID
-			INNER JOIN {$wpdb->term_taxonomy} tt_loc ON tr_loc.term_taxonomy_id = tt_loc.term_taxonomy_id";
-		$location_where  = ' AND tt_loc.taxonomy = %s AND tt_loc.term_id = %d ';
-		$location_params = array( 'location', (int) $location_term->term_id );
+		$args['filter_taxonomy'] = 'location';
+		$args['filter_term_id']  = (int) $location_term->term_id;
 	}
 
-	$sql = "SELECT t.term_id, t.name, t.slug, COUNT(DISTINCT p.ID) AS event_count
-		FROM {$wpdb->term_relationships} tr
-		INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-		INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
-		INNER JOIN {$wpdb->posts} p ON tr.object_id = p.ID
-		INNER JOIN {$wpdb->prefix}datamachine_event_dates ed ON p.ID = ed.post_id
-		{$location_join}
-		WHERE tt.taxonomy = %s
-		AND p.post_type = 'data_machine_events'
-		AND p.post_status = 'publish'
-		AND ed.start_datetime >= %s
-		{$location_where}
-		{$parent_clause}
-		GROUP BY t.term_id
-		ORDER BY event_count DESC";
-
-	$params = array_merge( array( $taxonomy, $today ), $location_params );
-
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-	$rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ) );
-
-	if ( empty( $rows ) ) {
-		return array();
+	$result = $ability->execute( $args );
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	$terms = array();
-	foreach ( $rows as $row ) {
-		$url = get_term_link( (int) $row->term_id, $taxonomy );
-		if ( is_wp_error( $url ) ) {
-			continue;
-		}
-
-		$terms[] = array(
-			'term_id' => (int) $row->term_id,
-			'name'    => $row->name,
-			'slug'    => $row->slug,
-			'count'   => (int) $row->event_count,
-			'url'     => $url,
-		);
-	}
-
-	return $terms;
+	return $result['terms'] ?? array();
 }
 
 /**
  * Get upcoming count for a single taxonomy term by slug.
+ *
+ * Delegates to the data-machine-events/get-upcoming-counts ability (bulk
+ * query for the taxonomy, then pick the requested term) so all counting goes
+ * through the single owning primitive.
  *
  * @param string $slug     Term slug.
  * @param string $taxonomy Taxonomy slug.
@@ -243,42 +231,16 @@ function extrachill_events_single_upcoming_count( string $slug, string $taxonomy
 		return null;
 	}
 
-	global $wpdb;
-	$today = gmdate( 'Y-m-d 00:00:00' );
-
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-	$count = (int) $wpdb->get_var(
-		$wpdb->prepare(
-			"SELECT COUNT(DISTINCT p.ID)
-			FROM {$wpdb->posts} p
-			INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
-			INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-			INNER JOIN {$wpdb->prefix}datamachine_event_dates ed ON p.ID = ed.post_id
-			WHERE tt.term_id = %d
-			AND tt.taxonomy = %s
-			AND p.post_type = 'data_machine_events'
-			AND p.post_status = 'publish'
-			AND ed.start_datetime >= %s",
-			$term->term_id,
-			$taxonomy,
-			$today
-		)
-	);
-
-	if ( $count < 1 ) {
+	$terms = extrachill_events_query_upcoming_counts( $taxonomy );
+	if ( is_wp_error( $terms ) ) {
 		return null;
 	}
 
-	$url = get_term_link( $term );
-	if ( is_wp_error( $url ) ) {
-		return null;
+	foreach ( $terms as $row ) {
+		if ( (int) $row['term_id'] === (int) $term->term_id ) {
+			return $row;
+		}
 	}
 
-	return array(
-		'term_id' => $term->term_id,
-		'name'    => $term->name,
-		'slug'    => $term->slug,
-		'count'   => $count,
-		'url'     => $url,
-	);
+	return null;
 }

--- a/inc/core/data-machine-events/assets.php
+++ b/inc/core/data-machine-events/assets.php
@@ -76,7 +76,8 @@ function extrachill_events_enqueue_single_styles() {
  */
 function extrachill_events_enqueue_calendar_styles() {
 	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : null;
-	if ( ! $events_blog_id || get_current_blog_id() !== $events_blog_id || ( ! is_front_page() && ! is_tax() ) ) {
+	$is_router_page = function_exists( 'extrachill_events_is_router_page' ) && extrachill_events_is_router_page();
+	if ( ! $events_blog_id || get_current_blog_id() !== $events_blog_id || ( ! is_front_page() && ! is_tax() && ! $is_router_page ) ) {
 		return;
 	}
 

--- a/inc/core/router-pages.php
+++ b/inc/core/router-pages.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Router Pages
+ *
+ * Two virtual pages that turn the events homepage into a router:
+ *
+ *   /all     — the full all-cities calendar firehose (the calendar block that
+ *              used to live on the homepage), for power users.
+ *   /cities  — a directory of every city with upcoming events, grouped by
+ *              region. Region sections are driven by the location taxonomy
+ *              hierarchy and appear only when they have events.
+ *
+ * Implemented with rewrite rules + the extrachill_template_archive override,
+ * mirroring the discovery-pages pattern. No physical WP pages required.
+ *
+ * @package ExtraChillEvents
+ * @since 0.24.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the router-page query var and rewrite rules.
+ *
+ * @hook init
+ */
+function extrachill_events_router_rewrite_rules() {
+	if ( ! ec_is_events_site() ) {
+		return;
+	}
+
+	add_rewrite_tag( '%ec_events_router%', '(all|cities)' );
+
+	add_rewrite_rule( '^all/?$', 'index.php?ec_events_router=all', 'top' );
+	add_rewrite_rule( '^cities/?$', 'index.php?ec_events_router=cities', 'top' );
+}
+add_action( 'init', 'extrachill_events_router_rewrite_rules' );
+
+/**
+ * Get the current router page slug, or empty string.
+ *
+ * @return string 'all', 'cities', or ''.
+ */
+function extrachill_events_get_router_page(): string {
+	$page = get_query_var( 'ec_events_router', '' );
+	return in_array( $page, array( 'all', 'cities' ), true ) ? (string) $page : '';
+}
+
+/**
+ * Whether the current request is a router page.
+ *
+ * @return bool
+ */
+function extrachill_events_is_router_page(): bool {
+	return ec_is_events_site() && '' !== extrachill_events_get_router_page();
+}
+
+/**
+ * Route the request to the matching router-page template.
+ *
+ * Runs at priority 20 (after the events archive override at 10 and the
+ * discovery override at 15) so it wins when ec_events_router is set.
+ *
+ * @hook extrachill_template_archive
+ * @param string $template Current template path.
+ * @return string Router-page template path or original.
+ */
+function extrachill_events_router_template( string $template ): string {
+	$page = extrachill_events_get_router_page();
+	if ( '' === $page ) {
+		return $template;
+	}
+
+	if ( 'all' === $page ) {
+		return EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/templates/all-events.php';
+	}
+
+	return EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/templates/cities.php';
+}
+add_filter( 'extrachill_template_archive', 'extrachill_events_router_template', 20 );
+
+/**
+ * Force the router pages to resolve as a successful (200) archive request.
+ *
+ * Without a matched post/term, WordPress would 404 the virtual URL before
+ * the template filter runs. Mark it as an archive and clear the 404 flag.
+ *
+ * @hook parse_query
+ * @param \WP_Query $query Main query.
+ */
+function extrachill_events_router_query_flags( $query ) {
+	if ( ! $query->is_main_query() || is_admin() ) {
+		return;
+	}
+	if ( '' === extrachill_events_get_router_page() ) {
+		return;
+	}
+
+	$query->is_404     = false;
+	$query->is_archive = true;
+	$query->is_home    = false;
+	status_header( 200 );
+}
+add_action( 'parse_query', 'extrachill_events_router_query_flags' );
+
+/**
+ * Document title for router pages.
+ *
+ * @hook document_title_parts
+ * @param array $parts Title parts.
+ * @return array
+ */
+function extrachill_events_router_title( array $parts ): array {
+	$page = extrachill_events_get_router_page();
+	if ( '' === $page ) {
+		return $parts;
+	}
+
+	$parts['title'] = ( 'all' === $page )
+		? __( 'All Live Music Events', 'extrachill-events' )
+		: __( 'Browse Events by City', 'extrachill-events' );
+
+	return $parts;
+}
+add_filter( 'document_title_parts', 'extrachill_events_router_title', 1000 );

--- a/inc/home/location-badges.php
+++ b/inc/home/location-badges.php
@@ -2,7 +2,9 @@
 /**
  * Events Homepage Location Badges
  *
- * Displays location badges with upcoming event counts for easy city filtering.
+ * Homepage router: shows the top N cities by upcoming-event count as badges,
+ * with a "Browse all cities" link to the full /cities directory. Keeps the
+ * homepage glanceable instead of rendering every qualifying city (147+).
  *
  * @package ExtraChillEvents
  * @since 0.3.2
@@ -12,10 +14,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Number of city badges to surface on the homepage router.
+ *
+ * @since 0.24.0
+ */
+$top_n = (int) apply_filters( 'extrachill_events_home_badge_limit', 25 );
+
 $request = new WP_REST_Request( 'GET', '/extrachill/v1/events/upcoming-counts' );
 $request->set_query_params(
 	array(
 		'taxonomy' => 'location',
+		'limit'    => $top_n,
 	)
 );
 
@@ -30,18 +40,6 @@ $location_counts = $response->get_data();
 if ( empty( $location_counts ) || ! is_array( $location_counts ) ) {
 	return;
 }
-
-$min_events      = apply_filters( 'extrachill_events_badge_min_count', 20 );
-$location_counts = array_filter(
-	$location_counts,
-	function ( $location ) use ( $min_events ) {
-		return $location['count'] >= $min_events;
-	}
-);
-
-if ( empty( $location_counts ) ) {
-	return;
-}
 ?>
 	<div class="taxonomy-badges ec-edge-gutter">
 	<?php foreach ( $location_counts as $location ) : ?>
@@ -50,3 +48,9 @@ if ( empty( $location_counts ) ) {
 		</a>
 	<?php endforeach; ?>
 	</div>
+
+	<p class="events-browse-all-cities">
+		<a href="<?php echo esc_url( home_url( '/cities/' ) ); ?>">
+			<?php esc_html_e( 'Browse all cities &rarr;', 'extrachill-events' ); ?>
+		</a>
+	</p>

--- a/inc/templates/all-events.php
+++ b/inc/templates/all-events.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * All Events Template (/all)
+ *
+ * The full all-cities calendar firehose. This is the calendar block that
+ * previously lived on the homepage, moved to its own page so the homepage
+ * can act as a glanceable router.
+ *
+ * @package ExtraChillEvents
+ * @since 0.24.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_header();
+extrachill_breadcrumbs();
+?>
+
+<div class="events-calendar-container ec-mobile-full-width-panel">
+	<div class="page-content">
+		<header class="taxonomy-archive-header">
+			<h1 class="page-title"><?php esc_html_e( 'All Live Music Events', 'extrachill-events' ); ?></h1>
+			<?php extrachill_events_render_calendar_stats(); ?>
+		</header>
+	</div>
+
+	<div class="page-content">
+		<?php echo do_blocks( '<!-- wp:data-machine-events/calendar {"showScopePresets":true} /-->' ); ?>
+	</div>
+</div>
+
+<?php get_footer(); ?>

--- a/inc/templates/cities.php
+++ b/inc/templates/cities.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Cities Directory Template (/cities)
+ *
+ * Full directory of every city with upcoming events, grouped by region. The
+ * region grouping is driven entirely by the location taxonomy hierarchy
+ * (region root -> state -> city); a region section only renders when it has
+ * cities with upcoming events. Region headers show the rolled-up total via
+ * the data-machine-events ancestor rollup primitive.
+ *
+ * No region names are hard-coded here — buckets come from the taxonomy tree.
+ *
+ * @package ExtraChillEvents
+ * @since 0.24.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_header();
+extrachill_breadcrumbs();
+
+/**
+ * Minimum upcoming-event count for a city to appear in the directory.
+ *
+ * @since 0.24.0
+ */
+$min_events = (int) apply_filters( 'extrachill_events_directory_min_count', 1 );
+
+// All cities with upcoming events (leaf location terms), count desc.
+$cities_request = new WP_REST_Request( 'GET', '/extrachill/v1/events/upcoming-counts' );
+$cities_request->set_query_params( array( 'taxonomy' => 'location' ) );
+$cities_response = rest_do_request( $cities_request );
+$cities          = $cities_response->is_error() ? array() : (array) $cities_response->get_data();
+
+// Region rollup totals (ancestor subtree counts). Keyed by term_id.
+$rollup_request = new WP_REST_Request( 'GET', '/extrachill/v1/events/upcoming-counts' );
+$rollup_request->set_query_params(
+	array(
+		'taxonomy' => 'location',
+		'rollup'   => true,
+	)
+);
+$rollup_response = $rollup_request->is_error() ? null : rest_do_request( $rollup_request );
+$rollup_terms   = ( $rollup_response && ! $rollup_response->is_error() ) ? (array) $rollup_response->get_data() : array();
+
+$rollup_by_id = array();
+foreach ( $rollup_terms as $r ) {
+	$rollup_by_id[ (int) $r['term_id'] ] = (int) $r['count'];
+}
+
+// Bucket cities under their region root using taxonomy ancestry. A city with
+// no region ancestor falls into a generic bucket so nothing is dropped.
+$regions             = array(); // root_term_id => array of city rows.
+$region_meta         = array(); // root_term_id => WP_Term.
+$ungrouped           = array();
+$ungrouped_label_key = 0;
+
+foreach ( $cities as $city ) {
+	if ( (int) $city['count'] < $min_events ) {
+		continue;
+	}
+
+	$ancestors = get_ancestors( (int) $city['term_id'], 'location', 'taxonomy' );
+	if ( empty( $ancestors ) ) {
+		$ungrouped[] = $city;
+		continue;
+	}
+
+	// Topmost ancestor is the region root.
+	$root_id = (int) end( $ancestors );
+	if ( ! isset( $region_meta[ $root_id ] ) ) {
+		$root_term = get_term( $root_id, 'location' );
+		if ( ! $root_term || is_wp_error( $root_term ) ) {
+			$ungrouped[] = $city;
+			continue;
+		}
+		$region_meta[ $root_id ] = $root_term;
+		$regions[ $root_id ]     = array();
+	}
+	$regions[ $root_id ][] = $city;
+}
+
+// Order regions by their rolled-up total, descending.
+uksort(
+	$regions,
+	static function ( $a, $b ) use ( $rollup_by_id ) {
+		return ( $rollup_by_id[ $b ] ?? 0 ) <=> ( $rollup_by_id[ $a ] ?? 0 );
+	}
+);
+?>
+
+<div class="events-calendar-container ec-mobile-full-width-panel">
+	<div class="page-content">
+		<header class="taxonomy-archive-header">
+			<h1 class="page-title"><?php esc_html_e( 'Browse Events by City', 'extrachill-events' ); ?></h1>
+			<p class="cities-directory-intro">
+				<?php esc_html_e( 'Every city with upcoming live music. Pick a city to see its calendar.', 'extrachill-events' ); ?>
+			</p>
+		</header>
+	</div>
+
+	<div class="page-content cities-directory">
+		<?php foreach ( $regions as $root_id => $region_cities ) : ?>
+			<?php
+			$region      = $region_meta[ $root_id ];
+			$region_link = get_term_link( $region );
+			$region_total = $rollup_by_id[ $root_id ] ?? 0;
+			?>
+			<section class="cities-region">
+				<h2 class="cities-region-title">
+					<?php if ( ! is_wp_error( $region_link ) ) : ?>
+						<a href="<?php echo esc_url( $region_link ); ?>"><?php echo esc_html( $region->name ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $region->name ); ?>
+					<?php endif; ?>
+					<?php if ( $region_total > 0 ) : ?>
+						<span class="cities-region-count">(<?php echo esc_html( number_format_i18n( $region_total ) ); ?>)</span>
+					<?php endif; ?>
+				</h2>
+				<div class="taxonomy-badges">
+					<?php foreach ( $region_cities as $city ) : ?>
+						<a href="<?php echo esc_url( $city['url'] ); ?>" class="taxonomy-badge location-badge location-<?php echo esc_attr( $city['slug'] ); ?>">
+							<?php echo esc_html( $city['name'] ); ?> (<?php echo esc_html( $city['count'] ); ?>)
+						</a>
+					<?php endforeach; ?>
+				</div>
+			</section>
+		<?php endforeach; ?>
+
+		<?php if ( ! empty( $ungrouped ) ) : ?>
+			<section class="cities-region cities-region-other">
+				<h2 class="cities-region-title"><?php esc_html_e( 'Other', 'extrachill-events' ); ?></h2>
+				<div class="taxonomy-badges">
+					<?php foreach ( $ungrouped as $city ) : ?>
+						<a href="<?php echo esc_url( $city['url'] ); ?>" class="taxonomy-badge location-badge location-<?php echo esc_attr( $city['slug'] ); ?>">
+							<?php echo esc_html( $city['name'] ); ?> (<?php echo esc_html( $city['count'] ); ?>)
+						</a>
+					<?php endforeach; ?>
+				</div>
+			</section>
+		<?php endif; ?>
+	</div>
+</div>
+
+<?php get_footer(); ?>

--- a/scripts/deploy-homepage-router.sh
+++ b/scripts/deploy-homepage-router.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Deploy step for the events homepage router (PR #187).
+#
+# Removes the data-machine-events/calendar block from the events.extrachill.com
+# homepage (page_on_front, post ID 5) and updates the intro copy. The router
+# badges + "Browse all cities" link render ABOVE this content via the
+# extrachill_events_home_before_calendar hook, so once the calendar block is
+# gone the homepage becomes a clean router. The full calendar lives at /all.
+#
+# Idempotent: re-running just re-sets the same content. Run AFTER PR #187 is
+# merged and deployed (so /all and /cities routes exist), then flush rewrites.
+#
+# Usage:  bash scripts/deploy-homepage-router.sh
+#
+set -euo pipefail
+
+WP="wp --path=/var/www/extrachill.com --url=events.extrachill.com"
+HOME_ID="$($WP option get page_on_front)"
+
+if [ "$HOME_ID" != "5" ]; then
+	echo "WARNING: page_on_front is $HOME_ID, expected 5. Verify before proceeding." >&2
+fi
+
+# New homepage content: intro paragraph only. No calendar block — the router
+# badges render via hook, and the firehose lives at /all.
+read -r -d '' NEW_CONTENT <<'EOF' || true
+<!-- wp:paragraph -->
+<p>Find live music near you. Pick a city below, <a href="/cities/">browse all cities</a>, or <a href="/all/">see every event</a>.</p>
+<!-- /wp:paragraph -->
+EOF
+
+# Back up current content first.
+BACKUP="/tmp/events-homepage-content.$(date +%Y%m%d%H%M%S).html"
+$WP post get "$HOME_ID" --field=post_content > "$BACKUP"
+echo "Backed up current homepage content to $BACKUP"
+
+# Apply new content.
+$WP post update "$HOME_ID" --post_content="$NEW_CONTENT"
+echo "Homepage content updated (calendar block removed)."
+
+# Flush rewrite rules so /all and /cities resolve.
+$WP rewrite flush
+echo "Rewrite rules flushed."
+
+echo
+echo "Done. Verify:"
+echo "  https://events.extrachill.com/        (router: badges + browse link, no firehose)"
+echo "  https://events.extrachill.com/cities/ (region-grouped directory)"
+echo "  https://events.extrachill.com/all/    (full calendar)"


### PR DESCRIPTION
## Summary
- **Homepage = router.** Badges now show the **top ~25 cities** by upcoming-event count + a **"Browse all cities →"** link, instead of the full 147-city wall.
- **New `/cities` directory.** Every city with upcoming events, **grouped by region** from the location taxonomy hierarchy. Region sections render only when they have events; headers show the rolled-up total. No region names hard-coded.
- **New `/all` page.** The full all-cities calendar firehose (the block that used to live on the homepage), for power users.
- **Single source of truth for counts.** `extrachill/events-upcoming-counts` now **delegates** to `data-machine-events/get-upcoming-counts` instead of duplicating the count SQL — resolves #185.

## Why
The homepage was `stats → 147 city badges → all-events calendar`: a wall on top of a firehose. This makes the homepage glanceable, moves the firehose to its own page, and lays the foundation for region-sectioned navigation as the calendar scales across cities/continents.

## How
- `/all` + `/cities` are virtual pages via rewrite rules + the `extrachill_template_archive` override (same pattern as discovery-pages). `parse_query` marks them as 200 archives.
- `/cities` buckets cities under their region root via `get_ancestors()`; region totals come from the new ancestor **rollup** mode.
- The counts wrapper keeps only EC-specific concerns: 6h transient cache, `limit` slicing, and venue `location_slug` scoping (mapped onto the ability's `filter_taxonomy`/`filter_term_id`). Duplicate SQL deleted.

## Validation (live events.extrachill.com data)
- 184 cities bucket cleanly under **United States**, **0 ungrouped**, no empty region sections.
- `Europe` / `South America` correctly absent (no cities with events yet) → they'll appear automatically once they get events.

## Deploy note
The `data-machine-events/calendar` block must be removed from the homepage `page_on_front` post content at deploy time (data, not code). Badges + browse link render above it via the `extrachill_events_home_before_calendar` hook, so emptying the block leaves a clean router homepage.

## Dependencies / related
- **Depends on** Extra-Chill/data-machine-events#387 / PR #388 (rollup primitive) for **non-zero `/cities` region totals**. Homepage top-N + flat city list work without it (rollup is opt-in).
- Resolves #185 (counts SQL dedup). Refs #184. Slots under Discovery Pages epic #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)