### PR TITLE
feat: notify festival subscribers of new events

### DIFF
--- a/inc/core/data-machine-events/festival-notifications.php
+++ b/inc/core/data-machine-events/festival-notifications.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Festival event notifications.
+ *
+ * @package ExtraChillEvents
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER = 'extrachill-events-festival-notifications';
+
+/**
+ * Register festival event notification hooks.
+ *
+ * @return void
+ */
+function extrachill_events_init_festival_notifications(): void {
+	add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_events_authorize_festival_notification_producer', 10, 4 );
+	add_action( 'transition_post_status', 'extrachill_events_notify_festival_subscribers', 10, 3 );
+}
+
+/**
+ * Authorize this plugin to resolve private festival notification recipients.
+ *
+ * @param bool   $authorized Whether the producer is already authorized.
+ * @param string $producer   Producer identifier.
+ * @param array  $entity     Normalized entity identity.
+ * @param string $delivery   Requested delivery channel.
+ * @return bool Whether the producer may resolve recipients.
+ */
+function extrachill_events_authorize_festival_notification_producer( $authorized, $producer, $entity, $delivery ): bool {
+	if ( EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER !== $producer || 'notification' !== $delivery ) {
+		return (bool) $authorized;
+	}
+
+	return is_array( $entity ) && 'festival' === ( $entity['entity_type'] ?? '' ) && 'festival' === ( $entity['taxonomy'] ?? '' );
+}
+
+/**
+ * Notify festival subscribers when an event first becomes published.
+ *
+ * @param string   $new_status New post status.
+ * @param string   $old_status Previous post status.
+ * @param \WP_Post $post       Post transitioning status.
+ * @return void
+ */
+function extrachill_events_notify_festival_subscribers( $new_status, $old_status, $post ): void {
+	if ( 'publish' !== $new_status || 'publish' === $old_status || ! $post instanceof \WP_Post ) {
+		return;
+	}
+
+	if ( ! defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) || DATA_MACHINE_EVENTS_POST_TYPE !== get_post_type( $post ) ) {
+		return;
+	}
+
+	if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify' ) ) {
+		return;
+	}
+
+	$festival_slugs = wp_get_post_terms( $post->ID, 'festival', array( 'fields' => 'slugs' ) );
+	if ( is_wp_error( $festival_slugs ) || empty( $festival_slugs ) ) {
+		return;
+	}
+
+	$recipient_ids = array();
+	foreach ( $festival_slugs as $festival_slug ) {
+		$recipients = extrachill_users_entity_subscription_recipients(
+			EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER,
+			'festival',
+			'festival',
+			$festival_slug
+		);
+		if ( is_wp_error( $recipients ) ) {
+			continue;
+		}
+
+		$recipient_ids = array_merge( $recipient_ids, $recipients );
+	}
+
+	$recipient_ids = array_values( array_unique( array_map( 'absint', $recipient_ids ) ) );
+	if ( empty( $recipient_ids ) ) {
+		return;
+	}
+
+	ec_users_notify(
+		$recipient_ids,
+		array(
+			'actor_id' => (int) $post->post_author,
+			'type'     => 'festival_event_published',
+			/* translators: %s: event title. */
+			'title'    => sprintf( __( 'New event: %s', 'extrachill-events' ), get_the_title( $post ) ),
+			'link'     => get_permalink( $post ),
+			'item_id'  => (int) $post->ID,
+		)
+	);
+}

--- a/inc/core/data-machine-events/init.php
+++ b/inc/core/data-machine-events/init.php
@@ -20,6 +20,7 @@ require_once __DIR__ . '/post-meta.php';
 require_once __DIR__ . '/assets.php';
 require_once __DIR__ . '/promoter-badges.php';
 require_once __DIR__ . '/venue-promos.php';
+require_once __DIR__ . '/festival-notifications.php';
 
 /**
  * Initialize all DataMachine Events integrations
@@ -33,4 +34,5 @@ function extrachill_events_init_data_machine_integration() {
 	extrachill_events_init_assets();
 	extrachill_events_init_promoter_badges();
 	extrachill_events_init_venue_promos();
+	extrachill_events_init_festival_notifications();
 }

--- a/tests/Unit/FestivalNotificationsTest.php
+++ b/tests/Unit/FestivalNotificationsTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Tests for festival event notifications.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! class_exists( 'WP_Post' ) ) {
+	class WP_Post {
+		public $ID;
+		public $post_author;
+		public $post_type;
+		public $post_title;
+
+		public function __construct( array $values ) {
+			foreach ( $values as $key => $value ) {
+				$this->{$key} = $value;
+			}
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action() {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter() {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'get_post_type' ) ) {
+	function get_post_type( $post ) {
+		return $post->post_type;
+	}
+}
+
+if ( ! function_exists( 'wp_get_post_terms' ) ) {
+	function wp_get_post_terms() {
+		return $GLOBALS['festival_notification_terms'];
+	}
+}
+
+if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) ) {
+	function extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug ) {
+		$GLOBALS['festival_notification_resolutions'][] = compact( 'producer', 'entity_type', 'taxonomy', 'slug' );
+		return $GLOBALS['festival_notification_recipients'][ $slug ] ?? array();
+	}
+}
+
+if ( ! function_exists( 'ec_users_notify' ) ) {
+	function ec_users_notify( $user_ids, array $data ) {
+		$GLOBALS['festival_notification_calls'][] = array(
+			'user_ids' => $user_ids,
+			'data'     => $data,
+		);
+		return count( $user_ids );
+	}
+}
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ) {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! function_exists( 'get_the_title' ) ) {
+	function get_the_title( $post ) {
+		return $post->post_title;
+	}
+}
+
+if ( ! function_exists( 'get_permalink' ) ) {
+	function get_permalink( $post ) {
+		return 'https://events.example/events/' . $post->ID . '/';
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text ) {
+		return $text;
+	}
+}
+
+if ( ! defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ) {
+	define( 'DATA_MACHINE_EVENTS_POST_TYPE', 'data_machine_events' );
+}
+
+require_once dirname( __DIR__, 2 ) . '/inc/core/data-machine-events/festival-notifications.php';
+
+class FestivalNotificationsTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['festival_notification_terms']       = array();
+		$GLOBALS['festival_notification_recipients']  = array();
+		$GLOBALS['festival_notification_resolutions'] = array();
+		$GLOBALS['festival_notification_calls']       = array();
+	}
+
+	public function test_authorizes_only_festival_notification_resolution(): void {
+		$entity = array(
+			'entity_type' => 'festival',
+			'taxonomy'    => 'festival',
+		);
+
+		$this->assertTrue( extrachill_events_authorize_festival_notification_producer( false, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER, $entity, 'notification' ) );
+		$this->assertFalse( extrachill_events_authorize_festival_notification_producer( false, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER, $entity, 'email' ) );
+		$this->assertFalse( extrachill_events_authorize_festival_notification_producer( false, 'untrusted', $entity, 'notification' ) );
+	}
+
+	public function test_notifies_deduplicated_recipients_for_every_festival(): void {
+		$GLOBALS['festival_notification_terms']      = array( 'summer-jam', 'river-fest' );
+		$GLOBALS['festival_notification_recipients'] = array(
+			'summer-jam' => array( 7, 9 ),
+			'river-fest' => array( 9, 11 ),
+		);
+		$post = new WP_Post(
+			array(
+				'ID'          => 42,
+				'post_author' => 3,
+				'post_type'   => DATA_MACHINE_EVENTS_POST_TYPE,
+				'post_title'  => 'The Big Show',
+			)
+		);
+
+		extrachill_events_notify_festival_subscribers( 'publish', 'draft', $post );
+
+		$this->assertCount( 2, $GLOBALS['festival_notification_resolutions'] );
+		$this->assertSame( array( 7, 9, 11 ), $GLOBALS['festival_notification_calls'][0]['user_ids'] );
+		$this->assertSame( 'New event: The Big Show', $GLOBALS['festival_notification_calls'][0]['data']['title'] );
+		$this->assertSame( 'https://events.example/events/42/', $GLOBALS['festival_notification_calls'][0]['data']['link'] );
+	}
+
+	public function test_does_not_notify_for_published_post_updates(): void {
+		$post = new WP_Post(
+			array(
+				'ID'          => 42,
+				'post_author' => 3,
+				'post_type'   => DATA_MACHINE_EVENTS_POST_TYPE,
+				'post_title'  => 'The Big Show',
+			)
+		);
+
+		extrachill_events_notify_festival_subscribers( 'publish', 'publish', $post );
+
+		$this->assertSame( array(), $GLOBALS['festival_notification_resolutions'] );
+		$this->assertSame( array(), $GLOBALS['festival_notification_calls'] );
+	}
+}


### PR DESCRIPTION
## Summary
- authorize the stable Events festival-notification producer through the Users entity-subscription filter
- notify de-duplicated private festival subscribers only when a Data Machine event first publishes
- add focused coverage for authorization, multi-festival delivery, and routine update suppression

## Verification
- `php -l inc/core/data-machine-events/festival-notifications.php && php -l inc/core/data-machine-events/init.php && php -l tests/Unit/FestivalNotificationsTest.php`
- `./vendor/bin/phpcs --standard=WordPress inc/core/data-machine-events/festival-notifications.php inc/core/data-machine-events/init.php`
- `./vendor/bin/phpunit tests/Unit/FestivalNotificationsTest.php`
- `composer test` (fails in existing unrelated QualifyRecheckHandler and CanonicalLocationsAbility tests due shared global test stubs)
- `composer lint:php` (exceeded the 120-second command limit before completion)

Closes #245