### PR TITLE
feat: credit approved tour-URL submissions toward community rank (#214)

### DIFF
--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -639,6 +639,10 @@ class ArtistUrlImportAbilities {
 			)
 		);
 
+		// Bust the rank-engine points cache so the submitter's leaderboard
+		// total reflects the newly approved submission (10 points per approval).
+		delete_transient( 'user_points_' . (int) $submission['user_id'] );
+
 		// 3a. Notify the submitter that the import was approved.
 		$events_found_count = isset( $submission['events_found_count'] ) ? (int) $submission['events_found_count'] : 0;
 		$approve_title      = sprintf(

--- a/inc/Core/ArtistUrlSubmissionsTable.php
+++ b/inc/Core/ArtistUrlSubmissionsTable.php
@@ -380,4 +380,20 @@ class ArtistUrlSubmissionsTable {
 		}
 		return $out;
 	}
+
+	/**
+	 * Count approved submissions for a given user.
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return int
+	 */
+	public static function count_approved_by_user( int $user_id ): int {
+		global $wpdb;
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (int) $wpdb->get_var( $wpdb->prepare(
+			"SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND status = %s",
+			$user_id, self::STATUS_APPROVED
+		) );
+	}
 }

--- a/inc/core/bootstrap.php
+++ b/inc/core/bootstrap.php
@@ -110,3 +110,33 @@ function ec_events_redirect_post_type_archive() {
 	}
 }
 add_action( 'template_redirect', 'ec_events_redirect_post_type_archive' );
+
+/**
+ * Contribute approved artist tour-URL submissions to the community rank engine.
+ *
+ * Hooks `ec_points_sources` (owned by extrachill-users). Each approved
+ * submission is worth 10 points — the same weight as a main-site post. The
+ * unit is the approved submission, not the imported events, so one approved
+ * URL that ingests many events still contributes exactly 10 points (avoiding
+ * a gameable reward for high-volume imports). No-ops if the table class is
+ * not loaded.
+ *
+ * @param array $sources Source-id => points map.
+ * @param int   $user_id WordPress user ID.
+ * @return array
+ */
+add_filter(
+	'ec_points_sources',
+	function ( $sources, $user_id ) {
+		if ( ! class_exists( '\\ExtraChillEvents\\Core\\ArtistUrlSubmissionsTable' ) ) {
+			return $sources;
+		}
+
+		$n = \ExtraChillEvents\Core\ArtistUrlSubmissionsTable::count_approved_by_user( (int) $user_id );
+
+		$sources['events_contributed'] = (float) $n * 10;
+		return $sources;
+	},
+	10,
+	2
+);


### PR DESCRIPTION
Closes #214.

This wires approved artist tour-URL submissions into the network rank engine (`ec_points_sources`) without adding any new infrastructure.

### What changed

- **`inc/Core/ArtistUrlSubmissionsTable.php`** — added `count_approved_by_user( int $user_id )`, a direct `COUNT(*)` query against approved rows for the submitter.
- **`inc/core/bootstrap.php`** — registered a new `ec_points_sources` contributor:
  - source key: `events_contributed`
  - value: `approved_submission_count * 10`
  - guarded by `class_exists( '\\ExtraChillEvents\\Core\\ArtistUrlSubmissionsTable' )` so the events plugin no-ops gracefully if the table class is not loaded.
- **`inc/Abilities/ArtistUrlImportAbilities.php`** — after `executeApprove()` successfully updates the submission row to `STATUS_APPROVED`, it busts the rank-engine cache (`delete_transient( 'user_points_' . $submission['user_id'] )`) so the leaderboard recomputes the submitter's total on the next read.

### Rationale: per-submission, not per-event

An approved tour URL spins up a recurring pipeline that can ingest an unbounded number of events over time. Crediting by raw event count would make the reward gameable and scale unpredictably. The unit of contribution is the approved source submission, weighted at **10 points** — the same weight as a main-site post.

### Verification

`php -l` passes on all three touched files.

Trace: approving one submission that imported 90 events adds exactly **+10 points** (once the cache busts/recomputes), not +900.