### PR TITLE
feat: compose attendance-first past-event pages with import-at-intent

### DIFF
--- a/inc/core/concert-tracking-integration.php
+++ b/inc/core/concert-tracking-integration.php
@@ -3,7 +3,9 @@
  * Concert Tracking Integration
  *
  * Hooks into data_machine_events_action_buttons to render attendance buttons
- * on single event pages. Delegates rendering to extrachill-users.
+ * on single event pages. This is the composition layer — it decides how the
+ * event action row is arranged based on event timing, and delegates all
+ * attendance/nudge markup to extrachill-users.
  *
  * @package ExtraChillEvents
  * @since 0.18.0
@@ -19,6 +21,20 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Fires on the data_machine_events_action_buttons hook at priority 5
  * (before the share button at 10) to place it as the primary CTA.
  *
+ * Composition is tense-aware. data-machine-events passes the event timing
+ * ('past' | 'ongoing' | 'upcoming') into the hook and de-emphasizes its own
+ * ticket / add-to-calendar CTAs on past events. This layer arranges the
+ * attendance CTA accordingly:
+ *
+ * - PAST: request the attendance-first 'past-hero' variant so "I Was There"
+ *   becomes the primary action with archive-payoff framing. For logged-in
+ *   visitors, also render the import-at-intent nudge immediately after the
+ *   attendance button — moving the concert-history unlock from the buried
+ *   /my-shows/ tab to the moment of intent. We do NOT re-promote the ticket /
+ *   add-to-calendar CTAs here; the generic per-#406 de-emphasis stands.
+ * - UPCOMING / ONGOING: unchanged — the standard inline attendance toggle,
+ *   secondary to the ticket-first action row.
+ *
  * Guards:
  * - Only on events.extrachill.com (blog_id check)
  * - Graceful no-op if extrachill-users isn't active
@@ -26,8 +42,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @hook data_machine_events_action_buttons
  * @param int    $post_id    Event post ID.
  * @param string $ticket_url Ticket URL (may be empty).
+ * @param string $timing     Event timing state: 'past' | 'ongoing' | 'upcoming'.
  */
-function ec_events_render_attendance_button( $post_id, $ticket_url ) {
+function ec_events_render_attendance_button( $post_id, $ticket_url, $timing = '' ) {
 	if ( ! ec_is_events_site() ) {
 		return;
 	}
@@ -36,6 +53,34 @@ function ec_events_render_attendance_button( $post_id, $ticket_url ) {
 		return;
 	}
 
-	ec_users_render_attendance_button( (int) $post_id );
+	$event_id = (int) $post_id;
+
+	if ( 'past' === $timing ) {
+		// Attendance-first hero: "I Was There" becomes the primary action with
+		// archive-payoff framing (logged-out framing is handled by the provider
+		// via its logged_out_* copy when the visitor isn't signed in).
+		ec_users_render_attendance_button(
+			$event_id,
+			array(
+				'variant'               => 'past-hero',
+				'hero_heading'          => __( 'Were you there?', 'extrachill-events' ),
+				'hero_subheading'       => __( 'Add this show to your concert archive.', 'extrachill-events' ),
+				'logged_out_heading'    => __( 'Were you there?', 'extrachill-events' ),
+				'logged_out_subheading' => __( "Sign up to build your concert archive — every show you've seen, in one place.", 'extrachill-events' ),
+			)
+		);
+
+		// Import-at-intent: once a logged-in visitor is at the point of marking
+		// "I Was There", surface the concert-history import path (setlist.fm /
+		// phish.net) right here rather than the buried /my-shows/ tab.
+		if ( is_user_logged_in() && function_exists( 'ec_users_render_import_nudge' ) ) {
+			ec_users_render_import_nudge();
+		}
+
+		return;
+	}
+
+	// Upcoming / ongoing: unchanged — standard inline attendance toggle.
+	ec_users_render_attendance_button( $event_id );
 }
-add_action( 'data_machine_events_action_buttons', 'ec_events_render_attendance_button', 5, 2 );
+add_action( 'data_machine_events_action_buttons', 'ec_events_render_attendance_button', 5, 3 );


### PR DESCRIPTION
## Summary

Makes the single-event action row **tense-aware** in the composition layer (`extrachill-events`). ~60% of events-site pageviews land on **past-event pages** — the peak "I was at this show" audience — yet today they get a dead "Get Tickets" CTA with "I Was There" demoted below it and no archive payoff. This PR arranges the page around the one action that matters on a past show.

Consumes the now-merged upstream APIs:
- **data-machine-events#406** — `data_machine_events_action_buttons` now passes `$timing` (`past` | `ongoing` | `upcoming`) and de-emphasizes its own ticket / add-to-calendar CTAs on past events.
- **extrachill-users#163 / #164** — `ec_users_render_attendance_button( int $event_id, array $args )` with a `past-hero` variant + framing copy, plus the new `ec_users_render_import_nudge()` helper.

## What changed (composition only)

**Past events → attendance-first hero.** `ec_events_render_attendance_button()` now receives `$timing` (hook `add_action` arg count raised 2 → 3). On `past` timing it requests the `past-hero` variant so **"I Was There" becomes the primary action** with archive-payoff framing:
- Logged in: _"Were you there?" / "Add this show to your concert archive."_
- Logged out: signup-framed _"Sign up to build your concert archive — every show you've seen, in one place."_ (framing handled by the provider's `logged_out_*` copy, not a login wall).

**Import-at-intent nudge.** On past timing **and** logged in, `ec_users_render_import_nudge()` renders immediately after the attendance button — moving the concert-history import (setlist.fm / phish.net) from the buried `/my-shows/` tab to the moment of intent. Guarded with `function_exists` so it no-ops if extrachill-users is inactive.

**Ticket/calendar de-emphasis honored.** This layer does **not** re-promote the ticket or add-to-calendar CTAs on past pages — the generic per-#406 de-emphasis stands.

**Upcoming / ongoing unchanged.** Those paths still render the standard inline attendance toggle, secondary to the ticket-first action row.

## Layer & platform discipline

- **No back-compat shim.** We own the single caller — the old 1-arg `ec_users_render_attendance_button( $post_id )` call is updated to the new config-array signature and the old path deleted (owned platform).
- **Guards kept.** `function_exists()` guards for the cross-plugin calls (extrachill-users / data-machine-events may be inactive on a given blog) are graceful degradation, not back-compat — retained.
- **Shared primitives per the #205 constraint.** This is a public/SEO/server-rendered surface. All attendance + nudge markup is owned by extrachill-users (composed via its render fns using shared theme CSS classes); this PR only decides ordering / variant / framing args. No ad-hoc React on this surface.

## Verification

- Exactly one caller of the old signature existed in this repo (`inc/core/concert-tracking-integration.php`); updated. `grep` confirms no other callers.
- `php -l` clean; PHPCS clean on the changed file (remaining repo lint findings are pre-existing debt in unrelated files; eslint reports 0 findings).
- `homeboy test` bootstrap fails at the WP Codebox CLI harness (`wp-codebox --version` — host/env issue, no tests ran); the repo's unit suite (`qualify-v2-unit`) does not cover concert-tracking composition, so it is unaffected by this change.
- Blog-context guard (`ec_is_events_site()`) and cross-plugin `function_exists` guards intact.

Closes #205