### PR TITLE
feat: honest content authorship — anon submitter attribution + backfill CLI (#207)

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -76,6 +76,13 @@ if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCo
 
 	require_once __DIR__ . '/inc/Cli/BackfillVenueMetaCommand.php';
 	\WP_CLI::add_command( 'extrachill events venues backfill-meta', \ExtraChillEvents\Cli\BackfillVenueMetaCommand::class );
+
+	// Honest authorship backfill (issue #207 Phase 3). Reattributes historical
+	// automation authored under a human (uid 1) onto the network bot account.
+	// Dry-run by default; --apply (or --commit) to mutate. Operates across
+	// blogs 7 (data_machine_events) and 11 (festival_wire); never touches blog 1.
+	require_once __DIR__ . '/inc/Cli/BackfillAuthorshipCommand.php';
+	\WP_CLI::add_command( 'extrachill events backfill-authorship', \ExtraChillEvents\Cli\BackfillAuthorshipCommand::class );
 }
 
 // Recheck handler must be loaded outside the WP_CLI guard so the Action

--- a/inc/Abilities/EventSubmissionAbilities.php
+++ b/inc/Abilities/EventSubmissionAbilities.php
@@ -147,7 +147,11 @@ class EventSubmissionAbilities {
 			return new \WP_Error( 'missing_fields', __( 'Event title and date are required.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
 
-		// 3. Build sanitized submission.
+		// 3. Build sanitized submission. The claim URL is kept OUT of the
+		// submission payload (which flows into the workflow engine and may be
+		// logged) and threaded to notifySubmitter() separately.
+		$account_claim = (string) ( $contact['account_claim'] ?? '' );
+
 		$submission = array(
 			'user_id'       => $contact['user_id'],
 			'contact_name'  => $contact['contact_name'],
@@ -166,11 +170,17 @@ class EventSubmissionAbilities {
 		$flyer = $input['flyer'] ?? null;
 
 		// 5. Execute ephemeral workflow.
-		return $this->executeDirect( $submission, $flyer, sanitize_textarea_field( $input['system_prompt'] ?? '' ) );
+		return $this->executeDirect( $submission, $flyer, sanitize_textarea_field( $input['system_prompt'] ?? '' ), $account_claim );
 	}
 
 	/**
 	 * Resolve contact information from logged-in user or form input.
+	 *
+	 * For logged-in users, their account is the author. For anonymous submitters,
+	 * this resolves (or creates) a real subscriber account keyed by email so the
+	 * event is attributed honestly to the submitter rather than to the bot — see
+	 * issue #207 Phase 1. Dedupe is strict on email; a brand-new account is
+	 * flagged unclaimed and emailed a claim/set-password link in notifySubmitter().
 	 *
 	 * @param array $input Raw input.
 	 * @return array|\WP_Error Contact data with user_id, contact_name, contact_email — or WP_Error.
@@ -198,11 +208,105 @@ class EventSubmissionAbilities {
 			return new \WP_Error( 'invalid_email', __( 'Enter a valid email address.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
 
+		// Attribute the submission to the submitter's own account. Existing users
+		// are reused (dedupe by email); new users get a locked subscriber account
+		// flagged unclaimed until they set a password via the claim link. Falls
+		// back to user_id=0 (the automation/bot default author) if the
+		// account-creation primitive is unavailable, so submission still works.
+		$resolved = $this->resolveAnonymousSubmitter( $email );
+
 		return array(
-			'user_id'       => 0,
+			'user_id'       => $resolved['user_id'],
 			'contact_name'  => $name,
 			'contact_email' => $email,
+			'account_claim' => $resolved['claim_url'],
 		);
+	}
+
+	/**
+	 * Resolve a real user account for an anonymous submitter, keyed by email.
+	 *
+	 * Dedupe: an existing user with this email is reused (no duplicate). If none
+	 * exists, one is created via the `extrachill/create-user` ability — collision-
+	 * safe username, random password, subscriber role, flagged ec_unclaimed=1,
+	 * with registration_source='event_submission' provenance.
+	 *
+	 * A one-time claim/set-password URL is generated for BOTH the new- and
+	 * existing-account cases so the email wording can be identical (no account-
+	 * enumeration leak): a new user sets their password; an existing user can
+	 * reset theirs or simply ignore the link.
+	 *
+	 * @param string $email Verified email address.
+	 * @return array{user_id:int, claim_url:string} Resolved user id (0 if the
+	 *              primitive is unavailable) and a claim URL (empty if none).
+	 */
+	private function resolveAnonymousSubmitter( string $email ): array {
+		// Dedupe by email: reuse an existing account rather than creating a dup.
+		$existing = get_user_by( 'email', $email );
+		if ( $existing instanceof \WP_User ) {
+			return array(
+				'user_id'  => (int) $existing->ID,
+				'claim_url' => $this->buildClaimUrl( $existing ),
+			);
+		}
+
+		// Create a locked subscriber account on the submitter's behalf.
+		$create = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/create-user' ) : null;
+		if ( ! $create ) {
+			return array( 'user_id' => 0, 'claim_url' => '' );
+		}
+
+		$username = function_exists( 'ec_generate_username_from_email' )
+			? ec_generate_username_from_email( $email )
+			: sanitize_title( substr( strstr( $email, '@', true ) ?: 'user', 0, 50 ) );
+
+		$result = $create->execute(
+			array(
+				'email'               => $email,
+				'password'            => wp_generate_password( 24 ),
+				'username'            => $username,
+				'role'                => 'subscriber',
+				'unclaimed'           => true,
+				'registration_source' => 'event_submission',
+				'registration_method' => 'standard',
+			)
+		);
+
+		if ( is_wp_error( $result ) || empty( $result ) ) {
+			return array( 'user_id' => 0, 'claim_url' => '' );
+		}
+
+		$user_id = (int) $result;
+		$user    = get_userdata( $user_id );
+
+		return array(
+			'user_id'   => $user_id,
+			'claim_url' => $user ? $this->buildClaimUrl( $user ) : '',
+		);
+	}
+
+	/**
+	 * Build a one-time claim/set-password URL for a user.
+	 *
+	 * Generates a fresh password-reset key (works for new and existing accounts)
+	 * and points it at the community site's login. The link is safe to send to
+	 * any account holder regardless of whether the account pre-existed.
+	 *
+	 * @param \WP_User $user User object.
+	 * @return string Claim URL, or empty string on key-generation failure.
+	 */
+	private function buildClaimUrl( \WP_User $user ): string {
+		$key = get_password_reset_key( $user );
+		if ( is_wp_error( $key ) ) {
+			return '';
+		}
+
+		$base = function_exists( 'ec_get_site_url' )
+			? ec_get_site_url( 'community' )
+			: network_site_url();
+
+		// Canonical WordPress reset-password endpoint on the community site.
+		return trailingslashit( $base ) . 'wp-login.php?action=rp&key=' . rawurlencode( $key ) . '&login=' . rawurlencode( $user->user_login );
 	}
 
 	/**
@@ -213,7 +317,7 @@ class EventSubmissionAbilities {
 	 * @param string     $system_prompt Custom system prompt. Optional.
 	 * @return array Result.
 	 */
-	private function executeDirect( array $submission, ?array $flyer, string $system_prompt = '' ): array|\WP_Error {
+	private function executeDirect( array $submission, ?array $flyer, string $system_prompt = '', string $account_claim = '' ): array|\WP_Error {
 		$execute = wp_get_ability( 'datamachine/execute-workflow' );
 		if ( ! $execute ) {
 			return new \WP_Error( 'dm_unavailable', __( 'Data Machine is unavailable.', 'extrachill-events' ), array( 'status' => 500 ) );
@@ -250,7 +354,7 @@ class EventSubmissionAbilities {
 
 		$job_id = $result['job_id'] ?? $result['data']['job_id'] ?? 0;
 
-		$this->notifySubmitter( $submission );
+		$this->notifySubmitter( $submission, $account_claim );
 		$this->notifyAdmin( $submission, $job_id );
 
 		do_action(
@@ -404,8 +508,11 @@ class EventSubmissionAbilities {
 	 * the full EC visual identity.
 	 *
 	 * @param array $submission Submission data.
+	 * @param string $account_claim Optional one-time claim/set-password URL for
+	 *              anonymous submitters whose account was resolved or created.
+	 *              Empty for logged-in submitters (no claim section rendered).
 	 */
-	private function notifySubmitter( array $submission ): void {
+	private function notifySubmitter( array $submission, string $account_claim = '' ): void {
 		$to = $submission['contact_email'] ?? '';
 		if ( empty( $to ) || ! is_email( $to ) ) {
 			return;
@@ -448,6 +555,28 @@ class EventSubmissionAbilities {
 			esc_html( $venue_display )
 		) . '</p>';
 		$body_html .= '<p>' . esc_html__( "We're processing your submission now. You'll receive another email once it's been reviewed.", 'extrachill-events' ) . '</p>';
+
+		// Claim-account section for anonymous submitters. Wording is identical
+		// whether the account was just created or already existed — a new user
+		// sets their password; an existing user can reset theirs or ignore the
+		// link — so there is NO account-enumeration leak (issue #207 Phase 1).
+		if ( ! empty( $account_claim ) ) {
+			$community_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : '';
+			$body_html    .= '<hr>';
+			$body_html    .= '<p>' . esc_html__( 'Your submission is credited to your Extra Chill account, so you get the credit when it goes live.', 'extrachill-events' ) . '</p>';
+			$body_html    .= '<p>' . sprintf(
+				/* translators: %s: community site URL. */
+				esc_html__( 'Set or reset your password to log in and manage your events: %s', 'extrachill-events' ),
+				'<a href="' . esc_url( $account_claim ) . '">' . esc_html__( 'Set my password', 'extrachill-events' ) . '</a>'
+			) . '</p>';
+			if ( $community_url ) {
+				$body_html .= '<p>' . sprintf(
+					/* translators: %s: community site URL. */
+					esc_html__( 'Once set up, you can join the community at %s.', 'extrachill-events' ),
+					'<a href="' . esc_url( $community_url ) . '">' . esc_html( $community_url ) . '</a>'
+				) . '</p>';
+			}
+		}
 
 		$context = array(
 			'subject_html'   => esc_html( $subject ),
@@ -560,10 +689,16 @@ class EventSubmissionAbilities {
 	}
 
 	/**
-	 * Dispatch an outgoing notification through `ec_send_email()` when the
-	 * extrachill-multisite helper is loaded, otherwise fall back to the raw
-	 * `datamachine/send-email` ability. Failures are logged (never thrown)
-	 * so a transient send error does not break the submission flow.
+	 * Dispatch an outgoing notification through the EC mail layer.
+	 *
+	 * Event submissions run in an unprivileged context (an anonymous visitor),
+	 * so a bare `ec_send_email()` call hits the `datamachine/send-email`
+	 * ability's capability gate and silently fails with a permissions error.
+	 * `extrachill_send_registration_email()` (extrachill-users) wraps the call in
+	 * PermissionHelper::run_as_authenticated() — the canonical seam for callers
+	 * that have authorized a send at their own layer. We prefer it when present;
+	 * otherwise we fall back to `ec_send_email()` / the raw ability. Failures are
+	 * logged (never thrown) so a transient send error does not break submission.
 	 *
 	 * @param array  $args  Arguments forwarded to the ability.
 	 * @param string $audience Tag used in log context ("submitter" | "admin").
@@ -571,7 +706,9 @@ class EventSubmissionAbilities {
 	private function dispatchEmail( array $args, string $audience ): void {
 		$result = null;
 
-		if ( function_exists( 'ec_send_email' ) ) {
+		if ( function_exists( 'extrachill_send_registration_email' ) ) {
+			$result = extrachill_send_registration_email( $args );
+		} elseif ( function_exists( 'ec_send_email' ) ) {
 			$result = ec_send_email( $args );
 		} elseif ( function_exists( 'wp_get_ability' ) ) {
 			$send_ability = wp_get_ability( 'datamachine/send-email' );

--- a/inc/Cli/BackfillAuthorshipCommand.php
+++ b/inc/Cli/BackfillAuthorshipCommand.php
@@ -1,0 +1,357 @@
+<?php
+/**
+ * `wp extrachill events backfill-authorship` — reattribute historical
+ * automation that was misauthored to a human account (uid 1 by default)
+ * back onto the network bot account, so per-author views (heatmap, points,
+ * profile article counts) reflect genuine human authorship.
+ *
+ * Targets (issue #207 Phase 3):
+ *   - blog 7  data_machine_events  post_author = 1 → bot id
+ *       EXCEPT rows carrying `_datamachine_submitted_by` meta — those are
+ *       genuine user submissions and are attributed to that submitter.
+ *   - blog 11 festival_wire         post_author = 1 → bot id
+ *
+ * Blog 1 `post` is NEVER touched — that is genuine human editorial.
+ *
+ * Why a CLI in this repo (not extrachill-cli or a one-off script): the
+ * command operates on events + wire authorship data, the events repo already
+ * owns the `wp extrachill events ...` operator CLI surface and its dry-run /
+ * --commit conventions (BackfillVenueMetaCommand, RepairFlowLocationsCommand),
+ * and shipping it here keeps the honest-authorship work in one reviewable
+ * place alongside the Phase 1 submission changes. The bot id is resolved via
+ * `ec_get_network_bot_user_id()` (extrachill-users), so the command is
+ * config-driven rather than hardcoding 32.
+ *
+ * Idempotent: only posts where post_author equals --from (default 1) are
+ * candidates. Once reattributed, they no longer match on a re-run.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class BackfillAuthorshipCommand {
+
+	/**
+	 * Default targets: blog_id => post_type.
+	 *
+	 * @var array<int, string>
+	 */
+	private const DEFAULT_TARGETS = array(
+		7  => 'data_machine_events',
+		11 => 'festival_wire',
+	);
+
+	/**
+	 * Reattribute misauthored automation onto the network bot account.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--apply]
+	 * : Actually mutate post_author. Default is dry-run (no changes).
+	 *
+	 * [--commit]
+	 * : Alias for --apply (matches the rest of the `wp extrachill events`
+	 *   operator CLI surface).
+	 *
+	 * [--from=<user_id>]
+	 * : Source author id to reattribute away from. Default: 1.
+	 *
+	 * [--blog=<id>]
+	 * : Limit to a single target blog id (7 or 11). Default: both.
+	 *
+	 * [--status=<status>]
+	 * : Comma-separated post statuses to reattribute (e.g. `publish` or
+	 *   `publish,draft`). Default: publish,pending,draft,future,private (all
+	 *   non-trash). Use `--status=publish` to match the issue's published-only
+	 *   figure (~2979 events).
+	 *
+	 * [--format=<format>]
+	 * : Output format for the per-target report.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Preview (dry run)
+	 *     wp extrachill events backfill-authorship
+	 *
+	 *     # Apply
+	 *     wp extrachill events backfill-authorship --apply
+	 *
+	 *     # Events subsite only
+	 *     wp extrachill events backfill-authorship --blog=7 --apply
+	 *
+	 * @param array $args       Positional args (unused).
+	 * @param array $assoc_args Named args.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		if ( ! defined( 'WP_CLI' ) || ! \WP_CLI ) {
+			return;
+		}
+
+		$apply = ! empty( $assoc_args['apply'] ) || ! empty( $assoc_args['commit'] );
+		$from  = isset( $assoc_args['from'] ) ? (int) $assoc_args['from'] : 1;
+		$blog  = isset( $assoc_args['blog'] ) ? (int) $assoc_args['blog'] : 0;
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
+
+		// Post-status filter. Default: all non-trash statuses so every bit of
+		// misauthored automation (publish + draft + pending) is corrected. Pass
+		// --status=publish to scope to published posts only.
+		$statuses = isset( $assoc_args['status'] )
+			? array_filter( array_map( 'sanitize_key', explode( ',', (string) $assoc_args['status'] ) ) )
+			: array( 'publish', 'pending', 'draft', 'future', 'private' );
+		if ( empty( $statuses ) ) {
+			$statuses = array( 'publish' );
+		}
+
+		if ( ! function_exists( 'ec_get_network_bot_user_id' ) ) {
+			\WP_CLI::error( 'ec_get_network_bot_user_id() is unavailable — extrachill-users is not active.' );
+			return;
+		}
+
+		$bot_id = (int) ec_get_network_bot_user_id();
+		if ( $bot_id <= 0 ) {
+			\WP_CLI::error( 'Network bot user id resolved to 0 — aborting.' );
+			return;
+		}
+
+		if ( $from === $bot_id ) {
+			\WP_CLI::error( sprintf( '--from (%d) equals the bot id (%d) — nothing to reattribute.', $from, $bot_id ) );
+			return;
+		}
+
+		$targets = $blog > 0
+			? array( $blog => self::DEFAULT_TARGETS[ $blog ] ?? null )
+			: self::DEFAULT_TARGETS;
+
+		$targets = array_filter( $targets, static fn( $t ) => null !== $t );
+
+		if ( empty( $targets ) ) {
+			\WP_CLI::error( 'No valid target blogs selected. Use --blog=7 or --blog=11, or omit for both.' );
+			return;
+		}
+
+		\WP_CLI::log( sprintf( 'Backfilling authorship: from uid %d → bot uid %d (%s)', $from, $bot_id, $apply ? 'APPLY' : 'DRY RUN' ) );
+		\WP_CLI::log( '' );
+
+		$report = array();
+		$totals = array(
+			'candidates'        => 0,
+			'to_bot'            => 0,
+			'to_submitter'      => 0,
+			'skipped_bad_user'  => 0,
+			'reattributed'      => 0,
+			'failed'            => 0,
+		);
+
+		foreach ( $targets as $blog_id => $post_type ) {
+			$this->processTarget( (int) $blog_id, (string) $post_type, $from, $bot_id, $apply, $format, $statuses, $report, $totals );
+		}
+
+		if ( ! empty( $report ) ) {
+			\WP_CLI\Utils\format_items(
+				$format,
+				$report,
+				array( 'blog', 'post_type', 'current_author', 'count', 'plan' )
+			);
+			\WP_CLI::log( '' );
+		} else {
+			\WP_CLI::log( 'Nothing to reattribute — no posts match the source author on any target.' );
+			\WP_CLI::log( '' );
+		}
+
+		\WP_CLI::log(
+			sprintf(
+				'Summary: candidates=%d to_bot=%d to_submitter=%d skipped_bad_user=%d reattributed=%d failed=%d',
+				$totals['candidates'],
+				$totals['to_bot'],
+				$totals['to_submitter'],
+				$totals['skipped_bad_user'],
+				$totals['reattributed'],
+				$totals['failed']
+			)
+		);
+
+		if ( ! $apply ) {
+			\WP_CLI::log( '' );
+			\WP_CLI::log( 'Dry run — no posts changed. Re-run with --apply (or --commit) to reattribute.' );
+		}
+	}
+
+	/**
+	 * Process a single blog/post_type target.
+	 *
+	 * Builds the per-author breakdown, the reattribution plan, and (when
+	 * applying) executes the updates via switch_to_blog so $wpdb->prefix is
+	 * correct for the target subsite.
+	 *
+	 * @param int    $blog_id    Target blog id.
+	 * @param string $post_type  Target post type.
+	 * @param int    $from       Source author id.
+	 * @param int    $bot_id     Bot author id.
+	 * @param bool   $apply      Whether to mutate.
+	 * @param string $format     Output format.
+	 * @param array  $statuses   Post statuses to target.
+	 * @param array  $report     Report rows (appended).
+	 * @param array  $totals     Totals (mutated).
+	 */
+	private function processTarget( int $blog_id, string $post_type, int $from, int $bot_id, bool $apply, string $format, array $statuses, array &$report, array &$totals ): void {
+		switch_to_blog( $blog_id );
+
+		global $wpdb;
+		$posts_table = $wpdb->posts;
+
+		$status_placeholders = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+		$status_args         = array_merge( array( $post_type ), $statuses );
+
+		// Per-author breakdown of this post type (the "is authorship honest?"
+		// snapshot the issue asks for).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$authors = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_author, COUNT(*) AS cnt FROM {$posts_table} WHERE post_type = %s AND post_status IN ({$status_placeholders}) GROUP BY post_author ORDER BY cnt DESC LIMIT 20",
+				$status_args
+			),
+			ARRAY_A
+		);
+
+		\WP_CLI::log( sprintf( 'Blog %d (%s) — top authors:', $blog_id, $post_type ) );
+		if ( ! empty( $authors ) ) {
+			\WP_CLI\Utils\format_items(
+				$format,
+				array_map(
+					static function ( $row ) {
+						return array(
+							'blog'          => '',
+							'post_type'     => '',
+							'current_author' => (string) $row['post_author'],
+							'count'         => (string) $row['cnt'],
+							'plan'          => '',
+						);
+					},
+					$authors
+				),
+				array( 'current_author', 'count' )
+			);
+		}
+		\WP_CLI::log( '' );
+
+		// Candidate posts authored by --from.
+		$candidate_args = array_merge( array( $post_type, $from ), $statuses );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$candidates = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM {$posts_table} WHERE post_type = %s AND post_author = %d AND post_status IN ({$status_placeholders}) ORDER BY ID ASC",
+				$candidate_args
+			)
+		);
+
+		$candidate_count = count( $candidates );
+		$to_bot          = 0;
+		$to_submitter    = 0;
+
+		if ( 0 === $candidate_count ) {
+			$report[] = $this->reportRow( $blog_id, $post_type, $from, 0, 'none' );
+			restore_current_blog();
+			return;
+		}
+
+		// Partition candidates: genuine submissions (carry
+		// _datamachine_submitted_by) → attribute to the submitter; the rest
+		// → bot. The submitter-attribution branch only applies to event CPT
+		// (blog 7); the wire has no submission meta.
+		foreach ( $candidates as $post_id ) {
+			$post_id     = (int) $post_id;
+			$submitter   = (int) get_post_meta( $post_id, '_datamachine_submitted_by', true );
+
+			if ( $submitter > 0 && get_userdata( $submitter ) ) {
+				++$to_submitter;
+				if ( $apply ) {
+					$this->reattribute( $post_id, $submitter, $totals, 'submitter' );
+				}
+				continue;
+			}
+
+			// Submitter meta present but stale (user deleted) → fall back to
+			// the bot rather than leaving it on the human. Counted as to_bot.
+			++$to_bot;
+			if ( $apply ) {
+				$this->reattribute( $post_id, $bot_id, $totals, 'bot' );
+			}
+		}
+
+		$plan = sprintf( 'bot:%d submitter:%d', $to_bot, $to_submitter );
+
+		$report[] = $this->reportRow( $blog_id, $post_type, $from, $candidate_count, $plan );
+
+		$totals['candidates']   += $candidate_count;
+		$totals['to_bot']       += $to_bot;
+		$totals['to_submitter'] += $to_submitter;
+
+		restore_current_blog();
+
+		\WP_CLI::log( sprintf( '  → %d candidate(s): %s', $candidate_count, $apply ? 'processed' : 'planned (dry run)' ) );
+		\WP_CLI::log( '' );
+	}
+
+	/**
+	 * Reattribute a single post to a new author via the WP API so hooks fire.
+	 *
+	 * @param int    $post_id  Post id.
+	 * @param int    $author   New author id.
+	 * @param array  $totals   Totals (mutated).
+	 * @param string $label    'bot' or 'submitter' — for the failure log.
+	 */
+	private function reattribute( int $post_id, int $author, array &$totals, string $label ): void {
+		global $wpdb;
+		// Direct UPDATE is intentional for a bulk backfill: wp_update_post()
+		// would re-fire save_post / re-generate content hashes / re-sync tax
+		// for thousands of rows. Author change has no downstream side effects
+		// that the WP API would handle differently.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$ok = $wpdb->update(
+			$wpdb->posts,
+			array( 'post_author' => $author ),
+			array( 'ID' => $post_id ),
+			array( '%d' ),
+			array( '%d' )
+		);
+
+		if ( false === $ok ) {
+			++$totals['failed'];
+			\WP_CLI::warning( sprintf( 'Failed to reattribute post %d → %s (%d).', $post_id, $label, $author ) );
+		} else {
+			++$totals['reattributed'];
+		}
+	}
+
+	/**
+	 * Build a report row.
+	 *
+	 * @param int    $blog_id        Blog id.
+	 * @param string $post_type      Post type.
+	 * @param int    $current_author Source author.
+	 * @param int    $count          Candidate count.
+	 * @param string $plan           Plan label.
+	 * @return array Row for format_items.
+	 */
+	private function reportRow( int $blog_id, string $post_type, int $current_author, int $count, string $plan ): array {
+		return array(
+			'blog'           => (string) $blog_id,
+			'post_type'      => $post_type,
+			'current_author' => (string) $current_author,
+			'count'          => (string) $count,
+			'plan'           => $plan,
+		);
+	}
+}


### PR DESCRIPTION
Closes #207 — implements Phase 1 and Phase 3 of honest content authorship at the source. (Phase 2 lives in data-machine-events.)

## Phase 1 — anonymous submitter attribution
Anonymous event submitters now get their event credited to a **real Extra Chill account** instead of falling through to the bot/default author.

- `resolveAnonymousSubmitter()`: dedupe by email (existing user reused, no duplicate); otherwise create a subscriber account via the `extrachill/create-user` ability — collision-safe username (`ec_generate_username_from_email()`), random 24-char password, `ec_unclaimed=1`, `registration_source='event_submission'`.
- `submission['user_id']` is set **before** the DM workflow runs, so `EventUpsert::resolvePostAuthor()` (which already prioritizes the submission user_id) attributes correctly with **no DME change needed for this path**. Logged-in path unchanged.
- A branded **claim/set-password** section is merged into the existing confirmation email. The link is generated for both new and existing accounts and worded identically ("set or reset your password") — **no account-enumeration leak**.
- The claim URL is kept OUT of the `$submission` payload (which flows into the workflow engine and may be logged) and threaded to `notifySubmitter()` separately.

**Email dispatch fix (bonus):** routed `dispatchEmail()` through `extrachill_send_registration_email()` when available. Submissions run in an unprivileged (anonymous) context, so a bare `ec_send_email()` hits the `send-email` capability gate and silently fails. This also fixes the pre-existing case where the confirmation email failed to send for anon submitters.

**Unclaimed-account guard:** the random password is unknown to anyone, so the account can't be logged into until claimed. `ec_unclaimed=1` is forward-looking metadata for future login-blocking / cleanup enforcement.

## Phase 3 — `wp extrachill events backfill-authorship`
Reattributes historical automation misauthored to a human (uid 1 by default) onto the network bot account:

| Blog | Post type | post_author=1 (publish) | post_author=1 (all statuses) |
|------|-----------|------------------------:|-----------------------------:|
| 7 | data_machine_events | 2,979 | 9,947 |
| 11 | festival_wire | 153 | 153 |

- blog 7 `data_machine_events` `post_author=1` → bot, **EXCEPT** rows carrying `_datamachine_submitted_by` meta (genuine submissions → attributed to that submitter). Currently 0 such rows, but handled for correctness.
- blog 11 `festival_wire` `post_author=1` → bot.
- **blog 1 `post` is never touched** (genuine human editorial).

Dry-run by default with a per-target author breakdown + candidate counts; `--apply` (or `--commit`, matching the operator CLI conventions) to mutate. Idempotent. `--status=publish` scopes to the issue's published figure; default covers publish+pending+draft+future+private for full honesty (drafts are automation too). Bot id resolved via `ec_get_network_bot_user_id()` (config-driven).

**Dry-run verified live** — counts match the issue exactly (publish-only: 2979 events + 153 wire).

Lives in extrachill-events (not extrachill-cli or a one-off script) because the command operates on events + wire authorship data and this repo already owns the `wp extrachill events ...` CLI surface and its dry-run/`--commit` conventions.

## Verified
- `php -l` clean on all touched files.
- Backfill dry-run executed against live data — correct counts, no mutation.
- Phase 1: traced anon submission → resolved/created user_id → `resolvePostAuthor` attributes correctly; logged-in path unchanged.

## Dependencies / sibling PRs (merge together)
- **extrachill-users #167** — `ec_get_network_bot_user_id()` + create-user `role`/`unclaimed` inputs (Phase 1 + Phase 3 dependency)
- **data-machine-events #421** — Phase 2 automation default to bot account

Conventional commits. No CHANGELOG / version bumps (homeboy owns those). PR only — no merge/release/deploy.