### PR TITLE
fix: register abilities on wp_abilities_api_init instead of firing outside the action

### DIFF
--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -220,11 +220,7 @@ class ArtistUrlImportAbilities {
 			$this->registerRejectAbility();
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	// ────────────────────────────────────────────────────────────────────

--- a/inc/Abilities/CityAbilities.php
+++ b/inc/Abilities/CityAbilities.php
@@ -112,11 +112,7 @@ class CityAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/EventSubmissionAbilities.php
+++ b/inc/Abilities/EventSubmissionAbilities.php
@@ -114,11 +114,7 @@ class EventSubmissionAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/QualifyDigestAbilities.php
+++ b/inc/Abilities/QualifyDigestAbilities.php
@@ -89,13 +89,7 @@ class QualifyDigestAbilities {
 			);
 		};
 
-		if ( function_exists( 'doing_action' ) && doing_action( 'wp_abilities_api_init' ) ) {
-			$callback();
-		} elseif ( function_exists( 'did_action' ) && ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $callback );
-		} else {
-			$callback();
-		}
+		add_action( 'wp_abilities_api_init', $callback );
 	}
 
 	/**

--- a/inc/Abilities/VenueAddAbilities.php
+++ b/inc/Abilities/VenueAddAbilities.php
@@ -120,11 +120,7 @@ class VenueAddAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/VenueDiscoveryAbilities.php
+++ b/inc/Abilities/VenueDiscoveryAbilities.php
@@ -98,11 +98,7 @@ class VenueDiscoveryAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/VenueQualificationAbilities.php
+++ b/inc/Abilities/VenueQualificationAbilities.php
@@ -162,11 +162,7 @@ class VenueQualificationAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**


### PR DESCRIPTION
## Root cause

WordPress 6.9 `wp_register_ability()` (`wp-includes/abilities-api.php:278-291`) emits a `_doing_it_wrong()` notice and returns `null` unless it is called **while** the `wp_abilities_api_init` action is actively firing — it gates on `doing_action(...)`, not `did_action(...)`:

```php
function wp_register_ability( string $name, array $args ): ?WP_Ability {
	if ( ! doing_action( 'wp_abilities_api_init' ) ) {
		_doing_it_wrong(
			__FUNCTION__,
			...
			'6.9.0'
		);
		return null;
	}
	...
}
```

The buggy idiom used `did_action( 'wp_abilities_api_init' )` to decide whether to call the register callback immediately. Once the hook has fired, `did_action()` is `true` forever but `doing_action()` is `false` — so the immediate branch always registered **outside** the action context, tripping the notice and silently failing to register the ability (null return). Registering post-hook is impossible-by-design in 6.9.

## The fix (mechanical)

Replace the whole `if ( did_action(...) ) {...} else {...}` wrapper with just:

```php
add_action( 'wp_abilities_api_init', $register_callback );
```

The `private static bool $registered` dedupe guard is preserved untouched. No `doing_action()` OR-check workaround was added — registering outside the action is forbidden by core, so the dead immediate branch is simply dropped.

## Files changed

**6 standard files** — `did_action` immediate-branch removed, replaced with `add_action`:
- `inc/Abilities/ArtistUrlImportAbilities.php`
- `inc/Abilities/CityAbilities.php`
- `inc/Abilities/EventSubmissionAbilities.php`
- `inc/Abilities/VenueAddAbilities.php`
- `inc/Abilities/VenueDiscoveryAbilities.php`
- `inc/Abilities/VenueQualificationAbilities.php`

**1 special case** — `QualifyDigestAbilities.php` had a "smarter" 3-branch guard (`doing_action` → immediate, `!did_action` → hook, `else` → immediate). Its final `else { $callback(); }` still fired an immediate registration in the already-fired case, so it still tripped the notice. Collapsed the whole 3-branch guard down to a single:

```php
add_action( 'wp_abilities_api_init', $callback );
```

## Already-correct files (deliberately left untouched)

These 7 files already used the correct reference pattern — `add_action( 'wp_abilities_api_init', array( $this, 'register' ) )` only, no immediate branch — and were not modified:
- `inc/Abilities/PriorityEventAbilities.php`
- `inc/Abilities/EventTimeAuditAbilities.php`
- `inc/Abilities/LocationEventAbilities.php`
- `inc/Abilities/MarketReportAbilities.php`
- `inc/Abilities/PriorityVenueAbilities.php`
- `inc/Abilities/EventLocationAlignmentAbilities.php`
- `inc/Abilities/EventRoundupAbilities.php`

## Verification

- `grep -rn "did_action( 'wp_abilities_api_init'" inc/` → **0 matches** (clean).
- `grep -rn "doing_action( 'wp_abilities_api_init'" inc/` → **0 matches** (clean).
- `php -l` on all 7 changed files → **no syntax errors**.
- `homeboy review extrachill-events lint` → PHPCS **passed**, PHPStan **passed** (ESLint infra step failed with 0 findings, unrelated to PHP-only changes).

## Why safe

Ability classes double as service objects that are `new`'d ad-hoc to call `->executeX()` — those don't need registry registration. The lazy CLI consumer (`extrachill-cli LocationCommand`) relies on the already-correct classes (`EventLocationAlignmentAbilities`, `EventTimeAuditAbilities`, `MarketReportAbilities`, `EventRoundupAbilities`) and works by instantiating before the first `wp_has_ability()` call, which fires the hook once.

This eliminates the recurring WP 6.9 `doing_it_wrong` notices in the network `debug.log`.