### PR TITLE
fix: correct stale 'update' step_type and add admin notification for URL tour-import submissions

### DIFF
--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -413,6 +413,20 @@ class ArtistUrlImportAbilities {
 				)
 			);
 
+			if ( null !== $submission_id ) {
+				$this->notifyAdminSubmission(
+					array(
+						'url'                   => $normalized,
+						'contact_name'          => $contact_name,
+						'contact_email'         => $contact_email,
+						'detected_format'       => '',
+						'events_found_count'    => 0,
+						'suggested_artist_name' => '',
+						'status'                => ArtistUrlSubmissionsTable::STATUS_SCRAPING_FAILED,
+					)
+				);
+			}
+
 			return array(
 				'success'       => false,
 				'submission_id' => (int) $submission_id,
@@ -442,6 +456,26 @@ class ArtistUrlImportAbilities {
 		if ( null === $submission_id ) {
 			return new \WP_Error( 'insert_failed', __( 'Failed to record submission.', 'extrachill-events' ), array( 'status' => 500 ) );
 		}
+
+		$this->notifyAdminSubmission(
+			array(
+				'url'                   => $normalized,
+				'contact_name'          => $contact_name,
+				'contact_email'         => $contact_email,
+				'detected_format'       => $probe['detected_format'],
+				'events_found_count'    => (int) $probe['events_found'],
+				'suggested_artist_name' => $suggestion['name'],
+				'status'                => ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
+			)
+		);
+
+		$this->notifySubmitterConfirmation(
+			array(
+				'url'           => $normalized,
+				'contact_name'  => $contact_name,
+				'contact_email' => $contact_email,
+			)
+		);
 
 		return array(
 			'success'       => true,
@@ -500,7 +534,7 @@ class ArtistUrlImportAbilities {
 
 		$pipeline_name = sprintf( '%s — Tour Import', $artist_name );
 
-		// 1. Create the pipeline scaffold (event_import → ai → update).
+		// 1. Create the pipeline scaffold (event_import → ai → upsert).
 		$pipeline_ability = wp_get_ability( 'datamachine/create-pipeline' );
 		if ( ! $pipeline_ability ) {
 			return new \WP_Error( 'missing_ability', __( 'datamachine/create-pipeline ability is not available.', 'extrachill-events' ), array( 'status' => 500 ) );
@@ -512,7 +546,7 @@ class ArtistUrlImportAbilities {
 				'steps'         => array(
 					array( 'step_type' => 'event_import', 'label' => 'Event Import' ),
 					array( 'step_type' => 'ai',           'label' => 'AI Agent' ),
-					array( 'step_type' => 'update',       'label' => 'Update' ),
+					array( 'step_type' => 'upsert',       'label' => 'Upsert' ),
 				),
 			)
 		);
@@ -569,7 +603,7 @@ class ArtistUrlImportAbilities {
 						'handler_slug'   => self::SCRAPER_HANDLER_SLUG,
 						'handler_config' => $import_handler_config,
 					),
-					'update'       => array(
+					'upsert'       => array(
 						'handler_slug'   => 'upsert_event',
 						'handler_config' => $update_handler_config,
 					),
@@ -1216,7 +1250,7 @@ class ArtistUrlImportAbilities {
 				$step['enabled']         = true;
 			}
 
-			if ( 'update' === $step_type ) {
+			if ( 'upsert' === $step_type ) {
 				$step['handler_slugs']   = array( 'upsert_event' );
 				$step['handler_configs'] = array( 'upsert_event' => $update_handler_config );
 				$step['enabled']         = true;
@@ -1234,5 +1268,238 @@ class ArtistUrlImportAbilities {
 			array( 'flow_config' => wp_json_encode( $config ) ),
 			array( 'flow_id' => $flow_id )
 		);
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// Submission notifications (issue #210)
+	// ────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Send an admin notification about a new artist URL submission.
+	 *
+	 * Fires for both `pending_review` and `scraping_failed` statuses so the
+	 * admin always knows a submission is waiting in the moderation queue.
+	 * Mirrors the dispatch pattern from EventSubmissionAbilities::notifyAdmin()
+	 * — uses the `extrachill/minimal` template through the EC mail layer.
+	 *
+	 * @param array $data Submission details: url, contact_name, contact_email,
+	 *                    detected_format, events_found_count,
+	 *                    suggested_artist_name, status.
+	 */
+	private function notifyAdminSubmission( array $data ): void {
+		$to = get_option( 'admin_email' );
+		if ( empty( $to ) || ! is_email( $to ) ) {
+			return;
+		}
+
+		$site_name = get_bloginfo( 'name' );
+		$url       = (string) ( $data['url'] ?? '' );
+		$status    = (string) ( $data['status'] ?? '' );
+
+		$status_label = ArtistUrlSubmissionsTable::STATUS_SCRAPING_FAILED === $status
+			? __( 'Scrape failed', 'extrachill-events' )
+			: __( 'Pending review', 'extrachill-events' );
+
+		$subject = sprintf(
+			/* translators: 1: site name, 2: status label. */
+			__( '[%1$s] New Artist URL Submission: %2$s', 'extrachill-events' ),
+			$site_name,
+			$status_label
+		);
+
+		$preheader = sprintf(
+			/* translators: %s: submitter name. */
+			__( 'Artist URL submission from %s.', 'extrachill-events' ),
+			(string) ( $data['contact_name'] ?? '' )
+		);
+
+		$body_html  = '<p>' . esc_html__( 'A new artist URL submission has been received:', 'extrachill-events' ) . '</p>';
+		$body_html .= '<ul>';
+		$body_html .= '<li>' . sprintf(
+			/* translators: %s: submitted URL. */
+			esc_html__( 'URL: %s', 'extrachill-events' ),
+			'<strong>' . esc_html( $url ) . '</strong>'
+		) . '</li>';
+		$body_html .= '<li>' . sprintf(
+			/* translators: 1: submitter name, 2: submitter email. */
+			esc_html__( 'Submitted by: %1$s (%2$s)', 'extrachill-events' ),
+			esc_html( (string) ( $data['contact_name'] ?? '' ) ),
+			esc_html( (string) ( $data['contact_email'] ?? '' ) )
+		) . '</li>';
+		$body_html .= '<li>' . sprintf(
+			/* translators: %s: detected format. */
+			esc_html__( 'Detected format: %s', 'extrachill-events' ),
+			'<code>' . esc_html( (string) ( $data['detected_format'] ?? '' ) ) . '</code>'
+		) . '</li>';
+		$body_html .= '<li>' . sprintf(
+			/* translators: %d: events found count. */
+			esc_html__( 'Events found: %d', 'extrachill-events' ),
+			(int) ( $data['events_found_count'] ?? 0 )
+		) . '</li>';
+
+		$suggested_artist = (string) ( $data['suggested_artist_name'] ?? '' );
+		if ( '' !== $suggested_artist ) {
+			$body_html .= '<li>' . sprintf(
+				/* translators: %s: suggested artist name. */
+				esc_html__( 'Suggested artist: %s', 'extrachill-events' ),
+				'<strong>' . esc_html( $suggested_artist ) . '</strong>'
+			) . '</li>';
+		}
+
+		$body_html .= '<li>' . sprintf(
+			/* translators: %s: status label. */
+			esc_html__( 'Status: %s', 'extrachill-events' ),
+			esc_html( $status_label )
+		) . '</li>';
+		$body_html .= '</ul>';
+
+		$queue_url = $this->moderationQueueUrl();
+
+		$body_html .= '<p><a href="' . esc_url( $queue_url ) . '">' . esc_html__( 'Review artist URL submissions', 'extrachill-events' ) . '</a></p>';
+
+		$context = array(
+			'subject_html' => esc_html( $subject ),
+			'preheader'    => $preheader,
+			'body_html'    => $body_html,
+		);
+
+		$this->dispatchEmail(
+			array(
+				'to'       => $to,
+				'subject'  => $subject,
+				'template' => 'extrachill/minimal',
+				'context'  => array_merge(
+					$context,
+					array(
+						'cta_url'   => $queue_url,
+						'cta_label' => __( 'Review artist URL submissions', 'extrachill-events' ),
+					)
+				),
+			),
+			'admin'
+		);
+	}
+
+	/**
+	 * Send a confirmation email to the submitter of an artist URL.
+	 *
+	 * Mirrors EventSubmissionAbilities::notifySubmitter() — uses the
+	 * `extrachill/branded` template through the EC mail layer. Only sent
+	 * for `pending_review` submissions (not for `scraping_failed`, where
+	 * the API response already carries the failure message).
+	 *
+	 * @param array $data Submission details: url, contact_name, contact_email.
+	 */
+	private function notifySubmitterConfirmation( array $data ): void {
+		$to = (string) ( $data['contact_email'] ?? '' );
+		if ( '' === $to || ! is_email( $to ) ) {
+			return;
+		}
+
+		$site_name = get_bloginfo( 'name' );
+		$url       = (string) ( $data['url'] ?? '' );
+
+		$subject = sprintf(
+			/* translators: 1: site name, 2: submitted URL. */
+			__( '[%1$s] Artist URL Submission Received: %2$s', 'extrachill-events' ),
+			$site_name,
+			$url
+		);
+
+		$preheader = sprintf(
+			/* translators: %s: submitted URL. */
+			__( 'We received your tour URL submission for %s.', 'extrachill-events' ),
+			$url
+		);
+
+		$body_html  = '<p>' . esc_html__( 'Thanks for submitting an artist tour URL!', 'extrachill-events' ) . '</p>';
+		$body_html .= '<p>' . sprintf(
+			/* translators: %s: submitted URL. */
+			esc_html__( 'We received your submission for: %s', 'extrachill-events' ),
+			'<strong>' . esc_html( $url ) . '</strong>'
+		) . '</p>';
+		$body_html .= '<p>' . esc_html__( "We'll review it and set up automatic event imports if it looks good. You'll hear from us once it's been reviewed.", 'extrachill-events' ) . '</p>';
+
+		$context = array(
+			'subject_html'   => esc_html( $subject ),
+			'preheader'      => $preheader,
+			'recipient_name' => (string) ( $data['contact_name'] ?? '' ),
+			'body_html'      => $body_html,
+		);
+
+		$this->dispatchEmail(
+			array(
+				'to'       => $to,
+				'subject'  => $subject,
+				'template' => 'extrachill/branded',
+				'context'  => $context,
+			),
+			'submitter'
+		);
+	}
+
+	/**
+	 * Dispatch an outgoing notification through the EC mail layer.
+	 *
+	 * Mirrors EventSubmissionAbilities::dispatchEmail() — prefers
+	 * `extrachill_send_registration_email()` (extrachill-users) which wraps
+	 * the send in PermissionHelper::run_as_authenticated(), then falls back
+	 * to `ec_send_email()` and the raw `datamachine/send-email` ability.
+	 * Failures are logged (never thrown) so a transient send error does not
+	 * break submission.
+	 *
+	 * @param array  $args     Arguments forwarded to the ability.
+	 * @param string $audience Tag used in log context ("submitter" | "admin").
+	 */
+	private function dispatchEmail( array $args, string $audience ): void {
+		$result = null;
+
+		if ( function_exists( 'extrachill_send_registration_email' ) ) {
+			$result = extrachill_send_registration_email( $args );
+		} elseif ( function_exists( 'ec_send_email' ) ) {
+			$result = ec_send_email( $args );
+		} elseif ( function_exists( 'wp_get_ability' ) ) {
+			$send_ability = wp_get_ability( 'datamachine/send-email' );
+			if ( $send_ability ) {
+				$result = $send_ability->execute( $args );
+			}
+		}
+
+		$sent = is_array( $result ) ? (bool) ( $result['success'] ?? false ) : false;
+
+		if ( ! $sent ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				sprintf( 'ArtistUrlImport: %s notification failed to send', $audience ),
+				array(
+					'audience' => $audience,
+					'to'       => $args['to'] ?? '',
+					'subject'  => $args['subject'] ?? '',
+					'result'   => is_array( $result ) ? $result : array( 'result' => $result ),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Build the admin URL for the artist URL submissions moderation queue.
+	 *
+	 * Resolves the events post-type slug via data-machine-events' public
+	 * constant and the page slug from ArtistUrlSubmissionsAdmin when the
+	 * admin class is loaded (admin context). Falls back to the known slug
+	 * literal for non-admin contexts (REST/CLI) where the admin class may
+	 * not be loaded.
+	 *
+	 * @return string
+	 */
+	private function moderationQueueUrl(): string {
+		$post_type = defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events';
+
+		$page_slug = class_exists( '\ExtraChillEvents\Admin\ArtistUrlSubmissionsAdmin' )
+			? \ExtraChillEvents\Admin\ArtistUrlSubmissionsAdmin::PAGE_SLUG
+			: 'extrachill-events-artist-url-submissions';
+
+		return admin_url( 'edit.php?post_type=' . $post_type . '&page=' . $page_slug );
 	}
 }

--- a/inc/Abilities/CityAbilities.php
+++ b/inc/Abilities/CityAbilities.php
@@ -267,8 +267,8 @@ class CityAbilities {
 						'label'     => 'AI Agent',
 					),
 					array(
-						'step_type' => 'update',
-						'label'     => 'Update',
+						'step_type' => 'upsert',
+						'label'     => 'Upsert',
 					),
 				),
 			)
@@ -676,7 +676,7 @@ class CityAbilities {
 							'exclude_keywords'    => '',
 						),
 					),
-					'update'       => array(
+					'upsert'       => array(
 						'handler_slug'   => 'upsert_event',
 						'handler_config' => array(
 							'post_status'                 => 'publish',
@@ -704,7 +704,7 @@ class CityAbilities {
 		$flow_id = $result['flow_id'] ?? null;
 
 		// Patch flow steps directly — step_configs via create-flow may not apply
-		// the update step due to ability registration timing in CLI context.
+		// the upsert step due to ability registration timing in CLI context.
 		if ( $flow_id ) {
 			$this->patchFlowSteps(
 				$flow_id,
@@ -799,7 +799,7 @@ class CityAbilities {
 	 * @param int    $flow_id        Flow ID to patch.
 	 * @param string $import_handler Handler slug for the event_import step.
 	 * @param array  $import_config  Handler config for the event_import step.
-	 * @param string $location_term  Location taxonomy term for the update step.
+	 * @param string $location_term  Location taxonomy term for the upsert step.
 	 * @param string $ai_message     Source-delta prompt for the AI step. Empty for
 	 *                               bulk sources whose identity is carried structurally
 	 *                               (flow name + location taxonomy + handler config);
@@ -833,7 +833,7 @@ class CityAbilities {
 				$step['enabled']         = true;
 			}
 
-			if ( 'update' === $step_type ) {
+			if ( 'upsert' === $step_type ) {
 				$step['handler_slugs']   = array( 'upsert_event' );
 				$step['handler_configs'] = array(
 					'upsert_event' => array(

--- a/inc/Abilities/VenueAddAbilities.php
+++ b/inc/Abilities/VenueAddAbilities.php
@@ -358,7 +358,7 @@ class VenueAddAbilities {
 				$step['enabled']         = true;
 			}
 
-			if ( 'update' === $step_type ) {
+			if ( 'upsert' === $step_type ) {
 				$step['handler_slugs']   = array( 'upsert_event' );
 				$step['handler_configs'] = array(
 					'upsert_event' => array(


### PR DESCRIPTION
Fixes #209
Fixes #210

## Summary

Two bugs fixed in one PR: a stale step_type token that broke pipeline creation, and a missing admin notification on URL tour-import submissions.

---

## Bug 1 — Stale `update` step_type breaks pipeline creation (#209)

**Cause:** `data-machine-events` renamed the pipeline step type `update` → `upsert`. Valid step types are now: `fetch`, `publish`, `upsert`, `ai`, `webhook_gate`, `system_task`, `event_import`. All live pipelines already use `event_import, ai, upsert`, but three abilities in extrachill-events still emitted the stale `update` token, causing pipeline creation to fail with:

```
Failed to create pipeline: Step at index 2 has invalid step_type 'update'.
```

**Fix:** Changed every pipeline-creation `step_type` token and `step_configs` key from `update` → `upsert`, plus `patchFlowSteps` comparisons. Only the step_type TOKEN and step_configs KEY were changed — variable names (`$update_handler_config`) and handler slugs (`upsert_event`) were left untouched as instructed.

### Files / lines changed

**`inc/Abilities/ArtistUrlImportAbilities.php`**
- `executeApprove()` pipeline steps array: `'step_type' => 'update'` / `'label' => 'Update'` → `'upsert'` / `'Upsert'`
- `executeApprove()` step_configs key: `'update' =>` → `'upsert' =>`
- `patchFlowSteps()` comparison: `if ( 'update' === $step_type )` → `if ( 'upsert' === $step_type )`
- Comment: `event_import → ai → update` → `event_import → ai → upsert`

**`inc/Abilities/CityAbilities.php`**
- `executeAddCity()` pipeline steps array: `'step_type' => 'update'` / `'label' => 'Update'` → `'upsert'` / `'Upsert'`
- `createTicketmasterFlow()` step_configs key: `'update' =>` → `'upsert' =>`
- `patchFlowSteps()` comparison: `if ( 'update' === $step_type )` → `if ( 'upsert' === $step_type )`
- Comments: "the update step" → "the upsert step" (inline + docblock)

**`inc/Abilities/VenueAddAbilities.php`**
- `patchFlowSteps()` comparison: `if ( 'update' === $step_type )` → `if ( 'upsert' === $step_type )`

---

## Bug 2 — URL tour-import submissions send no notification (#210)

**Cause:** `ArtistUrlImportAbilities::executeSubmit()` inserted a moderation-queue row (`pending_review` or `scraping_failed`) and returned success, but sent NO email. The admin was never told a submission was waiting; the submitter got no confirmation.

**Fix:** Added admin notification fired after a successful insert in `executeSubmit()` — fires for both `pending_review` and `scraping_failed` statuses. Reuses the same EC mail-layer dispatch pattern as `EventSubmissionAbilities` (`extrachill_send_registration_email()` → `ec_send_email()` → `datamachine/send-email` ability fallback chain). No second mail path invented.

### Admin email includes
- Submitter name + email
- Submitted URL
- Detected format
- Events found count
- Suggested artist name (when present)
- Submission status (pending review / scrape failed)
- Link to the moderation queue admin screen (Events → Artist URL Submissions)

### Submitter confirmation email
**Added** for `pending_review` submissions only. Uses the `extrachill/branded` template (same as `EventSubmissionAbilities::notifySubmitter()`). Not sent for `scraping_failed` — the API response already carries the failure message, and a "we failed" email adds noise without value. The dispatch infrastructure made this cheap to add alongside the required admin notification.

### CC + sender identity
Mirrors the existing `EventSubmissionAbilities` pattern — no explicit CC or sender identity hardcoded in the caller. The EC mail layer (`ec_send_email` / `datamachine/send-email` ability / `extrachill_send_registration_email`) handles CC and sender identity, same as it does for single-event submissions.

### Files / lines changed

**`inc/Abilities/ArtistUrlImportAbilities.php`**
- `executeSubmit()` scraping_failed path: added `notifyAdminSubmission()` call after successful insert (with null guard)
- `executeSubmit()` pending_review path: added `notifyAdminSubmission()` + `notifySubmitterConfirmation()` calls after null check
- New method `notifyAdminSubmission()` — builds and sends admin email via `extrachill/minimal` template
- New method `notifySubmitterConfirmation()` — builds and sends submitter email via `extrachill/branded` template
- New method `dispatchEmail()` — mirrors `EventSubmissionAbilities::dispatchEmail()` fallback chain
- New method `moderationQueueUrl()` — resolves the admin moderation-queue URL using `ArtistUrlSubmissionsAdmin::PAGE_SLUG` (with fallback for non-admin contexts where the admin class isn't loaded)

---

## Verification
- `php -l` syntax check passed on all three files
- `grep` confirmed no stale `'update'` step_type token remains in any of the three files
- No `CHANGELOG.md` or version strings touched (homeboy owns both)