### PR TITLE
fix: reconcile canonical location terms safely

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -29,6 +29,8 @@ define( 'EXTRACHILL_EVENTS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'EXTRACHILL_EVENTS_PLUGIN_FILE', __FILE__ );
 define( 'EXTRACHILL_EVENTS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
+require_once __DIR__ . '/inc/Core/LocationTermIntegrity.php';
+
 // WP-CLI commands.
 if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCommand.php' ) ) {
 	require_once __DIR__ . '/inc/Cli/AddCityCommand.php';
@@ -73,6 +75,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCo
 
 	require_once __DIR__ . '/inc/Cli/PruneOrphanLocationsCommand.php';
 	\WP_CLI::add_command( 'extrachill events locations prune-orphans', \ExtraChillEvents\Cli\PruneOrphanLocationsCommand::class );
+
+	require_once __DIR__ . '/inc/Cli/ReconcileLocationTermsCommand.php';
+	\WP_CLI::add_command( 'extrachill events locations reconcile-integrity', \ExtraChillEvents\Cli\ReconcileLocationTermsCommand::class );
 
 	require_once __DIR__ . '/inc/Cli/BackfillVenueMetaCommand.php';
 	\WP_CLI::add_command( 'extrachill events venues backfill-meta', \ExtraChillEvents\Cli\BackfillVenueMetaCommand::class );

--- a/inc/Cli/ReconcileLocationTermsCommand.php
+++ b/inc/Cli/ReconcileLocationTermsCommand.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Reconcile exact legacy root city duplicates into canonical hierarchy terms.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+use ExtraChillEvents\Core\LocationTermIntegrity;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class ReconcileLocationTermsCommand {
+
+	/**
+	 * Diagnose location integrity and optionally reconcile safe exact matches.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--apply]
+	 * : Create redirects, move relationships, and delete matched duplicates. Default is dry-run.
+	 *
+	 * [--format=<format>]
+	 * : table, json, or csv. Default: table.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill events locations reconcile-integrity --url=events.extrachill.com
+	 *     wp extrachill events locations reconcile-integrity --url=events.extrachill.com --apply
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		unset( $args );
+		if ( ! taxonomy_exists( 'location' ) ) {
+			\WP_CLI::error( 'The location taxonomy is not registered. Use --url=events.extrachill.com.' );
+		}
+
+		$apply = ! empty( $assoc_args['apply'] );
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'location',
+				'hide_empty' => false,
+				'number'     => 0,
+			)
+		);
+		if ( is_wp_error( $terms ) ) {
+			\WP_CLI::error( $terms->get_error_message() );
+		}
+
+		$rows = array();
+		foreach ( $terms as $term ) {
+			$match = LocationTermIntegrity::match_root_term( $term, $terms );
+			if ( 'not_candidate' === $match['status'] ) {
+				continue;
+			}
+
+			$canonical = $match['canonical'];
+			$status    = $match['status'];
+			if ( $apply && 'safe_match' === $status ) {
+				$status = $this->reconcile( $term, $canonical );
+			}
+
+			$rows[] = array(
+				'duplicate_id'  => (int) $term->term_id,
+				'duplicate'     => $term->name,
+				'canonical_id'  => $canonical ? (int) $canonical->term_id : '',
+				'canonical'     => $canonical ? $canonical->name : '',
+				'relationships' => (int) $term->count,
+				'status'        => $apply ? $status : ( 'safe_match' === $status ? 'would_reconcile' : $status ),
+				'reason'        => $match['reason'],
+			);
+		}
+
+		\WP_CLI\Utils\format_items(
+			(string) ( $assoc_args['format'] ?? 'table' ),
+			$rows,
+			array( 'duplicate_id', 'duplicate', 'canonical_id', 'canonical', 'relationships', 'status', 'reason' )
+		);
+
+		if ( ! $apply ) {
+			\WP_CLI::log( 'Dry run: no redirects, relationships, or terms were changed. Re-run with --apply after review.' );
+		}
+	}
+
+	private function reconcile( \WP_Term $duplicate, \WP_Term $canonical ): string {
+		$redirect_ability = wp_get_ability( 'extrachill-seo/add-redirect' );
+		if ( ! $redirect_ability ) {
+			return 'blocked_redirect_ability_unavailable';
+		}
+
+		$from_link = get_term_link( $duplicate );
+		$to_link   = get_term_link( $canonical );
+		if ( is_wp_error( $from_link ) || is_wp_error( $to_link ) ) {
+			return 'blocked_invalid_term_url';
+		}
+
+		$from = wp_parse_url( $from_link, PHP_URL_PATH );
+		$to   = wp_parse_url( $to_link, PHP_URL_PATH );
+		if ( ! is_string( $from ) || ! is_string( $to ) ) {
+			return 'blocked_invalid_term_url';
+		}
+
+		$object_ids = get_objects_in_term( (int) $duplicate->term_id, 'location' );
+		if ( is_wp_error( $object_ids ) ) {
+			return 'failed_relationship_lookup';
+		}
+
+		// Add every canonical relationship before removing any legacy relationship.
+		foreach ( $object_ids as $object_id ) {
+			$added = wp_set_object_terms( (int) $object_id, array( (int) $canonical->term_id ), 'location', true );
+			if ( is_wp_error( $added ) ) {
+				return 'failed_relationship_add';
+			}
+		}
+
+		foreach ( $object_ids as $object_id ) {
+			$removed = wp_remove_object_terms( (int) $object_id, array( (int) $duplicate->term_id ), 'location' );
+			if ( is_wp_error( $removed ) ) {
+				return 'failed_relationship_remove';
+			}
+		}
+
+		$redirect = $redirect_ability->execute(
+			array(
+				'from_url'    => $from,
+				'to_url'      => $to,
+				'status_code' => 301,
+				'note'        => 'Location taxonomy integrity reconciliation',
+			)
+		);
+		if ( is_wp_error( $redirect ) || empty( $redirect['success'] ) ) {
+			return 'blocked_redirect_creation_failed';
+		}
+
+		$deleted = wp_delete_term( (int) $duplicate->term_id, 'location' );
+		return true === $deleted ? 'reconciled' : 'failed_delete';
+	}
+}

--- a/inc/Core/LocationTermIntegrity.php
+++ b/inc/Core/LocationTermIntegrity.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Exact-match rules for detecting noncanonical root location terms.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class LocationTermIntegrity {
+	/**
+	 * Reject a root duplicate when its exact canonical hierarchical city exists.
+	 *
+	 * @param string|\WP_Error $term     Proposed term name.
+	 * @param string           $taxonomy Taxonomy name.
+	 * @param array            $args     Insert arguments.
+	 * @return string|\WP_Error
+	 */
+	public static function prevent_root_duplicate( $term, string $taxonomy, array $args ) {
+		if ( 'location' !== $taxonomy || is_wp_error( $term ) || ! empty( $args['parent'] ) ) {
+			return $term;
+		}
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'location',
+				'hide_empty' => false,
+				'number'     => 0,
+			)
+		);
+		if ( is_wp_error( $terms ) ) {
+			return $term;
+		}
+
+		$candidate = (object) array(
+			'term_id' => 0,
+			'name'    => (string) $term,
+			'parent'  => 0,
+		);
+		$match     = self::match_root_term( $candidate, $terms );
+		if ( 'safe_match' !== $match['status'] ) {
+			return $term;
+		}
+
+		return new \WP_Error(
+			'location_root_duplicate',
+			sprintf(
+				'Use canonical location term #%d (%s) instead of creating a root duplicate.',
+				(int) $match['canonical']->term_id,
+				$match['canonical']->name
+			)
+		);
+	}
+
+	/**
+	 * Match a root "City, ST" term to one canonical City child of that state.
+	 *
+	 * @param object        $root  Root term candidate.
+	 * @param array<object> $terms All location terms.
+	 * @return array{status:string,canonical:?object,reason:string}
+	 */
+	public static function match_root_term( object $root, array $terms ): array {
+		if ( 0 !== (int) $root->parent ) {
+			return self::result( 'not_candidate', null, 'term_is_not_root' );
+		}
+
+		if ( ! preg_match( '/^(.+),\s*([A-Za-z]{2})$/', trim( (string) $root->name ), $parts ) ) {
+			return self::result( 'not_candidate', null, 'name_has_no_state_suffix' );
+		}
+
+		$city       = self::key( $parts[1] );
+		$state_name = self::state_name( $parts[2] );
+		if ( null === $state_name ) {
+			return self::result( 'ambiguous', null, 'unknown_state_abbreviation' );
+		}
+
+		$states = array();
+		foreach ( $terms as $term ) {
+			if ( self::key( $term->name ) === self::key( $state_name ) ) {
+				$states[] = (int) $term->term_id;
+			}
+		}
+
+		$matches = array();
+		foreach ( $terms as $term ) {
+			if ( self::key( $term->name ) === $city && in_array( (int) $term->parent, $states, true ) ) {
+				$matches[] = $term;
+			}
+		}
+
+		if ( 1 === count( $matches ) ) {
+			return self::result( 'safe_match', $matches[0], 'exact_city_and_state_parent' );
+		}
+
+		return self::result(
+			empty( $matches ) ? 'unresolved' : 'ambiguous',
+			null,
+			empty( $matches ) ? 'no_exact_canonical_match' : 'multiple_exact_canonical_matches'
+		);
+	}
+
+	private static function key( string $value ): string {
+		return strtolower( trim( $value ) );
+	}
+
+	private static function state_name( string $abbreviation ): ?string {
+		$abbreviations = explode( ' ', 'AL AK AZ AR CA CO CT DE DC FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY' );
+		$names         = explode( '|', 'Alabama|Alaska|Arizona|Arkansas|California|Colorado|Connecticut|Delaware|District of Columbia|Florida|Georgia|Hawaii|Idaho|Illinois|Indiana|Iowa|Kansas|Kentucky|Louisiana|Maine|Maryland|Massachusetts|Michigan|Minnesota|Mississippi|Missouri|Montana|Nebraska|Nevada|New Hampshire|New Jersey|New Mexico|New York|North Carolina|North Dakota|Ohio|Oklahoma|Oregon|Pennsylvania|Rhode Island|South Carolina|South Dakota|Tennessee|Texas|Utah|Vermont|Virginia|Washington|West Virginia|Wisconsin|Wyoming' );
+		$states        = array_combine( $abbreviations, $names );
+
+		return $states[ strtoupper( trim( $abbreviation ) ) ] ?? null;
+	}
+
+	private static function result( string $status, ?object $canonical, string $reason ): array {
+		return array(
+			'status'    => $status,
+			'canonical' => $canonical,
+			'reason'    => $reason,
+		);
+	}
+}
+
+add_filter( 'pre_insert_term', array( LocationTermIntegrity::class, 'prevent_root_duplicate' ), 10, 3 );

--- a/tests/Unit/Core/LocationTermIntegrityTest.php
+++ b/tests/Unit/Core/LocationTermIntegrityTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use ExtraChillEvents\Core\LocationTermIntegrity;
+use PHPUnit\Framework\TestCase;
+
+final class LocationTermIntegrityTest extends TestCase {
+	public function test_matches_explicit_state_suffix_to_exact_hierarchical_city(): void {
+		$terms = array(
+			(object) array( 'term_id' => 1, 'name' => 'South Carolina', 'parent' => 100 ),
+			(object) array( 'term_id' => 2, 'name' => 'Charleston', 'parent' => 1 ),
+			(object) array( 'term_id' => 3, 'name' => 'Charleston, SC', 'parent' => 0 ),
+		);
+
+		$result = LocationTermIntegrity::match_root_term( $terms[2], $terms );
+
+		$this->assertSame( 'safe_match', $result['status'] );
+		$this->assertSame( 2, $result['canonical']->term_id );
+	}
+
+	public function test_does_not_fuzzily_match_a_different_city_name(): void {
+		$terms = array(
+			(object) array( 'term_id' => 1, 'name' => 'South Carolina', 'parent' => 100 ),
+			(object) array( 'term_id' => 2, 'name' => 'Charleston Heights', 'parent' => 1 ),
+			(object) array( 'term_id' => 3, 'name' => 'Charleston, SC', 'parent' => 0 ),
+		);
+
+		$result = LocationTermIntegrity::match_root_term( $terms[2], $terms );
+
+		$this->assertSame( 'unresolved', $result['status'] );
+		$this->assertNull( $result['canonical'] );
+	}
+
+	public function test_reports_multiple_exact_state_matches_as_ambiguous(): void {
+		$terms = array(
+			(object) array( 'term_id' => 1, 'name' => 'Georgia', 'parent' => 100 ),
+			(object) array( 'term_id' => 2, 'name' => 'Greensboro', 'parent' => 1 ),
+			(object) array( 'term_id' => 3, 'name' => 'Greensboro', 'parent' => 1 ),
+			(object) array( 'term_id' => 4, 'name' => 'Greensboro, GA', 'parent' => 0 ),
+		);
+
+		$result = LocationTermIntegrity::match_root_term( $terms[3], $terms );
+
+		$this->assertSame( 'ambiguous', $result['status'] );
+		$this->assertNull( $result['canonical'] );
+	}
+
+	public function test_root_city_without_state_is_not_an_automatic_candidate(): void {
+		$terms = array( (object) array( 'term_id' => 1, 'name' => 'Portland', 'parent' => 0 ) );
+
+		$result = LocationTermIntegrity::match_root_term( $terms[0], $terms );
+
+		$this->assertSame( 'not_candidate', $result['status'] );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,6 +46,12 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	}
 }
 
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		return true;
+	}
+}
+
 if ( ! function_exists( 'esc_url_raw' ) ) {
 	function esc_url_raw( $url ) {
 		return is_string( $url ) ? trim( $url ) : '';
@@ -82,4 +88,5 @@ require_once dirname( __DIR__ ) . '/inc/Core/QualifyVerdict.php';
 require_once dirname( __DIR__ ) . '/inc/Core/QualifyVerdictResolver.php';
 require_once dirname( __DIR__ ) . '/inc/Core/PlatformDetector.php';
 require_once dirname( __DIR__ ) . '/inc/Core/QualifyFingerprinter.php';
+require_once dirname( __DIR__ ) . '/inc/Core/LocationTermIntegrity.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueQualificationAbilities.php';


### PR DESCRIPTION
## Summary
- detect root-level `City, ST` location terms and match them only to an exact city name under the corresponding canonical state parent
- prevent future exact root duplicates while leaving unknown, unresolved, and ambiguous names untouched
- add a dry-run-first reconciliation command that preserves event relationships, creates the legacy taxonomy URL redirect, and only then deletes a safely matched duplicate

## Detected integrity classes
- `safe_match`: exactly one hierarchical city matches both the parsed city name and explicit state parent
- `unresolved`: no exact canonical city/state-parent match exists
- `ambiguous`: the state abbreviation is unknown or multiple exact canonical matches exist
- non-candidates: non-root terms and root names without an explicit two-letter state suffix

## Safety rules
- matching is exact and case-insensitive; there is no fuzzy city matching
- root names without an explicit state suffix are never merged automatically
- ambiguous or unresolved terms are report-only, including duplicate canonical candidates
- apply mode preflights the SEO redirect ability and both term URLs before changing relationships
- all canonical relationships are added before any legacy relationship is removed
- deletion only occurs after relationship migration and successful 301 redirect creation

## Dry-run and apply semantics
`wp extrachill events locations reconcile-integrity` is dry-run by default and reports `would_reconcile`, `unresolved`, and `ambiguous` rows without mutation. `--apply` is the sole mutation switch.

## Redirect and relationship behavior
For each safe match, apply mode appends the canonical term to every attached object, verifies those additions, removes the duplicate relationships, creates a 301 redirect from the duplicate term archive path to the canonical term archive path through `extrachill-seo/add-redirect`, and then deletes the duplicate term. A missing/failed redirect ability or invalid term URL blocks deletion.

## Tests
- exact `Charleston, SC` to Charleston-under-South-Carolina matching
- refusal to fuzzily match a similar city name
- ambiguous multiple exact canonical matches
- refusal to treat an unsuffixed root city as an automatic merge candidate
- `homeboy review extrachill-events lint --changed-only`: passed with no findings
- PHP syntax checks: passed
- PHPUnit execution was not available because the host WP Codebox runner is missing its recipe-builder module; the runner failed before tests started

## Post-merge operator commands
These commands are documentation only and **were not run**:

```bash
# Review the complete report first (no mutation).
wp --allow-root --path=/var/www/extrachill.com --url=events.extrachill.com extrachill events locations reconcile-integrity

# After reviewing every safe match, explicitly apply reconciliation.
wp --allow-root --path=/var/www/extrachill.com --url=events.extrachill.com extrachill events locations reconcile-integrity --apply
```

No production taxonomy data was inspected or mutated by this change.

Closes #228