### PR TITLE
feat: expose canonical event locations ability

### DIFF
--- a/inc/abilities/events-locations.php
+++ b/inc/abilities/events-locations.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Canonical Event Locations Ability
+ *
+ * Searches and resolves selectable locations from the Events site's
+ * authoritative location taxonomy.
+ *
+ * @package ExtraChillEvents
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_events_register_locations_ability' );
+
+/**
+ * Register extrachill/events-locations.
+ */
+function extrachill_events_register_locations_ability(): void {
+	$location_schema         = array(
+		'type'       => 'object',
+		'properties' => array(
+			'term_id'     => array( 'type' => 'integer' ),
+			'name'        => array( 'type' => 'string' ),
+			'slug'        => array( 'type' => 'string' ),
+			'archive_url' => array( 'type' => 'string' ),
+			'coordinates' => array(
+				'type'       => array( 'object', 'null' ),
+				'properties' => array(
+					'lat' => array( 'type' => 'number' ),
+					'lon' => array( 'type' => 'number' ),
+				),
+			),
+			'hierarchy'   => array(
+				'type'       => 'object',
+				'properties' => array(
+					'region' => array( 'type' => 'string' ),
+					'state'  => array( 'type' => 'string' ),
+					'label'  => array( 'type' => 'string' ),
+				),
+			),
+		),
+	);
+	$resolved_schema         = $location_schema;
+	$resolved_schema['type'] = array( 'object', 'null' );
+
+	wp_register_ability(
+		'extrachill/events-locations',
+		array(
+			'label'               => __( 'Canonical Event Locations', 'extrachill-events' ),
+			'description'         => __( 'Search or resolve selectable locations from the canonical Events taxonomy.', 'extrachill-events' ),
+			'category'            => 'extrachill-events',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'mode' ),
+				'properties' => array(
+					'mode'   => array(
+						'type' => 'string',
+						'enum' => array( 'search', 'resolve' ),
+					),
+					'search' => array( 'type' => 'string' ),
+					'slug'   => array( 'type' => 'string' ),
+					'limit'  => array(
+						'type'    => 'integer',
+						'default' => 10,
+						'minimum' => 1,
+						'maximum' => 20,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'locations' => array(
+						'type'  => 'array',
+						'items' => $location_schema,
+					),
+					'location'  => $resolved_schema,
+				),
+			),
+			'execute_callback'    => 'extrachill_events_ability_locations',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Search or resolve canonical event locations.
+ *
+ * Search returns an empty locations array for an empty query or no matches.
+ * Resolve returns location_not_found for unknown or non-selectable slugs.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error Canonical location response or error.
+ */
+function extrachill_events_ability_locations( array $input ): array|\WP_Error {
+	$mode           = sanitize_key( $input['mode'] ?? '' );
+	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 0;
+	$events_blog_id = (int) apply_filters( 'extrachill_events_canonical_blog_id', $events_blog_id );
+
+	if ( $events_blog_id <= 0 || ( is_multisite() && ! get_site( $events_blog_id ) ) ) {
+		return new \WP_Error( 'events_site_unavailable', __( 'The canonical Events site is unavailable.', 'extrachill-events' ), array( 'status' => 500 ) );
+	}
+
+	$switched = get_current_blog_id() !== $events_blog_id;
+	if ( $switched && ! switch_to_blog( $events_blog_id ) ) {
+		return new \WP_Error( 'events_site_unavailable', __( 'The canonical Events site is unavailable.', 'extrachill-events' ), array( 'status' => 500 ) );
+	}
+
+	try {
+		if ( ! taxonomy_exists( 'location' ) ) {
+			return new \WP_Error( 'location_taxonomy_unavailable', __( 'The canonical location taxonomy is unavailable.', 'extrachill-events' ), array( 'status' => 500 ) );
+		}
+
+		if ( 'search' === $mode ) {
+			$search = trim( sanitize_text_field( $input['search'] ?? '' ) );
+			if ( '' === $search ) {
+				return array(
+					'locations' => array(),
+					'location'  => null,
+				);
+			}
+
+			$terms = get_terms(
+				array(
+					'taxonomy'   => 'location',
+					'hide_empty' => false,
+					'search'     => $search,
+					'number'     => 100,
+				)
+			);
+			if ( is_wp_error( $terms ) ) {
+				return new \WP_Error( 'location_search_failed', $terms->get_error_message(), array( 'status' => 500 ) );
+			}
+
+			$locations = array();
+			$limit     = min( 20, max( 1, (int) ( $input['limit'] ?? 10 ) ) );
+			foreach ( $terms as $term ) {
+				$location = extrachill_events_prepare_canonical_location( $term );
+				if ( null === $location ) {
+					continue;
+				}
+				$locations[] = $location;
+				if ( count( $locations ) >= $limit ) {
+					break;
+				}
+			}
+
+			return array(
+				'locations' => $locations,
+				'location'  => null,
+			);
+		}
+
+		if ( 'resolve' !== $mode ) {
+			return new \WP_Error( 'invalid_location_mode', __( 'mode must be search or resolve.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+
+		$slug = sanitize_title( $input['slug'] ?? '' );
+		if ( '' === $slug ) {
+			return new \WP_Error( 'invalid_location_slug', __( 'A location slug is required for resolve mode.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+
+		$term     = get_term_by( 'slug', $slug, 'location' );
+		$location = $term && ! is_wp_error( $term ) ? extrachill_events_prepare_canonical_location( $term ) : null;
+		if ( null === $location ) {
+			return new \WP_Error( 'location_not_found', __( 'No selectable canonical event location matched that slug.', 'extrachill-events' ), array( 'status' => 404 ) );
+		}
+
+		return array(
+			'locations' => array(),
+			'location'  => $location,
+		);
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
+}
+
+/**
+ * Format a selectable city term for public consumers.
+ *
+ * The canonical hierarchy is region root, state/province, then city. Deeper
+ * children remain selectable because the taxonomy also models city districts.
+ *
+ * @param WP_Term $term Location term.
+ * @return array|null Formatted location, or null when not selectable.
+ */
+function extrachill_events_prepare_canonical_location( WP_Term $term ): ?array {
+	$ancestor_ids = get_ancestors( $term->term_id, 'location', 'taxonomy' );
+	if ( count( $ancestor_ids ) < 2 ) {
+		return null;
+	}
+
+	$ancestors = array();
+	foreach ( array_reverse( $ancestor_ids ) as $ancestor_id ) {
+		$ancestor = get_term( $ancestor_id, 'location' );
+		if ( $ancestor && ! is_wp_error( $ancestor ) ) {
+			$ancestors[] = $ancestor;
+		}
+	}
+
+	if ( count( $ancestors ) < 2 ) {
+		return null;
+	}
+
+	$archive_url = get_term_link( $term );
+	$state       = $ancestors[ count( $ancestors ) - 1 ]->name;
+
+	return array(
+		'term_id'     => (int) $term->term_id,
+		'name'        => $term->name,
+		'slug'        => $term->slug,
+		'archive_url' => is_wp_error( $archive_url ) ? '' : $archive_url,
+		'coordinates' => extrachill_events_get_location_coordinates( (int) $term->term_id ),
+		'hierarchy'   => array(
+			'region' => $ancestors[0]->name,
+			'state'  => $state,
+			'label'  => sprintf( '%s, %s', $term->name, $state ),
+		),
+	);
+}

--- a/inc/abilities/register.php
+++ b/inc/abilities/register.php
@@ -46,6 +46,7 @@ function extrachill_events_register_abilities_category(): void {
 // directly. See Extra-Chill/extrachill-events#104.
 require_once __DIR__ . '/events-calendar.php';
 require_once __DIR__ . '/events-filters.php';
+require_once __DIR__ . '/events-locations.php';
 require_once __DIR__ . '/events-geocode.php';
 require_once __DIR__ . '/events-upcoming-counts.php';
 require_once __DIR__ . '/events-list-venues.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,7 @@
 		<testsuite name="qualify-v2-unit">
 			<directory>tests/Unit/Core</directory>
 			<file>tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php</file>
+			<file>tests/Unit/Abilities/CanonicalLocationsAbilityTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/Unit/Abilities/CanonicalLocationsAbilityTest.php
+++ b/tests/Unit/Abilities/CanonicalLocationsAbilityTest.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Canonical event locations Ability tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+// phpcs:disable -- This isolated fixture intentionally declares WordPress test doubles.
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private $data;
+
+		public function __construct( string $code, string $message, $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data() {
+			return $this->data;
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_Term' ) ) {
+	class WP_Term {
+		public int $term_id;
+		public string $name;
+		public string $slug;
+		public int $parent;
+
+		public function __construct( int $term_id, string $name, string $slug, int $parent = 0 ) {
+			$this->term_id = $term_id;
+			$this->name    = $name;
+			$this->slug    = $slug;
+			$this->parent  = $parent;
+		}
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action() {}
+}
+if ( ! function_exists( '__' ) ) {
+	function __( $text ) {
+		return $text;
+	}
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $value ) {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $value ) );
+	}
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $value ) {
+		return trim( strtolower( preg_replace( '/[^a-z0-9]+/i', '-', (string) $value ) ), '-' );
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error;
+	}
+}
+if ( ! function_exists( 'ec_get_blog_id' ) ) {
+	function ec_get_blog_id() {
+		return 7;
+	}
+}
+if ( ! function_exists( 'is_multisite' ) ) {
+	function is_multisite() {
+		return true;
+	}
+}
+if ( ! function_exists( 'get_site' ) ) {
+	function get_site( $blog_id ) {
+		return 7 === $blog_id ? (object) array( 'blog_id' => 7 ) : null;
+	}
+}
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id() {
+		return $GLOBALS['ec_locations_blog_id'];
+	}
+}
+if ( ! function_exists( 'switch_to_blog' ) ) {
+	function switch_to_blog( $blog_id ) {
+		$GLOBALS['ec_locations_blog_stack'][] = $GLOBALS['ec_locations_blog_id'];
+		$GLOBALS['ec_locations_blog_id']      = $blog_id;
+		return true;
+	}
+}
+if ( ! function_exists( 'restore_current_blog' ) ) {
+	function restore_current_blog() {
+		$GLOBALS['ec_locations_blog_id'] = array_pop( $GLOBALS['ec_locations_blog_stack'] );
+		return true;
+	}
+}
+if ( ! function_exists( 'taxonomy_exists' ) ) {
+	function taxonomy_exists() {
+		return true;
+	}
+}
+if ( ! function_exists( 'get_term' ) ) {
+	function get_term( $term_id ) {
+		return $GLOBALS['ec_locations_terms'][ $term_id ] ?? null;
+	}
+}
+if ( ! function_exists( 'get_term_by' ) ) {
+	function get_term_by( $field, $value ) {
+		foreach ( $GLOBALS['ec_locations_terms'] as $term ) {
+			if ( 'slug' === $field && $term->slug === $value ) {
+				return $term;
+			}
+		}
+		return false;
+	}
+}
+if ( ! function_exists( 'get_ancestors' ) ) {
+	function get_ancestors( $term_id ) {
+		$ancestors = array();
+		while ( ! empty( $GLOBALS['ec_locations_terms'][ $term_id ]->parent ) ) {
+			$term_id     = $GLOBALS['ec_locations_terms'][ $term_id ]->parent;
+			$ancestors[] = $term_id;
+		}
+		return $ancestors;
+	}
+}
+if ( ! function_exists( 'get_terms' ) ) {
+	function get_terms( $args ) {
+		$search = strtolower( $args['search'] );
+		return array_values(
+			array_filter(
+				$GLOBALS['ec_locations_terms'],
+				static fn( $term ) => false !== strpos( strtolower( $term->name ), $search )
+			)
+		);
+	}
+}
+if ( ! function_exists( 'get_term_link' ) ) {
+	function get_term_link( $term ) {
+		return 'https://events.example/location/' . $term->slug . '/';
+	}
+}
+if ( ! function_exists( 'extrachill_events_get_location_coordinates' ) ) {
+	function extrachill_events_get_location_coordinates( int $term_id ): ?array {
+		return $GLOBALS['ec_locations_coordinates'][ $term_id ] ?? null;
+	}
+}
+
+require_once dirname( __DIR__, 3 ) . '/inc/abilities/events-locations.php';
+
+final class CanonicalLocationsAbilityTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['ec_locations_blog_id']    = 2;
+		$GLOBALS['ec_locations_blog_stack'] = array();
+		$GLOBALS['ec_locations_terms']      = array(
+			1  => new WP_Term( 1, 'USA', 'usa' ),
+			2  => new WP_Term( 2, 'South Carolina', 'south-carolina', 1 ),
+			3  => new WP_Term( 3, 'Texas', 'texas', 1 ),
+			10 => new WP_Term( 10, 'Charleston', 'charleston-sc', 2 ),
+			11 => new WP_Term( 11, 'Charleston', 'charleston-tx', 3 ),
+		);
+		$GLOBALS['ec_locations_coordinates'] = array(
+			10 => array(
+				'lat' => 32.7765,
+				'lon' => -79.9311,
+			),
+		);
+	}
+
+	public function test_search_returns_only_selectable_cities_and_restores_blog(): void {
+		$result = extrachill_events_ability_locations(
+			array(
+				'mode'   => 'search',
+				'search' => 'charleston',
+			)
+		);
+
+		$this->assertSame( 2, $GLOBALS['ec_locations_blog_id'] );
+		$this->assertCount( 2, $result['locations'] );
+		$this->assertSame( 'Charleston, South Carolina', $result['locations'][0]['hierarchy']['label'] );
+		$this->assertSame( 'Charleston, Texas', $result['locations'][1]['hierarchy']['label'] );
+	}
+
+	public function test_search_excludes_region_and_state_terms(): void {
+		$result = extrachill_events_ability_locations(
+			array(
+				'mode'   => 'search',
+				'search' => 'south',
+			)
+		);
+
+		$this->assertSame( array(), $result['locations'] );
+	}
+
+	public function test_empty_search_has_explicit_empty_response(): void {
+		$result = extrachill_events_ability_locations( array( 'mode' => 'search', 'search' => '' ) );
+
+		$this->assertSame( array(), $result['locations'] );
+		$this->assertNull( $result['location'] );
+		$this->assertSame( 2, $GLOBALS['ec_locations_blog_id'] );
+	}
+
+	public function test_resolve_returns_coordinates_and_hierarchy(): void {
+		$result = extrachill_events_ability_locations( array( 'mode' => 'resolve', 'slug' => 'charleston-sc' ) );
+
+		$this->assertSame( 'charleston-sc', $result['location']['slug'] );
+		$this->assertSame( 32.7765, $result['location']['coordinates']['lat'] );
+		$this->assertSame( 'USA', $result['location']['hierarchy']['region'] );
+		$this->assertSame( 'https://events.example/location/charleston-sc/', $result['location']['archive_url'] );
+		$this->assertSame( 2, $GLOBALS['ec_locations_blog_id'] );
+	}
+
+	public function test_missing_and_nonselectable_slugs_return_not_found(): void {
+		$missing = extrachill_events_ability_locations( array( 'mode' => 'resolve', 'slug' => 'missing' ) );
+		$state   = extrachill_events_ability_locations( array( 'mode' => 'resolve', 'slug' => 'texas' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $missing );
+		$this->assertSame( 'No selectable canonical event location matched that slug.', $missing->get_error_message() );
+		$this->assertInstanceOf( WP_Error::class, $state );
+		$this->assertSame( 2, $GLOBALS['ec_locations_blog_id'] );
+	}
+}


### PR DESCRIPTION
## Summary
- add the public read-only `extrachill/events-locations` Ability for canonical event-market search and resolution
- own selectability, hierarchy labels, coordinates, and archive URLs in the Events domain
- always query the Events site's authoritative taxonomy and restore the caller's multisite context

## Existing primitives checked
- `extrachill/events-filters` delegates to the generic calendar filter list and does not guarantee canonical Events-blog context, city eligibility, coordinates, hierarchy labels, or exact resolution
- `extrachill/events-upcoming-counts` is count-oriented and excludes canonical locations without upcoming events
- WordPress `/wp/v2/location` is scoped to the current blog, so it cannot safely serve network consumers directly
- the implementation therefore uses WordPress taxonomy queries directly and reuses `extrachill_events_get_location_coordinates()` without introducing storage, a registry, or a wrapper around calendar queries

## Ability contract
Ability: `extrachill/events-locations`

Input schema:
```json
{
  "type": "object",
  "required": ["mode"],
  "properties": {
    "mode": { "type": "string", "enum": ["search", "resolve"] },
    "search": { "type": "string" },
    "slug": { "type": "string" },
    "limit": { "type": "integer", "default": 10, "minimum": 1, "maximum": 20 }
  }
}
```

Output schema:
```json
{
  "locations": [
    {
      "term_id": 1618,
      "name": "Charleston",
      "slug": "charleston",
      "archive_url": "https://events.extrachill.com/location/charleston/",
      "coordinates": { "lat": 32.7765, "lon": -79.9311 },
      "hierarchy": {
        "region": "USA",
        "state": "South Carolina",
        "label": "Charleston, South Carolina"
      }
    }
  ],
  "location": null
}
```

`search` mode populates `locations` and leaves `location` null. `resolve` mode returns an empty `locations` array and populates `location` with the same object schema. `coordinates` is null when unavailable.

## Eligibility and behavior
- selectable terms must have at least two valid ancestors in the canonical hierarchy: region root, state/province, then city
- deeper terms remain selectable because the taxonomy also models city districts
- duplicate city names remain distinct by slug and receive state-qualified hierarchy labels
- empty search and no search matches return `{ "locations": [], "location": null }`
- empty resolve slugs return `invalid_location_slug` with status 400
- unknown or non-selectable resolve slugs return `location_not_found` with status 404
- unavailable Events site, taxonomy, or failed term search returns an explicit 500-class `WP_Error`

## Multisite behavior
The Ability resolves `ec_get_blog_id( 'events' )`, switches only when the caller is on another blog, performs every taxonomy/link/meta read in Events context, and restores the original blog in `finally`, including empty, not-found, and error paths.

## Consumer migration
- Extra-Chill/extrachill-users#179: store only the selected slug; replace direct blog switching, hierarchy checks, term links, and coordinate parsing with `mode: resolve`
- Extra-Chill/extrachill-community#156: replace Community-context `/wp/v2/location` autocomplete with `mode: search`; use `hierarchy.label` for duplicate-safe option labels
- Extra-Chill/extrachill-events#231: consume the users-owned resolved setting after users#179 delegates canonical resolution here; no generic Data Machine Events changes are needed
- Extra-Chill/extrachill-blog#39: continue consuming the resolved users setting, whose canonical shape should now come from this Ability

## Tests
- `./vendor/bin/phpunit --filter CanonicalLocationsAbilityTest` (5 tests, 17 assertions)
- `./vendor/bin/phpunit` (137 tests, 280 assertions)
- changed-file WordPress PHPCS passes
- PHP lint and `git diff --check` pass
- Homeboy PHP lint passes; its broader gate remains blocked by existing JS `@wordpress/*` dependency-resolution findings and a broken PHPStan PHAR (`manifest cannot be larger than 100 MB`)
- Homeboy audit reports existing repository-wide heuristic findings only; none target this Ability

Closes #233