### PR TITLE
fix: clear release lint findings

### DIFF
--- a/assets/js/discovery.js
+++ b/assets/js/discovery.js
@@ -279,8 +279,7 @@
 					triggerLazyRender( calendar );
 				}
 			} )
-			.catch( function ( error ) {
-				console.error( 'Error fetching scoped events:', error );
+			.catch( function () {
 				content.innerHTML =
 					'<div class="data-machine-events-error"><p>Error loading events. Please try again.</p></div>';
 			} )

--- a/blocks/event-submission/src/edit.js
+++ b/blocks/event-submission/src/edit.js
@@ -65,10 +65,7 @@ export default function Edit( { attributes, setAttributes } ) {
 				<RichText
 					tagName="h3"
 					className="ec-event-submission-editor__headline"
-					placeholder={ __(
-						'Add a headline…',
-						'extrachill-events'
-					) }
+					placeholder={ __( 'Add a headline…', 'extrachill-events' ) }
 					value={ headline }
 					onChange={ ( value ) =>
 						setAttributes( { headline: value } )

--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -406,10 +406,14 @@ class ArtistUrlImportAbilities {
 
 		$hash     = ArtistUrlSubmissionsTable::url_hash( $normalized );
 		$existing = ArtistUrlSubmissionsTable::find_by_hash( $hash );
-		if ( $existing && in_array( $existing['status'], array(
-			ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
-			ArtistUrlSubmissionsTable::STATUS_APPROVED,
-		), true ) ) {
+		if ( $existing && in_array(
+			$existing['status'],
+			array(
+				ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
+				ArtistUrlSubmissionsTable::STATUS_APPROVED,
+			),
+			true
+		) ) {
 			return new \WP_Error(
 				'url_already_tracked',
 				__( 'This URL is already being tracked.', 'extrachill-events' ),
@@ -470,10 +474,14 @@ class ArtistUrlImportAbilities {
 
 		$hash     = ArtistUrlSubmissionsTable::url_hash( $normalized );
 		$existing = ArtistUrlSubmissionsTable::find_by_hash( $hash );
-		if ( $existing && in_array( $existing['status'], array(
-			ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
-			ArtistUrlSubmissionsTable::STATUS_APPROVED,
-		), true ) ) {
+		if ( $existing && in_array(
+			$existing['status'],
+			array(
+				ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
+				ArtistUrlSubmissionsTable::STATUS_APPROVED,
+			),
+			true
+		) ) {
 			return new \WP_Error(
 				'url_already_tracked',
 				__( 'This URL is already being tracked.', 'extrachill-events' ),
@@ -642,17 +650,17 @@ class ArtistUrlImportAbilities {
 		$artist_name = ( $artist_term && ! is_wp_error( $artist_term ) ) ? (string) $artist_term->name : 'Artist ' . $artist_term_id;
 
 		// 1. Resolve the single shared Artist Tour Import pipeline (B1).
-		//    One pipeline is reused across every approved artist URL; each
-		//    approval creates a NEW FLOW on it carrying the per-artist
-		//    config (source_url + PRE_SELECTED artist term). There is no
-		//    per-artist pipeline and no per-artist pipeline-level AI prompt.
+		// One pipeline is reused across every approved artist URL; each
+		// approval creates a NEW FLOW on it carrying the per-artist
+		// config (source_url + PRE_SELECTED artist term). There is no
+		// per-artist pipeline and no per-artist pipeline-level AI prompt.
 		$pipeline_id = $this->resolveSharedArtistImportPipeline();
 		if ( is_wp_error( $pipeline_id ) ) {
 			return $pipeline_id;
 		}
 
 		// 2. Create the flow with universal_web_scraper handler and the
-		//    SelectionMode-driven taxonomy bindings on the shared pipeline.
+		// SelectionMode-driven taxonomy bindings on the shared pipeline.
 		$flow_ability = wp_get_ability( 'datamachine/create-flow' );
 		if ( ! $flow_ability ) {
 			return new \WP_Error( 'missing_ability', __( 'datamachine/create-flow ability is not available.', 'extrachill-events' ), array( 'status' => 500 ) );
@@ -765,11 +773,11 @@ class ArtistUrlImportAbilities {
 		);
 
 		// 4. Trigger first scrape immediately.
-		//    datamachine/run-flow starts the job asynchronously, so a real
-		//    immediate import count is not available. Returning null keeps the
-		//    output schema (integer|null) clean; a boolean here caused
-		//    validation failures (#221). If a future run result ever exposes a
-		//    count, use it.
+		// datamachine/run-flow starts the job asynchronously, so a real
+		// immediate import count is not available. Returning null keeps the
+		// output schema (integer|null) clean; a boolean here caused
+		// validation failures (#221). If a future run result ever exposes a
+		// count, use it.
 		$events_imported_immediately = null;
 		$run_ability                 = wp_get_ability( 'datamachine/run-flow' );
 		if ( $run_ability ) {

--- a/inc/Abilities/EventSubmissionAbilities.php
+++ b/inc/Abilities/EventSubmissionAbilities.php
@@ -509,7 +509,7 @@ class EventSubmissionAbilities {
 	 * edge cases. Uses the `extrachill/branded` template — submitters get
 	 * the full EC visual identity.
 	 *
-	 * @param array $submission Submission data.
+	 * @param array  $submission Submission data.
 	 * @param string $account_claim Optional one-time claim/set-password URL for
 	 *              anonymous submitters whose account was resolved or created.
 	 *              Empty for logged-in submitters (no claim section rendered).

--- a/inc/Core/ArtistUrlSubmissionsTable.php
+++ b/inc/Core/ArtistUrlSubmissionsTable.php
@@ -394,11 +394,13 @@ class ArtistUrlSubmissionsTable {
 		global $wpdb;
 		$table = self::table_name();
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		return (int) $wpdb->get_var( $wpdb->prepare(
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is a trusted internal table name returned by self::table_name(); not user input.
-			"SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND status = %s",
-			$user_id,
-			self::STATUS_APPROVED
-		) );
+				"SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND status = %s",
+				$user_id,
+				self::STATUS_APPROVED
+			)
+		);
 	}
 }

--- a/inc/core/account-market.php
+++ b/inc/core/account-market.php
@@ -380,12 +380,18 @@ function extrachill_events_update_archive_scene( WP_Term $term, string $nonce ):
  * Handle the archive Local Scene form submission.
  */
 function extrachill_events_handle_archive_scene_update(): void {
-	$term = extrachill_events_get_archive_scene_term();
-	if ( null === $term || 'POST' !== ( $_SERVER['REQUEST_METHOD'] ?? '' ) || ! isset( $_POST['extrachill_events_scene_action'] ) ) {
+	$term           = extrachill_events_get_archive_scene_term();
+	$request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) : '';
+	if ( null === $term || 'POST' !== $request_method || ! isset( $_POST['extrachill_events_scene_action'] ) || ! isset( $_POST['extrachill_events_scene_nonce'] ) ) {
 		return;
 	}
 
-	$nonce  = isset( $_POST['extrachill_events_scene_nonce'] ) && is_scalar( $_POST['extrachill_events_scene_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['extrachill_events_scene_nonce'] ) ) : '';
+	$nonce = isset( $_POST['extrachill_events_scene_nonce'] ) && is_scalar( $_POST['extrachill_events_scene_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['extrachill_events_scene_nonce'] ) ) : '';
+	if ( ! wp_verify_nonce( $nonce, 'extrachill_events_save_scene_' . $term->term_id ) ) {
+		wp_safe_redirect( add_query_arg( 'scene_status', 'failed', get_term_link( $term ) ) );
+		exit;
+	}
+
 	$status = extrachill_events_update_archive_scene( $term, $nonce ) ? 'saved' : 'failed';
 	wp_safe_redirect( add_query_arg( 'scene_status', $status, get_term_link( $term ) ) );
 	exit;
@@ -405,7 +411,8 @@ function extrachill_events_render_archive_scene_cta(): void {
 	$is_logged_in = is_user_logged_in();
 	$current      = extrachill_events_get_account_market();
 	$is_current   = $current && (int) $current['term_id'] === (int) $term->term_id;
-	$status       = isset( $_GET['scene_status'] ) && is_scalar( $_GET['scene_status'] ) ? sanitize_text_field( wp_unslash( $_GET['scene_status'] ) ) : '';
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only flash status set by this handler's nonce-protected redirect.
+	$status = isset( $_GET['scene_status'] ) && is_scalar( $_GET['scene_status'] ) ? sanitize_text_field( wp_unslash( $_GET['scene_status'] ) ) : '';
 
 	if ( $is_logged_in ) {
 		if ( ! defined( 'DONOTCACHEPAGE' ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,110 @@
 				"@extrachill/components": "^0.9.0"
 			},
 			"devDependencies": {
+				"@wordpress/block-editor": "^15.23.0",
+				"@wordpress/blocks": "^15.23.0",
+				"@wordpress/components": "^36.1.0",
+				"@wordpress/element": "^8.2.0",
 				"@wordpress/scripts": "^27.1.0",
 				"ajv": "^8.20.0",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1"
 			}
+		},
+		"node_modules/@ariakit/components": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.5.tgz",
+			"integrity": "sha512-LnvU9bcOU2IkQS3jCFm2rxcULNtG55+M+fh66mFf4EEBHJnDoTdN7zNRtm1dyzcFn6hAn/AoLl3Hyg95RIGUOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/store": "0.1.4",
+				"@ariakit/utils": "0.1.4"
+			}
+		},
+		"node_modules/@ariakit/react": {
+			"version": "0.4.32",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.32.tgz",
+			"integrity": "sha512-ar5lyS/Pp/+p1TdAqsS8gHzL/E9df8uWXYmEsD/Olpv4hp9LVEtwM6FfOu57sn6qaycs2xWFN9GinmXkMd8LWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-components": "0.3.1"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@ariakit/react-components": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.3.1.tgz",
+			"integrity": "sha512-SJ/xfL3vj20TX6p/Gx39wbQtfNKL66uQ8MtnW8yU7Mv3DnOr/riFUKZnTuVjl+rMfwCdiGoHK1DdYiFKSaHG5w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/components": "0.1.5",
+				"@ariakit/react-store": "0.1.5",
+				"@ariakit/react-utils": "0.2.0",
+				"@ariakit/store": "0.1.4",
+				"@ariakit/utils": "0.1.4",
+				"@floating-ui/dom": "^1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@ariakit/react-store": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.5.tgz",
+			"integrity": "sha512-EMB7dG0aD+MqI/0M8dzmwPObGYoWx7lvJK4tKmTDDbuGIW+XwrKfG3n1dMkWgg/TEq5lDNE7S3WbpE8mRfXpPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-utils": "0.2.0",
+				"@ariakit/store": "0.1.4",
+				"@ariakit/utils": "0.1.4",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@ariakit/react-utils": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.2.0.tgz",
+			"integrity": "sha512-tyIx/qxYY5i8ntGSzDYZ5Olak7zZ58QeEYjbbMNSZEywgtrQlKhZXkVnXK72UkGXmCLg7OrrTsesv8Qh6Bx2LQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/store": "0.1.4",
+				"@ariakit/utils": "0.1.4"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@ariakit/store": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.4.tgz",
+			"integrity": "sha512-VQDtp5eq4MgIjxzo6M/6NN2sVx8WykiSs9HNMv2AnfAGntF1fMA6cxCuBIFFWkHekNMGWwe/utzbTt3J/mtuiA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/utils": "0.1.4"
+			}
+		},
+		"node_modules/@ariakit/utils": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.4.tgz",
+			"integrity": "sha512-gIC/FR/gcOtp2FQQDOnRPfxizJjqp4PSQWS7fH2tNr6O6iTwwW8CPao7VUpu8Y8xKeMXrvzHvkOHhBhfBf4OrA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.29.7",
@@ -1982,6 +2081,68 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@base-ui/react": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+			"integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.3.1",
+				"@floating-ui/react-dom": "^2.1.8",
+				"@floating-ui/utils": "^0.2.11",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
+				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@date-fns/tz": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				},
+				"date-fns": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@base-ui/utils": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+			"integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@floating-ui/utils": "^0.2.11",
+				"reselect": "^5.2.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@bcoe/v8-coverage": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -2006,6 +2167,20 @@
 				"postcss-selector-parser": "^6.0.10"
 			}
 		},
+		"node_modules/@date-fns/tz": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+			"integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@date-fns/utc": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.1.tgz",
+			"integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@discoveryjs/json-ext": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -2015,6 +2190,196 @@
 			"engines": {
 				"node": ">=10.0.0"
 			}
+		},
+		"node_modules/@emotion/babel-plugin": {
+			"version": "11.13.5",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+			"integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/runtime": "^7.18.3",
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/serialize": "^1.3.3",
+				"babel-plugin-macros": "^3.1.0",
+				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-root": "^1.1.0",
+				"source-map": "^0.5.7",
+				"stylis": "4.2.0"
+			}
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@emotion/cache": {
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+			"integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.2",
+				"@emotion/weak-memoize": "^0.4.0",
+				"stylis": "4.2.0"
+			}
+		},
+		"node_modules/@emotion/css": {
+			"version": "11.13.5",
+			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+			"integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/babel-plugin": "^11.13.5",
+				"@emotion/cache": "^11.13.5",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.2"
+			}
+		},
+		"node_modules/@emotion/hash": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emotion/is-prop-valid": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+			"integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/memoize": "^0.9.0"
+			}
+		},
+		"node_modules/@emotion/memoize": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emotion/react": {
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"@emotion/babel-plugin": "^11.13.5",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+				"@emotion/utils": "^1.4.2",
+				"@emotion/weak-memoize": "^0.4.0",
+				"hoist-non-react-statics": "^3.3.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@emotion/serialize": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+			"integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/unitless": "^0.10.0",
+				"@emotion/utils": "^1.4.2",
+				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@emotion/sheet": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+			"integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emotion/styled": {
+			"version": "11.14.1",
+			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+			"integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"@emotion/babel-plugin": "^11.13.5",
+				"@emotion/is-prop-valid": "^1.3.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+				"@emotion/utils": "^1.4.2"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.0.0-rc.0",
+				"react": ">=16.8.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@emotion/unitless": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+			"integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+			"integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@emotion/utils": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emotion/weak-memoize": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+			"integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@es-joy/jsdoccomment": {
 			"version": "0.41.0",
@@ -2193,6 +2558,48 @@
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0"
 			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+			"integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.12"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+			"integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/core": "^1.8.0",
+				"@floating-ui/utils": "^0.2.12"
+			}
+		},
+		"node_modules/@floating-ui/react-dom": {
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+			"integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.8.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+			"integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@hapi/hoek": {
 			"version": "9.3.0",
@@ -3158,6 +3565,34 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@preact/signals": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.4.tgz",
+			"integrity": "sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@preact/signals-core": "^1.7.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			},
+			"peerDependencies": {
+				"preact": "10.x"
+			}
+		},
+		"node_modules/@preact/signals-core": {
+			"version": "1.14.4",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+			"integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			}
+		},
 		"node_modules/@puppeteer/browsers": {
 			"version": "1.4.6",
 			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
@@ -3270,6 +3705,412 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@radix-ui/primitive": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.5.tgz",
+			"integrity": "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+			"integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-context": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+			"integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dialog": {
+			"version": "1.1.19",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.19.tgz",
+			"integrity": "sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.5",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-context": "1.2.0",
+				"@radix-ui/react-dismissable-layer": "1.1.15",
+				"@radix-ui/react-focus-guards": "1.1.4",
+				"@radix-ui/react-focus-scope": "1.1.12",
+				"@radix-ui/react-id": "1.1.2",
+				"@radix-ui/react-portal": "1.1.13",
+				"@radix-ui/react-presence": "1.1.7",
+				"@radix-ui/react-primitive": "2.1.7",
+				"@radix-ui/react-slot": "1.3.0",
+				"@radix-ui/react-use-controllable-state": "1.2.3",
+				"aria-hidden": "^1.2.4",
+				"react-remove-scroll": "^2.7.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dismissable-layer": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.15.tgz",
+			"integrity": "sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.5",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-primitive": "2.1.7",
+				"@radix-ui/react-use-callback-ref": "1.1.2",
+				"@radix-ui/react-use-effect-event": "0.0.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-guards": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+			"integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-scope": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.12.tgz",
+			"integrity": "sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-primitive": "2.1.7",
+				"@radix-ui/react-use-callback-ref": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-id": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+			"integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-portal": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz",
+			"integrity": "sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.7",
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-presence": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.7.tgz",
+			"integrity": "sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+			"integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.3.0"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+			"integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-callback-ref": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+			"integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+			"integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-effect-event": "0.0.3",
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-effect-event": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+			"integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+			"integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@react-spring/animated": {
+			"version": "9.7.5",
+			"resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+			"integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@react-spring/shared": "~9.7.5",
+				"@react-spring/types": "~9.7.5"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-spring/core": {
+			"version": "9.7.5",
+			"resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+			"integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@react-spring/animated": "~9.7.5",
+				"@react-spring/shared": "~9.7.5",
+				"@react-spring/types": "~9.7.5"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/react-spring/donate"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-spring/rafz": {
+			"version": "9.7.5",
+			"resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+			"integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@react-spring/shared": {
+			"version": "9.7.5",
+			"resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+			"integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@react-spring/rafz": "~9.7.5",
+				"@react-spring/types": "~9.7.5"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-spring/types": {
+			"version": "9.7.5",
+			"resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+			"integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@react-spring/web": {
+			"version": "9.7.5",
+			"resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
+			"integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@react-spring/animated": "~9.7.5",
+				"@react-spring/core": "~9.7.5",
+				"@react-spring/shared": "~9.7.5",
+				"@react-spring/types": "~9.7.5"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/@rtsao/scc": {
@@ -3727,6 +4568,16 @@
 				"url": "https://github.com/sponsors/gregberge"
 			}
 		},
+		"node_modules/@tabby_ai/hijri-converter": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+			"integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/@tannin/compile": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
@@ -3759,6 +4610,13 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
 			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tannin/sprintf": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.3.tgz",
+			"integrity": "sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3933,6 +4791,20 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/gradient-parser": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-1.1.0.tgz",
+			"integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/highlight-words-core": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@types/highlight-words-core/-/highlight-words-core-1.2.3.tgz",
+			"integrity": "sha512-PWNU/NR0CaYEsK38mcCTyDzeS2TlEGK9kRhRMz1i86jVAe836ZlA3gl6QYpu+CG6IpfNKTgWpEnJuRededvC0g==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/http-errors": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -4024,6 +4896,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/mousetrap": {
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
+			"integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
 			"version": "25.9.3",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
@@ -4058,6 +4937,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/prop-types": {
+			"version": "15.7.15",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/qs": {
 			"version": "6.15.1",
 			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -4071,6 +4957,27 @@
 			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/react": {
+			"version": "18.3.31",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+			"integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/prop-types": "*",
+				"csstype": "^3.2.2"
+			}
+		},
+		"node_modules/@types/react-dom": {
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
+			}
 		},
 		"node_modules/@types/retry": {
 			"version": "0.12.0",
@@ -4519,6 +5426,26 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/@use-gesture/core": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+			"integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@use-gesture/react": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+			"integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@use-gesture/core": "10.3.1"
+			},
+			"peerDependencies": {
+				"react": ">= 16.8.0"
+			}
+		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -4727,6 +5654,53 @@
 				}
 			}
 		},
+		"node_modules/@wordpress/a11y": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.50.0.tgz",
+			"integrity": "sha512-c/1EeqliArkmxSlRmDzbRoNGGMmhsAiCgenWmvJzpWwF3rVoyjF/DClps5GagAO1sbg+6Q1bsxgg3svCEhLdAg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/dom-ready": "^4.50.0",
+				"@wordpress/i18n": "^6.23.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/a11y/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/a11y/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/api-fetch": {
 			"version": "6.55.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
@@ -4740,6 +5714,17 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/autop": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.50.0.tgz",
+			"integrity": "sha512-HuHssPsSQQxqlaB6MIDXXG/kLpbloiqYYT49kfPXB4b39nPy/vYmMB+K0J8MB3+HttWMVu0E/4ALQO6qatM1/g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
@@ -4786,6 +5771,308 @@
 			"dev": true,
 			"license": "GPL-2.0-or-later"
 		},
+		"node_modules/@wordpress/blob": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.50.0.tgz",
+			"integrity": "sha512-eDKSl+kfhq9wcSuOReor2YFDyih1BrvuzzCI0hXJjBv3IStb65AfzYii4/dYmjipqkJEmjsU7crLr5612EMIdw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor": {
+			"version": "15.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.23.0.tgz",
+			"integrity": "sha512-L/oGA/DHwo4s8MzzqaQ+UegehiujXVo184ttmyhgOzj69HT1P403ju6Of8o4tfRh+2xzH6GIjIOt0HPse9ZKpg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@react-spring/web": "^9.4.5",
+				"@wordpress/a11y": "^4.50.0",
+				"@wordpress/base-styles": "^10.2.0",
+				"@wordpress/blob": "^4.50.0",
+				"@wordpress/block-serialization-default-parser": "^5.50.0",
+				"@wordpress/blocks": "^15.23.0",
+				"@wordpress/commands": "^1.50.0",
+				"@wordpress/components": "^36.1.0",
+				"@wordpress/compose": "^8.3.0",
+				"@wordpress/data": "^10.50.0",
+				"@wordpress/dataviews": "^17.1.0",
+				"@wordpress/date": "^5.50.0",
+				"@wordpress/deprecated": "^4.50.0",
+				"@wordpress/dom": "^4.50.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/escape-html": "^3.50.0",
+				"@wordpress/global-styles-engine": "^1.17.0",
+				"@wordpress/hooks": "^4.50.0",
+				"@wordpress/html-entities": "^4.50.0",
+				"@wordpress/i18n": "^6.23.0",
+				"@wordpress/icons": "^15.1.0",
+				"@wordpress/image-cropper": "^1.14.0",
+				"@wordpress/interactivity": "^6.50.0",
+				"@wordpress/is-shallow-equal": "^5.50.0",
+				"@wordpress/keyboard-shortcuts": "^5.50.0",
+				"@wordpress/keycodes": "^4.50.0",
+				"@wordpress/notices": "^5.50.0",
+				"@wordpress/preferences": "^4.50.0",
+				"@wordpress/priority-queue": "^3.50.0",
+				"@wordpress/private-apis": "^1.50.0",
+				"@wordpress/rich-text": "^7.50.0",
+				"@wordpress/style-engine": "^2.50.0",
+				"@wordpress/token-list": "^3.50.0",
+				"@wordpress/ui": "^0.17.0",
+				"@wordpress/upload-media": "^0.35.0",
+				"@wordpress/url": "^4.50.0",
+				"@wordpress/warning": "^3.50.0",
+				"@wordpress/wordcount": "^4.50.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.9.3",
+				"deepmerge": "^4.3.1",
+				"diff": "^8.0.3",
+				"fast-deep-equal": "^3.1.3",
+				"memize": "^2.1.0",
+				"parsel-js": "^1.1.2",
+				"postcss": "^8.4.38",
+				"postcss-prefix-selector": "^1.16.0",
+				"postcss-urlrebase": "^1.4.0",
+				"react-autosize-textarea": "^7.1.0",
+				"react-easy-crop": "^5.4.2",
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/base-styles": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.2.0.tgz",
+			"integrity": "sha512-iDPbyyeUnxLFq4ec+03x87jT8lRoBzK2rDoEg24l2KNAR9ZJ2kwI0z2E/wW0fOZC37A7qr377KJslPHKLtMgyQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.50.0.tgz",
+			"integrity": "sha512-BtyCkA7pk5pMMx+dVjT10OuhQwr9ZjYY1LLcXJcYJjhhFsP16be2BiytrBnKDZj/479/icvEYwlooawZCPrxYQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.23.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/url": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.50.0.tgz",
+			"integrity": "sha512-k9lJLhDDzuNfoI3LAXVqTocYQxQJcH2ee08uy9fPd7l8JgfkGmFRm4zWnyEncZn2n8SG19kC4t6MvykaQZk9Gw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/warning": {
+			"version": "3.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.50.0.tgz",
+			"integrity": "sha512-6X3ioKOGfmRuZFngmG2QZZW9CBVMTBr5FXqs6Q3li5ryhnAqn3u/ocqsx556YnB5dYdVxK14TiH9o7DDElt8gw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-serialization-default-parser": {
+			"version": "5.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.50.0.tgz",
+			"integrity": "sha512-iaBZFUv0eL1kxSg5N+suHof7kshaUneqN2EI0eD7elCfpeG76mO3FXgO3Z3Xxv86O6VYRozZw3EbmxLLld0kXw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/blocks": {
+			"version": "15.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.23.0.tgz",
+			"integrity": "sha512-MUyE7zUOxlHSb3rrzO0kvdv1AqP8XIk8EORf3nf4q2qYk23eU4VsTzlasempM0jc/kdiizineLDYcaNpug3TDQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/autop": "^4.50.0",
+				"@wordpress/blob": "^4.50.0",
+				"@wordpress/block-serialization-default-parser": "^5.50.0",
+				"@wordpress/data": "^10.50.0",
+				"@wordpress/deprecated": "^4.50.0",
+				"@wordpress/dom": "^4.50.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/hooks": "^4.50.0",
+				"@wordpress/html-entities": "^4.50.0",
+				"@wordpress/i18n": "^6.23.0",
+				"@wordpress/is-shallow-equal": "^5.50.0",
+				"@wordpress/private-apis": "^1.50.0",
+				"@wordpress/rich-text": "^7.50.0",
+				"@wordpress/shortcode": "^4.50.0",
+				"@wordpress/warning": "^3.50.0",
+				"change-case": "^4.1.2",
+				"colord": "^2.9.3",
+				"fast-deep-equal": "^3.1.3",
+				"hpq": "^1.3.0",
+				"is-plain-object": "^5.0.0",
+				"marked": "^18.0.3",
+				"memize": "^2.1.0",
+				"react-is": "^18.3.0",
+				"remove-accents": "^0.5.0",
+				"simple-html-tokenizer": "^0.5.7",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/blocks/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/blocks/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/blocks/node_modules/@wordpress/warning": {
+			"version": "3.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.50.0.tgz",
+			"integrity": "sha512-6X3ioKOGfmRuZFngmG2QZZW9CBVMTBr5FXqs6Q3li5ryhnAqn3u/ocqsx556YnB5dYdVxK14TiH9o7DDElt8gw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/blocks/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/blocks/node_modules/uuid": {
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+			"integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
 		"node_modules/@wordpress/browserslist-config": {
 			"version": "5.41.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.41.0.tgz",
@@ -4794,6 +6081,539 @@
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/@wordpress/commands": {
+			"version": "1.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.50.0.tgz",
+			"integrity": "sha512-5T6VF6BWXbbTwheNwWBYUcUuXeS5xuXVCFTU3WTj+3SWxx/oU7zACSgdML6xCA50zJiRF/17vez/viyXVL+d0g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/base-styles": "^10.2.0",
+				"@wordpress/components": "^36.1.0",
+				"@wordpress/data": "^10.50.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/i18n": "^6.23.0",
+				"@wordpress/icons": "^15.1.0",
+				"@wordpress/keyboard-shortcuts": "^5.50.0",
+				"@wordpress/preferences": "^4.50.0",
+				"@wordpress/private-apis": "^1.50.0",
+				"@wordpress/warning": "^3.50.0",
+				"clsx": "^2.1.1",
+				"cmdk": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/commands/node_modules/@wordpress/base-styles": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.2.0.tgz",
+			"integrity": "sha512-iDPbyyeUnxLFq4ec+03x87jT8lRoBzK2rDoEg24l2KNAR9ZJ2kwI0z2E/wW0fOZC37A7qr377KJslPHKLtMgyQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/commands/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/commands/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/commands/node_modules/@wordpress/warning": {
+			"version": "3.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.50.0.tgz",
+			"integrity": "sha512-6X3ioKOGfmRuZFngmG2QZZW9CBVMTBr5FXqs6Q3li5ryhnAqn3u/ocqsx556YnB5dYdVxK14TiH9o7DDElt8gw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/components": {
+			"version": "36.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.1.0.tgz",
+			"integrity": "sha512-EapV2VXhNIDhWA+yTukQz++IfpqY8gVDvQ9bU8g1RKJqK3dhaVJ9NG2Rqk3TPsFxrmEGNHJwdb+SRUdLFAr3Zg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.29",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "^1.1.0",
+				"@types/highlight-words-core": "^1.2.1",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.50.0",
+				"@wordpress/base-styles": "^10.2.0",
+				"@wordpress/compose": "^8.3.0",
+				"@wordpress/date": "^5.50.0",
+				"@wordpress/deprecated": "^4.50.0",
+				"@wordpress/dom": "^4.50.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/escape-html": "^3.50.0",
+				"@wordpress/hooks": "^4.50.0",
+				"@wordpress/html-entities": "^4.50.0",
+				"@wordpress/i18n": "^6.23.0",
+				"@wordpress/icons": "^15.1.0",
+				"@wordpress/is-shallow-equal": "^5.50.0",
+				"@wordpress/keycodes": "^4.50.0",
+				"@wordpress/primitives": "^4.50.0",
+				"@wordpress/private-apis": "^1.50.0",
+				"@wordpress/rich-text": "^7.50.0",
+				"@wordpress/style-runtime": "^0.6.0",
+				"@wordpress/ui": "^0.17.0",
+				"@wordpress/warning": "^3.50.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.9.3",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "^1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/base-styles": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.2.0.tgz",
+			"integrity": "sha512-iDPbyyeUnxLFq4ec+03x87jT8lRoBzK2rDoEg24l2KNAR9ZJ2kwI0z2E/wW0fOZC37A7qr377KJslPHKLtMgyQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/keycodes": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.50.0.tgz",
+			"integrity": "sha512-BtyCkA7pk5pMMx+dVjT10OuhQwr9ZjYY1LLcXJcYJjhhFsP16be2BiytrBnKDZj/479/icvEYwlooawZCPrxYQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.23.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/warning": {
+			"version": "3.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.50.0.tgz",
+			"integrity": "sha512-6X3ioKOGfmRuZFngmG2QZZW9CBVMTBr5FXqs6Q3li5ryhnAqn3u/ocqsx556YnB5dYdVxK14TiH9o7DDElt8gw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/components/node_modules/uuid": {
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+			"integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/@wordpress/compose": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.3.0.tgz",
+			"integrity": "sha512-nHrV8mLanqnLO67l+6RkotG9eRgiW1D6uVb919z8wVWwoZVfimFyN1nznH92tdE/xW6SnX37XDoLoLcS9IkwhQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.50.0",
+				"@wordpress/dom": "^4.50.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/is-shallow-equal": "^5.50.0",
+				"@wordpress/keycodes": "^4.50.0",
+				"@wordpress/priority-queue": "^3.50.0",
+				"@wordpress/private-apis": "^1.50.0",
+				"@wordpress/undo-manager": "^1.50.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/compose/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/compose/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/compose/node_modules/@wordpress/keycodes": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.50.0.tgz",
+			"integrity": "sha512-BtyCkA7pk5pMMx+dVjT10OuhQwr9ZjYY1LLcXJcYJjhhFsP16be2BiytrBnKDZj/479/icvEYwlooawZCPrxYQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.23.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/data": {
+			"version": "10.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.50.0.tgz",
+			"integrity": "sha512-bZ5ro1OAeItVhWrcghLI085RgH3TFU6MY1IF9LFmPQxcZyx8syaK7DnYqVIPVNPpGElNyKRX2Se8EwV2cjTnYA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/compose": "^8.3.0",
+				"@wordpress/deprecated": "^4.50.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/is-shallow-equal": "^5.50.0",
+				"@wordpress/priority-queue": "^3.50.0",
+				"@wordpress/private-apis": "^1.50.0",
+				"@wordpress/redux-routine": "^5.50.0",
+				"deepmerge": "^4.3.1",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"redux": "^5.0.1",
+				"rememo": "^4.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/data/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/dataviews": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-17.1.0.tgz",
+			"integrity": "sha512-tI09o5MadPL0EoQQQIkuUOOP5ihB6Wf9FNjqwQoZZj/ig3PDD3Ce7QcxWoDWXXQboSVJZnQigXESGuTxxrMtQA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.29",
+				"@wordpress/base-styles": "^10.2.0",
+				"@wordpress/components": "^36.1.0",
+				"@wordpress/compose": "^8.3.0",
+				"@wordpress/data": "^10.50.0",
+				"@wordpress/date": "^5.50.0",
+				"@wordpress/deprecated": "^4.50.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/i18n": "^6.23.0",
+				"@wordpress/icons": "^15.1.0",
+				"@wordpress/keycodes": "^4.50.0",
+				"@wordpress/primitives": "^4.50.0",
+				"@wordpress/private-apis": "^1.50.0",
+				"@wordpress/ui": "^0.17.0",
+				"@wordpress/warning": "^3.50.0",
+				"clsx": "^2.1.1",
+				"colord": "^2.9.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/base-styles": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.2.0.tgz",
+			"integrity": "sha512-iDPbyyeUnxLFq4ec+03x87jT8lRoBzK2rDoEg24l2KNAR9ZJ2kwI0z2E/wW0fOZC37A7qr377KJslPHKLtMgyQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/keycodes": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.50.0.tgz",
+			"integrity": "sha512-BtyCkA7pk5pMMx+dVjT10OuhQwr9ZjYY1LLcXJcYJjhhFsP16be2BiytrBnKDZj/479/icvEYwlooawZCPrxYQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.23.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/warning": {
+			"version": "3.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.50.0.tgz",
+			"integrity": "sha512-6X3ioKOGfmRuZFngmG2QZZW9CBVMTBr5FXqs6Q3li5ryhnAqn3u/ocqsx556YnB5dYdVxK14TiH9o7DDElt8gw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/date": {
+			"version": "5.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.50.0.tgz",
+			"integrity": "sha512-cTRKN9dweiDdRj+NUMsZiEQ0EldKXDNahSRLq8ByJR2TTG73o484SYD0UitcbdIL2DryAYzZ9o57AoRpMaGMvA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.50.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
@@ -4810,6 +6630,56 @@
 			},
 			"peerDependencies": {
 				"webpack": "^5.0.0"
+			}
+		},
+		"node_modules/@wordpress/deprecated": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.50.0.tgz",
+			"integrity": "sha512-TVJavTbunFoCSo2g64EKtGwmDVJhvlSqsc4T1EM4aBwsYGIJPjHcAzh6KS8Z171QXFnBxZ7We8CCDAvOFU9iaA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/hooks": "^4.50.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/deprecated/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dom": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.50.0.tgz",
+			"integrity": "sha512-2Mognc1rwe1+tlIfbSeZPqbuAh6vJagELzw9cLasObiVayWhaG+LCIp0sJz2pPG9ppz8L31gGUgna7zrSRu85Q==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.50.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dom-ready": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.50.0.tgz",
+			"integrity": "sha512-y+nZ8/gm91cV+F6DP1hoQTtYIy+3/YYGQui0lRRgTMOywrlZLt7rDbKBsEsznPOsDo0880LspEOTDX12Qrps8A==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
@@ -4834,6 +6704,48 @@
 			},
 			"peerDependencies": {
 				"@playwright/test": ">=1"
+			}
+		},
+		"node_modules/@wordpress/element": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.2.0.tgz",
+			"integrity": "sha512-cTnKRHUdZbYAd4RaJiUwhDKdQDDWY7VoGiwektCmhiBQF6WTFYlhsxl/dmHE0Sok3q7PJQwAg538XEb8WuTaew==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.50.0",
+				"@wordpress/escape-html": "^3.50.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/element/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/escape-html": {
+			"version": "3.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.50.0.tgz",
+			"integrity": "sha512-EECt++WB1RNPQBwBS7/6rKO4eUNq2xe6nb6Guv6uT+F74DgtM3+aZtNs7JhKFxRMORPtu7T0LhlAOBa4H5CsPQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
@@ -4897,6 +6809,70 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@wordpress/global-styles-engine": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.17.0.tgz",
+			"integrity": "sha512-/RZMt/BJsxBSOratwGJsFypXZ4fegaN2iWOWz6PQd+s1UPBL31z/WZ6bugDGNAn/U6CbmbN+Bh/AceH30tsuSw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/blocks": "^15.23.0",
+				"@wordpress/data": "^10.50.0",
+				"@wordpress/i18n": "^6.23.0",
+				"@wordpress/style-engine": "^2.50.0",
+				"colord": "^2.9.3",
+				"deepmerge": "^4.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/global-styles-engine/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/@wordpress/hooks": {
 			"version": "3.58.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
@@ -4908,6 +6884,17 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/html-entities": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.50.0.tgz",
+			"integrity": "sha512-RWoT58IXeX82fC7zBLiTNEDdKN/fTAHWlMJbEwMH65UTzJt5jNWtmVdbtTZP248ceyAK3lUsWaXei2t1bqAyNA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/i18n": {
@@ -4929,6 +6916,119 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/icons": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.1.0.tgz",
+			"integrity": "sha512-KPFEe24QJ5MTp6XMREKPPW1tHWjQau/vwYuZqkddSiJEhUBSrNaDHRqneCMC6WVhWCSmWNJcjUtdkFQpLb5W+A==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/primitives": "^4.50.0",
+				"change-case": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/image-cropper": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.14.0.tgz",
+			"integrity": "sha512-Uu441xNKPfGcSr52obC3AoyXr++8t2Iepsk1XG0rXHE5OW7xbEit8fMwrn3lxQL4sZ78UFTI8ojNsieCpKK3RQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/components": "^36.1.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/i18n": "^6.23.0",
+				"clsx": "^2.1.1",
+				"dequal": "^2.0.3",
+				"react-easy-crop": "^5.4.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/image-cropper/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/image-cropper/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/interactivity": {
+			"version": "6.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.50.0.tgz",
+			"integrity": "sha512-jScebsDZocz/l+vbutSpR8U5zZweb1rQzHPyjncHTmYqTCSGoYiGajS/lIZvTYQ2Ve4V0wTaeS2GuaFuWTEHxw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@preact/signals": "^1.3.0",
+				"@preact/signals-core": "^1.7.0",
+				"preact": "^10.29.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/is-shallow-equal": {
+			"version": "5.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.50.0.tgz",
+			"integrity": "sha512-Cq1brW/OhGVNnCqSztHgmKQ1DsNUtEq4F1xIo1awBKVmXDWFggJRxzaWZHWC+sDZmBp7pu03jWqq2u/s+hazSQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
@@ -4966,6 +7066,85 @@
 				"jest": ">=29"
 			}
 		},
+		"node_modules/@wordpress/keyboard-shortcuts": {
+			"version": "5.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.50.0.tgz",
+			"integrity": "sha512-8ytzJgkdukPrOBpMUFp0LhTd2V5LmIknYM1o9p5AYgw+TvuV5rkxXbJR+b5MaWeVVJxwL316rgWW6ojQzco8iA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/data": "^10.50.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/keycodes": "^4.50.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/keycodes": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.50.0.tgz",
+			"integrity": "sha512-BtyCkA7pk5pMMx+dVjT10OuhQwr9ZjYY1LLcXJcYJjhhFsP16be2BiytrBnKDZj/479/icvEYwlooawZCPrxYQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.23.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@wordpress/keycodes": {
 			"version": "3.58.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.58.0.tgz",
@@ -4978,6 +7157,32 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/notices": {
+			"version": "5.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.50.0.tgz",
+			"integrity": "sha512-5SbGOxvgme21Slf1smiWRh4SFmL6mbMrPPcSOHHwkqxlCOZu9dp5gXGQbJNYz9arLqOIHze6+o1/8gsfJJNtPA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/a11y": "^4.50.0",
+				"@wordpress/components": "^36.1.0",
+				"@wordpress/data": "^10.50.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
@@ -5010,6 +7215,83 @@
 				"postcss": "^8.0.0"
 			}
 		},
+		"node_modules/@wordpress/preferences": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.50.0.tgz",
+			"integrity": "sha512-KptPNtUWvuI6qQ0NafXjgRJoU5M3gwcSDtX0xB4BCwOBfJycSz+v+GHaMlOEs3ZOJpdsq9zXtCt/psG88z+7ew==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/a11y": "^4.50.0",
+				"@wordpress/base-styles": "^10.2.0",
+				"@wordpress/components": "^36.1.0",
+				"@wordpress/compose": "^8.3.0",
+				"@wordpress/data": "^10.50.0",
+				"@wordpress/deprecated": "^4.50.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/i18n": "^6.23.0",
+				"@wordpress/icons": "^15.1.0",
+				"@wordpress/private-apis": "^1.50.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/preferences/node_modules/@wordpress/base-styles": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.2.0.tgz",
+			"integrity": "sha512-iDPbyyeUnxLFq4ec+03x87jT8lRoBzK2rDoEg24l2KNAR9ZJ2kwI0z2E/wW0fOZC37A7qr377KJslPHKLtMgyQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/preferences/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/preferences/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/prettier-config": {
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-3.15.0.tgz",
@@ -5021,6 +7303,172 @@
 			},
 			"peerDependencies": {
 				"prettier": ">=3"
+			}
+		},
+		"node_modules/@wordpress/primitives": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.50.0.tgz",
+			"integrity": "sha512-X/Vf1BUwPsxsyJq+z2UwjOHFoT4p1XI0VoxgN2JsbK0ZwbLPA9PQur1hGw9ujXqNZ4XG1U2rQ0aM+3yap7iC3g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.2.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/priority-queue": {
+			"version": "3.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.50.0.tgz",
+			"integrity": "sha512-OyuAplepKQpNYr8z+nGGGNXWK2v2u9Bqnawkg7V5YkvOKYj/iBJNCiUxiWXOBMeLF1ze36RDR5LEcNDmXRev2Q==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"requestidlecallback": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/private-apis": {
+			"version": "1.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.50.0.tgz",
+			"integrity": "sha512-bCVLL9YuWfnPNNqlhl4eTKPipjWbJ8MzAlasJ/SR+h979MyeMFjNPapxKqsPqnJOhDEVSdCTkRN/Wa+Xk8qFdw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/redux-routine": {
+			"version": "5.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.50.0.tgz",
+			"integrity": "sha512-flSjGWuU5C2CrH4hommSDyN0Zz+VRDTUvclLbpByRmUc8gsfgscmjJo+99o1KvU/f7ApItRdFKkbjdxzwtXorw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"rungen": "^0.3.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"redux": ">=4"
+			}
+		},
+		"node_modules/@wordpress/redux-routine/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/rich-text": {
+			"version": "7.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.50.0.tgz",
+			"integrity": "sha512-i3lFUjzeIx+0xWoWUWKIcr5pWyT6D75JlMnB0wgLE5hyaI1NUryUziOohW9b1j6xKvY1CS0j6JJVmnJAmHXHsQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/a11y": "^4.50.0",
+				"@wordpress/compose": "^8.3.0",
+				"@wordpress/data": "^10.50.0",
+				"@wordpress/deprecated": "^4.50.0",
+				"@wordpress/dom": "^4.50.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/escape-html": "^3.50.0",
+				"@wordpress/i18n": "^6.23.0",
+				"@wordpress/keycodes": "^4.50.0",
+				"@wordpress/private-apis": "^1.50.0",
+				"colord": "^2.9.3",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/@wordpress/keycodes": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.50.0.tgz",
+			"integrity": "sha512-BtyCkA7pk5pMMx+dVjT10OuhQwr9ZjYY1LLcXJcYJjhhFsP16be2BiytrBnKDZj/479/icvEYwlooawZCPrxYQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.23.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/scripts": {
@@ -5102,6 +7550,53 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/shortcode": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.50.0.tgz",
+			"integrity": "sha512-mMPHJr3UT6Z4wlU+q/61S6Cv6j3zcyd96AhVfJHXSxhZbjgTXkX+zhi79jt12Xnfzz4A6FfXTFCuwVV6Jvz1ZQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/style-engine": {
+			"version": "2.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.50.0.tgz",
+			"integrity": "sha512-7iAvYbPniJ3fBV2S5zRVDdNqHLWKsXZlx6/IqVz2uOASXEn/qTACqf+nWv2Az8lJkKyXUmO9EWBrGTOvGX0ulg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"change-case": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/style-runtime": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.6.0.tgz",
+			"integrity": "sha512-PSNzFecFRJ7gmah5YxHFv0a0ZUwZOdeO9/B8GNyv2LgC/ZLXS8CtsAblOKVRO3W7ExwazbHwexaTAOzU/+7Mug==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
 		"node_modules/@wordpress/stylelint-config": {
 			"version": "21.41.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.41.0.tgz",
@@ -5119,6 +7614,271 @@
 				"stylelint": "^14.2"
 			}
 		},
+		"node_modules/@wordpress/token-list": {
+			"version": "3.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.50.0.tgz",
+			"integrity": "sha512-NgmApEUrObbO67/9GHoYpmO4gS/iWpfiYt56JohFXUSbk3h3DJ1kILkxL3k0KDfeLoQRtwWiPnB6Q4Ez89IUjQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.17.0.tgz",
+			"integrity": "sha512-+mMnJmkvFjTk7veIioU/idaPfb6HJCcBV408v1gKsbpLa+dxG+rLdlrpzJILLlZmHUyCrJXk9EmYZi6MkFoL9A==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@base-ui/react": "^1.5.0",
+				"@wordpress/a11y": "^4.50.0",
+				"@wordpress/compose": "^8.3.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/i18n": "^6.23.0",
+				"@wordpress/icons": "^15.1.0",
+				"@wordpress/keycodes": "^4.50.0",
+				"@wordpress/primitives": "^4.50.0",
+				"@wordpress/private-apis": "^1.50.0",
+				"@wordpress/style-runtime": "^0.6.0",
+				"@wordpress/theme": "^0.17.0",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/keycodes": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.50.0.tgz",
+			"integrity": "sha512-BtyCkA7pk5pMMx+dVjT10OuhQwr9ZjYY1LLcXJcYJjhhFsP16be2BiytrBnKDZj/479/icvEYwlooawZCPrxYQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.23.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/theme": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.17.0.tgz",
+			"integrity": "sha512-BU+PLBLxMBM4WJYrd1QEwy+IA64vUP+8IEEB9lLx2NfB+3/45vvuvXx9o3qPKRDHvtMtEaRArld4Kn05UIW9IA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/compose": "^8.2.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/style-runtime": "^0.5.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"esbuild": "^0.27.2",
+				"postcss": "^8.0.0",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2",
+				"vite": "^7.3.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
+				"stylelint": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/theme/node_modules/@wordpress/style-runtime": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.5.0.tgz",
+			"integrity": "sha512-hrXvdDUJpOzT1KIomgtysysgbc5bkkwAuJyEUAXiOCgVBXBeMkZlgfN19W0PuNY51j53K7VQ42txfayxgVmfgA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wordpress/undo-manager": {
+			"version": "1.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.50.0.tgz",
+			"integrity": "sha512-599I3GPXSMpmAE2jqzHteqypI7rdt5HPDAw8GrHMkDWR1T9gK2L3gObv8I1Hs4eSDM88wgAB0Ifnqpy7zPn5rw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/is-shallow-equal": "^5.50.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/upload-media": {
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.35.0.tgz",
+			"integrity": "sha512-Xpka03EVJZd0BORFsgYZhGnrSHwolwXkDR+g4S+VQoWOCbhZSX9VRPgEiPSxzp3i4HTCvgXyeEo6sEKNrhlllg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/blob": "^4.50.0",
+				"@wordpress/compose": "^8.3.0",
+				"@wordpress/data": "^10.50.0",
+				"@wordpress/element": "^8.2.0",
+				"@wordpress/i18n": "^6.23.0",
+				"@wordpress/preferences": "^4.50.0",
+				"@wordpress/private-apis": "^1.50.0",
+				"@wordpress/url": "^4.50.0",
+				"@wordpress/vips": "^2.3.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/upload-media/node_modules/@wordpress/hooks": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/upload-media/node_modules/@wordpress/i18n": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.50.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/upload-media/node_modules/@wordpress/url": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.50.0.tgz",
+			"integrity": "sha512-k9lJLhDDzuNfoI3LAXVqTocYQxQJcH2ee08uy9fPd7l8JgfkGmFRm4zWnyEncZn2n8SG19kC4t6MvykaQZk9Gw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/upload-media/node_modules/uuid": {
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+			"integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
 		"node_modules/@wordpress/url": {
 			"version": "3.59.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
@@ -5133,6 +7893,21 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@wordpress/vips": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-2.3.0.tgz",
+			"integrity": "sha512-MeJZckJBJOjEe9htBQysYjfqKdbqeaSOEKtGMgqY4Jlt9EUUyc9LknLKwxlFR0Km/AW7b+8J2j5Dx5gNLwN9QQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/worker-threads": "^1.10.0",
+				"wasm-vips": "^0.0.18"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/warning": {
 			"version": "2.58.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.58.0.tgz",
@@ -5141,6 +7916,31 @@
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/wordcount": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.50.0.tgz",
+			"integrity": "sha512-rWJkzoBEkcQF7/y3K39K8bPHDXzWEGXJ3iQgYCnpca4/m3lzP1eRQKX9B/X2zicqW4K7l1h9jui/F5fdj5bcSw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/worker-threads": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.10.0.tgz",
+			"integrity": "sha512-sW/yKL5OE/Ke9X3itP4eICcbFANfRkuMtoUDTtSRqxZZoupZuDeXvxgjhNYTIBzfJnA79I0k5PKB4lu5VGCnGg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"comctx": "^1.4.3"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@xtuc/ieee754": {
@@ -5462,6 +8262,19 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/aria-hidden": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+			"integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/aria-query": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -5763,6 +8576,13 @@
 				"postcss": "^8.1.0"
 			}
 		},
+		"node_modules/autosize": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz",
+			"integrity": "sha512-5yxLQ22O0fCRGoxGfeLSNt3J8LB1v+umtpMnPW6XjkTWXKoN0AmXAIhelJcDtFT/Y/wYWmfE+oqU10Q0b8FhaQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5948,6 +8768,39 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/babel-plugin-macros": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"cosmiconfig": "^7.0.0",
+				"resolve": "^1.19.0"
+			},
+			"engines": {
+				"node": ">=10",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
@@ -6832,6 +9685,33 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/cmdk": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+			"integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "^1.1.1",
+				"@radix-ui/react-dialog": "^1.1.6",
+				"@radix-ui/react-id": "^1.1.0",
+				"@radix-ui/react-primitive": "^2.0.2"
+			},
+			"peerDependencies": {
+				"react": "^18 || ^19 || ^19.0.0-rc",
+				"react-dom": "^18 || ^19 || ^19.0.0-rc"
+			}
+		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6884,6 +9764,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/colorjs.io": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
+			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/color"
+			}
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -6896,6 +9787,13 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/comctx": {
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/comctx/-/comctx-1.7.5.tgz",
+			"integrity": "sha512-0fsxsxr1Hg2T99wOIteUbsJOX6jMmnhAJepcVRqNRMWpcbxRhbm2+0R8qEuQEaE4gWjfdXaKeAGYAn0yeElylQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/commander": {
 			"version": "12.1.0",
@@ -6972,6 +9870,12 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/computed-style": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
+			"integrity": "sha512-WpAmaKbMNmS3OProfHIdJiNleNJdgUrJfbKArXua28QF7+0CoZjlLn0lp6vlc+dl5r2/X9GQiQRQQU4BzSa69w==",
+			"dev": true
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -7604,6 +10508,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/csstype": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cwd": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
@@ -7703,6 +10614,24 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
+		"node_modules/date-fns-jalali": {
+			"version": "4.1.0-0",
+			"resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+			"integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/debounce": {
 			"version": "1.2.1",
@@ -7968,6 +10897,16 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/destroy": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -8007,12 +10946,29 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/detect-node-es": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/devtools-protocol": {
 			"version": "0.0.1155343",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1155343.tgz",
 			"integrity": "sha512-oD9vGBV2wTc7fAzAM6KC0chSgs234V8+qDEeK+mcbRj2UvcuA7lgBztGi/opj/iahcXD3BSj8Ymvib628yy9FA==",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
 		},
 		"node_modules/diff-sequences": {
 			"version": "29.6.3",
@@ -8309,6 +11265,13 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/equivalent-key-map": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
+			"integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/error-ex": {
 			"version": "1.3.4",
@@ -10125,6 +13088,13 @@
 				"find-process": "bin/find-process.js"
 			}
 		},
+		"node_modules/find-root": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/find-up": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -10289,6 +13259,34 @@
 				"url": "https://github.com/sponsors/rawify"
 			}
 		},
+		"node_modules/framer-motion": {
+			"version": "11.18.2",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+			"integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"motion-dom": "^11.18.1",
+				"motion-utils": "^11.18.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"@emotion/is-prop-valid": "*",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/is-prop-valid": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -10442,6 +13440,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-nonce": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/get-package-type": {
@@ -10728,6 +13736,15 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/gradient-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.2.0.tgz",
+			"integrity": "sha512-6ABGa9CR7WR/0pAJicBy5SJkiikbFM6kf/JjykwX7x+t+s8ORWVnlbi6FkHeFFb36yWsjUpHqSYrygd7ofEUqA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -10873,6 +13890,30 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/highlight-words-core": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.3.tgz",
+			"integrity": "sha512-m1O9HW3/GNHxzSIXWw1wCNXXsgLlxrP0OI6+ycGUhiUHkikqW3OrwVHz+lxeNBe5yqLESdIcj8PowHQ2zLvUvQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"react-is": "^16.7.0"
+			}
+		},
+		"node_modules/hoist-non-react-statics/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/homedir-polyfill": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -10971,6 +14012,13 @@
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
+		},
+		"node_modules/hpq": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.4.0.tgz",
+			"integrity": "sha512-ycJQMRaRPBcfnoT1gS5I1XCvbbw9KO94Y0vkwksuOjcJMqNZtb03MF2tCItLI2mQbkZWSSeFinoRDPmjzv4tKg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "3.0.0",
@@ -11868,6 +14916,13 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -13442,6 +16497,19 @@
 				"url": "https://github.com/sponsors/antonk52"
 			}
 		},
+		"node_modules/line-height": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
+			"integrity": "sha512-YExecgqPwnp5gplD2+Y8e8A5+jKpr25+DzMbFdI1/1UAr0FJrTFv4VkHLf8/6B590i1wUPJWMKKldkd/bdQ//w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"computed-style": "~0.1.3"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -13818,6 +16886,19 @@
 			"integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/marked": {
+			"version": "18.0.6",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.6.tgz",
+			"integrity": "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
 		},
 		"node_modules/marky": {
 			"version": "1.3.0",
@@ -14197,6 +17278,53 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/moment": {
+			"version": "2.30.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/moment-timezone": {
+			"version": "0.5.48",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+			"integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"moment": "^2.29.4"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/motion-dom": {
+			"version": "11.18.1",
+			"resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+			"integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"motion-utils": "^11.18.1"
+			}
+		},
+		"node_modules/motion-utils": {
+			"version": "11.18.1",
+			"resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+			"integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/mousetrap": {
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+			"integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
+			"dev": true,
+			"license": "Apache-2.0 WITH LLVM-exception"
+		},
 		"node_modules/mrmime": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -14430,6 +17558,13 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/normalize-wheel": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+			"integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/npm-bundled": {
 			"version": "1.1.2",
@@ -15085,6 +18220,23 @@
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
+		},
+		"node_modules/parsel-js": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/parsel-js/-/parsel-js-1.2.3.tgz",
+			"integrity": "sha512-kJHFmSNnujpusFfVEXjNaoJ09VYHF8Ih0aVUn7Clu+Ug8AFoA2wx7Ezh17JfW4+vhm/lauAd9A+//uFkmydZtQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/LeaVerou"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/leaverou"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/parseurl": {
 			"version": "1.3.3",
@@ -15886,6 +19038,16 @@
 				"postcss": "^8.4.31"
 			}
 		},
+		"node_modules/postcss-prefix-selector": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.1.tgz",
+			"integrity": "sha512-Umxu+FvKMwlY6TyDzGFoSUnzW+NOfMBLyC1tAkIjgX+Z/qGspJeRjVC903D7mx7TuBpJlwti2ibXtWuA7fKMeQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"postcss": ">4 <9"
+			}
+		},
 		"node_modules/postcss-reduce-initial": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.1.0.tgz",
@@ -16017,12 +19179,44 @@
 				"postcss": "^8.4.31"
 			}
 		},
+		"node_modules/postcss-urlrebase": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/postcss-urlrebase/-/postcss-urlrebase-1.4.0.tgz",
+			"integrity": "sha512-rRaxMmWvXrn8Rk1PqsxmaJwldRHsr0WbbASKKCZYxXwotHkM/5X/6IrwaEe8pdzpbNGCEY86yhYMN0MhgOkADA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.3.0"
+			}
+		},
 		"node_modules/postcss-value-parser": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/preact": {
+			"version": "10.29.7",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+			"integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			},
+			"peerDependencies": {
+				"preact-render-to-string": ">=5"
+			},
+			"peerDependenciesMeta": {
+				"preact-render-to-string": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -16510,6 +19704,17 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/re-resizable": {
+			"version": "6.11.2",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+			"integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
 		"node_modules/react": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -16520,6 +19725,56 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-autosize-textarea": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
+			"integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"autosize": "^4.0.2",
+				"line-height": "^0.3.1",
+				"prop-types": "^15.5.6"
+			},
+			"peerDependencies": {
+				"react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+				"react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/react-colorful": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.7.0.tgz",
+			"integrity": "sha512-fuesYIemttah97XmsIHmz4OORDHiSFzyc9HMAIrCHJou2jaRQmL8cFJ76K4zQhhj8jzwOBlOi4BaGTjjOZCfTg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/react-day-picker": {
+			"version": "9.14.0",
+			"resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+			"integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@date-fns/tz": "^1.4.1",
+				"@tabby_ai/hijri-converter": "1.0.5",
+				"date-fns": "^4.1.0",
+				"date-fns-jalali": "4.1.0-0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/gpbl"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
 			}
 		},
 		"node_modules/react-dom": {
@@ -16534,6 +19789,21 @@
 			},
 			"peerDependencies": {
 				"react": "^18.3.1"
+			}
+		},
+		"node_modules/react-easy-crop": {
+			"version": "5.5.7",
+			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.7.tgz",
+			"integrity": "sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"normalize-wheel": "^1.0.1",
+				"tslib": "^2.0.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.4.0",
+				"react-dom": ">=16.4.0"
 			}
 		},
 		"node_modules/react-is": {
@@ -16551,6 +19821,78 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-remove-scroll": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+			"integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"react-remove-scroll-bar": "^2.3.7",
+				"react-style-singleton": "^2.2.3",
+				"tslib": "^2.1.0",
+				"use-callback-ref": "^1.3.3",
+				"use-sidecar": "^1.1.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-remove-scroll-bar": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+			"integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"react-style-singleton": "^2.2.2",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-style-singleton": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+			"integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-nonce": "^1.0.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/read-pkg": {
@@ -16693,6 +20035,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/redux": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -16802,10 +20151,24 @@
 				"regjsparser": "bin/parser"
 			}
 		},
+		"node_modules/rememo": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+			"integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/remove-accents": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
 			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/requestidlecallback": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+			"integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16843,6 +20206,13 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/reselect": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+			"integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -17095,6 +20465,13 @@
 			"dependencies": {
 				"queue-microtask": "^1.2.2"
 			}
+		},
+		"node_modules/rungen": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
+			"integrity": "sha512-zWl10xu2D7zoR8zSC2U6bg5bYF6T/Wk7rxwp8IPaJH7f0Ge21G03kNHVgHR7tyVkSSfAOG0Rqf/Cl38JftSmtw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/rxjs": {
 			"version": "7.8.2",
@@ -17716,6 +21093,13 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/simple-html-tokenizer": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
+			"integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/sirv": {
 			"version": "2.0.4",
@@ -18533,6 +21917,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/stylis": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -18644,6 +22035,13 @@
 			"funding": {
 				"url": "https://opencollective.com/synckit"
 			}
+		},
+		"node_modules/tabbable": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+			"integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/table": {
 			"version": "6.9.0",
@@ -19575,6 +22973,71 @@
 				"requires-port": "^1.0.0"
 			}
 		},
+		"node_modules/use-callback-ref": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+			"integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/use-memo-one": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+			"integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/use-sidecar": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+			"integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"detect-node-es": "^1.1.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/use-sync-external-store": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -19708,6 +23171,16 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"makeerror": "1.0.12"
+			}
+		},
+		"node_modules/wasm-vips": {
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.18.tgz",
+			"integrity": "sha512-AJyCvxZj/3qceKNnh+YyEobu/IaJFoPN7x7SxyyHmYBS3kASMqJqxQEuN0ZHKQDWsCJ8armfx4Tq3uKrNc+nMA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=17.0.0"
 			}
 		},
 		"node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
 		"lint:js:fix": "wp-scripts lint-js --fix"
 	},
 	"devDependencies": {
+		"@wordpress/block-editor": "^15.23.0",
+		"@wordpress/blocks": "^15.23.0",
+		"@wordpress/components": "^36.1.0",
+		"@wordpress/element": "^8.2.0",
 		"@wordpress/scripts": "^27.1.0",
 		"ajv": "^8.20.0",
 		"react": "^18.3.1",

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -334,8 +334,8 @@ final class AccountMarketTest extends TestCase {
 				);
 			}
 		};
-		$_GET = array();
-		$result = extrachill_events_calendar_account_market_defaults( array(), array( 'archive_term' => null ) );
+		$_GET                                   = array();
+		$result                                 = extrachill_events_calendar_account_market_defaults( array(), array( 'archive_term' => null ) );
 
 		$this->assertSame( array( 'location' => array( 1618 ) ), $result['tax_filter'] );
 		$this->assertSame( array(), $_GET );
@@ -388,7 +388,7 @@ final class AccountMarketTest extends TestCase {
 				);
 			}
 		};
-		$_GET = array( 'explore_all' => '1' );
+		$_GET                                   = array( 'explore_all' => '1' );
 
 		$this->assertTrue( extrachill_events_is_exploring_all_markets() );
 		$this->assertSame( array(), extrachill_events_calendar_account_market_defaults( array(), array( 'archive_term' => null ) ) );
@@ -449,7 +449,7 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['test_is_front_page'] = true;
 		$this->assertTrue( extrachill_events_supports_account_market() );
 
-		$GLOBALS['test_is_front_page']     = false;
+		$GLOBALS['test_is_front_page']      = false;
 		$GLOBALS['test_is_all_events_page'] = true;
 		$this->assertTrue( extrachill_events_supports_account_market() );
 
@@ -467,9 +467,9 @@ final class AccountMarketTest extends TestCase {
 
 	public function test_router_query_flags_use_the_query_being_parsed(): void {
 		$query = new class( array( 'ec_events_router' => 'all' ) ) {
-			public bool $is_404 = true;
+			public bool $is_404     = true;
 			public bool $is_archive = false;
-			public bool $is_home = true;
+			public bool $is_home    = true;
 			private array $vars;
 
 			public function __construct( array $vars ) {
@@ -644,10 +644,10 @@ final class AccountMarketTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_archive_cta_shows_save_form_or_current_confirmation(): void {
-		$GLOBALS['test_is_tax']           = true;
+		$GLOBALS['test_is_tax']            = true;
 		$GLOBALS['test_is_user_logged_in'] = true;
-		$GLOBALS['test_queried_term']     = new WP_Term( 1618, 'Charleston', 'charleston' );
-		$GLOBALS['test_term_ancestors']   = array( 22, 1 );
+		$GLOBALS['test_queried_term']      = new WP_Term( 1618, 'Charleston', 'charleston' );
+		$GLOBALS['test_term_ancestors']    = array( 22, 1 );
 
 		ob_start();
 		extrachill_events_render_archive_scene_cta();
@@ -662,10 +662,10 @@ final class AccountMarketTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_archive_cta_confirms_current_scene_without_save_form(): void {
-		$GLOBALS['test_is_tax']           = true;
-		$GLOBALS['test_is_user_logged_in'] = true;
-		$GLOBALS['test_queried_term']     = new WP_Term( 1618, 'Charleston', 'charleston' );
-		$GLOBALS['test_term_ancestors']   = array( 22, 1 );
+		$GLOBALS['test_is_tax']                 = true;
+		$GLOBALS['test_is_user_logged_in']      = true;
+		$GLOBALS['test_queried_term']           = new WP_Term( 1618, 'Charleston', 'charleston' );
+		$GLOBALS['test_term_ancestors']         = array( 22, 1 );
 		$GLOBALS['test_account_market_ability'] = new class() {
 			public function execute(): array {
 				return array(
@@ -689,8 +689,8 @@ final class AccountMarketTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_archive_update_requires_login_and_nonce_and_uses_settings_ability(): void {
-		$term = new WP_Term( 1618, 'Charleston', 'charleston' );
-		$calls = new ArrayObject();
+		$term                                 = new WP_Term( 1618, 'Charleston', 'charleston' );
+		$calls                                = new ArrayObject();
 		$GLOBALS['test_update_scene_ability'] = new class( $calls ) {
 			private ArrayObject $calls;
 			public function __construct( ArrayObject $calls ) {

--- a/tests/location-market-map-smoke.php
+++ b/tests/location-market-map-smoke.php
@@ -134,7 +134,7 @@ $fail = 0;
 
 foreach ( $cases as $case ) {
 	list( $city, $state, $zip, $expected ) = $case;
-	$got = extrachill_events_get_market_slug_for_venue( $city, $state, $zip );
+	$got                                   = extrachill_events_get_market_slug_for_venue( $city, $state, $zip );
 
 	if ( $got === $expected ) {
 		++$pass;


### PR DESCRIPTION
## Summary
- Apply PHPCBF formatting fixes and add request-boundary nonce verification for Local Scene updates.
- Declare the WordPress block packages imported by editor sources, remove an error-only console statement, and fix the remaining Prettier formatting.
- Supersedes the closed stale lint PRs #143, #204, and #219.

## Lint Results
- Before: PHPCS 4 errors / 3 warnings; ESLint 16 errors / 1 warning.
- After: PHPCS passed with 0 findings; ESLint passed with 0 findings.
- `php -l inc/core/account-market.php` and `npm run lint:js` pass.
- `homeboy review extrachill-events lint --force-hot` remains non-passing only because the global PHPStan runner cannot load its oversized PHAR before analysis. Tracked upstream: Extra-Chill/homeboy-extensions#2230.

## Changes by Commit
- `style: phpcbf autofix formatting`: PHPCBF-only arrays, indentation, spacing, and comment formatting.
- `fix: resolve remaining phpcs findings`: validates the submitted nonce before request processing, retains the helper-level nonce check, and marks the read-only redirect status with a targeted PHPCS justification. No behavior changes to valid submissions.

## PHPCS Ignores
- `inc/core/account-market.php`: one targeted `NonceVerification.Recommended` ignore for the read-only `scene_status` flash parameter, which is set only by this handler's nonce-protected redirect.