### PR TITLE
feat(events): map Add-to-Calendar toggle to theme button classes

### DIFF
--- a/docs/hooks/data-machine-events-filters.md
+++ b/docs/hooks/data-machine-events-filters.md
@@ -196,6 +196,35 @@ data-machine-events single event template when rendering ticket button
 <a href="[ticket-url]" class="datamachine-ticket-button button-1 button-large">Buy Tickets</a>
 ```
 
+---
+
+### data_machine_events_add_to_calendar_button_classes
+
+**Purpose:** Route the single-event "Add to Calendar" toggle through theme button classes
+
+**Parameters:**
+- `$classes` (array): Default style classes from data-machine-events (`['ticket-button']`)
+- `$post_id` (int): Event post ID
+
+**Return Value:**
+Enhanced style classes with theme styling
+
+**Usage:**
+```php
+add_filter('data_machine_events_add_to_calendar_button_classes', array($this, 'add_calendar_toggle_button_classes'), 10, 1);
+
+public function add_calendar_toggle_button_classes($classes) {
+    $classes[] = 'button-1';
+    $classes[] = 'button-medium';
+    return $classes;
+}
+```
+
+**When Fired:**
+data-machine-events single event template when rendering the Add-to-Calendar toggle
+
+**Note:** The toggle's base classes (`dm-events-action-btn dm-events-add-to-calendar-toggle`) are always present and handle layout; the filter only augments the style classes.
+
 ## Breadcrumb Filter
 
 ### data_machine_events_breadcrumbs
@@ -276,6 +305,7 @@ For all filters and actions to work, the data-machine-events plugin must:
 2. **Provide button filters:**
    - `data_machine_events_modal_button_classes`
    - `data_machine_events_ticket_button_classes`
+   - `data_machine_events_add_to_calendar_button_classes`
 
 3. **Provide breadcrumb filter:**
    - `data_machine_events_breadcrumbs`

--- a/docs/integration/button-styling.md
+++ b/docs/integration/button-styling.md
@@ -102,6 +102,38 @@ public function add_ticket_button_classes($classes) {
 add_filter('data_machine_events_ticket_button_classes', array($this, 'add_ticket_button_classes'), 10, 1);
 ```
 
+## Add to Calendar Toggle Styling
+
+### data_machine_events_add_to_calendar_button_classes Filter
+
+Routes the single-event "Add to Calendar" toggle through the same theme button
+styling as the ticket button, so the action-button row (Ticket / Attendance /
+Add to Calendar / Share) stays visually consistent in the Extra Chill design
+system instead of falling back to the plugin's default `ticket-button` styling.
+
+**Filter Parameters:**
+- `$classes` (array): Default style classes from data-machine-events (`['ticket-button']`)
+
+**Class Mapping:**
+```php
+$classes[] = 'button-1';       // Theme's primary blue accent button
+$classes[] = 'button-medium';  // Medium button size
+```
+
+### Filter Implementation
+```php
+public function add_calendar_toggle_button_classes($classes) {
+    $classes[] = 'button-1';
+    $classes[] = 'button-medium';
+    return $classes;
+}
+add_filter('data_machine_events_add_to_calendar_button_classes', array($this, 'add_calendar_toggle_button_classes'), 10, 1);
+```
+
+The toggle's own base classes (`dm-events-action-btn dm-events-add-to-calendar-toggle`)
+are always present and handle layout (icon alignment, dropdown positioning); the
+filter only augments the style classes.
+
 ## Theme Button Classes
 
 ### button-1 (Primary)

--- a/docs/plugin-classes.md
+++ b/docs/plugin-classes.md
@@ -374,6 +374,20 @@ if (isset($integrations['data_machine_events'])) {
 
 ---
 
+#### add_calendar_toggle_button_classes()
+**Visibility:** public
+
+**Hook:** `data_machine_events_add_to_calendar_button_classes`
+
+**Parameters:**
+- `$classes` (array)
+
+**Return Value:** array
+
+**Purpose:** Route the Add-to-Calendar toggle through theme button classes (action-row parity)
+
+---
+
 #### override_breadcrumbs()
 **Visibility:** public
 

--- a/inc/core/data-machine-events/button-styling.php
+++ b/inc/core/data-machine-events/button-styling.php
@@ -18,6 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function extrachill_events_init_button_styling() {
 	add_filter( 'data_machine_events_modal_button_classes', 'extrachill_events_add_modal_button_classes', 10, 2 );
 	add_filter( 'data_machine_events_ticket_button_classes', 'extrachill_events_add_ticket_button_classes', 10, 1 );
+	add_filter( 'data_machine_events_add_to_calendar_button_classes', 'extrachill_events_add_calendar_toggle_button_classes', 10, 1 );
 	add_filter( 'data_machine_events_more_info_button_classes', 'extrachill_events_add_more_info_button_classes', 10, 1 );
 }
 
@@ -56,6 +57,26 @@ function extrachill_events_add_modal_button_classes( $classes, $button_type ) {
  * @return array Enhanced button classes with theme styling.
  */
 function extrachill_events_add_ticket_button_classes( $classes ) {
+	$classes[] = 'button-1';
+	$classes[] = 'button-medium';
+	return $classes;
+}
+
+/**
+ * Add theme button classes to the Add-to-Calendar toggle
+ *
+ * Routes the data-machine-events Add-to-Calendar toggle through the same
+ * theme button styling as the ticket button (button-1 + button-medium), so
+ * the single-event action-button row (Ticket / Attendance / Add to Calendar /
+ * Share) is visually consistent in the Extra Chill design system rather than
+ * falling back to the plugin's default ad-hoc styling. The toggle's own base
+ * classes handle layout (icon alignment, dropdown positioning); this only
+ * replaces the default `ticket-button` style class.
+ *
+ * @param array $classes Default style classes from data-machine-events.
+ * @return array Enhanced button classes with theme styling.
+ */
+function extrachill_events_add_calendar_toggle_button_classes( $classes ) {
 	$classes[] = 'button-1';
 	$classes[] = 'button-medium';
 	return $classes;


### PR DESCRIPTION
## Summary

Closes the consumer-side half of the events action-button design-system drift. The single-event row (Ticket / Attendance / Add to Calendar / Share) had the Add-to-Calendar toggle falling back to data-machine-events' default `ticket-button` styling, which references an undefined `--data-machine-*` token namespace on the EC theme — so it rendered with generic styling while the other buttons used the EC design system.

- Hooks the new `data_machine_events_add_to_calendar_button_classes` filter and maps the toggle to `button-1 button-medium`, matching the ticket button. The toggle's base classes still handle layout (icon alignment, dropdown positioning).
- Docs updated across `integration/button-styling.md`, `hooks/data-machine-events-filters.md`, and `plugin-classes.md`.

## Depends on

- **Extra-Chill/data-machine-events#400** — adds the `data_machine_events_add_to_calendar_button_classes` filter this PR consumes. This filter is a no-op until that PR ships; merge order: data-machine-events#400 → release → this PR.
- Related: data-machine-events#212 (token-namespace cleanup), data-machine-events#399 (issue this resolves the consumer side of).

Closes #198