### PR TITLE
feat(home): all-city badges + My Shows/Submit feature cards, hold off /location

### DIFF
--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -114,3 +114,68 @@
     font-weight: normal;
     font-size: 0.8em;
 }
+
+/* Homepage intro line under the H1. */
+.events-home-intro {
+    color: var(--muted-text);
+    font-size: var(--font-size-body);
+    margin-bottom: var(--spacing-sm);
+}
+
+/* "See every event" link below the city badges. */
+.events-browse-all-cities {
+    margin: var(--spacing-md) 0 0;
+    text-align: center;
+    font-size: var(--font-size-body);
+}
+
+/* Homepage feature cards (My Shows + Submit). */
+.events-feature-cards {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-md);
+    margin: var(--spacing-xl) 0;
+}
+
+.events-feature-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-lg);
+    background: var(--background-color);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius, 8px);
+    box-shadow: var(--card-shadow);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.events-feature-card:hover {
+    border-color: var(--accent);
+    transform: translateY(-2px);
+}
+
+.events-feature-card__title {
+    margin: 0;
+}
+
+.events-feature-card__body {
+    margin: 0;
+    color: var(--muted-text);
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-relaxed);
+}
+
+.events-feature-card__cta {
+    margin-top: auto;
+    color: var(--accent);
+    font-weight: 600;
+    font-size: var(--font-size-sm);
+}
+
+@media (max-width: 600px) {
+    .events-feature-cards {
+        grid-template-columns: 1fr;
+    }
+}

--- a/inc/core/router-pages.php
+++ b/inc/core/router-pages.php
@@ -34,14 +34,18 @@ function extrachill_events_router_rewrite_rules() {
 	}
 
 	add_rewrite_tag( '%ec_events_router%', '(all)' );
-	add_rewrite_tag( '%ec_events_location_index%', '(1)' );
-
 	add_rewrite_rule( '^all/?$', 'index.php?ec_events_router=all', 'top' );
 
-	// The bare location taxonomy base (no term) renders the directory. The
-	// catch-all location/(.+?) rule requires a term, so /location/ would 404
-	// without this. 'top' priority matches before that catch-all.
-	add_rewrite_rule( '^location/?$', 'index.php?ec_events_location_index=1', 'top' );
+	// The /location directory is built but held off for now. When enabled, the
+	// bare location taxonomy base (no term) renders the region-grouped
+	// directory; the catch-all location/(.+?) rule requires a term, so
+	// /location/ would 404 without this rule. 'top' priority matches before
+	// that catch-all. Flip extrachill_events_enable_location_directory to true
+	// (and flush rewrites) to turn it on.
+	if ( extrachill_events_location_directory_enabled() ) {
+		add_rewrite_tag( '%ec_events_location_index%', '(1)' );
+		add_rewrite_rule( '^location/?$', 'index.php?ec_events_location_index=1', 'top' );
+	}
 }
 add_action( 'init', 'extrachill_events_router_rewrite_rules' );
 
@@ -55,12 +59,26 @@ function extrachill_events_is_all_events_page(): bool {
 }
 
 /**
+ * Whether the /location directory page is enabled.
+ *
+ * Held off by default. Filter to true (and flush rewrites) to expose it.
+ *
+ * @return bool
+ * @since 0.25.0
+ */
+function extrachill_events_location_directory_enabled(): bool {
+	return (bool) apply_filters( 'extrachill_events_enable_location_directory', false );
+}
+
+/**
  * Whether the current request is the /location/ directory page.
  *
  * @return bool
  */
 function extrachill_events_is_location_index(): bool {
-	return ec_is_events_site() && '1' === (string) get_query_var( 'ec_events_location_index', '' );
+	return ec_is_events_site()
+		&& extrachill_events_location_directory_enabled()
+		&& '1' === (string) get_query_var( 'ec_events_location_index', '' );
 }
 
 /**

--- a/inc/home/actions.php
+++ b/inc/home/actions.php
@@ -26,6 +26,18 @@ function extrachill_events_location_badges() {
 add_action( 'extrachill_events_home_before_calendar', 'extrachill_events_location_badges', 10 );
 
 /**
+ * Render the homepage feature cards (My Shows + Submit) below the badges.
+ *
+ * @hook extrachill_events_home_before_calendar
+ * @return void
+ * @since 0.25.0
+ */
+function extrachill_events_home_feature_cards() {
+	include EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/home/feature-cards.php';
+}
+add_action( 'extrachill_events_home_before_calendar', 'extrachill_events_home_feature_cards', 20 );
+
+/**
  * Render venue badges on a location taxonomy archive
  *
  * Lists every venue with upcoming events in the current city, mirroring the

--- a/inc/home/feature-cards.php
+++ b/inc/home/feature-cards.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Events Homepage Feature Cards
+ *
+ * Two side-by-side cards below the city badges surfacing the platform's
+ * personalization + contribution features: building a personal concert
+ * archive (My Shows) and adding events to the calendar (Submit).
+ *
+ * @package ExtraChillEvents
+ * @since 0.25.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div class="events-feature-cards ec-edge-gutter">
+	<a class="events-feature-card events-feature-card--my-shows" href="<?php echo esc_url( home_url( '/my-shows/' ) ); ?>">
+		<h2 class="events-feature-card__title"><?php esc_html_e( 'My Shows', 'extrachill-events' ); ?></h2>
+		<p class="events-feature-card__body">
+			<?php esc_html_e( 'Track the concerts you\'re going to and the ones you\'ve seen. Build your own concert archive over time.', 'extrachill-events' ); ?>
+		</p>
+		<span class="events-feature-card__cta"><?php esc_html_e( 'Start your archive &rarr;', 'extrachill-events' ); ?></span>
+	</a>
+
+	<a class="events-feature-card events-feature-card--submit" href="<?php echo esc_url( home_url( '/submit/' ) ); ?>">
+		<h2 class="events-feature-card__title"><?php esc_html_e( 'Submit an Event', 'extrachill-events' ); ?></h2>
+		<p class="events-feature-card__body">
+			<?php esc_html_e( 'Playing a show or know one we\'re missing? Add it to the calendar so fans can find it.', 'extrachill-events' ); ?>
+		</p>
+		<span class="events-feature-card__cta"><?php esc_html_e( 'Submit a show &rarr;', 'extrachill-events' ); ?></span>
+	</a>
+</div>

--- a/inc/home/location-badges.php
+++ b/inc/home/location-badges.php
@@ -2,9 +2,9 @@
 /**
  * Events Homepage Location Badges
  *
- * Homepage router: shows the top N cities by upcoming-event count as badges,
- * with a "Browse all cities" link to the full /location/ directory. Keeps the
- * homepage glanceable instead of rendering every qualifying city (147+).
+ * Displays a badge for every city with enough upcoming events, plus a
+ * "See every event" link to the full /all calendar. Lets visitors jump
+ * straight to a city's calendar.
  *
  * @package ExtraChillEvents
  * @since 0.3.2
@@ -14,18 +14,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Number of city badges to surface on the homepage router.
- *
- * @since 0.24.0
- */
-$top_n = (int) apply_filters( 'extrachill_events_home_badge_limit', 25 );
-
 $request = new WP_REST_Request( 'GET', '/extrachill/v1/events/upcoming-counts' );
 $request->set_query_params(
 	array(
 		'taxonomy' => 'location',
-		'limit'    => $top_n,
 	)
 );
 
@@ -40,6 +32,18 @@ $location_counts = $response->get_data();
 if ( empty( $location_counts ) || ! is_array( $location_counts ) ) {
 	return;
 }
+
+$min_events      = (int) apply_filters( 'extrachill_events_badge_min_count', 20 );
+$location_counts = array_filter(
+	$location_counts,
+	static function ( $location ) use ( $min_events ) {
+		return $location['count'] >= $min_events;
+	}
+);
+
+if ( empty( $location_counts ) ) {
+	return;
+}
 ?>
 	<div class="taxonomy-badges ec-edge-gutter">
 	<?php foreach ( $location_counts as $location ) : ?>
@@ -50,7 +54,7 @@ if ( empty( $location_counts ) || ! is_array( $location_counts ) ) {
 	</div>
 
 	<p class="events-browse-all-cities">
-		<a href="<?php echo esc_url( home_url( '/location/' ) ); ?>">
-			<?php esc_html_e( 'Browse all cities &rarr;', 'extrachill-events' ); ?>
+		<a href="<?php echo esc_url( home_url( '/all/' ) ); ?>">
+			<?php esc_html_e( 'See every event &rarr;', 'extrachill-events' ); ?>
 		</a>
 	</p>

--- a/inc/templates/homepage.php
+++ b/inc/templates/homepage.php
@@ -20,6 +20,9 @@ extrachill_breadcrumbs();
 	<div class="page-content">
 		<header>
 			<h1 class="page-title"><?php esc_html_e( 'Live Music Calendar', 'extrachill-events' ); ?></h1>
+			<p class="events-home-intro">
+				<?php esc_html_e( 'Find live music near you. Pick a city below, track your shows, or see every event.', 'extrachill-events' ); ?>
+			</p>
 			<?php extrachill_events_render_calendar_stats(); ?>
 		</header>
 	</div>

--- a/scripts/deploy-homepage-router.sh
+++ b/scripts/deploy-homepage-router.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 #
-# Deploy step for the events homepage router (PR #187).
+# Deploy step for the events homepage.
 #
-# Removes the data-machine-events/calendar block from the events.extrachill.com
-# homepage (page_on_front, post ID 5) and updates the intro copy. The router
-# badges + "Browse all cities" link render ABOVE this content via the
-# extrachill_events_home_before_calendar hook, so once the calendar block is
-# gone the homepage becomes a clean router. The full calendar lives at /all.
+# Empties the events.extrachill.com homepage (page_on_front, post ID 5) post
+# content. The homepage is fully template-driven now: intro copy, city badges,
+# and the My Shows / Submit feature cards all render via the homepage template
+# + the extrachill_events_home_before_calendar hook. The full calendar lives at
+# /all. Any leftover blocks in the post content (old intro paragraph, calendar
+# block) would render as orphaned content below the cards, so we clear it.
 #
-# Idempotent: re-running just re-sets the same content. Run AFTER PR #187 is
-# merged and deployed (so /all and /location/ routes exist), then flush rewrites.
+# Idempotent: re-running just re-clears the content. Run AFTER the matching
+# plugin version is deployed, then flush rewrites so /all resolves.
 #
 # Usage:  bash scripts/deploy-homepage-router.sh
 #
@@ -22,29 +23,20 @@ if [ "$HOME_ID" != "5" ]; then
 	echo "WARNING: page_on_front is $HOME_ID, expected 5. Verify before proceeding." >&2
 fi
 
-# New homepage content: intro paragraph only. No calendar block — the router
-# badges render via hook, and the firehose lives at /all.
-read -r -d '' NEW_CONTENT <<'EOF' || true
-<!-- wp:paragraph -->
-<p>Find live music near you. Pick a city below, <a href="/location/">browse all locations</a>, or <a href="/all/">see every event</a>.</p>
-<!-- /wp:paragraph -->
-EOF
-
 # Back up current content first.
 BACKUP="/tmp/events-homepage-content.$(date +%Y%m%d%H%M%S).html"
 $WP post get "$HOME_ID" --field=post_content > "$BACKUP"
 echo "Backed up current homepage content to $BACKUP"
 
-# Apply new content.
-$WP post update "$HOME_ID" --post_content="$NEW_CONTENT"
-echo "Homepage content updated (calendar block removed)."
+# Clear the post content — the homepage is template-driven.
+$WP post update "$HOME_ID" --post_content=""
+echo "Homepage post content cleared (template-driven now)."
 
-# Flush rewrite rules so /all and /location/ resolve.
+# Flush rewrite rules so /all resolves.
 $WP rewrite flush
 echo "Rewrite rules flushed."
 
 echo
 echo "Done. Verify:"
-echo "  https://events.extrachill.com/        (router: badges + browse link, no firehose)"
-echo "  https://events.extrachill.com/location/ (region-grouped directory)"
-echo "  https://events.extrachill.com/all/    (full calendar)"
+echo "  https://events.extrachill.com/     (intro + stats + city badges + feature cards)"
+echo "  https://events.extrachill.com/all/ (full calendar)"


### PR DESCRIPTION
## Summary
Makes the events homepage feel alive instead of empty, and surfaces the platform's personalization/contribution features.

- **All cities back:** show a badge for every city with ≥20 upcoming events again (reverts the top-25 cap).
- **Feature cards:** two side-by-side cards below the badges — **My Shows** ("build your own concert archive" → `/my-shows`) and **Submit an Event** (→ `/submit`). Rendered via the `extrachill_events_home_before_calendar` hook.
- **Intro fixed:** the welcome line moves to the **top** (under the H1, above stats) instead of being orphaned at the bottom of the page.
- **Browse link → `/all`:** "See every event →" points at the full calendar, not a directory.
- **`/location` held off:** its rewrite rule + detection are gated behind `extrachill_events_enable_location_directory` (default **false**). The route and template stay in code for later; `/location/` falls back to 404 until enabled.

## Why
The pure-router homepage felt empty — all navigation, no content, with the intro copy stranded at the bottom. Feature cards fill the space with the actual platform features (track your shows / contribute), which is more welcoming than a bigger wall of badges.

## Homepage now
`intro → stats → all-city badges → "See every event" link → [My Shows | Submit] cards`

## Deploy
`scripts/deploy-homepage-router.sh` now **clears** the `page_on_front` post content (homepage is fully template-driven) and flushes rewrites.

## Follow-ups (filed)
- #193 — artist self-import pipeline (submit a website event feed → per-artist import). Strategic, separate track.
- /location directory and a "Popular Artists" strip remain built/planned for when we re-enable them.

Refs #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)