### PR TITLE
fix(location): /location directory 500 — is_error() on request instead of response

### DIFF
--- a/inc/templates/location-directory.php
+++ b/inc/templates/location-directory.php
@@ -46,8 +46,8 @@ $rollup_request->set_query_params(
 		'rollup'   => true,
 	)
 );
-$rollup_response = $rollup_request->is_error() ? null : rest_do_request( $rollup_request );
-$rollup_terms    = ( $rollup_response && ! $rollup_response->is_error() ) ? (array) $rollup_response->get_data() : array();
+$rollup_response = rest_do_request( $rollup_request );
+$rollup_terms    = $rollup_response->is_error() ? array() : (array) $rollup_response->get_data();
 
 $rollup_by_id = array();
 foreach ( $rollup_terms as $r ) {


### PR DESCRIPTION
## Summary
Fixes a fatal `Call to undefined method WP_REST_Request::is_error()` on `/location` (the events location directory), which returned a 500.

`is_error()` is a `WP_REST_Response` method. It was mistakenly called on the `WP_REST_Request` object when fetching the rollup totals. Now the request is dispatched first and `is_error()` is checked on the response — matching the cities-counts call directly above it.

## Verified
- phpcs clean.
- Live REST simulation: rollup call returns 190 terms, no error.

Caught immediately after deploy. `/all` and the homepage were unaffected.