### PR TITLE
feat: audit location taxonomy integrity

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -74,6 +74,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCo
 	require_once __DIR__ . '/inc/Cli/PruneOrphanLocationsCommand.php';
 	\WP_CLI::add_command( 'extrachill events locations prune-orphans', \ExtraChillEvents\Cli\PruneOrphanLocationsCommand::class );
 
+	require_once __DIR__ . '/inc/Core/LocationIntegrityAuditor.php';
+	require_once __DIR__ . '/inc/Cli/AuditLocationIntegrityCommand.php';
+	\WP_CLI::add_command( 'extrachill events locations audit-integrity', \ExtraChillEvents\Cli\AuditLocationIntegrityCommand::class );
+
 	require_once __DIR__ . '/inc/Cli/BackfillVenueMetaCommand.php';
 	\WP_CLI::add_command( 'extrachill events venues backfill-meta', \ExtraChillEvents\Cli\BackfillVenueMetaCommand::class );
 

--- a/inc/Cli/AuditLocationIntegrityCommand.php
+++ b/inc/Cli/AuditLocationIntegrityCommand.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Read-only location taxonomy integrity audit.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+use ExtraChillEvents\Core\LocationIntegrityAuditor;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class AuditLocationIntegrityCommand {
+
+	/**
+	 * Report root-level city overlaps and duplicate canonical city names.
+	 *
+	 * This command never changes terms or relationships. Findings require
+	 * operator review because same-named cities in different states can be valid.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill events locations audit-integrity --url=events.extrachill.com
+	 *     wp extrachill events locations audit-integrity --format=json --url=events.extrachill.com
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		if ( ! defined( 'WP_CLI' ) || ! \WP_CLI ) {
+			return;
+		}
+
+		if ( ! taxonomy_exists( 'location' ) ) {
+			\WP_CLI::error( 'The location taxonomy is not registered on this site. Run with --url=events.extrachill.com.' );
+			return;
+		}
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'location',
+				'hide_empty' => false,
+			)
+		);
+		if ( is_wp_error( $terms ) ) {
+			\WP_CLI::error( $terms->get_error_message() );
+			return;
+		}
+
+		$rows = array_map(
+			static function ( \WP_Term $term ): array {
+				return array(
+					'term_id' => (int) $term->term_id,
+					'name'    => $term->name,
+					'slug'    => $term->slug,
+					'parent'  => (int) $term->parent,
+					'count'   => (int) $term->count,
+				);
+			},
+			$terms
+		);
+
+		$findings = LocationIntegrityAuditor::audit( $rows );
+		if ( empty( $findings ) ) {
+			\WP_CLI::success( 'No location hierarchy or canonical city overlaps found.' );
+			return;
+		}
+
+		\WP_CLI\Utils\format_items(
+			(string) ( $assoc_args['format'] ?? 'table' ),
+			$findings,
+			array( 'issue', 'reason', 'candidate_id', 'candidate_name', 'candidate_slug', 'candidate_count', 'canonical_id', 'canonical_name', 'canonical_slug', 'canonical_count' )
+		);
+		\WP_CLI::warning( sprintf( '%d review candidate(s) found. This audit is read-only; no terms were changed.', count( $findings ) ) );
+	}
+}

--- a/inc/Core/LocationIntegrityAuditor.php
+++ b/inc/Core/LocationIntegrityAuditor.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Read-only location taxonomy integrity checks.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+class LocationIntegrityAuditor {
+
+	/**
+	 * Find root-level terms that overlap cities and canonical cities sharing a name.
+	 *
+	 * Matching is deliberately exact. Results are operator-review candidates, not
+	 * merge instructions.
+	 *
+	 * @param array $terms Location term rows containing term_id, name, slug, parent, and count.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function audit( array $terms ): array {
+		$by_id = array();
+		foreach ( $terms as $term ) {
+			$term_id = (int) ( $term['term_id'] ?? 0 );
+			if ( $term_id > 0 ) {
+				$by_id[ $term_id ] = $term;
+			}
+		}
+
+		$roots  = array();
+		$cities = array();
+		foreach ( $by_id as $term ) {
+			$depth = self::depth( $term, $by_id );
+			if ( 0 === $depth ) {
+				$roots[] = $term;
+			} elseif ( $depth >= 2 ) {
+				$cities[] = $term;
+			}
+		}
+
+		$findings = array();
+		foreach ( $roots as $root ) {
+			foreach ( $cities as $city ) {
+				$reason = self::root_overlap_reason( $root, $city );
+				if ( null === $reason ) {
+					continue;
+				}
+
+				$findings[] = self::finding( 'root_city_overlap', $reason, $root, $city );
+			}
+		}
+
+		$city_count = count( $cities );
+		for ( $left = 0; $left < $city_count; ++$left ) {
+			for ( $right = $left + 1; $right < $city_count; ++$right ) {
+				if ( self::normalize_name( $cities[ $left ]['name'] ?? '' ) !== self::normalize_name( $cities[ $right ]['name'] ?? '' ) ) {
+					continue;
+				}
+
+				$findings[] = self::finding( 'canonical_city_overlap', 'exact_name', $cities[ $left ], $cities[ $right ] );
+			}
+		}
+
+		usort(
+			$findings,
+			static function ( array $a, array $b ): int {
+				return array( $a['issue'], $a['candidate_name'], $a['canonical_name'], $a['candidate_id'] ) <=> array( $b['issue'], $b['candidate_name'], $b['canonical_name'], $b['candidate_id'] );
+			}
+		);
+
+		return $findings;
+	}
+
+	/**
+	 * Determine a term's hierarchy depth without taxonomy lookups.
+	 */
+	private static function depth( array $term, array $by_id ): int {
+		$depth   = 0;
+		$parent  = (int) ( $term['parent'] ?? 0 );
+		$visited = array();
+
+		while ( $parent > 0 && isset( $by_id[ $parent ] ) && ! isset( $visited[ $parent ] ) ) {
+			$visited[ $parent ] = true;
+			++$depth;
+			$parent = (int) ( $by_id[ $parent ]['parent'] ?? 0 );
+		}
+
+		return $depth;
+	}
+
+	/**
+	 * Return the exact overlap rule, or null when no conservative rule matches.
+	 */
+	private static function root_overlap_reason( array $root, array $city ): ?string {
+		$root_name = self::normalize_name( $root['name'] ?? '' );
+		$city_name = self::normalize_name( $city['name'] ?? '' );
+		$root_slug = self::normalize_slug( $root['slug'] ?? '' );
+		$city_slug = self::normalize_slug( $city['slug'] ?? '' );
+
+		if ( '' !== $root_name && $root_name === $city_name ) {
+			return 'exact_name';
+		}
+		if ( '' !== $root_slug && $root_slug === $city_slug ) {
+			return 'exact_slug';
+		}
+		if ( '' !== $city_name && 1 === preg_match( '/^' . preg_quote( $city_name, '/' ) . ',\s*[a-z]{2,3}$/', $root_name ) ) {
+			return 'state_qualified_name';
+		}
+		if ( '' !== $city_slug && 1 === preg_match( '/^' . preg_quote( $city_slug, '/' ) . '-[a-z]{2,3}$/', $root_slug ) ) {
+			return 'state_qualified_slug';
+		}
+
+		return null;
+	}
+
+	private static function finding( string $issue, string $reason, array $candidate, array $canonical ): array {
+		return array(
+			'issue'          => $issue,
+			'reason'         => $reason,
+			'candidate_id'   => (int) $candidate['term_id'],
+			'candidate_name' => (string) $candidate['name'],
+			'candidate_slug' => (string) $candidate['slug'],
+			'candidate_count' => (int) ( $candidate['count'] ?? 0 ),
+			'canonical_id'   => (int) $canonical['term_id'],
+			'canonical_name' => (string) $canonical['name'],
+			'canonical_slug' => (string) $canonical['slug'],
+			'canonical_count' => (int) ( $canonical['count'] ?? 0 ),
+		);
+	}
+
+	private static function normalize_name( $name ): string {
+		return strtolower( trim( preg_replace( '/\s+/', ' ', (string) $name ) ) );
+	}
+
+	private static function normalize_slug( $slug ): string {
+		return strtolower( trim( (string) $slug, "- \t\n\r\0\x0B" ) );
+	}
+}

--- a/tests/Unit/Core/LocationIntegrityAuditorTest.php
+++ b/tests/Unit/Core/LocationIntegrityAuditorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use ExtraChillEvents\Core\LocationIntegrityAuditor;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__, 3 ) . '/inc/Core/LocationIntegrityAuditor.php';
+
+class LocationIntegrityAuditorTest extends TestCase {
+
+	public function test_reports_exact_and_state_qualified_root_overlaps(): void {
+		$findings = LocationIntegrityAuditor::audit( $this->terms() );
+		$root_findings = array_values( array_filter( $findings, static fn( array $finding ): bool => 'root_city_overlap' === $finding['issue'] ) );
+
+		$this->assertCount( 4, $root_findings );
+		$this->assertSame(
+			array( 'exact_name', 'state_qualified_name', 'state_qualified_name', 'state_qualified_name' ),
+			array_column( $root_findings, 'reason' )
+		);
+	}
+
+	public function test_reports_same_named_hierarchical_cities_for_operator_review(): void {
+		$findings = LocationIntegrityAuditor::audit( $this->terms() );
+		$canonical = array_values( array_filter( $findings, static fn( array $finding ): bool => 'canonical_city_overlap' === $finding['issue'] ) );
+
+		$this->assertCount( 1, $canonical );
+		$this->assertSame( 'Greensboro', $canonical[0]['candidate_name'] );
+		$this->assertSame( 'Greensboro', $canonical[0]['canonical_name'] );
+		$this->assertSame( 'exact_name', $canonical[0]['reason'] );
+	}
+
+	public function test_does_not_use_fuzzy_city_matching(): void {
+		$terms = $this->terms();
+		$terms[] = array( 'term_id' => 20, 'name' => 'Charlestown', 'slug' => 'charlestown', 'parent' => 0, 'count' => 2 );
+		$terms[] = array( 'term_id' => 21, 'name' => 'North Charleston', 'slug' => 'north-charleston', 'parent' => 2, 'count' => 4 );
+
+		$findings = LocationIntegrityAuditor::audit( $terms );
+
+		$this->assertNotContains( 20, array_column( $findings, 'candidate_id' ) );
+		$this->assertNotContains( 21, array_column( $findings, 'canonical_id' ) );
+	}
+
+	public function test_ignores_root_regions_and_state_nodes(): void {
+		$findings = LocationIntegrityAuditor::audit(
+			array(
+				array( 'term_id' => 1, 'name' => 'United States', 'slug' => 'united-states', 'parent' => 0, 'count' => 0 ),
+				array( 'term_id' => 2, 'name' => 'South Carolina', 'slug' => 'south-carolina', 'parent' => 1, 'count' => 0 ),
+				array( 'term_id' => 3, 'name' => 'Charleston', 'slug' => 'charleston', 'parent' => 2, 'count' => 10 ),
+			)
+		);
+
+		$this->assertSame( array(), $findings );
+	}
+
+	private function terms(): array {
+		return array(
+			array( 'term_id' => 1, 'name' => 'United States', 'slug' => 'united-states', 'parent' => 0, 'count' => 0 ),
+			array( 'term_id' => 2, 'name' => 'South Carolina', 'slug' => 'south-carolina', 'parent' => 1, 'count' => 0 ),
+			array( 'term_id' => 3, 'name' => 'Georgia', 'slug' => 'georgia', 'parent' => 1, 'count' => 0 ),
+			array( 'term_id' => 4, 'name' => 'North Carolina', 'slug' => 'north-carolina', 'parent' => 1, 'count' => 0 ),
+			array( 'term_id' => 5, 'name' => 'Charleston', 'slug' => 'charleston', 'parent' => 2, 'count' => 10 ),
+			array( 'term_id' => 6, 'name' => 'Isle of Palms', 'slug' => 'isle-of-palms', 'parent' => 2, 'count' => 5 ),
+			array( 'term_id' => 7, 'name' => 'Greensboro', 'slug' => 'greensboro-ga', 'parent' => 3, 'count' => 2 ),
+			array( 'term_id' => 8, 'name' => 'Greensboro', 'slug' => 'greensboro', 'parent' => 4, 'count' => 8 ),
+			array( 'term_id' => 10, 'name' => 'Charleston', 'slug' => 'charleston-old', 'parent' => 0, 'count' => 1 ),
+			array( 'term_id' => 11, 'name' => 'Isle of Palms, SC', 'slug' => 'isle-of-palms-sc', 'parent' => 0, 'count' => 1 ),
+			array( 'term_id' => 12, 'name' => 'Greensboro, GA', 'slug' => 'greensboro-ga-old', 'parent' => 0, 'count' => 1 ),
+		);
+	}
+}


### PR DESCRIPTION
Adds a read-only operator diagnostic for root-level city overlaps and exact canonical same-name review candidates. Never merges or mutates terms automatically. Live duplicate data was reconciled separately with redirects. Tests: 4 passing, 9 assertions. Fixes #228.