### PR TITLE
feat: notify artist subscribers of new events

### DIFF
--- a/inc/core/data-machine-events/festival-notifications.php
+++ b/inc/core/data-machine-events/festival-notifications.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Festival event notifications.
+ * Event entity notifications.
  *
  * @package ExtraChillEvents
  */
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 const EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER = 'extrachill-events-festival-notifications';
 
 /**
- * Register festival event notification hooks.
+ * Register event entity notification hooks.
  *
  * @return void
  */
@@ -22,7 +22,7 @@ function extrachill_events_init_festival_notifications(): void {
 }
 
 /**
- * Authorize this plugin to resolve private festival notification recipients.
+ * Authorize this plugin to resolve private event entity notification recipients.
  *
  * @param bool   $authorized Whether the producer is already authorized.
  * @param string $producer   Producer identifier.
@@ -35,11 +35,11 @@ function extrachill_events_authorize_festival_notification_producer( $authorized
 		return (bool) $authorized;
 	}
 
-	return is_array( $entity ) && 'festival' === ( $entity['entity_type'] ?? '' ) && 'festival' === ( $entity['taxonomy'] ?? '' );
+	return is_array( $entity ) && in_array( $entity['entity_type'] ?? '', array( 'artist', 'festival' ), true ) && ( $entity['entity_type'] ?? '' ) === ( $entity['taxonomy'] ?? '' );
 }
 
 /**
- * Notify festival subscribers when an event first becomes published.
+ * Notify artist and festival subscribers when an event first becomes published.
  *
  * @param string   $new_status New post status.
  * @param string   $old_status Previous post status.
@@ -59,24 +59,26 @@ function extrachill_events_notify_festival_subscribers( $new_status, $old_status
 		return;
 	}
 
-	$festival_slugs = wp_get_post_terms( $post->ID, 'festival', array( 'fields' => 'slugs' ) );
-	if ( is_wp_error( $festival_slugs ) || empty( $festival_slugs ) ) {
-		return;
-	}
-
 	$recipient_ids = array();
-	foreach ( $festival_slugs as $festival_slug ) {
-		$recipients = extrachill_users_entity_subscription_recipients(
-			EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER,
-			'festival',
-			'festival',
-			$festival_slug
-		);
-		if ( is_wp_error( $recipients ) ) {
+	foreach ( array( 'artist', 'festival' ) as $taxonomy ) {
+		$slugs = wp_get_post_terms( $post->ID, $taxonomy, array( 'fields' => 'slugs' ) );
+		if ( is_wp_error( $slugs ) || empty( $slugs ) ) {
 			continue;
 		}
 
-		$recipient_ids = array_merge( $recipient_ids, $recipients );
+		foreach ( $slugs as $slug ) {
+			$recipients = extrachill_users_entity_subscription_recipients(
+				EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER,
+				$taxonomy,
+				$taxonomy,
+				$slug
+			);
+			if ( is_wp_error( $recipients ) ) {
+				continue;
+			}
+
+			$recipient_ids = array_merge( $recipient_ids, $recipients );
+		}
 	}
 
 	$recipient_ids = array_values( array_unique( array_map( 'absint', $recipient_ids ) ) );

--- a/tests/Unit/FestivalNotificationsTest.php
+++ b/tests/Unit/FestivalNotificationsTest.php
@@ -51,8 +51,8 @@ if ( ! function_exists( 'get_post_type' ) ) {
 }
 
 if ( ! function_exists( 'wp_get_post_terms' ) ) {
-	function wp_get_post_terms() {
-		return $GLOBALS['festival_notification_terms'];
+	function wp_get_post_terms( $post_id, $taxonomy ) {
+		return $GLOBALS['festival_notification_terms'][ $taxonomy ] ?? array();
 	}
 }
 
@@ -106,26 +106,34 @@ require_once dirname( __DIR__, 2 ) . '/inc/core/data-machine-events/festival-not
 class FestivalNotificationsTest extends TestCase {
 
 	protected function setUp(): void {
-		$GLOBALS['festival_notification_terms']       = array();
+		$GLOBALS['festival_notification_terms']       = array(
+			'artist'   => array(),
+			'festival' => array(),
+		);
 		$GLOBALS['festival_notification_recipients']  = array();
 		$GLOBALS['festival_notification_resolutions'] = array();
 		$GLOBALS['festival_notification_calls']       = array();
 	}
 
-	public function test_authorizes_only_festival_notification_resolution(): void {
-		$entity = array(
+	public function test_authorizes_only_event_entity_notification_resolution(): void {
+		$festival = array(
 			'entity_type' => 'festival',
 			'taxonomy'    => 'festival',
 		);
+		$artist   = array(
+			'entity_type' => 'artist',
+			'taxonomy'    => 'artist',
+		);
 
-		$this->assertTrue( extrachill_events_authorize_festival_notification_producer( false, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER, $entity, 'notification' ) );
-		$this->assertFalse( extrachill_events_authorize_festival_notification_producer( false, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER, $entity, 'email' ) );
-		$this->assertFalse( extrachill_events_authorize_festival_notification_producer( false, 'untrusted', $entity, 'notification' ) );
+		$this->assertTrue( extrachill_events_authorize_festival_notification_producer( false, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER, $festival, 'notification' ) );
+		$this->assertTrue( extrachill_events_authorize_festival_notification_producer( false, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER, $artist, 'notification' ) );
+		$this->assertFalse( extrachill_events_authorize_festival_notification_producer( false, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER, $artist, 'email' ) );
+		$this->assertFalse( extrachill_events_authorize_festival_notification_producer( false, 'untrusted', $artist, 'notification' ) );
 	}
 
 	public function test_notifies_deduplicated_recipients_for_every_festival(): void {
-		$GLOBALS['festival_notification_terms']      = array( 'summer-jam', 'river-fest' );
-		$GLOBALS['festival_notification_recipients'] = array(
+		$GLOBALS['festival_notification_terms']['festival'] = array( 'summer-jam', 'river-fest' );
+		$GLOBALS['festival_notification_recipients']        = array(
 			'summer-jam' => array( 7, 9 ),
 			'river-fest' => array( 9, 11 ),
 		);
@@ -144,6 +152,51 @@ class FestivalNotificationsTest extends TestCase {
 		$this->assertSame( array( 7, 9, 11 ), $GLOBALS['festival_notification_calls'][0]['user_ids'] );
 		$this->assertSame( 'New event: The Big Show', $GLOBALS['festival_notification_calls'][0]['data']['title'] );
 		$this->assertSame( 'https://events.example/events/42/', $GLOBALS['festival_notification_calls'][0]['data']['link'] );
+	}
+
+	public function test_notifies_artist_subscribers_and_deduplicates_across_entity_terms(): void {
+		$GLOBALS['festival_notification_terms']['artist']   = array( 'the-headliners', 'support-act' );
+		$GLOBALS['festival_notification_terms']['festival'] = array( 'summer-jam' );
+		$GLOBALS['festival_notification_recipients']        = array(
+			'the-headliners' => array( 7, 9 ),
+			'support-act'    => array( 9, 11 ),
+			'summer-jam'     => array( 11, 13 ),
+		);
+		$post = new WP_Post(
+			array(
+				'ID'          => 42,
+				'post_author' => 3,
+				'post_type'   => DATA_MACHINE_EVENTS_POST_TYPE,
+				'post_title'  => 'The Big Show',
+			)
+		);
+
+		extrachill_events_notify_festival_subscribers( 'publish', 'draft', $post );
+
+		$this->assertSame(
+			array(
+				array(
+					'producer'    => EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER,
+					'entity_type' => 'artist',
+					'taxonomy'    => 'artist',
+					'slug'        => 'the-headliners',
+				),
+				array(
+					'producer'    => EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER,
+					'entity_type' => 'artist',
+					'taxonomy'    => 'artist',
+					'slug'        => 'support-act',
+				),
+				array(
+					'producer'    => EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER,
+					'entity_type' => 'festival',
+					'taxonomy'    => 'festival',
+					'slug'        => 'summer-jam',
+				),
+			),
+			$GLOBALS['festival_notification_resolutions']
+		);
+		$this->assertSame( array( 7, 9, 11, 13 ), $GLOBALS['festival_notification_calls'][0]['user_ids'] );
 	}
 
 	public function test_does_not_notify_for_published_post_updates(): void {


### PR DESCRIPTION
## Summary
- Resolve private artist subscribers from explicitly assigned event artist terms through the existing Events producer.
- Preserve festival notifications, first-publication gating, notification delivery, and recipient deduplication across artist and festival terms.
- Cover artist authorization and mixed entity recipient resolution with focused unit tests.

## Verification
- `php -l inc/core/data-machine-events/festival-notifications.php`
- `php -l tests/Unit/FestivalNotificationsTest.php`
- `./vendor/bin/phpcs --standard=WordPress inc/core/data-machine-events/festival-notifications.php`
- `./vendor/bin/phpunit tests/Unit/FestivalNotificationsTest.php`
- `composer test` (fails on 5 pre-existing failures and 1 error outside this change)

Closes #248