### PR TITLE
test(location): Mexico tree — guard Rosarito against US market mis-mapping (#379)

### DIFF
--- a/tests/location-market-map-smoke.php
+++ b/tests/location-market-map-smoke.php
@@ -117,6 +117,13 @@ $cases = array(
 	array( 'Niagara Falls', 'ON', '', null ),
 	array( 'Burnaby', 'BC', '', 'vancouver-bc' ),
 
+	// Mexico: Rosarito (Baja California) must NOT roll into a US market via the
+	// map — it has its own Mexico-tree term (slug rosarito-bcn) and resolves via
+	// exact-name match. The map must return null so it never lands in San Diego.
+	// "BC" here is Baja California (MX), distinct from British Columbia (CA);
+	// because Rosarito is a unique city name it resolves without state collision.
+	array( 'Rosarito', 'BC', '', null ),
+
 	// Existing mappings must keep working.
 	array( 'Cambridge', 'MA', '02139', 'boston' ),
 	array( 'North Charleston', 'SC', '29405', 'charleston' ),


### PR DESCRIPTION
Refs #379

Companion to the new **Mexico location tree** (created in the events taxonomy):

```
Mexico (mexico)
└─ Baja California (baja-california)
   └─ Rosarito (rosarito-bcn)
```

Mexican border venues were tagged to the nearest **US** market — Rosarito's 5 events sat under **San Diego** (~15mi across the border). Rosarito has a unique city name, so it resolves via the resolver's exact-name match — no market-map entry or resolver country-awareness needed.

This PR adds a smoke-test guard asserting the market map returns `null` for Rosarito (so it can never roll into San Diego) and documents that "BC" here is **Baja California (MX)**, distinct from **British Columbia (CA)** — safe because Rosarito is a unique name (state disambiguation only fires on name collisions).

**Data already re-tagged:** 5 Rosarito events moved San Diego → Rosarito. Smoke test 51/51, lint green.