### PR TITLE
fix: expose canonical locations across network

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -6,14 +6,14 @@
  * Version: 0.39.0
  * Author: Chris Huber
  * Author URI: https://chubes.net
- * Requires Plugins: data-machine, data-machine-events
+ * Requires Plugins: data-machine
  * License: GPL v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: extrachill-events
  * Requires at least: 6.9
  * Tested up to: 6.9
  * Requires PHP: 7.4
- * Network: false
+ * Network: true
  *
  * @package ExtraChillEvents
  * @since 0.1.0
@@ -28,6 +28,15 @@ define( 'EXTRACHILL_EVENTS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'EXTRACHILL_EVENTS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'EXTRACHILL_EVENTS_PLUGIN_FILE', __FILE__ );
 define( 'EXTRACHILL_EVENTS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+
+// The canonical locations Ability is event-owned but consumed network-wide.
+require_once __DIR__ . '/inc/abilities/canonical-locations.php';
+require_once __DIR__ . '/inc/activation.php';
+
+$extrachill_events_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 7;
+if ( get_current_blog_id() !== $extrachill_events_blog_id ) {
+	return;
+}
 
 // WP-CLI commands.
 if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCommand.php' ) ) {
@@ -180,7 +189,6 @@ class ExtraChillEvents {
 	private function __construct() {
 		$this->init_hooks();
 		$this->load_dependencies();
-		$this->init_integrations();
 	}
 
 	private function init_hooks() {
@@ -188,6 +196,7 @@ class ExtraChillEvents {
 		add_action( 'init', array( $this, 'init_data_machine_handlers' ), 20 );
 		add_action( 'init', array( $this, 'init_abilities' ), 25 );
 		add_action( 'plugins_loaded', array( $this, 'maybe_install_schema' ), 20 );
+		add_action( 'plugins_loaded', array( $this, 'init_integrations' ), 20 );
 
 		// Artist URL Import moderation queue admin screen (migrated from
 		// data-machine-events in #200). Hooks DME's public post-type menu
@@ -195,8 +204,6 @@ class ExtraChillEvents {
 		if ( is_admin() ) {
 			add_action( 'init', array( $this, 'init_artist_url_admin' ), 5 );
 		}
-		register_activation_hook( __FILE__, array( $this, 'activate' ) );
-		register_deactivation_hook( __FILE__, array( $this, 'deactivate' ) );
 	}
 
 	public function load_textdomain() {
@@ -352,27 +359,10 @@ class ExtraChillEvents {
 	 * data-machine-events' public integration API (inc/public-api.php) so the
 	 * check survives internal namespace changes in DM-events.
 	 */
-	private function init_integrations() {
+	public function init_integrations() {
 		if ( defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ) {
 			extrachill_events_init_data_machine_integration();
 		}
-	}
-
-	public function activate() {
-		// Create/upgrade the qualify verdicts table at activation. Safe to
-		// call repeatedly — dbDelta handles idempotency.
-		\ExtraChillEvents\Core\QualifyVerdictsTable::create_table();
-
-		// Artist URL submissions table (migrated from data-machine-events in
-		// #200). Same table name as before — ownership transfers, no data move.
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ArtistUrlSubmissionsTable.php';
-		\ExtraChillEvents\Core\ArtistUrlSubmissionsTable::create_table();
-
-		flush_rewrite_rules();
-	}
-
-	public function deactivate() {
-		flush_rewrite_rules();
 	}
 
 	/**

--- a/inc/abilities/canonical-locations.php
+++ b/inc/abilities/canonical-locations.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Network bootstrap for the canonical event locations Ability.
+ *
+ * @package ExtraChillEvents
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_categories_init', 'extrachill_events_register_abilities_category' );
+
+/**
+ * Register the events-domain ability category.
+ */
+function extrachill_events_register_abilities_category(): void {
+	if ( ! function_exists( 'wp_register_ability_category' ) ) {
+		return;
+	}
+
+	if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'extrachill-events' ) ) {
+		return;
+	}
+
+	wp_register_ability_category(
+		'extrachill-events',
+		array(
+			'label'       => __( 'Extra Chill Events', 'extrachill-events' ),
+			'description' => __( 'Events calendar, filters, geocoding, venue lookup, submissions, and upcoming-count queries.', 'extrachill-events' ),
+		)
+	);
+}
+
+require_once __DIR__ . '/events-locations.php';

--- a/inc/abilities/register.php
+++ b/inc/abilities/register.php
@@ -14,31 +14,7 @@ declare( strict_types=1 );
 
 defined( 'ABSPATH' ) || exit;
 
-add_action( 'wp_abilities_api_categories_init', 'extrachill_events_register_abilities_category' );
-
-/**
- * Register the events-domain ability category.
- */
-function extrachill_events_register_abilities_category(): void {
-	if ( ! function_exists( 'wp_register_ability_category' ) ) {
-		return;
-	}
-
-	// The wp_abilities_api_categories_init action can fire more than once per
-	// request on multisite; guard against re-registering an already-registered
-	// category to avoid a _doing_it_wrong notice.
-	if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'extrachill-events' ) ) {
-		return;
-	}
-
-	wp_register_ability_category(
-		'extrachill-events',
-		array(
-			'label'       => __( 'Extra Chill Events', 'extrachill-events' ),
-			'description' => __( 'Events calendar, filters, geocoding, venue lookup, submissions, and upcoming-count queries.', 'extrachill-events' ),
-		)
-	);
-}
+require_once __DIR__ . '/canonical-locations.php';
 
 // Load ability files — each self-registers on wp_abilities_api_init.
 // Note: events-submit was removed as a pure pass-through wrapper around
@@ -46,7 +22,6 @@ function extrachill_events_register_abilities_category(): void {
 // directly. See Extra-Chill/extrachill-events#104.
 require_once __DIR__ . '/events-calendar.php';
 require_once __DIR__ . '/events-filters.php';
-require_once __DIR__ . '/events-locations.php';
 require_once __DIR__ . '/events-geocode.php';
 require_once __DIR__ . '/events-upcoming-counts.php';
 require_once __DIR__ . '/events-list-venues.php';

--- a/inc/activation.php
+++ b/inc/activation.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Network-safe activation lifecycle.
+ *
+ * @package ExtraChillEvents
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Run an activation callback in the Events blog context.
+ *
+ * @param callable $callback Activation or deactivation work.
+ * @return void
+ */
+function extrachill_events_run_on_events_site( callable $callback ): void {
+	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 7;
+	$switched       = get_current_blog_id() !== $events_blog_id;
+
+	if ( $switched && ! switch_to_blog( $events_blog_id ) ) {
+		return;
+	}
+
+	try {
+		$callback();
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
+}
+
+/**
+ * Install Events-owned schema and rewrite rules once on network activation.
+ */
+function extrachill_events_activate(): void {
+	extrachill_events_run_on_events_site(
+		static function (): void {
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdictsTable.php';
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ArtistUrlSubmissionsTable.php';
+			\ExtraChillEvents\Core\QualifyVerdictsTable::create_table();
+			\ExtraChillEvents\Core\ArtistUrlSubmissionsTable::create_table();
+			flush_rewrite_rules();
+		}
+	);
+}
+
+/**
+ * Flush only the Events site's rewrite rules on deactivation.
+ */
+function extrachill_events_deactivate(): void {
+	extrachill_events_run_on_events_site( 'flush_rewrite_rules' );
+}
+
+register_activation_hook( EXTRACHILL_EVENTS_PLUGIN_FILE, 'extrachill_events_activate' );
+register_deactivation_hook( EXTRACHILL_EVENTS_PLUGIN_FILE, 'extrachill_events_deactivate' );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,7 @@
 			<directory>tests/Unit/Core</directory>
 			<file>tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalLocationsAbilityTest.php</file>
+			<file>tests/Unit/Abilities/NetworkBootstrapTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/Unit/Abilities/NetworkBootstrapTest.php
+++ b/tests/Unit/Abilities/NetworkBootstrapTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Network bootstrap isolation tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that network loading cannot leak the Events runtime to other sites.
+ */
+final class NetworkBootstrapTest extends TestCase {
+	/** Verify the site gate follows the network Ability bootstrap. */
+	public function test_non_events_bootstrap_only_loads_canonical_ability(): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local test fixture.
+		$source = file_get_contents( dirname( __DIR__, 3 ) . '/extrachill-events.php' );
+
+		$ability_position   = strpos( $source, "require_once __DIR__ . '/inc/abilities/canonical-locations.php';" );
+		$site_gate_position = strpos( $source, 'if ( get_current_blog_id() !== $extrachill_events_blog_id )' );
+		$runtime_position   = strpos( $source, '// WP-CLI commands.' );
+
+		$this->assertNotFalse( $ability_position );
+		$this->assertNotFalse( $site_gate_position );
+		$this->assertNotFalse( $runtime_position );
+		$this->assertLessThan( $site_gate_position, $ability_position );
+		$this->assertLessThan( $runtime_position, $site_gate_position );
+	}
+
+	/** Verify the narrow bootstrap contains no UI integration hooks. */
+	public function test_network_bootstrap_has_no_frontend_or_admin_hooks(): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local test fixture.
+		$source = file_get_contents( dirname( __DIR__, 3 ) . '/inc/abilities/canonical-locations.php' );
+
+		$this->assertStringNotContainsString( 'wp_enqueue', $source );
+		$this->assertStringNotContainsString( 'template_', $source );
+		$this->assertStringNotContainsString( 'admin_', $source );
+		$this->assertStringContainsString( "require_once __DIR__ . '/events-locations.php';", $source );
+	}
+
+	/** Verify network activation does not require a site-active dependency. */
+	public function test_plugin_is_network_only_without_site_active_dependency(): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local test fixture.
+		$source = file_get_contents( dirname( __DIR__, 3 ) . '/extrachill-events.php' );
+
+		$this->assertStringContainsString( 'Network: true', $source );
+		$this->assertStringContainsString( 'Requires Plugins: data-machine', $source );
+		$this->assertStringNotContainsString( 'Requires Plugins: data-machine, data-machine-events', $source );
+	}
+
+	/** Verify activation restores the originating blog context. */
+	public function test_activation_lifecycle_switches_and_restores_events_blog(): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local test fixture.
+		$source = file_get_contents( dirname( __DIR__, 3 ) . '/inc/activation.php' );
+
+		$this->assertStringContainsString( 'switch_to_blog( $events_blog_id )', $source );
+		$this->assertStringContainsString( 'restore_current_blog()', $source );
+		$this->assertStringContainsString( "register_activation_hook( EXTRACHILL_EVENTS_PLUGIN_FILE, 'extrachill_events_activate' )", $source );
+	}
+}


### PR DESCRIPTION
## Summary
- network-load the event-owned canonical locations Ability while gating the complete Events runtime to the Events site
- make activation/deactivation switch to and restore the Events blog, and defer the site-active `data-machine-events` integration until `plugins_loaded`
- add focused coverage for cross-site execution, blog restoration, loading order, activation, and frontend/admin isolation

## Root cause
`extrachill/events-locations` could switch to blog 7 when executing, but its registration file only loaded when `extrachill-events` was site-active. Requests originating on main or Community therefore never registered the Ability. `switch_to_blog()` changes database context; it does not load plugins that are inactive on the originating site.

## Loading and activation architecture
`extrachill-events` is now network-only, but its network bootstrap loads only:

- the canonical locations Ability/category
- network-safe activation/deactivation callbacks

Every other plugin concern returns before registration unless the current blog is the Events blog. The plugin no longer declares site-active `data-machine-events` as a network activation dependency; instead, the Events-only integration initializes on `plugins_loaded`, after that site plugin has loaded. `data-machine` remains the declared network-active dependency.

Activation and deactivation switch to the Events blog, perform schema/rewrite work there, and restore the originating blog in a `finally` block.

## Layer purity
Location search and resolution remain owned entirely by `extrachill-events`. No event validation or canonical taxonomy rules moved into Users, API, Network, or generic `data-machine-events`, and no server-side HTTP loop was introduced.

## Site isolation proof
The main plugin file loads the narrow Ability bootstrap and lifecycle registration before an Events-blog gate. CLI commands, recurring tasks, schema installers, Data Machine handlers, REST/admin integrations, templates, blocks, assets, and all remaining Abilities stay after that gate. Focused tests assert this ordering and assert that the network bootstrap contains no frontend, template, or admin hooks.

Live WP-CLI checks confirmed the `location` taxonomy exists independently in main, Community, and Events contexts. Direct execution from main and Community returned successfully and restored blogs 1 and 2; the deployed Events Ability remained registered and executed on blog 7.

## Operational steps
After release packaging, replace the currently site-active activation with network activation:

1. Deactivate `extrachill-events` on Events.
2. Network-activate `extrachill-events`.
3. Verify `wp_get_ability( 'extrachill/events-locations' )` and execution under main, Community, and Events URLs.

No deployment or release was performed by this PR.

## Tests
- `vendor/bin/phpunit --filter '/(CanonicalLocationsAbilityTest|NetworkBootstrapTest)/'` (9 tests, 32 assertions)
- focused changed-file PHPCS: pass
- PHP syntax checks: pass
- `git diff --check`: pass
- WP-CLI execution smoke checks: main, Community, and Events pass with blog restoration
- full configured PHPUnit: 143 pass, 4 existing failures in `QualifyRecheckHandlerTest` unrelated to this change
- JavaScript: not touched; package has no `npm test` script

Closes #235