### PR TITLE
feat: connect Events to Local Scene

### DIFF
--- a/inc/core/account-market.php
+++ b/inc/core/account-market.php
@@ -14,11 +14,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Get the current user's resolved default event location.
+ * Get the current user's resolved Local Scene.
  *
- * The Ability contract is provided by extrachill-users#179. Until that
- * dependency is available, or when it returns an invalid/empty preference,
- * this fails open.
+ * When the Users Ability is unavailable or returns an invalid/empty
+ * preference, this fails open.
  *
  * @return array{lat: float|null, lon: float|null, slug: string, term_id: int, label: string, url: string}|null
  */
@@ -41,11 +40,11 @@ function extrachill_events_get_account_market(): ?array {
 	}
 
 	$result = $ability->execute( array() );
-	if ( is_wp_error( $result ) || ! is_array( $result ) || ! is_array( $result['default_event_location'] ?? null ) ) {
+	if ( is_wp_error( $result ) || ! is_array( $result ) || ! is_array( $result['local_scene'] ?? null ) ) {
 		return null;
 	}
 
-	$location    = $result['default_event_location'];
+	$location    = $result['local_scene'];
 	$coordinates = is_array( $location['coordinates'] ?? null ) ? $location['coordinates'] : array();
 	$lat         = filter_var( $coordinates['lat'] ?? null, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE );
 	$lon         = filter_var( $coordinates['lon'] ?? null, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE );
@@ -215,7 +214,7 @@ function extrachill_events_render_account_market_context(): void {
 		<div class="events-market-context__copy">
 			<?php if ( $market && $is_exploring ) : ?>
 				<strong><?php esc_html_e( 'Exploring all locations', 'extrachill-events' ); ?></strong>
-				<span><?php esc_html_e( 'Your saved market is still available whenever you want to focus the calendar again.', 'extrachill-events' ); ?></span>
+				<span><?php esc_html_e( 'Your Local Scene is still available whenever you want to focus the calendar again.', 'extrachill-events' ); ?></span>
 			<?php elseif ( $market ) : ?>
 				<strong>
 					<?php
@@ -228,20 +227,20 @@ function extrachill_events_render_account_market_context(): void {
 				</strong>
 			<?php elseif ( $is_logged_in ) : ?>
 				<strong><?php esc_html_e( 'Focus Events around your city', 'extrachill-events' ); ?></strong>
-				<span><?php esc_html_e( 'Set a default market once and use it across devices.', 'extrachill-events' ); ?></span>
+				<span><?php esc_html_e( 'Set your Local Scene once and use it across devices.', 'extrachill-events' ); ?></span>
 			<?php else : ?>
-				<span><?php esc_html_e( 'Sign in to save a default market across devices.', 'extrachill-events' ); ?></span>
+				<span><?php esc_html_e( 'Sign in to save your Local Scene across devices.', 'extrachill-events' ); ?></span>
 			<?php endif; ?>
 		</div>
 		<div class="events-market-context__actions">
 			<?php if ( $market && $is_exploring ) : ?>
-				<a href="<?php echo esc_url( $current_url ); ?>"><?php esc_html_e( 'Use my default market', 'extrachill-events' ); ?></a>
-				<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Change default', 'extrachill-events' ); ?></a>
+				<a href="<?php echo esc_url( $current_url ); ?>"><?php esc_html_e( 'Use my Local Scene', 'extrachill-events' ); ?></a>
+				<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Change Local Scene', 'extrachill-events' ); ?></a>
 			<?php elseif ( $market ) : ?>
-				<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Change default', 'extrachill-events' ); ?></a>
+				<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Change Local Scene', 'extrachill-events' ); ?></a>
 				<a href="<?php echo esc_url( $explore_url ); ?>"><?php esc_html_e( 'Explore all locations', 'extrachill-events' ); ?></a>
 			<?php elseif ( $is_logged_in ) : ?>
-				<a class="button-1 button-small" href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Set default market', 'extrachill-events' ); ?></a>
+				<a class="button-1 button-small" href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Set Local Scene', 'extrachill-events' ); ?></a>
 			<?php else : ?>
 				<a href="<?php echo esc_url( wp_login_url( $current_url ) ); ?>"><?php esc_html_e( 'Sign in', 'extrachill-events' ); ?></a>
 			<?php endif; ?>
@@ -286,13 +285,13 @@ function extrachill_events_render_home_market_router( array $locations ): void {
 	<section class="events-home-router ec-edge-gutter" aria-labelledby="events-market-heading">
 		<div class="events-home-router__heading">
 		<?php if ( $market ) : ?>
-			<h2 id="events-market-heading"><?php esc_html_e( 'Your market', 'extrachill-events' ); ?></h2>
+			<h2 id="events-market-heading"><?php esc_html_e( 'Your Local Scene', 'extrachill-events' ); ?></h2>
 		<?php elseif ( $is_logged_in ) : ?>
-			<h2 id="events-market-heading"><?php esc_html_e( 'Choose your market', 'extrachill-events' ); ?></h2>
-			<p><?php esc_html_e( 'Find a city now, or set a default to put it first on every visit.', 'extrachill-events' ); ?> <a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Set default market', 'extrachill-events' ); ?></a></p>
+			<h2 id="events-market-heading"><?php esc_html_e( 'Choose your Local Scene', 'extrachill-events' ); ?></h2>
+			<p><?php esc_html_e( 'Find a city now, or set your Local Scene to put it first on every visit.', 'extrachill-events' ); ?> <a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Set Local Scene', 'extrachill-events' ); ?></a></p>
 		<?php else : ?>
 			<h2 id="events-market-heading"><?php esc_html_e( 'Find your city', 'extrachill-events' ); ?></h2>
-			<p><?php esc_html_e( 'Search without an account.', 'extrachill-events' ); ?> <a href="<?php echo esc_url( wp_login_url( home_url( '/' ) ) ); ?>"><?php esc_html_e( 'Sign in to save a default', 'extrachill-events' ); ?></a></p>
+			<p><?php esc_html_e( 'Search without an account.', 'extrachill-events' ); ?> <a href="<?php echo esc_url( wp_login_url( home_url( '/' ) ) ); ?>"><?php esc_html_e( 'Sign in to save your Local Scene', 'extrachill-events' ); ?></a></p>
 		<?php endif; ?>
 		</div>
 
@@ -307,24 +306,24 @@ function extrachill_events_render_home_market_router( array $locations ): void {
 		<?php if ( $market ) : ?>
 			<article class="events-primary-market">
 				<div>
-					<span class="events-primary-market__eyebrow"><?php esc_html_e( 'Your default market', 'extrachill-events' ); ?></span>
+					<span class="events-primary-market__eyebrow"><?php esc_html_e( 'Your Local Scene', 'extrachill-events' ); ?></span>
 					<h3><?php echo esc_html( '' !== $market['label'] ? $market['label'] : $market['slug'] ); ?></h3>
 					<?php if ( $market_count > 0 ) : ?>
 						<p><?php echo esc_html( sprintf( /* translators: %s: Number of upcoming events. */ _n( '%s upcoming event', '%s upcoming events', $market_count, 'extrachill-events' ), number_format_i18n( $market_count ) ) ); ?></p>
 					<?php endif; ?>
 				</div>
-				<nav class="events-primary-market__links" aria-label="<?php esc_attr_e( 'Default market event views', 'extrachill-events' ); ?>">
+				<nav class="events-primary-market__links" aria-label="<?php esc_attr_e( 'Local Scene event views', 'extrachill-events' ); ?>">
 					<a href="<?php echo esc_url( trailingslashit( $market['url'] ) . 'tonight/' ); ?>"><?php esc_html_e( 'Tonight', 'extrachill-events' ); ?></a>
 					<a href="<?php echo esc_url( trailingslashit( $market['url'] ) . 'this-weekend/' ); ?>"><?php esc_html_e( 'This Weekend', 'extrachill-events' ); ?></a>
 					<a href="<?php echo esc_url( $market['url'] ); ?>"><?php esc_html_e( 'City calendar', 'extrachill-events' ); ?></a>
-					<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Change default', 'extrachill-events' ); ?></a>
+					<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Change Local Scene', 'extrachill-events' ); ?></a>
 				</nav>
 			</article>
 		<?php endif; ?>
 
 		<?php if ( $sample ) : ?>
 			<div class="events-market-sample">
-				<h3><?php echo esc_html( $market ? __( 'Explore other active markets', 'extrachill-events' ) : __( 'Active markets', 'extrachill-events' ) ); ?></h3>
+				<h3><?php echo esc_html( $market ? __( 'Explore other active scenes', 'extrachill-events' ) : __( 'Active scenes', 'extrachill-events' ) ); ?></h3>
 				<div class="taxonomy-badges">
 					<?php foreach ( $sample as $location ) : ?>
 						<a href="<?php echo esc_url( $location['url'] ); ?>" class="taxonomy-badge location-badge location-<?php echo esc_attr( $location['slug'] ); ?>"><?php echo esc_html( $location['label'] ); ?> (<?php echo esc_html( number_format_i18n( $location['count'] ) ); ?>)</a>
@@ -340,3 +339,102 @@ function extrachill_events_render_home_market_router( array $locations ): void {
 	</section>
 	<?php
 }
+
+/**
+ * Get a selectable city from the current location archive.
+ */
+function extrachill_events_get_archive_scene_term(): ?WP_Term {
+	if ( ! is_tax( 'location' ) ) {
+		return null;
+	}
+
+	$term = get_queried_object();
+	if ( ! $term instanceof WP_Term || count( get_ancestors( $term->term_id, 'location', 'taxonomy' ) ) < 2 ) {
+		return null;
+	}
+
+	return $term;
+}
+
+/**
+ * Save an explicitly selected archive city through the Users settings Ability.
+ *
+ * @param WP_Term $term  Selected city term.
+ * @param string  $nonce Submitted nonce.
+ * @return bool Whether the preference was saved.
+ */
+function extrachill_events_update_archive_scene( WP_Term $term, string $nonce ): bool {
+	if ( ! is_user_logged_in() || ! wp_verify_nonce( $nonce, 'extrachill_events_save_scene_' . $term->term_id ) || ! function_exists( 'wp_get_ability' ) ) {
+		return false;
+	}
+
+	$ability = wp_get_ability( 'extrachill/update-user-settings' );
+	if ( ! $ability ) {
+		return false;
+	}
+
+	return ! is_wp_error( $ability->execute( array( 'local_scene' => $term->slug ) ) );
+}
+
+/**
+ * Handle the archive Local Scene form submission.
+ */
+function extrachill_events_handle_archive_scene_update(): void {
+	$term = extrachill_events_get_archive_scene_term();
+	if ( null === $term || 'POST' !== ( $_SERVER['REQUEST_METHOD'] ?? '' ) || ! isset( $_POST['extrachill_events_scene_action'] ) ) {
+		return;
+	}
+
+	$nonce  = isset( $_POST['extrachill_events_scene_nonce'] ) && is_scalar( $_POST['extrachill_events_scene_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['extrachill_events_scene_nonce'] ) ) : '';
+	$status = extrachill_events_update_archive_scene( $term, $nonce ) ? 'saved' : 'failed';
+	wp_safe_redirect( add_query_arg( 'scene_status', $status, get_term_link( $term ) ) );
+	exit;
+}
+add_action( 'template_redirect', 'extrachill_events_handle_archive_scene_update', 5 );
+
+/**
+ * Render an explicit Local Scene choice on selectable city archives.
+ */
+function extrachill_events_render_archive_scene_cta(): void {
+	$term = extrachill_events_get_archive_scene_term();
+	if ( null === $term ) {
+		return;
+	}
+
+	$archive_url  = get_term_link( $term );
+	$is_logged_in = is_user_logged_in();
+	$current      = extrachill_events_get_account_market();
+	$is_current   = $current && (int) $current['term_id'] === (int) $term->term_id;
+	$status       = isset( $_GET['scene_status'] ) && is_scalar( $_GET['scene_status'] ) ? sanitize_text_field( wp_unslash( $_GET['scene_status'] ) ) : '';
+
+	if ( $is_logged_in ) {
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', true );
+		}
+		nocache_headers();
+	}
+	?>
+	<aside class="events-market-context<?php echo $is_logged_in ? '' : ' events-market-context--quiet'; ?>" aria-label="<?php esc_attr_e( 'Local Scene preference', 'extrachill-events' ); ?>" role="status">
+		<div class="events-market-context__copy">
+			<strong><?php echo esc_html( sprintf( /* translators: %s: City name. */ __( 'Is %s your local scene?', 'extrachill-events' ), $term->name ) ); ?></strong>
+			<?php if ( 'failed' === $status ) : ?>
+				<span><?php esc_html_e( 'We could not update your Local Scene. Please try again.', 'extrachill-events' ); ?></span>
+			<?php elseif ( $is_current || 'saved' === $status ) : ?>
+				<span><?php esc_html_e( 'This is your Local Scene.', 'extrachill-events' ); ?></span>
+			<?php endif; ?>
+		</div>
+		<div class="events-market-context__actions">
+			<?php if ( ! $is_logged_in ) : ?>
+				<a class="button-1 button-small" href="<?php echo esc_url( wp_login_url( $archive_url ) ); ?>"><?php esc_html_e( 'Sign in to save', 'extrachill-events' ); ?></a>
+			<?php elseif ( ! $is_current && 'saved' !== $status ) : ?>
+				<form method="post" action="<?php echo esc_url( $archive_url ); ?>">
+					<?php wp_nonce_field( 'extrachill_events_save_scene_' . $term->term_id, 'extrachill_events_scene_nonce' ); ?>
+					<input type="hidden" name="extrachill_events_scene_action" value="save">
+					<button class="button-1 button-small" type="submit"><?php esc_html_e( 'Make this my Local Scene', 'extrachill-events' ); ?></button>
+				</form>
+			<?php endif; ?>
+		</div>
+	</aside>
+	<?php
+}
+add_action( 'extrachill_archive_below_description', 'extrachill_events_render_archive_scene_cta', 4 );

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -27,7 +27,10 @@ if ( ! function_exists( 'is_user_logged_in' ) ) {
 
 if ( ! function_exists( 'wp_get_ability' ) ) {
 	function wp_get_ability( $name ) {
-		return 'extrachill/get-user-settings' === $name ? ( $GLOBALS['test_account_market_ability'] ?? null ) : null;
+		if ( 'extrachill/get-user-settings' === $name ) {
+			return $GLOBALS['test_account_market_ability'] ?? null;
+		}
+		return 'extrachill/update-user-settings' === $name ? ( $GLOBALS['test_update_scene_ability'] ?? null ) : null;
 	}
 }
 
@@ -208,6 +211,55 @@ if ( ! function_exists( 'home_url' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_Term' ) ) {
+	class WP_Term {
+		public int $term_id;
+		public string $name;
+		public string $slug;
+		public function __construct( int $term_id, string $name, string $slug ) {
+			$this->term_id = $term_id;
+			$this->name    = $name;
+			$this->slug    = $slug;
+		}
+	}
+}
+
+if ( ! function_exists( 'get_queried_object' ) ) {
+	function get_queried_object() {
+		return $GLOBALS['test_queried_term'] ?? null;
+	}
+}
+
+if ( ! function_exists( 'get_ancestors' ) ) {
+	function get_ancestors() {
+		return $GLOBALS['test_term_ancestors'] ?? array();
+	}
+}
+
+if ( ! function_exists( 'get_term_link' ) ) {
+	function get_term_link( $term ) {
+		return 'https://events.example/location/' . $term->slug . '/';
+	}
+}
+
+if ( ! function_exists( 'wp_nonce_field' ) ) {
+	function wp_nonce_field( $action, $name ) {
+		echo '<input type="hidden" name="' . esc_attr( $name ) . '" value="nonce-' . esc_attr( $action ) . '">';
+	}
+}
+
+if ( ! function_exists( 'nocache_headers' ) ) {
+	function nocache_headers() {
+		$GLOBALS['test_nocache_headers'] = true;
+	}
+}
+
+if ( ! function_exists( 'wp_verify_nonce' ) ) {
+	function wp_verify_nonce( $nonce, $action ) {
+		return $nonce === 'nonce-' . $action;
+	}
+}
+
 require_once dirname( __DIR__, 3 ) . '/inc/core/router-pages.php';
 require_once dirname( __DIR__, 3 ) . '/inc/core/account-market.php';
 
@@ -224,7 +276,7 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['test_account_market_ability'] = new class() {
 			public function execute(): array {
 				return array(
-					'default_event_location' => array(
+					'local_scene' => array(
 						'slug'        => 'Charleston SC',
 						'term_id'     => 1618,
 						'coordinates' => array(
@@ -271,7 +323,7 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['test_account_market_ability'] = new class() {
 			public function execute(): array {
 				return array(
-					'default_event_location' => array(
+					'local_scene' => array(
 						'slug'        => 'charleston',
 						'term_id'     => 1618,
 						'coordinates' => array(
@@ -325,7 +377,7 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['test_account_market_ability'] = new class() {
 			public function execute(): array {
 				return array(
-					'default_event_location' => array(
+					'local_scene' => array(
 						'slug'        => 'charleston',
 						'term_id'     => 1618,
 						'coordinates' => array(
@@ -347,7 +399,7 @@ final class AccountMarketTest extends TestCase {
 		extrachill_events_render_account_market_context();
 		$output = (string) ob_get_clean();
 		$this->assertStringContainsString( 'Exploring all locations', $output );
-		$this->assertStringContainsString( 'Use my default market', $output );
+		$this->assertStringContainsString( 'Use my Local Scene', $output );
 	}
 
 	public function test_explore_all_requires_exact_sanitized_flag(): void {
@@ -368,7 +420,7 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['test_account_market_ability'] = new class() {
 			public function execute(): array {
 				return array(
-					'default_event_location' => array(
+					'local_scene' => array(
 						'slug'        => 'charleston',
 						'term_id'     => 1618,
 						'coordinates' => array(
@@ -471,7 +523,7 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['test_account_market_ability'] = new class() {
 			public function execute(): array {
 				return array(
-					'default_event_location' => array(
+					'local_scene' => array(
 						'slug'      => 'charleston',
 						'term_id'   => 1618,
 						'hierarchy' => array( 'label' => '<script>Charleston</script>' ),
@@ -501,7 +553,7 @@ final class AccountMarketTest extends TestCase {
 		ob_start();
 		extrachill_events_render_home_market_router( array() );
 		$logged_in = (string) ob_get_clean();
-		$this->assertStringContainsString( 'Set default market', $logged_in );
+		$this->assertStringContainsString( 'Set Local Scene', $logged_in );
 
 		$GLOBALS['test_is_user_logged_in'] = false;
 		ob_start();
@@ -521,7 +573,7 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['test_account_market_ability'] = new class() {
 			public function execute(): array {
 				return array(
-					'default_event_location' => array(
+					'local_scene' => array(
 						'slug'        => 'charleston',
 						'term_id'     => 1618,
 						'hierarchy'   => array( 'label' => 'Charleston, South Carolina' ),
@@ -554,7 +606,7 @@ final class AccountMarketTest extends TestCase {
 		);
 		$output = (string) ob_get_clean();
 
-		$this->assertStringContainsString( 'Your market', $output );
+		$this->assertStringContainsString( 'Your Local Scene', $output );
 		$this->assertStringContainsString( 'Charleston, South Carolina', $output );
 		$this->assertStringContainsString( 'https://events.example/location/charleston/', $output );
 		$this->assertStringContainsString( '883 upcoming events', $output );
@@ -563,5 +615,97 @@ final class AccountMarketTest extends TestCase {
 		$this->assertStringContainsString( 'Austin, Texas', $output );
 		$this->assertStringContainsString( 'Browse all locations', $output );
 		$this->assertStringNotContainsString( 'Showing events for', $output );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_archive_cta_only_renders_for_selectable_city(): void {
+		$GLOBALS['test_is_tax']         = true;
+		$GLOBALS['test_queried_term']   = new WP_Term( 1618, 'Charleston', 'charleston' );
+		$GLOBALS['test_term_ancestors'] = array( 22 );
+
+		ob_start();
+		extrachill_events_render_archive_scene_cta();
+		$this->assertSame( '', (string) ob_get_clean() );
+
+		$GLOBALS['test_term_ancestors'] = array( 22, 1 );
+		ob_start();
+		extrachill_events_render_archive_scene_cta();
+		$output = (string) ob_get_clean();
+		$this->assertStringContainsString( 'Is Charleston your local scene?', $output );
+		$this->assertStringContainsString( 'Sign in to save', $output );
+		$this->assertStringContainsString( rawurlencode( 'https://events.example/location/charleston/' ), $output );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_archive_cta_shows_save_form_or_current_confirmation(): void {
+		$GLOBALS['test_is_tax']           = true;
+		$GLOBALS['test_is_user_logged_in'] = true;
+		$GLOBALS['test_queried_term']     = new WP_Term( 1618, 'Charleston', 'charleston' );
+		$GLOBALS['test_term_ancestors']   = array( 22, 1 );
+
+		ob_start();
+		extrachill_events_render_archive_scene_cta();
+		$output = (string) ob_get_clean();
+		$this->assertStringContainsString( 'Make this my Local Scene', $output );
+		$this->assertStringContainsString( 'extrachill_events_scene_nonce', $output );
+		$this->assertTrue( $GLOBALS['test_nocache_headers'] );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_archive_cta_confirms_current_scene_without_save_form(): void {
+		$GLOBALS['test_is_tax']           = true;
+		$GLOBALS['test_is_user_logged_in'] = true;
+		$GLOBALS['test_queried_term']     = new WP_Term( 1618, 'Charleston', 'charleston' );
+		$GLOBALS['test_term_ancestors']   = array( 22, 1 );
+		$GLOBALS['test_account_market_ability'] = new class() {
+			public function execute(): array {
+				return array(
+					'local_scene' => array(
+						'slug'    => 'charleston',
+						'term_id' => 1618,
+					),
+				);
+			}
+		};
+
+		ob_start();
+		extrachill_events_render_archive_scene_cta();
+		$output = (string) ob_get_clean();
+		$this->assertStringContainsString( 'This is your Local Scene.', $output );
+		$this->assertStringNotContainsString( 'Make this my Local Scene', $output );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_archive_update_requires_login_and_nonce_and_uses_settings_ability(): void {
+		$term = new WP_Term( 1618, 'Charleston', 'charleston' );
+		$calls = new ArrayObject();
+		$GLOBALS['test_update_scene_ability'] = new class( $calls ) {
+			private ArrayObject $calls;
+			public function __construct( ArrayObject $calls ) {
+				$this->calls = $calls;
+			}
+			public function execute( array $input ): array {
+				$this->calls[] = $input;
+				return array( 'local_scene' => $input['local_scene'] );
+			}
+		};
+
+		$this->assertFalse( extrachill_events_update_archive_scene( $term, 'nonce-extrachill_events_save_scene_1618' ) );
+		$GLOBALS['test_is_user_logged_in'] = true;
+		$this->assertFalse( extrachill_events_update_archive_scene( $term, 'wrong' ) );
+		$this->assertTrue( extrachill_events_update_archive_scene( $term, 'nonce-extrachill_events_save_scene_1618' ) );
+		$this->assertSame( array( array( 'local_scene' => 'charleston' ) ), $calls->getArrayCopy() );
 	}
 }


### PR DESCRIPTION
## Summary
- consume the Users-owned `local_scene` contract for existing Events personalization
- replace visitor-facing market terminology with Local Scene language
- offer an explicit city-archive CTA for saving or changing a Local Scene
- use nonce-protected POST through the Users settings Ability; never write user meta in Events
- keep public search/browsing read-only and preserve explicit filter precedence

## Verification
- `vendor/bin/phpunit tests/Unit/Core/AccountMarketTest.php` (`20 tests, 60 assertions`)
- `php -l inc/core/account-market.php`
- `git diff --check`

Depends on Extra-Chill/extrachill-users#184.
Fixes #243