### PR TITLE
feat: apply account market fallback to event discovery

### DIFF
--- a/assets/js/near-me.js
+++ b/assets/js/near-me.js
@@ -120,6 +120,13 @@
 	}
 
 	function onError( error ) {
+		// The server-rendered calendar/map already use the account market.
+		// Keep that result instead of dropping to anonymous city discovery.
+		if ( ecNearMe.hasAccountMarket ) {
+			hideDetectUI();
+			return;
+		}
+
 		let msg;
 		switch ( error.code ) {
 			case error.PERMISSION_DENIED:

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -243,6 +243,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/venue-map.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/artist-map.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-seo.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/account-market.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/near-me.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/discovery-pages.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/router-pages.php';

--- a/inc/core/account-market.php
+++ b/inc/core/account-market.php
@@ -16,10 +16,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Get the current user's resolved default event location.
  *
- * The Ability is introduced by extrachill-users#176. Until that dependency is
- * available, or when it returns an invalid/empty preference, this fails open.
+ * The Ability contract is provided by extrachill-users#179. Until that
+ * dependency is available, or when it returns an invalid/empty preference,
+ * this fails open.
  *
- * @return array{lat: float, lng: float, slug: string}|null
+ * @return array{lat: float|null, lon: float|null, slug: string, term_id: int}|null
  */
 function extrachill_events_get_account_market(): ?array {
 	static $resolved = false;
@@ -46,17 +47,26 @@ function extrachill_events_get_account_market(): ?array {
 
 	$location    = $result['default_event_location'];
 	$coordinates = is_array( $location['coordinates'] ?? null ) ? $location['coordinates'] : array();
-	$lat         = filter_var( $coordinates['lat'] ?? null, FILTER_VALIDATE_FLOAT );
-	$lng         = filter_var( $coordinates['lng'] ?? null, FILTER_VALIDATE_FLOAT );
+	$lat         = filter_var( $coordinates['lat'] ?? null, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE );
+	$lon         = filter_var( $coordinates['lon'] ?? null, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE );
+	$term_id     = absint( $location['term_id'] ?? 0 );
+	$slug        = sanitize_title( $location['slug'] ?? '' );
 
-	if ( false === $lat || false === $lng || $lat < -90 || $lat > 90 || $lng < -180 || $lng > 180 ) {
+	if ( $term_id < 1 || '' === $slug ) {
 		return null;
+	}
+	if ( null !== $lat && ( $lat < -90 || $lat > 90 ) ) {
+		$lat = null;
+	}
+	if ( null !== $lon && ( $lon < -180 || $lon > 180 ) ) {
+		$lon = null;
 	}
 
 	$market = array(
-		'lat'  => (float) $lat,
-		'lng'  => (float) $lng,
-		'slug' => sanitize_title( $location['slug'] ?? '' ),
+		'lat'     => null !== $lat ? (float) $lat : null,
+		'lon'     => null !== $lon ? (float) $lon : null,
+		'slug'    => $slug,
+		'term_id' => $term_id,
 	);
 
 	return $market;
@@ -99,65 +109,48 @@ function extrachill_events_supports_account_market(): bool {
 }
 
 /**
- * Seed account coordinates into an otherwise unscoped calendar render.
+ * Add account market defaults before the calendar request is parsed.
  *
- * DME already gives server-rendered geo attributes precedence over its browser
- * localStorage fallback. URL/archive inputs remain first because this hook does
- * nothing when either is present.
+ * Explicit request/archive state wins. Near Me receives geo defaults so browser
+ * geolocation can replace them; other public calendar surfaces receive the
+ * canonical taxonomy term. CalendarRequest sanitizes every injected value.
  *
- * @param array $parsed_block Parsed block data.
+ * @param array $query_args Assembled calendar request arguments.
+ * @param array $context    Calendar render context.
  * @return array
  */
-function extrachill_events_seed_account_market( array $parsed_block ): array {
-	if ( 'data-machine-events/calendar' !== ( $parsed_block['blockName'] ?? '' ) || ! extrachill_events_supports_account_market() || extrachill_events_has_explicit_market() ) {
-		return $parsed_block;
+function extrachill_events_calendar_account_market_defaults( array $query_args, array $context ): array {
+	if ( ! extrachill_events_supports_account_market() || ! empty( $context['archive_term'] ) || ! empty( $query_args['tax_filter'] ) ) {
+		return $query_args;
+	}
+
+	if ( ! empty( $query_args['lat'] ) || ! empty( $query_args['lng'] ) ) {
+		return $query_args;
 	}
 
 	$market = extrachill_events_get_account_market();
 	if ( null === $market ) {
-		return $parsed_block;
+		return $query_args;
 	}
 
-	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Temporarily preserving and seeding public read-only calendar parameters.
-	$GLOBALS['extrachill_events_account_market_request'][] = array(
-		'lat_exists' => isset( $_GET['lat'] ),
-		'lng_exists' => isset( $_GET['lng'] ),
-		'lat'        => isset( $_GET['lat'] ) ? sanitize_text_field( wp_unslash( $_GET['lat'] ) ) : null,
-		'lng'        => isset( $_GET['lng'] ) ? sanitize_text_field( wp_unslash( $_GET['lng'] ) ) : null,
-	);
-
-	$_GET['lat'] = (string) $market['lat'];
-	$_GET['lng'] = (string) $market['lng'];
-	// phpcs:enable WordPress.Security.NonceVerification.Recommended
-
-	return $parsed_block;
-}
-add_filter( 'render_block_data', 'extrachill_events_seed_account_market' );
-
-/**
- * Restore request globals after an account-scoped calendar has rendered.
- *
- * @param string $block_content Rendered block HTML.
- * @param array  $block         Parsed block data.
- * @return string
- */
-function extrachill_events_restore_account_market_request( string $block_content, array $block ): string {
-	if ( 'data-machine-events/calendar' !== ( $block['blockName'] ?? '' ) || empty( $GLOBALS['extrachill_events_account_market_request'] ) ) {
-		return $block_content;
-	}
-
-	$previous = array_pop( $GLOBALS['extrachill_events_account_market_request'] );
-	foreach ( array( 'lat', 'lng' ) as $key ) {
-		if ( $previous[ $key . '_exists' ] ) {
-			$_GET[ $key ] = $previous[ $key ];
-		} else {
-			unset( $_GET[ $key ] );
+	if ( function_exists( 'extrachill_events_is_near_me_page' ) && extrachill_events_is_near_me_page() ) {
+		if ( null !== $market['lat'] && null !== $market['lon'] ) {
+			$query_args += array(
+				'lat' => $market['lat'],
+				'lng' => $market['lon'],
+			);
 		}
+	} else {
+		$query_args += array(
+			'tax_filter' => array(
+				'location' => array( $market['term_id'] ),
+			),
+		);
 	}
 
-	return $block_content;
+	return $query_args;
 }
-add_filter( 'render_block', 'extrachill_events_restore_account_market_request', 10, 2 );
+add_filter( 'data_machine_events_calendar_request_args', 'extrachill_events_calendar_account_market_defaults', 10, 2 );
 
 /**
  * Use the account market as a map center only when no stronger context exists.
@@ -172,13 +165,13 @@ function extrachill_events_account_market_map_center( $center, array $context ) 
 	}
 
 	$market = extrachill_events_get_account_market();
-	if ( null === $market ) {
+	if ( null === $market || null === $market['lat'] || null === $market['lon'] ) {
 		return $center;
 	}
 
 	return array(
 		'lat' => $market['lat'],
-		'lon' => $market['lng'],
+		'lon' => $market['lon'],
 	);
 }
 add_filter( 'data_machine_events_map_center', 'extrachill_events_account_market_map_center', 5, 2 );

--- a/inc/core/account-market.php
+++ b/inc/core/account-market.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Account-backed event market integration.
+ *
+ * Extra Chill Users owns the private preference. This integration consumes its
+ * resolved coordinates and feeds them into Data Machine Events' existing geo
+ * inputs without teaching the generic event layer about accounts.
+ *
+ * @package ExtraChillEvents
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Get the current user's resolved default event location.
+ *
+ * The Ability is introduced by extrachill-users#176. Until that dependency is
+ * available, or when it returns an invalid/empty preference, this fails open.
+ *
+ * @return array{lat: float, lng: float, slug: string}|null
+ */
+function extrachill_events_get_account_market(): ?array {
+	static $resolved = false;
+	static $market   = null;
+
+	if ( $resolved ) {
+		return $market;
+	}
+	$resolved = true;
+
+	if ( ! is_user_logged_in() || ! function_exists( 'wp_get_ability' ) ) {
+		return null;
+	}
+
+	$ability = wp_get_ability( 'extrachill/get-user-settings' );
+	if ( ! $ability ) {
+		return null;
+	}
+
+	$result = $ability->execute( array() );
+	if ( is_wp_error( $result ) || ! is_array( $result ) || ! is_array( $result['default_event_location'] ?? null ) ) {
+		return null;
+	}
+
+	$location    = $result['default_event_location'];
+	$coordinates = is_array( $location['coordinates'] ?? null ) ? $location['coordinates'] : array();
+	$lat         = filter_var( $coordinates['lat'] ?? null, FILTER_VALIDATE_FLOAT );
+	$lng         = filter_var( $coordinates['lng'] ?? null, FILTER_VALIDATE_FLOAT );
+
+	if ( false === $lat || false === $lng || $lat < -90 || $lat > 90 || $lng < -180 || $lng > 180 ) {
+		return null;
+	}
+
+	$market = array(
+		'lat'  => (float) $lat,
+		'lng'  => (float) $lng,
+		'slug' => sanitize_title( $location['slug'] ?? '' ),
+	);
+
+	return $market;
+}
+
+/**
+ * Whether the request already carries an explicit location selection.
+ */
+function extrachill_events_has_explicit_market(): bool {
+	if ( is_tax() ) {
+		return true;
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public read-only calendar filters.
+	if ( ! empty( $_GET['tax_filter'] ) ) {
+		return true;
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public read-only geo parameters.
+	$lat = isset( $_GET['lat'] ) ? sanitize_text_field( wp_unslash( $_GET['lat'] ) ) : '';
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public read-only geo parameters.
+	$lng = isset( $_GET['lng'] ) ? sanitize_text_field( wp_unslash( $_GET['lng'] ) ) : '';
+	return '' !== $lat && '' !== $lng;
+}
+
+/**
+ * Whether this page owns the unscoped public calendar/map experience.
+ *
+ * Embedded calendars such as My Shows and related events have their own query
+ * contracts and must not inherit a market fallback.
+ */
+function extrachill_events_supports_account_market(): bool {
+	if ( function_exists( 'ec_is_events_site' ) && ! ec_is_events_site() ) {
+		return false;
+	}
+
+	return is_front_page()
+		|| ( function_exists( 'extrachill_events_is_all_events_page' ) && extrachill_events_is_all_events_page() )
+		|| ( function_exists( 'extrachill_events_is_near_me_page' ) && extrachill_events_is_near_me_page() );
+}
+
+/**
+ * Seed account coordinates into an otherwise unscoped calendar render.
+ *
+ * DME already gives server-rendered geo attributes precedence over its browser
+ * localStorage fallback. URL/archive inputs remain first because this hook does
+ * nothing when either is present.
+ *
+ * @param array $parsed_block Parsed block data.
+ * @return array
+ */
+function extrachill_events_seed_account_market( array $parsed_block ): array {
+	if ( 'data-machine-events/calendar' !== ( $parsed_block['blockName'] ?? '' ) || ! extrachill_events_supports_account_market() || extrachill_events_has_explicit_market() ) {
+		return $parsed_block;
+	}
+
+	$market = extrachill_events_get_account_market();
+	if ( null === $market ) {
+		return $parsed_block;
+	}
+
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Temporarily preserving and seeding public read-only calendar parameters.
+	$GLOBALS['extrachill_events_account_market_request'][] = array(
+		'lat_exists' => isset( $_GET['lat'] ),
+		'lng_exists' => isset( $_GET['lng'] ),
+		'lat'        => isset( $_GET['lat'] ) ? sanitize_text_field( wp_unslash( $_GET['lat'] ) ) : null,
+		'lng'        => isset( $_GET['lng'] ) ? sanitize_text_field( wp_unslash( $_GET['lng'] ) ) : null,
+	);
+
+	$_GET['lat'] = (string) $market['lat'];
+	$_GET['lng'] = (string) $market['lng'];
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+	return $parsed_block;
+}
+add_filter( 'render_block_data', 'extrachill_events_seed_account_market' );
+
+/**
+ * Restore request globals after an account-scoped calendar has rendered.
+ *
+ * @param string $block_content Rendered block HTML.
+ * @param array  $block         Parsed block data.
+ * @return string
+ */
+function extrachill_events_restore_account_market_request( string $block_content, array $block ): string {
+	if ( 'data-machine-events/calendar' !== ( $block['blockName'] ?? '' ) || empty( $GLOBALS['extrachill_events_account_market_request'] ) ) {
+		return $block_content;
+	}
+
+	$previous = array_pop( $GLOBALS['extrachill_events_account_market_request'] );
+	foreach ( array( 'lat', 'lng' ) as $key ) {
+		if ( $previous[ $key . '_exists' ] ) {
+			$_GET[ $key ] = $previous[ $key ];
+		} else {
+			unset( $_GET[ $key ] );
+		}
+	}
+
+	return $block_content;
+}
+add_filter( 'render_block', 'extrachill_events_restore_account_market_request', 10, 2 );
+
+/**
+ * Use the account market as a map center only when no stronger context exists.
+ *
+ * @param mixed $center  Existing map center.
+ * @param array $context Map render context.
+ * @return mixed
+ */
+function extrachill_events_account_market_map_center( $center, array $context ) {
+	if ( null !== $center || ! extrachill_events_supports_account_market() || ! empty( $context['is_taxonomy'] ) || extrachill_events_has_explicit_market() ) {
+		return $center;
+	}
+
+	$market = extrachill_events_get_account_market();
+	if ( null === $market ) {
+		return $center;
+	}
+
+	return array(
+		'lat' => $market['lat'],
+		'lon' => $market['lng'],
+	);
+}
+add_filter( 'data_machine_events_map_center', 'extrachill_events_account_market_map_center', 5, 2 );

--- a/inc/core/near-me.php
+++ b/inc/core/near-me.php
@@ -127,8 +127,9 @@ function extrachill_events_near_me_scripts() {
 		true
 	);
 
-	$geo            = extrachill_events_get_geo_params();
-	$account_market = extrachill_events_get_account_market();
+	$geo                = extrachill_events_get_geo_params();
+	$account_market     = extrachill_events_get_account_market();
+	$has_account_market = null !== $account_market && null !== $account_market['lat'] && null !== $account_market['lon'];
 
 	wp_localize_script(
 		'extrachill-events-near-me',
@@ -138,7 +139,7 @@ function extrachill_events_near_me_scripts() {
 			'lat'              => $geo['lat'],
 			'lng'              => $geo['lng'],
 			'pageUrl'          => get_permalink(),
-			'hasAccountMarket' => null !== $account_market,
+			'hasAccountMarket' => $has_account_market,
 		)
 	);
 }

--- a/inc/core/near-me.php
+++ b/inc/core/near-me.php
@@ -127,16 +127,18 @@ function extrachill_events_near_me_scripts() {
 		true
 	);
 
-	$geo = extrachill_events_get_geo_params();
+	$geo            = extrachill_events_get_geo_params();
+	$account_market = extrachill_events_get_account_market();
 
 	wp_localize_script(
 		'extrachill-events-near-me',
 		'ecNearMe',
 		array(
-			'hasLocation' => null !== $geo['lat'] && null !== $geo['lng'],
-			'lat'         => $geo['lat'],
-			'lng'         => $geo['lng'],
-			'pageUrl'     => get_permalink(),
+			'hasLocation'      => null !== $geo['lat'] && null !== $geo['lng'],
+			'lat'              => $geo['lat'],
+			'lng'              => $geo['lng'],
+			'pageUrl'          => get_permalink(),
+			'hasAccountMarket' => null !== $account_market,
 		)
 	);
 }

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Account market integration tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter() {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in() {
+		return (bool) ( $GLOBALS['test_is_user_logged_in'] ?? false );
+	}
+}
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( $name ) {
+		return 'extrachill/get-user-settings' === $name ? ( $GLOBALS['test_account_market_ability'] ?? null ) : null;
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error() {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $value ) {
+		return strtolower( preg_replace( '/[^a-z0-9]+/i', '-', trim( (string) $value ) ) );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ) {
+		return trim( (string) $value );
+	}
+}
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+	function wp_unslash( $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'is_tax' ) ) {
+	function is_tax() {
+		return (bool) ( $GLOBALS['test_is_tax'] ?? false );
+	}
+}
+
+if ( ! function_exists( 'is_front_page' ) ) {
+	function is_front_page() {
+		return (bool) ( $GLOBALS['test_is_front_page'] ?? false );
+	}
+}
+
+if ( ! function_exists( 'ec_is_events_site' ) ) {
+	function ec_is_events_site() {
+		return true;
+	}
+}
+
+require_once dirname( __DIR__, 3 ) . '/inc/core/account-market.php';
+
+/**
+ * Verifies the account preference integration and its precedence gates.
+ */
+final class AccountMarketTest extends TestCase {
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_resolves_coordinates_from_user_ability(): void {
+		$GLOBALS['test_is_user_logged_in']      = true;
+		$GLOBALS['test_account_market_ability'] = new class() {
+			public function execute(): array {
+				return array(
+					'default_event_location' => array(
+						'slug'        => 'Charleston SC',
+						'coordinates' => array(
+							'lat' => 32.7765,
+							'lng' => -79.9311,
+						),
+					),
+				);
+			}
+		};
+
+		$this->assertSame(
+			array(
+				'lat'  => 32.7765,
+				'lng'  => -79.9311,
+				'slug' => 'charleston-sc',
+			),
+			extrachill_events_get_account_market()
+		);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_fails_open_when_ability_is_unavailable(): void {
+		$GLOBALS['test_is_user_logged_in'] = true;
+
+		$this->assertNull( extrachill_events_get_account_market() );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_seeds_and_restores_existing_calendar_geo_inputs(): void {
+		$GLOBALS['test_is_user_logged_in']      = true;
+		$GLOBALS['test_is_front_page']          = true;
+		$GLOBALS['test_account_market_ability'] = new class() {
+			public function execute(): array {
+				return array(
+					'default_event_location' => array(
+						'slug'        => 'charleston',
+						'coordinates' => array(
+							'lat' => 32.7765,
+							'lng' => -79.9311,
+						),
+					),
+				);
+			}
+		};
+		$_GET = array();
+		$block = array( 'blockName' => 'data-machine-events/calendar' );
+
+		extrachill_events_seed_account_market( $block );
+		$this->assertSame( '32.7765', $_GET['lat'] );
+		$this->assertSame( '-79.9311', $_GET['lng'] );
+
+		extrachill_events_restore_account_market_request( '', $block );
+		$this->assertArrayNotHasKey( 'lat', $_GET );
+		$this->assertArrayNotHasKey( 'lng', $_GET );
+	}
+
+	public function test_explicit_geo_and_taxonomy_filters_win(): void {
+		$_GET = array(
+			'lat' => '40.7',
+			'lng' => '-74.0',
+		);
+		$this->assertTrue( extrachill_events_has_explicit_market() );
+
+		$_GET = array( 'tax_filter' => array( 'location' => array( 42 ) ) );
+		$this->assertTrue( extrachill_events_has_explicit_market() );
+	}
+
+	public function test_anonymous_request_does_not_resolve_account_market(): void {
+		$GLOBALS['test_is_user_logged_in'] = false;
+
+		$this->assertNull( extrachill_events_get_account_market() );
+	}
+}

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -37,6 +37,12 @@ if ( ! function_exists( 'sanitize_title' ) ) {
 	}
 }
 
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ) {
+		return abs( (int) $value );
+	}
+}
+
 if ( ! function_exists( 'sanitize_text_field' ) ) {
 	function sanitize_text_field( $value ) {
 		return trim( (string) $value );
@@ -67,6 +73,12 @@ if ( ! function_exists( 'ec_is_events_site' ) ) {
 	}
 }
 
+if ( ! function_exists( 'extrachill_events_is_near_me_page' ) ) {
+	function extrachill_events_is_near_me_page() {
+		return (bool) ( $GLOBALS['test_is_near_me_page'] ?? false );
+	}
+}
+
 require_once dirname( __DIR__, 3 ) . '/inc/core/account-market.php';
 
 /**
@@ -84,9 +96,10 @@ final class AccountMarketTest extends TestCase {
 				return array(
 					'default_event_location' => array(
 						'slug'        => 'Charleston SC',
+						'term_id'     => 1618,
 						'coordinates' => array(
 							'lat' => 32.7765,
-							'lng' => -79.9311,
+							'lon' => -79.9311,
 						),
 					),
 				);
@@ -95,9 +108,10 @@ final class AccountMarketTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'lat'  => 32.7765,
-				'lng'  => -79.9311,
-				'slug' => 'charleston-sc',
+				'lat'     => 32.7765,
+				'lon'     => -79.9311,
+				'slug'    => 'charleston-sc',
+				'term_id' => 1618,
 			),
 			extrachill_events_get_account_market()
 		);
@@ -117,7 +131,7 @@ final class AccountMarketTest extends TestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_seeds_and_restores_existing_calendar_geo_inputs(): void {
+	public function test_adds_taxonomy_default_without_mutating_request_globals(): void {
 		$GLOBALS['test_is_user_logged_in']      = true;
 		$GLOBALS['test_is_front_page']          = true;
 		$GLOBALS['test_account_market_ability'] = new class() {
@@ -125,24 +139,20 @@ final class AccountMarketTest extends TestCase {
 				return array(
 					'default_event_location' => array(
 						'slug'        => 'charleston',
+						'term_id'     => 1618,
 						'coordinates' => array(
 							'lat' => 32.7765,
-							'lng' => -79.9311,
+							'lon' => -79.9311,
 						),
 					),
 				);
 			}
 		};
 		$_GET = array();
-		$block = array( 'blockName' => 'data-machine-events/calendar' );
+		$result = extrachill_events_calendar_account_market_defaults( array(), array( 'archive_term' => null ) );
 
-		extrachill_events_seed_account_market( $block );
-		$this->assertSame( '32.7765', $_GET['lat'] );
-		$this->assertSame( '-79.9311', $_GET['lng'] );
-
-		extrachill_events_restore_account_market_request( '', $block );
-		$this->assertArrayNotHasKey( 'lat', $_GET );
-		$this->assertArrayNotHasKey( 'lng', $_GET );
+		$this->assertSame( array( 'location' => array( 1618 ) ), $result['tax_filter'] );
+		$this->assertSame( array(), $_GET );
 	}
 
 	public function test_explicit_geo_and_taxonomy_filters_win(): void {
@@ -154,6 +164,50 @@ final class AccountMarketTest extends TestCase {
 
 		$_GET = array( 'tax_filter' => array( 'location' => array( 42 ) ) );
 		$this->assertTrue( extrachill_events_has_explicit_market() );
+
+		$explicit_geo = array(
+			'lat' => '40.7',
+			'lng' => '-74.0',
+		);
+		$this->assertSame(
+			$explicit_geo,
+			extrachill_events_calendar_account_market_defaults( $explicit_geo, array( 'archive_term' => null ) )
+		);
+
+		$explicit_taxonomy = array( 'tax_filter' => array( 'location' => array( 42 ) ) );
+		$this->assertSame(
+			$explicit_taxonomy,
+			extrachill_events_calendar_account_market_defaults( $explicit_taxonomy, array( 'archive_term' => null ) )
+		);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_near_me_adds_geo_defaults_without_taxonomy_filter(): void {
+		$GLOBALS['test_is_user_logged_in']      = true;
+		$GLOBALS['test_is_near_me_page']        = true;
+		$GLOBALS['test_account_market_ability'] = new class() {
+			public function execute(): array {
+				return array(
+					'default_event_location' => array(
+						'slug'        => 'charleston',
+						'term_id'     => 1618,
+						'coordinates' => array(
+							'lat' => 32.7765,
+							'lon' => -79.9311,
+						),
+					),
+				);
+			}
+		};
+
+		$result = extrachill_events_calendar_account_market_defaults( array(), array( 'archive_term' => null ) );
+
+		$this->assertSame( 32.7765, $result['lat'] );
+		$this->assertSame( -79.9311, $result['lng'] );
+		$this->assertArrayNotHasKey( 'tax_filter', $result );
 	}
 
 	public function test_anonymous_request_does_not_resolve_account_market(): void {


### PR DESCRIPTION
## Summary
- consume the private account preference through the `extrachill/get-user-settings` Ability and its revised extrachill-users#179 canonical location shape
- use the merged `data_machine_events_calendar_request_args` pre-parse filter from Data Machine Events #445 instead of mutating request globals
- apply canonical taxonomy defaults on the events homepage and `/all`, while Near Me receives geo defaults that browser geolocation can replace
- retain the account-backed Near Me result when geolocation is denied or unavailable

## Precedence
1. Explicit URL geo/taxonomy values and taxonomy archives return unchanged.
2. Near Me browser geolocation replaces the account-derived server geo state when successful.
3. The account default supplies a canonical location taxonomy filter on homepage/`/all`, or coordinates on Near Me.
4. Data Machine Events' existing server-rendered state remains ahead of browser-local calendar state.
5. Existing global behavior remains the final fallback when no usable account market exists.

Defaults are added only when the relevant request keys are absent. The resulting array still passes through `CalendarRequest::fromQueryArgs()`, preserving its sanitization and the existing initial-render/frontend REST round trip.

## Layer Purity
This change remains entirely at the Extra Chill Events integration edge. `data-machine-events` stays generic and user/account agnostic. No personalized endpoint, duplicated calendar query path, `$_GET` mutation, or render-block restoration hook remains.

## Dependency Contract
- Data Machine Events #445 is merged and provides `data_machine_events_calendar_request_args` with block/display/archive context before `CalendarRequest` parsing.
- Extra Chill Events #234 is merged and owns canonical event location resolution.
- extrachill-users#179 provides the self-only `extrachill/get-user-settings` response with `default_event_location.term_id`, `slug`, and optional `coordinates.lat` / `coordinates.lon`.

The consumer checks Ability availability, validates the response shape and ranges, and fails open for anonymous users, unavailable dependencies, empty preferences, or unusable coordinates. A location without coordinates still supplies the canonical taxonomy default outside Near Me; Near Me falls through normally.

## Anonymous Behavior
Anonymous requests never resolve an account preference and retain the existing explicit URL, browser geolocation/local state, city-grid, and global fallback behavior.

## Tests
- `./vendor/bin/phpunit --filter AccountMarketTest` (6 tests, 12 assertions)
- `./vendor/bin/phpcs --standard=WordPress inc/core/account-market.php`
- `php -l inc/core/account-market.php`
- `npm run lint:js -- --no-cache assets/js/near-me.js`
- `npm run build`
- `git diff --check`
- full `./vendor/bin/phpunit` still has the four unrelated existing `QualifyRecheckHandlerTest` failures tracked in #230

Closes #229