### PR TITLE
feat: redesign personalized event market discovery

### DIFF
--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -99,53 +99,85 @@
     flex-shrink: 0;
 }
 
-/* Preferred route integrated with the homepage city chooser. */
-.events-home-market {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-wrap: wrap;
-    gap: var(--spacing-sm) var(--spacing-md);
-    margin: 0 auto var(--spacing-md);
-    color: var(--muted-text);
-    font-size: var(--font-size-sm);
+/* Progressive homepage router: search, preferred market, sample, directories. */
+.events-home-router {
+    display: grid;
+    gap: var(--spacing-lg);
+}
+
+.events-home-router__heading {
     text-align: center;
 }
 
-.events-home-market--active {
+.events-home-router__heading h2,
+.events-home-router__heading p,
+.events-primary-market h3,
+.events-primary-market p,
+.events-market-sample h3 {
+    margin: 0;
+}
+
+.events-home-router__heading p {
+    margin-top: var(--spacing-xs);
+    color: var(--muted-text);
+    font-size: var(--font-size-sm);
+}
+
+.events-location-search {
+    width: min(100%, 38rem);
+    margin: 0 auto;
+}
+
+.events-location-search label {
+    display: block;
+    margin-bottom: var(--spacing-xs);
+    font-weight: 600;
+}
+
+.events-location-search__controls {
+    display: flex;
+    gap: var(--spacing-sm);
+}
+
+.events-location-search input[type="search"] {
+    min-width: 0;
+    flex: 1;
+}
+
+.events-primary-market {
+    display: flex;
+    align-items: center;
     justify-content: space-between;
-    max-width: 42rem;
-    padding: var(--spacing-md);
-    color: inherit;
+    gap: var(--spacing-lg);
+    padding: var(--spacing-lg);
     background: var(--background-color);
     border: 1px solid var(--border-color);
     border-left: 3px solid var(--accent);
     border-radius: var(--border-radius, 8px);
-    text-align: left;
+    box-shadow: var(--card-shadow);
 }
 
-.events-home-market__copy {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs);
-}
-
-.events-home-market__eyebrow,
-.events-home-market__explore {
+.events-primary-market__eyebrow {
     color: var(--muted-text);
     font-size: var(--font-size-sm);
 }
 
-.events-home-market__actions {
+.events-primary-market__links,
+.events-home-router__paths {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: var(--spacing-md);
+    gap: var(--spacing-sm) var(--spacing-md);
 }
 
-.events-home-market__explore {
-    margin: 0 0 var(--spacing-sm);
+.events-market-sample h3 {
+    margin-bottom: var(--spacing-sm);
     text-align: center;
+}
+
+.events-home-router__paths {
+    justify-content: center;
+    font-weight: 600;
 }
 
 @media (max-width: 600px) {
@@ -158,11 +190,15 @@
         gap: var(--spacing-sm) var(--spacing-md);
     }
 
-    .events-home-market--active {
+    .events-primary-market {
         align-items: flex-start;
         flex-direction: column;
-        margin-left: var(--spacing-md);
-        margin-right: var(--spacing-md);
+        padding: var(--spacing-md);
+    }
+
+    .events-location-search__controls {
+        align-items: stretch;
+        flex-direction: column;
     }
 }
 
@@ -213,6 +249,21 @@
 
 .cities-region-title {
     margin-bottom: var(--spacing-md);
+}
+
+.cities-state {
+    margin-bottom: var(--spacing-lg);
+}
+
+.cities-state-title {
+    margin-bottom: var(--spacing-sm);
+    font-size: var(--font-size-body);
+}
+
+.cities-state-title span,
+.cities-directory-results,
+.cities-directory-empty {
+    color: var(--muted-text);
 }
 
 .cities-region-count {

--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -60,6 +60,56 @@
     margin-bottom: 0;
 }
 
+/* Account-backed market context on primary discovery surfaces. */
+.events-market-context {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    margin: 0 0 var(--spacing-lg);
+    padding: var(--spacing-md);
+    background: var(--background-color);
+    border: 1px solid var(--border-color);
+    border-left: 3px solid var(--accent);
+    border-radius: var(--border-radius, 8px);
+}
+
+.events-market-context--quiet {
+    border-left-color: var(--border-color);
+    color: var(--muted-text);
+    font-size: var(--font-size-sm);
+}
+
+.events-market-context__copy {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+}
+
+.events-market-context__copy span {
+    color: var(--muted-text);
+    font-size: var(--font-size-sm);
+}
+
+.events-market-context__actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-md);
+    flex-shrink: 0;
+}
+
+@media (max-width: 600px) {
+    .events-market-context {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .events-market-context__actions {
+        gap: var(--spacing-sm) var(--spacing-md);
+    }
+}
+
 .taxonomy-archive-header .calendar-stats {
     margin-bottom: var(--spacing-md);
 }

--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -99,6 +99,55 @@
     flex-shrink: 0;
 }
 
+/* Preferred route integrated with the homepage city chooser. */
+.events-home-market {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm) var(--spacing-md);
+    margin: 0 auto var(--spacing-md);
+    color: var(--muted-text);
+    font-size: var(--font-size-sm);
+    text-align: center;
+}
+
+.events-home-market--active {
+    justify-content: space-between;
+    max-width: 42rem;
+    padding: var(--spacing-md);
+    color: inherit;
+    background: var(--background-color);
+    border: 1px solid var(--border-color);
+    border-left: 3px solid var(--accent);
+    border-radius: var(--border-radius, 8px);
+    text-align: left;
+}
+
+.events-home-market__copy {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+}
+
+.events-home-market__eyebrow,
+.events-home-market__explore {
+    color: var(--muted-text);
+    font-size: var(--font-size-sm);
+}
+
+.events-home-market__actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-md);
+}
+
+.events-home-market__explore {
+    margin: 0 0 var(--spacing-sm);
+    text-align: center;
+}
+
 @media (max-width: 600px) {
     .events-market-context {
         align-items: flex-start;
@@ -107,6 +156,13 @@
 
     .events-market-context__actions {
         gap: var(--spacing-sm) var(--spacing-md);
+    }
+
+    .events-home-market--active {
+        align-items: flex-start;
+        flex-direction: column;
+        margin-left: var(--spacing-md);
+        margin-right: var(--spacing-md);
     }
 }
 

--- a/inc/core/account-market.php
+++ b/inc/core/account-market.php
@@ -199,7 +199,7 @@ add_filter( 'data_machine_events_map_center', 'extrachill_events_account_market_
  * Render account market context on primary Events discovery surfaces.
  */
 function extrachill_events_render_account_market_context(): void {
-	if ( ! extrachill_events_supports_account_market() || is_tax() || ( extrachill_events_has_explicit_market() && ! extrachill_events_is_exploring_all_markets() ) ) {
+	if ( is_front_page() || ! extrachill_events_supports_account_market() || is_tax() || ( extrachill_events_has_explicit_market() && ! extrachill_events_is_exploring_all_markets() ) ) {
 		return;
 	}
 
@@ -247,5 +247,42 @@ function extrachill_events_render_account_market_context(): void {
 			<?php endif; ?>
 		</div>
 	</aside>
+	<?php
+}
+
+/**
+ * Render the personalized route above the homepage city directory.
+ */
+function extrachill_events_render_home_market_router(): void {
+	if ( ! is_front_page() || ! extrachill_events_supports_account_market() ) {
+		return;
+	}
+
+	$community_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : 'https://community.extrachill.com';
+	$settings_url  = trailingslashit( $community_url ) . 'settings/#tab-account-details';
+	$market        = extrachill_events_get_account_market();
+	$is_logged_in  = is_user_logged_in();
+	?>
+	<div class="events-home-market<?php echo $market ? ' events-home-market--active' : ''; ?>">
+		<?php if ( $market ) : ?>
+			<div class="events-home-market__copy">
+				<span class="events-home-market__eyebrow"><?php esc_html_e( 'Your default market', 'extrachill-events' ); ?></span>
+				<strong><?php echo esc_html( '' !== $market['label'] ? $market['label'] : $market['slug'] ); ?></strong>
+			</div>
+			<div class="events-home-market__actions">
+				<a class="button-1 button-small" href="<?php echo esc_url( $market['url'] ); ?>"><?php esc_html_e( 'View local events', 'extrachill-events' ); ?></a>
+				<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Change default', 'extrachill-events' ); ?></a>
+			</div>
+		<?php elseif ( $is_logged_in ) : ?>
+			<span><?php esc_html_e( 'Choose a default market to put your city first whenever you visit Events.', 'extrachill-events' ); ?></span>
+			<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Set default market', 'extrachill-events' ); ?></a>
+		<?php else : ?>
+			<span><?php esc_html_e( 'Pick a city below, or sign in to save your default market.', 'extrachill-events' ); ?></span>
+			<a href="<?php echo esc_url( wp_login_url( home_url( '/' ) ) ); ?>"><?php esc_html_e( 'Sign in', 'extrachill-events' ); ?></a>
+		<?php endif; ?>
+	</div>
+	<?php if ( $market ) : ?>
+		<p class="events-home-market__explore"><?php esc_html_e( 'Or explore another location:', 'extrachill-events' ); ?></p>
+	<?php endif; ?>
 	<?php
 }

--- a/inc/core/account-market.php
+++ b/inc/core/account-market.php
@@ -251,9 +251,11 @@ function extrachill_events_render_account_market_context(): void {
 }
 
 /**
- * Render the personalized route above the homepage city directory.
+ * Render the progressive homepage market router.
+ *
+ * @param array $locations Canonical active city rows ordered by upcoming count.
  */
-function extrachill_events_render_home_market_router(): void {
+function extrachill_events_render_home_market_router( array $locations ): void {
 	if ( ! is_front_page() || ! extrachill_events_supports_account_market() ) {
 		return;
 	}
@@ -262,27 +264,79 @@ function extrachill_events_render_home_market_router(): void {
 	$settings_url  = trailingslashit( $community_url ) . 'settings/#tab-account-details';
 	$market        = extrachill_events_get_account_market();
 	$is_logged_in  = is_user_logged_in();
+	$market_count  = 0;
+	foreach ( $locations as $location ) {
+		if ( $market && (int) $location['term_id'] === (int) $market['term_id'] ) {
+			$market_count = (int) $location['count'];
+			break;
+		}
+	}
+	$sample_min_events = (int) apply_filters( 'extrachill_events_badge_min_count', 20 );
+	$sample            = array_values(
+		array_filter(
+			$locations,
+			static function ( array $location ) use ( $market, $sample_min_events ): bool {
+				$is_other_market = ! $market || (int) $location['term_id'] !== (int) $market['term_id'];
+				return $is_other_market && (int) $location['count'] >= $sample_min_events;
+			}
+		)
+	);
+	$sample            = array_slice( $sample, 0, 8 );
 	?>
-	<div class="events-home-market<?php echo $market ? ' events-home-market--active' : ''; ?>">
+	<section class="events-home-router ec-edge-gutter" aria-labelledby="events-market-heading">
+		<div class="events-home-router__heading">
 		<?php if ( $market ) : ?>
-			<div class="events-home-market__copy">
-				<span class="events-home-market__eyebrow"><?php esc_html_e( 'Your default market', 'extrachill-events' ); ?></span>
-				<strong><?php echo esc_html( '' !== $market['label'] ? $market['label'] : $market['slug'] ); ?></strong>
-			</div>
-			<div class="events-home-market__actions">
-				<a class="button-1 button-small" href="<?php echo esc_url( $market['url'] ); ?>"><?php esc_html_e( 'View local events', 'extrachill-events' ); ?></a>
-				<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Change default', 'extrachill-events' ); ?></a>
-			</div>
+			<h2 id="events-market-heading"><?php esc_html_e( 'Your market', 'extrachill-events' ); ?></h2>
 		<?php elseif ( $is_logged_in ) : ?>
-			<span><?php esc_html_e( 'Choose a default market to put your city first whenever you visit Events.', 'extrachill-events' ); ?></span>
-			<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Set default market', 'extrachill-events' ); ?></a>
+			<h2 id="events-market-heading"><?php esc_html_e( 'Choose your market', 'extrachill-events' ); ?></h2>
+			<p><?php esc_html_e( 'Find a city now, or set a default to put it first on every visit.', 'extrachill-events' ); ?> <a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Set default market', 'extrachill-events' ); ?></a></p>
 		<?php else : ?>
-			<span><?php esc_html_e( 'Pick a city below, or sign in to save your default market.', 'extrachill-events' ); ?></span>
-			<a href="<?php echo esc_url( wp_login_url( home_url( '/' ) ) ); ?>"><?php esc_html_e( 'Sign in', 'extrachill-events' ); ?></a>
+			<h2 id="events-market-heading"><?php esc_html_e( 'Find your city', 'extrachill-events' ); ?></h2>
+			<p><?php esc_html_e( 'Search without an account.', 'extrachill-events' ); ?> <a href="<?php echo esc_url( wp_login_url( home_url( '/' ) ) ); ?>"><?php esc_html_e( 'Sign in to save a default', 'extrachill-events' ); ?></a></p>
 		<?php endif; ?>
-	</div>
-	<?php if ( $market ) : ?>
-		<p class="events-home-market__explore"><?php esc_html_e( 'Or explore another location:', 'extrachill-events' ); ?></p>
-	<?php endif; ?>
+		</div>
+
+		<form class="events-location-search" role="search" method="get" action="<?php echo esc_url( home_url( '/location/' ) ); ?>">
+			<label for="events-location-search"><?php esc_html_e( 'Search cities', 'extrachill-events' ); ?></label>
+			<div class="events-location-search__controls">
+				<input id="events-location-search" name="search" type="search" autocomplete="off" required placeholder="<?php esc_attr_e( 'City or state', 'extrachill-events' ); ?>">
+				<button class="button-1 button-small" type="submit"><?php esc_html_e( 'Search', 'extrachill-events' ); ?></button>
+			</div>
+		</form>
+
+		<?php if ( $market ) : ?>
+			<article class="events-primary-market">
+				<div>
+					<span class="events-primary-market__eyebrow"><?php esc_html_e( 'Your default market', 'extrachill-events' ); ?></span>
+					<h3><?php echo esc_html( '' !== $market['label'] ? $market['label'] : $market['slug'] ); ?></h3>
+					<?php if ( $market_count > 0 ) : ?>
+						<p><?php echo esc_html( sprintf( /* translators: %s: Number of upcoming events. */ _n( '%s upcoming event', '%s upcoming events', $market_count, 'extrachill-events' ), number_format_i18n( $market_count ) ) ); ?></p>
+					<?php endif; ?>
+				</div>
+				<nav class="events-primary-market__links" aria-label="<?php esc_attr_e( 'Default market event views', 'extrachill-events' ); ?>">
+					<a href="<?php echo esc_url( trailingslashit( $market['url'] ) . 'tonight/' ); ?>"><?php esc_html_e( 'Tonight', 'extrachill-events' ); ?></a>
+					<a href="<?php echo esc_url( trailingslashit( $market['url'] ) . 'this-weekend/' ); ?>"><?php esc_html_e( 'This Weekend', 'extrachill-events' ); ?></a>
+					<a href="<?php echo esc_url( $market['url'] ); ?>"><?php esc_html_e( 'City calendar', 'extrachill-events' ); ?></a>
+					<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Change default', 'extrachill-events' ); ?></a>
+				</nav>
+			</article>
+		<?php endif; ?>
+
+		<?php if ( $sample ) : ?>
+			<div class="events-market-sample">
+				<h3><?php echo esc_html( $market ? __( 'Explore other active markets', 'extrachill-events' ) : __( 'Active markets', 'extrachill-events' ) ); ?></h3>
+				<div class="taxonomy-badges">
+					<?php foreach ( $sample as $location ) : ?>
+						<a href="<?php echo esc_url( $location['url'] ); ?>" class="taxonomy-badge location-badge location-<?php echo esc_attr( $location['slug'] ); ?>"><?php echo esc_html( $location['label'] ); ?> (<?php echo esc_html( number_format_i18n( $location['count'] ) ); ?>)</a>
+					<?php endforeach; ?>
+				</div>
+			</div>
+		<?php endif; ?>
+
+		<div class="events-home-router__paths">
+			<a href="<?php echo esc_url( home_url( '/location/' ) ); ?>"><?php esc_html_e( 'Browse all locations', 'extrachill-events' ); ?> &rarr;</a>
+			<a href="<?php echo esc_url( home_url( '/all/' ) ); ?>"><?php esc_html_e( 'See every event', 'extrachill-events' ); ?> &rarr;</a>
+		</div>
+	</section>
 	<?php
 }

--- a/inc/core/account-market.php
+++ b/inc/core/account-market.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * dependency is available, or when it returns an invalid/empty preference,
  * this fails open.
  *
- * @return array{lat: float|null, lon: float|null, slug: string, term_id: int}|null
+ * @return array{lat: float|null, lon: float|null, slug: string, term_id: int, label: string, url: string}|null
  */
 function extrachill_events_get_account_market(): ?array {
 	static $resolved = false;
@@ -51,6 +51,9 @@ function extrachill_events_get_account_market(): ?array {
 	$lon         = filter_var( $coordinates['lon'] ?? null, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE );
 	$term_id     = absint( $location['term_id'] ?? 0 );
 	$slug        = sanitize_title( $location['slug'] ?? '' );
+	$hierarchy   = is_array( $location['hierarchy'] ?? null ) ? $location['hierarchy'] : array();
+	$label       = sanitize_text_field( $hierarchy['label'] ?? $location['name'] ?? '' );
+	$url         = esc_url_raw( $location['archive_url'] ?? '' );
 
 	if ( $term_id < 1 || '' === $slug ) {
 		return null;
@@ -67,15 +70,31 @@ function extrachill_events_get_account_market(): ?array {
 		'lon'     => null !== $lon ? (float) $lon : null,
 		'slug'    => $slug,
 		'term_id' => $term_id,
+		'label'   => $label,
+		'url'     => $url,
 	);
 
 	return $market;
 }
 
 /**
+ * Whether this request explicitly opts out of account market fallback.
+ */
+function extrachill_events_is_exploring_all_markets(): bool {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public read-only discovery preference.
+	$value = isset( $_GET['explore_all'] ) && is_scalar( $_GET['explore_all'] ) ? sanitize_text_field( wp_unslash( $_GET['explore_all'] ) ) : '';
+
+	return '1' === $value;
+}
+
+/**
  * Whether the request already carries an explicit location selection.
  */
 function extrachill_events_has_explicit_market(): bool {
+	if ( extrachill_events_is_exploring_all_markets() ) {
+		return true;
+	}
+
 	if ( is_tax() ) {
 		return true;
 	}
@@ -120,7 +139,7 @@ function extrachill_events_supports_account_market(): bool {
  * @return array
  */
 function extrachill_events_calendar_account_market_defaults( array $query_args, array $context ): array {
-	if ( ! extrachill_events_supports_account_market() || ! empty( $context['archive_term'] ) || ! empty( $query_args['tax_filter'] ) ) {
+	if ( ! extrachill_events_supports_account_market() || extrachill_events_is_exploring_all_markets() || ! empty( $context['archive_term'] ) || ! empty( $query_args['tax_filter'] ) ) {
 		return $query_args;
 	}
 
@@ -175,3 +194,58 @@ function extrachill_events_account_market_map_center( $center, array $context ) 
 	);
 }
 add_filter( 'data_machine_events_map_center', 'extrachill_events_account_market_map_center', 5, 2 );
+
+/**
+ * Render account market context on primary Events discovery surfaces.
+ */
+function extrachill_events_render_account_market_context(): void {
+	if ( ! extrachill_events_supports_account_market() || is_tax() || ( extrachill_events_has_explicit_market() && ! extrachill_events_is_exploring_all_markets() ) ) {
+		return;
+	}
+
+	$community_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : 'https://community.extrachill.com';
+	$settings_url  = trailingslashit( $community_url ) . 'settings/#tab-account-details';
+	$current_url   = remove_query_arg( 'explore_all' );
+	$explore_url   = add_query_arg( 'explore_all', '1', $current_url );
+	$market        = extrachill_events_get_account_market();
+	$is_logged_in  = is_user_logged_in();
+	$is_exploring  = extrachill_events_is_exploring_all_markets();
+	?>
+	<aside class="events-market-context<?php echo $is_logged_in ? '' : ' events-market-context--quiet'; ?>" aria-label="<?php esc_attr_e( 'Event location preference', 'extrachill-events' ); ?>" role="status">
+		<div class="events-market-context__copy">
+			<?php if ( $market && $is_exploring ) : ?>
+				<strong><?php esc_html_e( 'Exploring all locations', 'extrachill-events' ); ?></strong>
+				<span><?php esc_html_e( 'Your saved market is still available whenever you want to focus the calendar again.', 'extrachill-events' ); ?></span>
+			<?php elseif ( $market ) : ?>
+				<strong>
+					<?php
+					printf(
+						/* translators: %s: Market hierarchy label. */
+						esc_html__( 'Showing events for %s', 'extrachill-events' ),
+						esc_html( '' !== $market['label'] ? $market['label'] : $market['slug'] )
+					);
+					?>
+				</strong>
+			<?php elseif ( $is_logged_in ) : ?>
+				<strong><?php esc_html_e( 'Focus Events around your city', 'extrachill-events' ); ?></strong>
+				<span><?php esc_html_e( 'Set a default market once and use it across devices.', 'extrachill-events' ); ?></span>
+			<?php else : ?>
+				<span><?php esc_html_e( 'Sign in to save a default market across devices.', 'extrachill-events' ); ?></span>
+			<?php endif; ?>
+		</div>
+		<div class="events-market-context__actions">
+			<?php if ( $market && $is_exploring ) : ?>
+				<a href="<?php echo esc_url( $current_url ); ?>"><?php esc_html_e( 'Use my default market', 'extrachill-events' ); ?></a>
+				<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Change default', 'extrachill-events' ); ?></a>
+			<?php elseif ( $market ) : ?>
+				<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Change default', 'extrachill-events' ); ?></a>
+				<a href="<?php echo esc_url( $explore_url ); ?>"><?php esc_html_e( 'Explore all locations', 'extrachill-events' ); ?></a>
+			<?php elseif ( $is_logged_in ) : ?>
+				<a class="button-1 button-small" href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Set default market', 'extrachill-events' ); ?></a>
+			<?php else : ?>
+				<a href="<?php echo esc_url( wp_login_url( $current_url ) ); ?>"><?php esc_html_e( 'Sign in', 'extrachill-events' ); ?></a>
+			<?php endif; ?>
+		</div>
+	</aside>
+	<?php
+}

--- a/inc/core/near-me.php
+++ b/inc/core/near-me.php
@@ -128,7 +128,7 @@ function extrachill_events_near_me_scripts() {
 	);
 
 	$geo                = extrachill_events_get_geo_params();
-	$account_market     = extrachill_events_get_account_market();
+	$account_market     = extrachill_events_is_exploring_all_markets() ? null : extrachill_events_get_account_market();
 	$has_account_market = null !== $account_market && null !== $account_market['lat'] && null !== $account_market['lon'];
 
 	wp_localize_script(
@@ -253,6 +253,10 @@ function extrachill_events_near_me_content( string $content ): string {
 	$html           .= '</div>';
 
 	$html .= '</div>';
+
+	ob_start();
+	extrachill_events_render_account_market_context();
+	$html = (string) ob_get_clean() . $html;
 
 	// City grid fallback (hidden by default, JS reveals if geo denied).
 	$locations = get_terms(

--- a/inc/core/router-pages.php
+++ b/inc/core/router-pages.php
@@ -36,12 +36,6 @@ function extrachill_events_router_rewrite_rules() {
 	add_rewrite_tag( '%ec_events_router%', '(all)' );
 	add_rewrite_rule( '^all/?$', 'index.php?ec_events_router=all', 'top' );
 
-	// The /location directory is built but held off for now. When enabled, the
-	// bare location taxonomy base (no term) renders the region-grouped
-	// directory; the catch-all location/(.+?) rule requires a term, so
-	// /location/ would 404 without this rule. 'top' priority matches before
-	// that catch-all. Flip extrachill_events_enable_location_directory to true
-	// (and flush rewrites) to turn it on.
 	if ( extrachill_events_location_directory_enabled() ) {
 		add_rewrite_tag( '%ec_events_location_index%', '(1)' );
 		add_rewrite_rule( '^location/?$', 'index.php?ec_events_location_index=1', 'top' );
@@ -61,13 +55,71 @@ function extrachill_events_is_all_events_page(): bool {
 /**
  * Whether the /location directory page is enabled.
  *
- * Held off by default. Filter to true (and flush rewrites) to expose it.
- *
  * @return bool
  * @since 0.25.0
  */
 function extrachill_events_location_directory_enabled(): bool {
-	return (bool) apply_filters( 'extrachill_events_enable_location_directory', false );
+	return (bool) apply_filters( 'extrachill_events_enable_location_directory', true );
+}
+
+/**
+ * Flush rewrites once when the public location directory route is introduced.
+ */
+function extrachill_events_maybe_flush_router_rewrites(): void {
+	$rewrite_version = '2';
+	if ( get_option( 'extrachill_events_router_rewrite_version' ) === $rewrite_version ) {
+		return;
+	}
+
+	flush_rewrite_rules( false );
+	update_option( 'extrachill_events_router_rewrite_version', $rewrite_version, false );
+}
+add_action( 'init', 'extrachill_events_maybe_flush_router_rewrites', 100 );
+
+/**
+ * Validate and enrich upcoming-count rows as canonical selectable cities.
+ *
+ * @param array $rows Upcoming location count rows.
+ * @return array Canonical city rows with taxonomy hierarchy metadata.
+ */
+function extrachill_events_prepare_location_rows( array $rows ): array {
+	$locations = array();
+
+	foreach ( $rows as $row ) {
+		$term_id = absint( $row['term_id'] ?? 0 );
+		$count   = absint( $row['count'] ?? 0 );
+		$term    = $term_id ? get_term( $term_id, 'location' ) : null;
+		if ( $count < 1 || ! $term instanceof WP_Term ) {
+			continue;
+		}
+
+		$ancestor_ids = get_ancestors( $term_id, 'location', 'taxonomy' );
+		if ( count( $ancestor_ids ) < 2 ) {
+			continue;
+		}
+
+		$root  = get_term( (int) end( $ancestor_ids ), 'location' );
+		$state = get_term( (int) $ancestor_ids[0], 'location' );
+		$url   = get_term_link( $term );
+		if ( ! $root instanceof WP_Term || ! $state instanceof WP_Term || is_wp_error( $url ) ) {
+			continue;
+		}
+
+		$locations[] = array(
+			'term_id'   => $term_id,
+			'name'      => $term->name,
+			'slug'      => $term->slug,
+			'count'     => $count,
+			'url'       => $url,
+			'label'     => sprintf( '%s, %s', $term->name, $state->name ),
+			'region_id' => (int) $root->term_id,
+			'region'    => $root->name,
+			'state_id'  => (int) $state->term_id,
+			'state'     => $state->name,
+		);
+	}
+
+	return $locations;
 }
 
 /**

--- a/inc/home/location-badges.php
+++ b/inc/home/location-badges.php
@@ -44,6 +44,8 @@ $location_counts = array_filter(
 if ( empty( $location_counts ) ) {
 	return;
 }
+
+extrachill_events_render_home_market_router();
 ?>
 	<div class="taxonomy-badges ec-edge-gutter">
 	<?php foreach ( $location_counts as $location ) : ?>

--- a/inc/home/location-badges.php
+++ b/inc/home/location-badges.php
@@ -33,30 +33,10 @@ if ( empty( $location_counts ) || ! is_array( $location_counts ) ) {
 	return;
 }
 
-$min_events      = (int) apply_filters( 'extrachill_events_badge_min_count', 20 );
-$location_counts = array_filter(
-	$location_counts,
-	static function ( $location ) use ( $min_events ) {
-		return $location['count'] >= $min_events;
-	}
-);
+$location_counts = extrachill_events_prepare_location_rows( $location_counts );
 
 if ( empty( $location_counts ) ) {
 	return;
 }
 
-extrachill_events_render_home_market_router();
-?>
-	<div class="taxonomy-badges ec-edge-gutter">
-	<?php foreach ( $location_counts as $location ) : ?>
-		<a href="<?php echo esc_url( $location['url'] ); ?>" class="taxonomy-badge location-badge location-<?php echo esc_attr( $location['slug'] ); ?>">
-			<?php echo esc_html( $location['name'] ); ?> (<?php echo esc_html( $location['count'] ); ?>)
-		</a>
-	<?php endforeach; ?>
-	</div>
-
-	<p class="events-browse-all-cities">
-		<a href="<?php echo esc_url( home_url( '/all/' ) ); ?>">
-			<?php esc_html_e( 'See every event &rarr;', 'extrachill-events' ); ?>
-		</a>
-	</p>
+extrachill_events_render_home_market_router( $location_counts );

--- a/inc/templates/all-events.php
+++ b/inc/templates/all-events.php
@@ -27,6 +27,7 @@ extrachill_breadcrumbs();
 	</div>
 
 	<div class="page-content">
+		<?php extrachill_events_render_account_market_context(); ?>
 		<?php
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- do_blocks() returns trusted, fully-rendered block HTML.
 		echo do_blocks( '<!-- wp:data-machine-events/calendar {"showScopePresets":true} /-->' );

--- a/inc/templates/homepage.php
+++ b/inc/templates/homepage.php
@@ -28,6 +28,7 @@ extrachill_breadcrumbs();
 	</div>
 
 		<div class="entry-content" itemprop="text">
+			<?php extrachill_events_render_account_market_context(); ?>
 			<?php do_action( 'extrachill_events_home_before_calendar' ); ?>
 			<div class="events-calendar-container ec-mobile-full-width-panel">
 				<?php

--- a/inc/templates/homepage.php
+++ b/inc/templates/homepage.php
@@ -28,7 +28,6 @@ extrachill_breadcrumbs();
 	</div>
 
 		<div class="entry-content" itemprop="text">
-			<?php extrachill_events_render_account_market_context(); ?>
 			<?php do_action( 'extrachill_events_home_before_calendar' ); ?>
 			<div class="events-calendar-container ec-mobile-full-width-panel">
 				<?php

--- a/inc/templates/location-directory.php
+++ b/inc/templates/location-directory.php
@@ -36,7 +36,20 @@ $min_events = (int) apply_filters( 'extrachill_events_directory_min_count', 1 );
 $cities_request = new WP_REST_Request( 'GET', '/extrachill/v1/events/upcoming-counts' );
 $cities_request->set_query_params( array( 'taxonomy' => 'location' ) );
 $cities_response = rest_do_request( $cities_request );
-$cities          = $cities_response->is_error() ? array() : (array) $cities_response->get_data();
+$cities          = $cities_response->is_error() ? array() : extrachill_events_prepare_location_rows( (array) $cities_response->get_data() );
+
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public read-only directory search.
+$directory_search = isset( $_GET['search'] ) && is_scalar( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
+if ( '' !== $directory_search ) {
+	$cities = array_values(
+		array_filter(
+			$cities,
+			static function ( array $city ) use ( $directory_search ): bool {
+				return false !== stripos( $city['label'], $directory_search ) || false !== stripos( $city['region'], $directory_search );
+			}
+		)
+	);
+}
 
 // Region rollup totals (ancestor subtree counts). Keyed by term_id.
 $rollup_request = new WP_REST_Request( 'GET', '/extrachill/v1/events/upcoming-counts' );
@@ -54,45 +67,48 @@ foreach ( $rollup_terms as $r ) {
 	$rollup_by_id[ (int) $r['term_id'] ] = (int) $r['count'];
 }
 
-// Bucket cities under their region root using taxonomy ancestry. A city with
-// no region ancestor falls into a generic bucket so nothing is dropped.
-$regions             = array(); // root_term_id => array of city rows.
-$region_meta         = array(); // root_term_id => WP_Term.
-$ungrouped           = array();
-$ungrouped_label_key = 0;
+// Bucket canonical cities by region and state/province.
+$regions = array();
 
 foreach ( $cities as $city ) {
 	if ( (int) $city['count'] < $min_events ) {
 		continue;
 	}
 
-	$ancestors = get_ancestors( (int) $city['term_id'], 'location', 'taxonomy' );
-	if ( empty( $ancestors ) ) {
-		$ungrouped[] = $city;
-		continue;
+	$region_id = (int) $city['region_id'];
+	$state_id  = (int) $city['state_id'];
+	if ( ! isset( $regions[ $region_id ] ) ) {
+		$regions[ $region_id ] = array(
+			'name'   => $city['region'],
+			'states' => array(),
+		);
 	}
-
-	// Topmost ancestor is the region root.
-	$root_id = (int) end( $ancestors );
-	if ( ! isset( $region_meta[ $root_id ] ) ) {
-		$root_term = get_term( $root_id, 'location' );
-		if ( ! $root_term || is_wp_error( $root_term ) ) {
-			$ungrouped[] = $city;
-			continue;
-		}
-		$region_meta[ $root_id ] = $root_term;
-		$regions[ $root_id ]     = array();
+	if ( ! isset( $regions[ $region_id ]['states'][ $state_id ] ) ) {
+		$regions[ $region_id ]['states'][ $state_id ] = array(
+			'name'   => $city['state'],
+			'cities' => array(),
+		);
 	}
-	$regions[ $root_id ][] = $city;
+	$regions[ $region_id ]['states'][ $state_id ]['cities'][] = $city;
 }
 
 // Order regions by their rolled-up total, descending.
 uksort(
 	$regions,
-	static function ( $a, $b ) use ( $rollup_by_id ) {
+	static function ( $a, $b ) use ( $rollup_by_id ): int {
 		return ( $rollup_by_id[ $b ] ?? 0 ) <=> ( $rollup_by_id[ $a ] ?? 0 );
 	}
 );
+
+foreach ( $regions as &$region ) {
+	uksort(
+		$region['states'],
+		static function ( $a, $b ) use ( $rollup_by_id ): int {
+			return ( $rollup_by_id[ $b ] ?? 0 ) <=> ( $rollup_by_id[ $a ] ?? 0 );
+		}
+	);
+}
+unset( $region );
 ?>
 
 <div class="events-calendar-container ec-mobile-full-width-panel">
@@ -103,47 +119,61 @@ uksort(
 				<?php esc_html_e( 'Every city with upcoming live music. Pick a city to see its calendar.', 'extrachill-events' ); ?>
 			</p>
 		</header>
+		<form class="events-location-search" role="search" method="get" action="<?php echo esc_url( home_url( '/location/' ) ); ?>">
+			<label for="location-directory-search"><?php esc_html_e( 'Search cities', 'extrachill-events' ); ?></label>
+			<div class="events-location-search__controls">
+				<input id="location-directory-search" name="search" type="search" value="<?php echo esc_attr( $directory_search ); ?>" placeholder="<?php esc_attr_e( 'City or state', 'extrachill-events' ); ?>">
+				<button class="button-1 button-small" type="submit"><?php esc_html_e( 'Search', 'extrachill-events' ); ?></button>
+			</div>
+		</form>
 	</div>
 
 	<div class="page-content cities-directory">
-		<?php foreach ( $regions as $root_id => $region_cities ) : ?>
+		<?php if ( '' !== $directory_search ) : ?>
+			<p class="cities-directory-results" role="status">
+				<?php
+				printf(
+					/* translators: 1: Result count, 2: Search query. */
+					esc_html( _n( '%1$s active city matching “%2$s”', '%1$s active cities matching “%2$s”', count( $cities ), 'extrachill-events' ) ),
+					esc_html( number_format_i18n( count( $cities ) ) ),
+					esc_html( $directory_search )
+				);
+				?>
+			</p>
+		<?php endif; ?>
+
+		<?php foreach ( $regions as $root_id => $region ) : ?>
 			<?php
-			$region       = $region_meta[ $root_id ];
-			$region_link  = get_term_link( $region );
+			$region_term  = get_term( $root_id, 'location' );
+			$region_link  = $region_term instanceof WP_Term ? get_term_link( $region_term ) : new WP_Error();
 			$region_total = $rollup_by_id[ $root_id ] ?? 0;
 			?>
 			<section class="cities-region">
 				<h2 class="cities-region-title">
 					<?php if ( ! is_wp_error( $region_link ) ) : ?>
-						<a href="<?php echo esc_url( $region_link ); ?>"><?php echo esc_html( $region->name ); ?></a>
+						<a href="<?php echo esc_url( $region_link ); ?>"><?php echo esc_html( $region['name'] ); ?></a>
 					<?php else : ?>
-						<?php echo esc_html( $region->name ); ?>
+						<?php echo esc_html( $region['name'] ); ?>
 					<?php endif; ?>
 					<?php if ( $region_total > 0 ) : ?>
 						<span class="cities-region-count">(<?php echo esc_html( number_format_i18n( $region_total ) ); ?>)</span>
 					<?php endif; ?>
 				</h2>
-				<div class="taxonomy-badges">
-					<?php foreach ( $region_cities as $city ) : ?>
-						<a href="<?php echo esc_url( $city['url'] ); ?>" class="taxonomy-badge location-badge location-<?php echo esc_attr( $city['slug'] ); ?>">
-							<?php echo esc_html( $city['name'] ); ?> (<?php echo esc_html( $city['count'] ); ?>)
-						</a>
-					<?php endforeach; ?>
-				</div>
+				<?php foreach ( $region['states'] as $state_id => $state ) : ?>
+					<section class="cities-state">
+						<h3 class="cities-state-title"><?php echo esc_html( $state['name'] ); ?> <span>(<?php echo esc_html( number_format_i18n( $rollup_by_id[ $state_id ] ?? 0 ) ); ?>)</span></h3>
+						<div class="taxonomy-badges">
+							<?php foreach ( $state['cities'] as $city ) : ?>
+								<a href="<?php echo esc_url( $city['url'] ); ?>" class="taxonomy-badge location-badge location-<?php echo esc_attr( $city['slug'] ); ?>"><?php echo esc_html( $city['name'] ); ?> (<?php echo esc_html( number_format_i18n( $city['count'] ) ); ?>)</a>
+							<?php endforeach; ?>
+						</div>
+					</section>
+				<?php endforeach; ?>
 			</section>
 		<?php endforeach; ?>
 
-		<?php if ( ! empty( $ungrouped ) ) : ?>
-			<section class="cities-region cities-region-other">
-				<h2 class="cities-region-title"><?php esc_html_e( 'Other', 'extrachill-events' ); ?></h2>
-				<div class="taxonomy-badges">
-					<?php foreach ( $ungrouped as $city ) : ?>
-						<a href="<?php echo esc_url( $city['url'] ); ?>" class="taxonomy-badge location-badge location-<?php echo esc_attr( $city['slug'] ); ?>">
-							<?php echo esc_html( $city['name'] ); ?> (<?php echo esc_html( $city['count'] ); ?>)
-						</a>
-					<?php endforeach; ?>
-				</div>
-			</section>
+		<?php if ( empty( $regions ) ) : ?>
+			<p class="cities-directory-empty"><?php esc_html_e( 'No active cities matched your search. Try another city or state.', 'extrachill-events' ); ?></p>
 		<?php endif; ?>
 	</div>
 </div>

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -49,6 +49,12 @@ if ( ! function_exists( 'sanitize_text_field' ) ) {
 	}
 }
 
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $value ) {
+		return filter_var( $value, FILTER_SANITIZE_URL );
+	}
+}
+
 if ( ! function_exists( 'wp_unslash' ) ) {
 	function wp_unslash( $value ) {
 		return $value;
@@ -79,6 +85,72 @@ if ( ! function_exists( 'extrachill_events_is_near_me_page' ) ) {
 	}
 }
 
+if ( ! function_exists( 'extrachill_events_is_all_events_page' ) ) {
+	function extrachill_events_is_all_events_page() {
+		return (bool) ( $GLOBALS['test_is_all_events_page'] ?? false );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_html__' ) ) {
+	function esc_html__( $value ) {
+		return esc_html( $value );
+	}
+}
+
+if ( ! function_exists( 'esc_html_e' ) ) {
+	function esc_html_e( $value ) {
+		echo esc_html( $value );
+	}
+}
+
+if ( ! function_exists( 'esc_attr_e' ) ) {
+	function esc_attr_e( $value ) {
+		echo esc_html( $value );
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $value ) {
+		return esc_html( $value );
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $value ) {
+		return rtrim( $value, '/' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'ec_get_site_url' ) ) {
+	function ec_get_site_url() {
+		return 'https://community.example';
+	}
+}
+
+if ( ! function_exists( 'remove_query_arg' ) ) {
+	function remove_query_arg() {
+		return 'https://events.example/all/';
+	}
+}
+
+if ( ! function_exists( 'add_query_arg' ) ) {
+	function add_query_arg( $key, $value, $url ) {
+		return $url . '?' . rawurlencode( $key ) . '=' . rawurlencode( $value );
+	}
+}
+
+if ( ! function_exists( 'wp_login_url' ) ) {
+	function wp_login_url( $redirect ) {
+		return 'https://events.example/login/?redirect_to=' . rawurlencode( $redirect );
+	}
+}
+
 require_once dirname( __DIR__, 3 ) . '/inc/core/account-market.php';
 
 /**
@@ -101,6 +173,8 @@ final class AccountMarketTest extends TestCase {
 							'lat' => 32.7765,
 							'lon' => -79.9311,
 						),
+						'hierarchy'   => array( 'label' => 'Charleston, South Carolina' ),
+						'archive_url' => 'https://events.example/location/charleston-sc/',
 					),
 				);
 			}
@@ -112,6 +186,8 @@ final class AccountMarketTest extends TestCase {
 				'lon'     => -79.9311,
 				'slug'    => 'charleston-sc',
 				'term_id' => 1618,
+				'label'   => 'Charleston, South Carolina',
+				'url'     => 'https://events.example/location/charleston-sc/',
 			),
 			extrachill_events_get_account_market()
 		);
@@ -185,6 +261,49 @@ final class AccountMarketTest extends TestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
+	public function test_explore_all_suppresses_fallback_without_mutating_preference(): void {
+		$GLOBALS['test_is_user_logged_in']      = true;
+		$GLOBALS['test_is_front_page']          = true;
+		$GLOBALS['test_account_market_ability'] = new class() {
+			public function execute(): array {
+				return array(
+					'default_event_location' => array(
+						'slug'        => 'charleston',
+						'term_id'     => 1618,
+						'coordinates' => array(
+							'lat' => 32.7765,
+							'lon' => -79.9311,
+						),
+					),
+				);
+			}
+		};
+		$_GET = array( 'explore_all' => '1' );
+
+		$this->assertTrue( extrachill_events_is_exploring_all_markets() );
+		$this->assertSame( array(), extrachill_events_calendar_account_market_defaults( array(), array( 'archive_term' => null ) ) );
+		$this->assertSame( 1618, extrachill_events_get_account_market()['term_id'] );
+		$this->assertSame( array( 'explore_all' => '1' ), $_GET );
+
+		ob_start();
+		extrachill_events_render_account_market_context();
+		$output = (string) ob_get_clean();
+		$this->assertStringContainsString( 'Exploring all locations', $output );
+		$this->assertStringContainsString( 'Use my default market', $output );
+	}
+
+	public function test_explore_all_requires_exact_sanitized_flag(): void {
+		$_GET = array( 'explore_all' => 'true' );
+		$this->assertFalse( extrachill_events_is_exploring_all_markets() );
+
+		$_GET = array( 'explore_all' => array( '1' ) );
+		$this->assertFalse( extrachill_events_is_exploring_all_markets() );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function test_near_me_adds_geo_defaults_without_taxonomy_filter(): void {
 		$GLOBALS['test_is_user_logged_in']      = true;
 		$GLOBALS['test_is_near_me_page']        = true;
@@ -214,5 +333,71 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['test_is_user_logged_in'] = false;
 
 		$this->assertNull( extrachill_events_get_account_market() );
+	}
+
+	public function test_supported_surfaces_are_limited_to_primary_discovery_pages(): void {
+		$GLOBALS['test_is_front_page'] = true;
+		$this->assertTrue( extrachill_events_supports_account_market() );
+
+		$GLOBALS['test_is_front_page']     = false;
+		$GLOBALS['test_is_all_events_page'] = true;
+		$this->assertTrue( extrachill_events_supports_account_market() );
+
+		$GLOBALS['test_is_all_events_page'] = false;
+		$GLOBALS['test_is_near_me_page']    = true;
+		$this->assertTrue( extrachill_events_supports_account_market() );
+
+		$GLOBALS['test_is_near_me_page'] = false;
+		$this->assertFalse( extrachill_events_supports_account_market() );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_active_market_context_escapes_label_and_links_to_account_details(): void {
+		$GLOBALS['test_is_user_logged_in']      = true;
+		$GLOBALS['test_is_front_page']          = true;
+		$GLOBALS['test_account_market_ability'] = new class() {
+			public function execute(): array {
+				return array(
+					'default_event_location' => array(
+						'slug'      => 'charleston',
+						'term_id'   => 1618,
+						'hierarchy' => array( 'label' => '<script>Charleston</script>' ),
+					),
+				);
+			}
+		};
+
+		ob_start();
+		extrachill_events_render_account_market_context();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'Showing events for Charleston', $output );
+		$this->assertStringNotContainsString( '<script>', $output );
+		$this->assertStringContainsString( '/settings/#tab-account-details', $output );
+		$this->assertStringContainsString( 'explore_all=1', $output );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_logged_in_without_market_and_anonymous_prompts(): void {
+		$GLOBALS['test_is_front_page']     = true;
+		$GLOBALS['test_is_user_logged_in'] = true;
+
+		ob_start();
+		extrachill_events_render_account_market_context();
+		$logged_in = (string) ob_get_clean();
+		$this->assertStringContainsString( 'Set default market', $logged_in );
+
+		$GLOBALS['test_is_user_logged_in'] = false;
+		ob_start();
+		extrachill_events_render_account_market_context();
+		$anonymous = (string) ob_get_clean();
+		$this->assertStringContainsString( 'Sign in to save a default market', $anonymous );
+		$this->assertStringContainsString( 'events-market-context--quiet', $anonymous );
 	}
 }

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -151,6 +151,12 @@ if ( ! function_exists( 'wp_login_url' ) ) {
 	}
 }
 
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '/' ) {
+		return 'https://events.example' . $path;
+	}
+}
+
 require_once dirname( __DIR__, 3 ) . '/inc/core/account-market.php';
 
 /**
@@ -263,7 +269,7 @@ final class AccountMarketTest extends TestCase {
 	 */
 	public function test_explore_all_suppresses_fallback_without_mutating_preference(): void {
 		$GLOBALS['test_is_user_logged_in']      = true;
-		$GLOBALS['test_is_front_page']          = true;
+		$GLOBALS['test_is_all_events_page']     = true;
 		$GLOBALS['test_account_market_ability'] = new class() {
 			public function execute(): array {
 				return array(
@@ -357,7 +363,7 @@ final class AccountMarketTest extends TestCase {
 	 */
 	public function test_active_market_context_escapes_label_and_links_to_account_details(): void {
 		$GLOBALS['test_is_user_logged_in']      = true;
-		$GLOBALS['test_is_front_page']          = true;
+		$GLOBALS['test_is_all_events_page']     = true;
 		$GLOBALS['test_account_market_ability'] = new class() {
 			public function execute(): array {
 				return array(
@@ -389,15 +395,47 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['test_is_user_logged_in'] = true;
 
 		ob_start();
-		extrachill_events_render_account_market_context();
+		extrachill_events_render_home_market_router();
 		$logged_in = (string) ob_get_clean();
 		$this->assertStringContainsString( 'Set default market', $logged_in );
 
 		$GLOBALS['test_is_user_logged_in'] = false;
 		ob_start();
-		extrachill_events_render_account_market_context();
+		extrachill_events_render_home_market_router();
 		$anonymous = (string) ob_get_clean();
-		$this->assertStringContainsString( 'Sign in to save a default market', $anonymous );
-		$this->assertStringContainsString( 'events-market-context--quiet', $anonymous );
+		$this->assertStringContainsString( 'Pick a city below', $anonymous );
+		$this->assertStringContainsString( 'Sign in', $anonymous );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_homepage_promotes_saved_market_as_primary_city_route(): void {
+		$GLOBALS['test_is_user_logged_in']      = true;
+		$GLOBALS['test_is_front_page']          = true;
+		$GLOBALS['test_account_market_ability'] = new class() {
+			public function execute(): array {
+				return array(
+					'default_event_location' => array(
+						'slug'        => 'charleston',
+						'term_id'     => 1618,
+						'hierarchy'   => array( 'label' => 'Charleston, South Carolina' ),
+						'archive_url' => 'https://events.example/location/charleston/',
+					),
+				);
+			}
+		};
+
+		ob_start();
+		extrachill_events_render_home_market_router();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'Your default market', $output );
+		$this->assertStringContainsString( 'Charleston, South Carolina', $output );
+		$this->assertStringContainsString( 'https://events.example/location/charleston/', $output );
+		$this->assertStringContainsString( 'View local events', $output );
+		$this->assertStringContainsString( 'Or explore another location:', $output );
+		$this->assertStringNotContainsString( 'Showing events for', $output );
 	}
 }

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -13,6 +13,12 @@ if ( ! function_exists( 'add_filter' ) ) {
 	}
 }
 
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action() {
+		return true;
+	}
+}
+
 if ( ! function_exists( 'is_user_logged_in' ) ) {
 	function is_user_logged_in() {
 		return (bool) ( $GLOBALS['test_is_user_logged_in'] ?? false );
@@ -85,9 +91,18 @@ if ( ! function_exists( 'extrachill_events_is_near_me_page' ) ) {
 	}
 }
 
-if ( ! function_exists( 'extrachill_events_is_all_events_page' ) ) {
-	function extrachill_events_is_all_events_page() {
-		return (bool) ( $GLOBALS['test_is_all_events_page'] ?? false );
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $name, $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'get_query_var' ) ) {
+	function get_query_var( $name, $default = '' ) {
+		if ( 'ec_events_router' === $name && ! empty( $GLOBALS['test_is_all_events_page'] ) ) {
+			return 'all';
+		}
+		return $default;
 	}
 }
 
@@ -103,6 +118,24 @@ if ( ! function_exists( 'esc_html__' ) ) {
 	}
 }
 
+if ( ! function_exists( '__' ) ) {
+	function __( $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( '_n' ) ) {
+	function _n( $single, $plural, $number ) {
+		return 1 === (int) $number ? $single : $plural;
+	}
+}
+
+if ( ! function_exists( 'number_format_i18n' ) ) {
+	function number_format_i18n( $number ) {
+		return number_format( (int) $number );
+	}
+}
+
 if ( ! function_exists( 'esc_html_e' ) ) {
 	function esc_html_e( $value ) {
 		echo esc_html( $value );
@@ -112,6 +145,12 @@ if ( ! function_exists( 'esc_html_e' ) ) {
 if ( ! function_exists( 'esc_attr_e' ) ) {
 	function esc_attr_e( $value ) {
 		echo esc_html( $value );
+	}
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $value ) {
+		return esc_html( $value );
 	}
 }
 
@@ -157,6 +196,7 @@ if ( ! function_exists( 'home_url' ) ) {
 	}
 }
 
+require_once dirname( __DIR__, 3 ) . '/inc/core/router-pages.php';
 require_once dirname( __DIR__, 3 ) . '/inc/core/account-market.php';
 
 /**
@@ -357,6 +397,10 @@ final class AccountMarketTest extends TestCase {
 		$this->assertFalse( extrachill_events_supports_account_market() );
 	}
 
+	public function test_location_directory_is_enabled_by_default(): void {
+		$this->assertTrue( extrachill_events_location_directory_enabled() );
+	}
+
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -395,15 +439,15 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['test_is_user_logged_in'] = true;
 
 		ob_start();
-		extrachill_events_render_home_market_router();
+		extrachill_events_render_home_market_router( array() );
 		$logged_in = (string) ob_get_clean();
 		$this->assertStringContainsString( 'Set default market', $logged_in );
 
 		$GLOBALS['test_is_user_logged_in'] = false;
 		ob_start();
-		extrachill_events_render_home_market_router();
+		extrachill_events_render_home_market_router( array() );
 		$anonymous = (string) ob_get_clean();
-		$this->assertStringContainsString( 'Pick a city below', $anonymous );
+		$this->assertStringContainsString( 'Search without an account', $anonymous );
 		$this->assertStringContainsString( 'Sign in', $anonymous );
 	}
 
@@ -428,14 +472,36 @@ final class AccountMarketTest extends TestCase {
 		};
 
 		ob_start();
-		extrachill_events_render_home_market_router();
+		extrachill_events_render_home_market_router(
+			array(
+				array(
+					'term_id' => 1618,
+					'name'    => 'Charleston',
+					'label'   => 'Charleston, South Carolina',
+					'slug'    => 'charleston',
+					'count'   => 883,
+					'url'     => 'https://events.example/location/charleston/',
+				),
+				array(
+					'term_id' => 42,
+					'name'    => 'Austin',
+					'label'   => 'Austin, Texas',
+					'slug'    => 'austin',
+					'count'   => 1458,
+					'url'     => 'https://events.example/location/austin/',
+				),
+			)
+		);
 		$output = (string) ob_get_clean();
 
-		$this->assertStringContainsString( 'Your default market', $output );
+		$this->assertStringContainsString( 'Your market', $output );
 		$this->assertStringContainsString( 'Charleston, South Carolina', $output );
 		$this->assertStringContainsString( 'https://events.example/location/charleston/', $output );
-		$this->assertStringContainsString( 'View local events', $output );
-		$this->assertStringContainsString( 'Or explore another location:', $output );
+		$this->assertStringContainsString( '883 upcoming events', $output );
+		$this->assertStringContainsString( 'location/charleston/tonight/', $output );
+		$this->assertStringContainsString( 'location/charleston/this-weekend/', $output );
+		$this->assertStringContainsString( 'Austin, Texas', $output );
+		$this->assertStringContainsString( 'Browse all locations', $output );
 		$this->assertStringNotContainsString( 'Showing events for', $output );
 	}
 }


### PR DESCRIPTION
## Summary
- replace the exhaustive homepage badge wall with a progressive, taxonomy-driven market router
- enable and harden the existing public `/location/` regional directory
- keep visible account-default context and reversible `explore_all=1` suppression on the actual calendar surfaces, `/all/` and `/near-me/`

## Progressive homepage router
The homepage remains a glanceable router, not a calendar. Its discovery progression is now:

`preferred/search -> 8 alternatives -> regional directory -> /all`

- **Public search:** a native keyboard-accessible city/state search form works without login and submits to `/location/?search=...`.
- **Saved market:** a primary card uses the Users-owned resolved hierarchy label, live upcoming count, and verified taxonomy routes for **Tonight**, **This Weekend**, and the full city calendar. The saved market is excluded from the alternative sample.
- **No saved market:** concise choose-your-market framing offers optional account setup without blocking search or browsing.
- **Alternatives:** up to eight active markets come from live upcoming counts and the location taxonomy, preserving the existing activity threshold without hardcoded curation.
- **Next paths:** **Browse all locations** leads to `/location/`; **See every event** leads to the `/all/` firehose.
- Existing **My Shows** and **Submit Event** feature cards remain in place.

## Location directory
- Enables the existing `/location/` virtual route by default and performs a one-time rewrite refresh on update.
- Revalidates every upcoming-count row against the canonical selectable-city hierarchy before display.
- Includes only canonical cities with upcoming events.
- Groups dynamically by taxonomy region and then state/province, ordered by live rolled-up counts.
- Supports public city/state/region search with escaped input, result status text, and an empty-result state.
- Uses responsive layouts and native form controls for mobile and keyboard usability.

No city or region is manually curated. Homepage, search, preferred counts, alternatives, and directory all consume the same taxonomy/count-driven source.

## Calendar personalization
On `/all/` and `/near-me/` only:
- active defaults show the resolved market with **Change default** and **Explore all locations**
- no-default accounts get a compact setup prompt
- anonymous users get a quiet optional sign-in prompt
- `explore_all=1` suppresses account calendar fallback, map centering, and Near Me account bootstrap for that request without mutating the saved preference

Explicit archives, taxonomy filters, URL coordinates, browser geolocation, and calendar choices continue to outrank account defaults. Embedded calendars and location archives do not receive duplicate context.

## Ownership and settings
- `extrachill-users` owns preference persistence and resolved market data.
- `extrachill-events` owns router/directory presentation and fallback consumption.
- `data-machine-events` remains generic; no new generic hooks or selector infrastructure were added.
- Community settings links use the verified `/settings/#tab-account-details` hash contract.

## Verification
- `vendor/bin/phpunit tests/Unit/Core/AccountMarketTest.php`: **13 tests, 41 assertions, pass**
- `homeboy review extrachill-events lint --changed-only`: **pass, no findings**
- PHP syntax checks for all changed PHP files: **pass**
- `npm run build`: **pass**
- `git diff --check`: **pass**
- Full `vendor/bin/phpunit`: **146/150 pass**; the same four existing `QualifyRecheckHandlerTest` failures remain outside this change
- Live route checks confirmed the canonical Charleston `/tonight/` and `/this-weekend/` discovery URLs and the existing `/all/` rewrite registration

## Render evidence
The live homepage was inspected before implementation to confirm its actual structure: heading/stats, badge wall, `/all/`, feature cards, and empty static content. Focused render tests cover saved-market count/routes, alternative exclusion/context, no-default and anonymous public access, calendar context, explore-all reversibility, settings destination, and escaping.

Closes #239