### PR TITLE
fix(location): Niagara Falls cross-border (NY->Buffalo, ON->Canada term) #379

### DIFF
--- a/inc/core/location-normalizer.php
+++ b/inc/core/location-normalizer.php
@@ -542,7 +542,13 @@ function extrachill_events_get_city_market_map() {
 			'kentucky' => 'cincinnati',
 			'ky'       => 'cincinnati',
 		),
-		'niagara falls'       => 'buffalo',
+		'niagara falls'       => array(
+			// US Niagara Falls (NY) rolls into the Buffalo market; the Ontario
+			// side has its own Canada-tree term and must NOT roll to Buffalo, so
+			// it is intentionally absent here and resolves via exact-name match.
+			'new york' => 'buffalo',
+			'ny'       => 'buffalo',
+		),
 		'noblesville'         => 'indianapolis',
 		'north charleston'    => 'charleston',
 		'north little rock'   => 'little-rock',

--- a/tests/location-market-map-smoke.php
+++ b/tests/location-market-map-smoke.php
@@ -111,6 +111,10 @@ $cases = array(
 	array( 'Abbotsford', 'BC', '', 'vancouver-bc' ),
 	array( 'Richmond', 'BC', '', 'vancouver-bc' ),
 	array( 'Richmond', 'VA', '', null ), // US Richmond stays null -> exact-name match resolves it
+	// Niagara Falls is cross-border: NY rolls to Buffalo; the Ontario side has
+	// its own Canada-tree term and must stay null (resolves via exact-name match).
+	array( 'Niagara Falls', 'NY', '', 'buffalo' ),
+	array( 'Niagara Falls', 'ON', '', null ),
 	array( 'Burnaby', 'BC', '', 'vancouver-bc' ),
 
 	// Existing mappings must keep working.


### PR DESCRIPTION
Refs #379

The network-wide map added `'niagara falls' => 'buffalo'` — correct for Niagara Falls, NY, but after the Canada tree landed it kept the **Ontario** side pinned to Buffalo (68 events) instead of the new `niagara-falls-on` term. State-key the entry to NY only; the ON side falls through to exact-name match. Smoke test 50/50, lint green.