### PR TITLE
fix: prevent virtual event router 404s

### DIFF
--- a/inc/core/router-pages.php
+++ b/inc/core/router-pages.php
@@ -143,6 +143,25 @@ function extrachill_events_is_router_page(): bool {
 }
 
 /**
+ * Whether a query targets one of the registered virtual router pages.
+ *
+ * @param \WP_Query $query Query being parsed or handled.
+ * @return bool
+ */
+function extrachill_events_query_is_router_page( $query ): bool {
+	if ( ! ec_is_events_site() ) {
+		return false;
+	}
+
+	if ( 'all' === $query->get( 'ec_events_router', '' ) ) {
+		return true;
+	}
+
+	return extrachill_events_location_directory_enabled()
+		&& '1' === (string) $query->get( 'ec_events_location_index', '' );
+}
+
+/**
  * Route the request to the matching virtual-page template.
  *
  * Runs at priority 20 (after the events archive override at 10 and the
@@ -178,16 +197,33 @@ function extrachill_events_router_query_flags( $query ) {
 	if ( ! $query->is_main_query() || is_admin() ) {
 		return;
 	}
-	if ( ! extrachill_events_is_router_page() ) {
+	if ( ! extrachill_events_query_is_router_page( $query ) ) {
 		return;
 	}
 
 	$query->is_404     = false;
 	$query->is_archive = true;
 	$query->is_home    = false;
-	status_header( 200 );
 }
 add_action( 'parse_query', 'extrachill_events_router_query_flags' );
+
+/**
+ * Prevent core from classifying an empty virtual-page query as a 404.
+ *
+ * @hook pre_handle_404
+ * @param bool|null $preempt Existing 404 preemption result.
+ * @param \WP_Query $query   Main query.
+ * @return bool|null
+ */
+function extrachill_events_router_pre_handle_404( $preempt, $query ) {
+	if ( ! extrachill_events_query_is_router_page( $query ) ) {
+		return $preempt;
+	}
+
+	status_header( 200 );
+	return true;
+}
+add_filter( 'pre_handle_404', 'extrachill_events_router_pre_handle_404', 10, 2 );
 
 /**
  * Document title for the virtual pages.

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -79,6 +79,18 @@ if ( ! function_exists( 'is_front_page' ) ) {
 	}
 }
 
+if ( ! function_exists( 'is_admin' ) ) {
+	function is_admin() {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'status_header' ) ) {
+	function status_header( $code ) {
+		$GLOBALS['test_status_header'] = $code;
+	}
+}
+
 if ( ! function_exists( 'ec_is_events_site' ) ) {
 	function ec_is_events_site() {
 		return true;
@@ -399,6 +411,54 @@ final class AccountMarketTest extends TestCase {
 
 	public function test_location_directory_is_enabled_by_default(): void {
 		$this->assertTrue( extrachill_events_location_directory_enabled() );
+	}
+
+	public function test_router_query_flags_use_the_query_being_parsed(): void {
+		$query = new class( array( 'ec_events_router' => 'all' ) ) {
+			public bool $is_404 = true;
+			public bool $is_archive = false;
+			public bool $is_home = true;
+			private array $vars;
+
+			public function __construct( array $vars ) {
+				$this->vars = $vars;
+			}
+
+			public function get( $key, $default = '' ) {
+				return $this->vars[ $key ] ?? $default;
+			}
+
+			public function is_main_query(): bool {
+				return true;
+			}
+		};
+
+		extrachill_events_router_query_flags( $query );
+
+		$this->assertFalse( $query->is_404 );
+		$this->assertTrue( $query->is_archive );
+		$this->assertFalse( $query->is_home );
+	}
+
+	public function test_router_pages_preempt_core_404_handling(): void {
+		$query = new class() {
+			public function get( $key, $default = '' ) {
+				return 'ec_events_location_index' === $key ? '1' : $default;
+			}
+		};
+
+		$this->assertTrue( extrachill_events_router_pre_handle_404( false, $query ) );
+		$this->assertSame( 200, $GLOBALS['test_status_header'] );
+	}
+
+	public function test_unrelated_queries_preserve_core_404_handling(): void {
+		$query = new class() {
+			public function get( $key, $default = '' ) {
+				return $default;
+			}
+		};
+
+		$this->assertNull( extrachill_events_router_pre_handle_404( null, $query ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- detect virtual router pages from the `WP_Query` currently being parsed rather than premature global query state
- preempt WordPress core's empty-query 404 handling for only `/all/` and `/location/`
- add regressions for query flags, location-directory 404 preemption, and unrelated request pass-through

## Verification
- `php -l inc/core/router-pages.php`
- `php -l tests/Unit/Core/AccountMarketTest.php`
- `vendor/bin/phpunit --filter 'router_(query_flags|pages_preempt|unrelated)' tests/Unit/Core/AccountMarketTest.php` (`2 tests, 5 assertions`)
- `git diff --check`

Fixes #241