### PR TITLE
feat: notify submitter on artist tour-import approval/rejection (#212)

### DIFF
--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -639,6 +639,27 @@ class ArtistUrlImportAbilities {
 			)
 		);
 
+		// 3a. Notify the submitter that the import was approved.
+		$events_found_count = isset( $submission['events_found_count'] ) ? (int) $submission['events_found_count'] : 0;
+		$approve_title      = sprintf(
+			/* translators: 1: artist name, 2: number of events found */
+			__( 'Your tour import for %1$s was approved — %2$d events added', 'extrachill-events' ),
+			$artist_name,
+			$events_found_count
+		);
+		$artist_archive_link = get_term_link( $artist_term_id, 'artist' );
+		if ( is_wp_error( $artist_archive_link ) || ! is_string( $artist_archive_link ) || '' === $artist_archive_link ) {
+			$artist_archive_link = home_url();
+		}
+
+		$this->notifySubmitter(
+			$submission,
+			'artist_import_approved',
+			$approve_title,
+			$artist_archive_link,
+			$artist_term_id
+		);
+
 		// 4. Trigger first scrape immediately.
 		$events_imported_immediately = null;
 		$run_ability                 = wp_get_ability( 'datamachine/run-flow' );
@@ -681,6 +702,26 @@ class ArtistUrlImportAbilities {
 				'reviewed_at'      => current_time( 'mysql', true ),
 				'reviewed_by'      => get_current_user_id(),
 			)
+		);
+
+		// Notify the submitter that the import was rejected.
+		$reject_title = __( 'Your tour import submission was not approved', 'extrachill-events' );
+		if ( '' !== $reason ) {
+			$reject_title = sprintf(
+				/* translators: %s: rejection reason */
+				__( 'Your tour import submission was not approved: %s', 'extrachill-events' ),
+				$reason
+			);
+		}
+
+		$submit_page_link = home_url( '/submit/' );
+
+		$this->notifySubmitter(
+			$submission,
+			'artist_import_rejected',
+			$reject_title,
+			$submit_page_link,
+			$submission_id
 		);
 
 		return array( 'success' => true );
@@ -1609,5 +1650,75 @@ class ArtistUrlImportAbilities {
 			: 'extrachill-events-artist-url-submissions';
 
 		return admin_url( 'edit.php?post_type=' . $post_type . '&page=' . $page_slug );
+	}
+
+	/**
+	 * Fire a bell notification for the submitter after approval/rejection.
+	 *
+	 * Consumes the network notification substrate from extrachill-users.
+	 * Failures are logged and never allowed to break the approval/rejection
+	 * transaction.
+	 *
+	 * @param array  $submission Submission row from ArtistUrlSubmissionsTable.
+	 * @param string $type       Notification type (sanitize_key'd by substrate).
+	 * @param string $title      Human-readable title.
+	 * @param string $link       Target URL for the notification.
+	 * @param int    $item_id    Optional related object ID.
+	 */
+	private function notifySubmitter( array $submission, string $type, string $title, string $link, int $item_id = 0 ): void {
+		if ( ! function_exists( 'ec_users_notify' ) ) {
+			return;
+		}
+
+		$submitter_id = isset( $submission['user_id'] ) ? (int) $submission['user_id'] : 0;
+		if ( $submitter_id <= 0 ) {
+			return;
+		}
+
+		$actor_id = get_current_user_id();
+		if ( $actor_id <= 0 ) {
+			return;
+		}
+
+		$data = array(
+			'actor_id' => $actor_id,
+			'type'     => $type,
+			'title'    => $title,
+			'link'     => $link,
+		);
+		if ( $item_id > 0 ) {
+			$data['item_id'] = $item_id;
+		}
+
+		$inserted = 0;
+		try {
+			$inserted = ec_users_notify( $submitter_id, $data );
+		} catch ( \Throwable $e ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'ArtistUrlImportAbilities: submitter notification threw an exception',
+				array(
+					'type'     => $type,
+					'user_id'  => $submitter_id,
+					'actor_id' => $actor_id,
+					'error'    => $e->getMessage(),
+				)
+			);
+			return;
+		}
+
+		if ( 0 === $inserted ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'ArtistUrlImportAbilities: submitter notification was not inserted',
+				array(
+					'type'     => $type,
+					'user_id'  => $submitter_id,
+					'actor_id' => $actor_id,
+				)
+			);
+		}
 	}
 }


### PR DESCRIPTION
Closes #212.

Adds a single user-facing bell notification for the submitter when an artist tour-URL import submission is approved or rejected, using the existing `ec_users_notify()` network substrate from `extrachill-users`.

## Fire points

- **Approval** (`executeApprove`): after `ArtistUrlSubmissionsTable::update(... STATUS_APPROVED ...)` succeeds, we notify `$submission['user_id']` with:
  - `type`: `artist_import_approved`
  - `actor_id`: `get_current_user_id()`
  - `title`: `Your tour import for {artist_name} was approved — {N} events added`
  - `link`: artist archive URL via `get_term_link( $artist_term_id, 'artist' )`, falling back to `home_url()`
  - `item_id`: the artist term ID

- **Rejection** (`executeReject`): after `ArtistUrlSubmissionsTable::update(... STATUS_REJECTED ...)` succeeds, we notify the submitter with:
  - `type`: `artist_import_rejected`
  - `actor_id`: `get_current_user_id()`
  - `title`: `Your tour import submission was not approved`, appended with `: {reason}` when a rejection reason is present
  - `link`: the tour URL submit page (`home_url( '/submit/' )`)
  - `item_id`: the submission ID

## Event-count source

The title uses `$submission['events_found_count']` (the count stored at submission time from the preview probe). `events_imported_immediately` is currently a boolean success flag rather than a count, so the preview count is the best available number to show the submitter how many events were discovered.

## Safety / one-shot semantics

- Guarded with `function_exists( 'ec_users_notify' )`.
- Notification failures are logged via `do_action( 'datamachine_log', ... )` and never throw, so an approval/rejection always returns successfully.
- Notifications are fired exactly once per approve/reject ability call; nothing was added to the recurring flow-run path.

## Verification

- `php -l inc/Abilities/ArtistUrlImportAbilities.php` is clean.
- Local `homeboy review` is blocked by an environment WP Codebox CLI setup issue (`wp-codebox --version` fails) and pre-existing phpcs findings elsewhere in the same file; the new notification code follows the existing file style.