### PR TITLE
feat: prioritize nearby artist show notifications

### DIFF
--- a/inc/core/data-machine-events/festival-notifications.php
+++ b/inc/core/data-machine-events/festival-notifications.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 const EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER = 'extrachill-events-festival-notifications';
+const EXTRACHILL_EVENTS_NEARBY_ARTIST_EVENT_NOTIFICATION = 'nearby_artist_event_published';
 
 /**
  * Register event entity notification hooks.
@@ -59,7 +60,8 @@ function extrachill_events_notify_festival_subscribers( $new_status, $old_status
 		return;
 	}
 
-	$recipient_ids = array();
+	$recipient_ids        = array();
+	$artist_recipient_ids = array();
 	foreach ( array( 'artist', 'festival' ) as $taxonomy ) {
 		$slugs = wp_get_post_terms( $post->ID, $taxonomy, array( 'fields' => 'slugs' ) );
 		if ( is_wp_error( $slugs ) || empty( $slugs ) ) {
@@ -78,6 +80,9 @@ function extrachill_events_notify_festival_subscribers( $new_status, $old_status
 			}
 
 			$recipient_ids = array_merge( $recipient_ids, $recipients );
+			if ( 'artist' === $taxonomy ) {
+				$artist_recipient_ids = array_merge( $artist_recipient_ids, $recipients );
+			}
 		}
 	}
 
@@ -86,15 +91,79 @@ function extrachill_events_notify_festival_subscribers( $new_status, $old_status
 		return;
 	}
 
+	$artist_recipient_ids = array_values( array_unique( array_map( 'absint', $artist_recipient_ids ) ) );
+	$nearby_recipient_ids = extrachill_events_get_nearby_artist_event_recipients( $post, $artist_recipient_ids );
+	$general_recipient_ids = array_values( array_diff( $recipient_ids, $nearby_recipient_ids ) );
+
+	if ( ! empty( $general_recipient_ids ) ) {
+		ec_users_notify(
+			$general_recipient_ids,
+			array(
+				'actor_id' => (int) $post->post_author,
+				'type'     => 'festival_event_published',
+				/* translators: %s: event title. */
+				'title'    => sprintf( __( 'New event: %s', 'extrachill-events' ), get_the_title( $post ) ),
+				'link'     => get_permalink( $post ),
+				'item_id'  => (int) $post->ID,
+			)
+		);
+	}
+
+	if ( empty( $nearby_recipient_ids ) ) {
+		return;
+	}
+
 	ec_users_notify(
-		$recipient_ids,
+		$nearby_recipient_ids,
 		array(
 			'actor_id' => (int) $post->post_author,
-			'type'     => 'festival_event_published',
+			'type'     => EXTRACHILL_EVENTS_NEARBY_ARTIST_EVENT_NOTIFICATION,
 			/* translators: %s: event title. */
-			'title'    => sprintf( __( 'New event: %s', 'extrachill-events' ), get_the_title( $post ) ),
+			'title'    => sprintf( __( 'Nearby show: %s', 'extrachill-events' ), get_the_title( $post ) ),
 			'link'     => get_permalink( $post ),
 			'item_id'  => (int) $post->ID,
 		)
 	);
+}
+
+/**
+ * Get artist subscribers whose private Local Scene matches this event.
+ *
+ * Recipient IDs are resolved through Users' authorized private subscription
+ * service before this runs. Local Scene values stay in-process and are used
+ * only to select a truthful notification variant.
+ *
+ * @param \WP_Post $post          Published event.
+ * @param int[]    $recipient_ids Artist subscription recipient IDs.
+ * @return int[] Nearby artist subscription recipient IDs.
+ */
+function extrachill_events_get_nearby_artist_event_recipients( \WP_Post $post, array $recipient_ids ): array {
+	if ( empty( $recipient_ids ) || ! function_exists( 'extrachill_users_get_local_scene' ) ) {
+		return array();
+	}
+
+	$location_slugs = wp_get_post_terms( $post->ID, 'location', array( 'fields' => 'slugs' ) );
+	if ( is_wp_error( $location_slugs ) || empty( $location_slugs ) ) {
+		return array();
+	}
+
+	$location_slugs = array_filter( array_map( 'sanitize_title', $location_slugs ) );
+	if ( empty( $location_slugs ) ) {
+		return array();
+	}
+
+	$nearby_recipient_ids = array();
+	foreach ( $recipient_ids as $recipient_id ) {
+		$scene = extrachill_users_get_local_scene( absint( $recipient_id ) );
+		if ( is_wp_error( $scene ) || ! is_array( $scene ) ) {
+			continue;
+		}
+
+		$scene_slug = sanitize_title( $scene['slug'] ?? '' );
+		if ( '' !== $scene_slug && in_array( $scene_slug, $location_slugs, true ) ) {
+			$nearby_recipient_ids[] = absint( $recipient_id );
+		}
+	}
+
+	return array_values( array_unique( $nearby_recipient_ids ) );
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,7 @@
 			<directory>tests/Unit/Core</directory>
 			<file>tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalLocationsAbilityTest.php</file>
+			<file>tests/Unit/FestivalNotificationsTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/Unit/FestivalNotificationsTest.php
+++ b/tests/Unit/FestivalNotificationsTest.php
@@ -73,6 +73,18 @@ if ( ! function_exists( 'ec_users_notify' ) ) {
 	}
 }
 
+if ( ! function_exists( 'extrachill_users_get_local_scene' ) ) {
+	function extrachill_users_get_local_scene( $user_id ) {
+		return $GLOBALS['festival_notification_scenes'][ $user_id ] ?? null;
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $value ) {
+		return strtolower( trim( (string) $value ) );
+	}
+}
+
 if ( ! function_exists( 'absint' ) ) {
 	function absint( $value ) {
 		return abs( (int) $value );
@@ -113,6 +125,7 @@ class FestivalNotificationsTest extends TestCase {
 		$GLOBALS['festival_notification_recipients']  = array();
 		$GLOBALS['festival_notification_resolutions'] = array();
 		$GLOBALS['festival_notification_calls']       = array();
+		$GLOBALS['festival_notification_scenes']      = array();
 	}
 
 	public function test_authorizes_only_event_entity_notification_resolution(): void {
@@ -197,6 +210,41 @@ class FestivalNotificationsTest extends TestCase {
 			$GLOBALS['festival_notification_resolutions']
 		);
 		$this->assertSame( array( 7, 9, 11, 13 ), $GLOBALS['festival_notification_calls'][0]['user_ids'] );
+	}
+
+	public function test_notifies_nearby_artist_subscribers_with_a_distinct_notification(): void {
+		$GLOBALS['festival_notification_terms'] = array(
+			'artist'   => array( 'the-headliners' ),
+			'festival' => array( 'summer-jam' ),
+			'location' => array( 'charleston-sc' ),
+		);
+		$GLOBALS['festival_notification_recipients'] = array(
+			'the-headliners' => array( 7, 9, 11 ),
+			'summer-jam'     => array( 11, 13 ),
+		);
+		$GLOBALS['festival_notification_scenes'] = array(
+			7  => array( 'slug' => 'charleston-sc' ),
+			9  => array( 'slug' => 'austin-tx' ),
+			11 => null,
+		);
+		$post = new WP_Post(
+			array(
+				'ID'          => 42,
+				'post_author' => 3,
+				'post_type'   => DATA_MACHINE_EVENTS_POST_TYPE,
+				'post_title'  => 'The Big Show',
+			)
+		);
+
+		extrachill_events_notify_festival_subscribers( 'publish', 'draft', $post );
+
+		$this->assertCount( 2, $GLOBALS['festival_notification_calls'] );
+		$this->assertSame( array( 9, 11, 13 ), $GLOBALS['festival_notification_calls'][0]['user_ids'] );
+		$this->assertSame( 'festival_event_published', $GLOBALS['festival_notification_calls'][0]['data']['type'] );
+		$this->assertSame( 'New event: The Big Show', $GLOBALS['festival_notification_calls'][0]['data']['title'] );
+		$this->assertSame( array( 7 ), $GLOBALS['festival_notification_calls'][1]['user_ids'] );
+		$this->assertSame( EXTRACHILL_EVENTS_NEARBY_ARTIST_EVENT_NOTIFICATION, $GLOBALS['festival_notification_calls'][1]['data']['type'] );
+		$this->assertSame( 'Nearby show: The Big Show', $GLOBALS['festival_notification_calls'][1]['data']['title'] );
 	}
 
 	public function test_does_not_notify_for_published_post_updates(): void {


### PR DESCRIPTION
## Summary
- classify already-authorized artist subscribers by matching their private resolved Local Scene against the event's canonical location term
- send matching recipients a distinct `nearby_artist_event_published` notification while preserving the general fallback and deduplication for everyone else
- add focused coverage for nearby, non-nearby, unset-scene, and festival-only recipients

## Verification
- `php -l inc/core/data-machine-events/festival-notifications.php`
- `php -l tests/Unit/FestivalNotificationsTest.php`
- focused manual execution of the new notification scenario
- `git diff --check`

`composer test` and `composer lint:php` could not run because this worktree has no installed `phpunit` or `phpcs` binary (and no lockfile for dependency hydration). Homeboy lint was additionally blocked by the host warm-machine policy.