### PR TITLE
refactor: adopt shared card-grid primitive across event blocks

### DIFF
--- a/blocks/concert-stats/src/components/ImportTab.js
+++ b/blocks/concert-stats/src/components/ImportTab.js
@@ -10,7 +10,7 @@
  * @package ExtraChillEvents
  */
 
-import { InlineStatus, Section } from '@extrachill/components';
+import { Grid, InlineStatus, Section } from '@extrachill/components';
 import ImportSourceCard from './ImportSourceCard';
 
 /**
@@ -46,7 +46,10 @@ const ImportTab = ( { bag } ) => {
 				Shows we don&rsquo;t already have we&rsquo;ll add for you so your full history comes in.
 			</p>
 
-			<div className="ec-concert-stats__import-cards">
+			<Grid
+				className="ec-concert-stats__import-cards"
+				minColumnWidth="280px"
+			>
 				{ sources.map( ( source ) => (
 					<ImportSourceCard
 						key={ source.slug }
@@ -56,7 +59,7 @@ const ImportTab = ( { bag } ) => {
 						onStart={ start }
 					/>
 				) ) }
-			</div>
+			</Grid>
 		</Section>
 	);
 };

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -198,11 +198,13 @@ a.ec-concert-stats__stat {
 
 /* ─── Leaderboards (inside Panel) ───────────────────────────────────────── */
 
-.ec-concert-stats__leaderboards {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-	gap: var(--spacing-lg, 1.5rem);
-}
+/*
+ * Grid layout is provided by the shared `.ec-card-grid` primitive
+ * (`<Grid>` from @extrachill/components, minColumnWidth="200px",
+ * gap="var(--spacing-lg, 1.5rem)"). Only the mobile override below
+ * remains local — it forces a single column earlier than the auto-fit
+ * floor would.
+ */
 
 .ec-concert-stats__leaderboard-title {
 	font-size: var(--font-size-sm, 0.875rem);
@@ -446,11 +448,12 @@ a.ec-concert-stats__stat {
 	color: var(--muted-text, #6b7280);
 }
 
-.ec-concert-stats__import-cards {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-	gap: var(--spacing-md, 1rem);
-}
+/*
+ * `.ec-concert-stats__import-cards` grid layout is provided by the shared
+ * `.ec-card-grid` primitive (`<Grid>` from @extrachill/components,
+ * minColumnWidth="280px"). The default gap (--spacing-md, 1rem) matches the
+ * previous local declaration, so no gap override is needed.
+ */
 
 /* Form layout inside the import Panel */
 .ec-concert-stats__import-card-form {

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -12,6 +12,7 @@ import {
 	BlockShell,
 	BlockShellInner,
 	BlockShellHeader,
+	Grid,
 	InlineStatus,
 	ResponsiveTabs,
 } from '@extrachill/components';
@@ -445,7 +446,11 @@ function ConcertStatsApp( {
 				}
 				if ( stats && hasAnyShows ) {
 					return (
-						<div className="ec-concert-stats__leaderboards">
+						<Grid
+							className="ec-concert-stats__leaderboards"
+							minColumnWidth="200px"
+							gap="var(--spacing-lg, 1.5rem)"
+						>
 							<Leaderboard
 								title="Top Artists"
 								items={ stats.top_artists }
@@ -460,7 +465,7 @@ function ConcertStatsApp( {
 								items={ stats.top_cities }
 								taxonomy="location"
 							/>
-						</div>
+						</Grid>
 					);
 				}
 				return null;

--- a/blocks/event-submission/style.css
+++ b/blocks/event-submission/style.css
@@ -34,9 +34,17 @@
 
 
 
+/*
+ * Mirrors the shared `.ec-card-grid` auto-fit pattern locally. This block's
+ * style.css is enqueued standalone (block.json "style": "file:./style.css")
+ * and does not load @extrachill/components CSS, so the shared class/token is
+ * not available here. The `min(100%, 220px)` floor keeps a single column from
+ * overflowing on narrow viewports — the overflow-safety the shared primitive
+ * provides, applied in-place without a cross-package dependency.
+ */
 .ec-event-submission__grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
 	gap: 16px;
 	margin-bottom: 20px;
 }
@@ -121,9 +129,11 @@
 	color: var(--muted-text);
 }
 
+/* Overflow-safe auto-fit grid, mirroring the shared `.ec-card-grid` pattern
+ * locally (see note above — this block's CSS loads standalone). */
 .ec-event-submission-editor__preview {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 160px), 1fr));
 	gap: 12px;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "extrachill-events",
 			"version": "0.3.3",
 			"dependencies": {
-				"@extrachill/components": "^0.8.1"
+				"@extrachill/components": "^0.9.0"
 			},
 			"devDependencies": {
 				"@wordpress/scripts": "^27.1.0",
@@ -2186,9 +2186,9 @@
 			}
 		},
 		"node_modules/@extrachill/components": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.8.0.tgz",
-			"integrity": "sha512-VrXHNEe/TX2unoXTShkEuJSmANgXB19szBFVUadBnF5HQtqBm69ZKdsaPx8Ylkx2cFrLs1ueT2hagqMyuOVpCg==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.9.0.tgz",
+			"integrity": "sha512-fPnJpnB80aDtvZ+iO/W+Kdc6n01Js4zTdqoyPTXoMJIVg9HCJMKzqIgn/xnRIqusJADDgjWEdJsnMdi1t1Q9Vg==",
 			"license": "GPL-2.0+",
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "extrachill-events",
 			"version": "0.3.3",
 			"dependencies": {
-				"@extrachill/components": "^0.6.0"
+				"@extrachill/components": "^0.8.1"
 			},
 			"devDependencies": {
 				"@wordpress/scripts": "^27.1.0",
@@ -2186,9 +2186,9 @@
 			}
 		},
 		"node_modules/@extrachill/components": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.6.0.tgz",
-			"integrity": "sha512-MnU3h8hHMnOpVzXibr/B2B+T2vh3uUk3Sq8lw4Y21EZqqJBWHwe5QT4yGnCeK7VhcSsDTroUi8rxkQBb7GyU4w==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.8.0.tgz",
+			"integrity": "sha512-VrXHNEe/TX2unoXTShkEuJSmANgXB19szBFVUadBnF5HQtqBm69ZKdsaPx8Ylkx2cFrLs1ueT2hagqMyuOVpCg==",
 			"license": "GPL-2.0+",
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
 		"react-dom": "^18.3.1"
 	},
 	"dependencies": {
-		"@extrachill/components": "^0.8.1"
+		"@extrachill/components": "^0.9.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
 		"react-dom": "^18.3.1"
 	},
 	"dependencies": {
-		"@extrachill/components": "^0.6.0"
+		"@extrachill/components": "^0.8.1"
 	}
 }


### PR DESCRIPTION
## Summary

Migrates the responsive auto-fit card grids in extrachill-events to the shared `Grid` / `.ec-card-grid` primitive from `@extrachill/components` (Extra-Chill/extrachill-components PR #17, Refs #16), consolidating the `repeat(auto-fit, minmax(...))` pattern and gaining the overflow-safe `min(100%, <floor>)` column floor everywhere. `Refs #16`.

## Grids migrated & approach chosen

Per-block, I verified whether `@extrachill/components` is actually a dependency of that block's bundle (both JS and CSS) before importing `Grid`, to avoid forcing a cross-package dependency where none exists (layer purity).

### concert-stats — `<Grid>` component
This block already imports `@extrachill/components` in its JS (`view.js`, `ImportTab.js`, etc.) **and** its SCSS imports the shared stylesheet (`@import '@extrachill/components/styles/components.scss'` in `src/style.scss`), so `.ec-card-grid` CSS is loaded here. Used the React `<Grid>` primitive:

- **Leaderboards** (`view.js`, was `minmax(200px, 1fr)`) → `<Grid className="ec-concert-stats__leaderboards" minColumnWidth="200px" gap="var(--spacing-lg, 1.5rem)">`. Dropped the local `grid-template-columns`/`gap`; **kept the mobile `1fr` override** at `max-width: 480px` (it forces a single column earlier than the auto-fit floor would).
- **Import cards** (`ImportTab.js`, was `minmax(280px, 1fr)`) → `<Grid className="ec-concert-stats__import-cards" minColumnWidth="280px">`. Dropped the local declaration; the primitive's default gap (`--spacing-md, 1rem`) matches the previous value, so no gap override needed.

### event-submission — local overflow-safe rewrite (no new dependency)
This block's `style.css` is enqueued **standalone** (`block.json` `"style": "file:./style.css"`) and does **not** load `@extrachill/components` CSS; its grid markup is server-rendered (`render.php`) / editor preview (`edit.js`), not React from the package. Adding the `.ec-card-grid` class would be inert (shared CSS not loaded), and adding a cross-package dependency to a block that never had one would violate layer purity. So I applied the overflow-safe `min(100%, <floor>)` pattern **in place** in the block's own CSS:

- `.ec-event-submission__grid` (was `minmax(220px, 1fr)`) → `minmax(min(100%, 220px), 1fr)`
- `.ec-event-submission-editor__preview` (was `minmax(160px, 1fr)`) → `minmax(min(100%, 160px), 1fr)`

This gains the same overflow-safety and consistency as the shared primitive without a new dependency.

## Dependency (>= 0.9.0 — published, mergeable)

`Grid` ships in **`@extrachill/components` 0.9.0** (published on npm, integrity verified). Because I imported `Grid` for the concert-stats block, `package.json` is pinned to `"@extrachill/components": "^0.9.0"` and `package-lock.json` resolves the real published 0.9.0 tarball. No file-link, no unpublished-version placeholder — the dependency is live, so this PR is mergeable as-is.

## Build verification

- `npm run build` passes against the published 0.9.0 (all blocks compile).
- Confirmed compiled `build/concert-stats/style-index.css` contains the shared `.ec-card-grid` rule (`minmax(min(100%, var(--ec-card-grid-min, 240px)), 1fr)`), that `.ec-concert-stats__leaderboards` now only carries the mobile `1fr` override, and that the `<Grid>` classNames are present in the view bundle.
- Confirmed `build/event-submission/style.css` contains the `min(100%, 220px)` / `min(100%, 160px)` overflow-safe patterns.
- `build/` is gitignored in this repo (build-on-deploy), so no build output is committed.

Refs #16
