### PR TITLE
feat: expose event taxonomy context

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -237,6 +237,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/ArtistUrlImportRoutes.php';
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/data-machine-events/init.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/events-by-term-taxonomy-context.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/cache-groups.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/page-cache.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/nav.php';

--- a/inc/core/events-by-term-taxonomy-context.php
+++ b/inc/core/events-by-term-taxonomy-context.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Events-owned taxonomy context for Data Machine Events rows.
+ *
+ * @package ExtraChillEvents
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_filter( 'wp_register_ability_args', 'extrachill_events_add_events_by_term_taxonomy_schema', 10, 2 );
+add_filter( 'data_machine_events_events_by_term_result', 'extrachill_events_add_events_by_term_taxonomy_context', 10, 2 );
+
+/**
+ * Declare Events-owned taxonomy context on the generic ability's response.
+ *
+ * @param array  $args Ability arguments.
+ * @param string $name Ability name.
+ * @return array Ability arguments.
+ */
+function extrachill_events_add_events_by_term_taxonomy_schema( array $args, string $name ): array {
+	if ( 'data-machine-events/events-by-term' !== $name || empty( $args['output_schema']['properties'] ) ) {
+		return $args;
+	}
+
+	$term_schema                                = array(
+		'type'       => array( 'object', 'null' ),
+		'properties' => array(
+			'name' => array( 'type' => 'string' ),
+			'slug' => array( 'type' => 'string' ),
+			'url'  => array( 'type' => 'string' ),
+		),
+	);
+	$location_schema                            = $term_schema;
+	$location_schema['properties']['display']   = array( 'type' => 'string' );
+	$location_schema['properties']['hierarchy'] = array(
+		'type'       => array( 'object', 'null' ),
+		'properties' => array(
+			'region' => array( 'type' => 'string' ),
+			'state'  => array( 'type' => 'string' ),
+			'label'  => array( 'type' => 'string' ),
+		),
+	);
+
+	$args['output_schema']['properties']['upcoming']['items']['properties']['relationships'] = array(
+		'type'       => 'object',
+		'properties' => array(
+			'venue'    => $term_schema,
+			'location' => $location_schema,
+			'festival' => $term_schema,
+		),
+	);
+	$args['output_schema']['properties']['past']['items']['properties']['relationships']     = $args['output_schema']['properties']['upcoming']['items']['properties']['relationships'];
+
+	return $args;
+}
+
+/**
+ * Add canonical Events taxonomy relationships to each returned event row.
+ *
+ * This filter runs while Data Machine Events remains switched to the events
+ * site, so relationship terms and archive URLs resolve in their canonical
+ * context.
+ *
+ * @param array $result Events-by-term result.
+ * @param array $input  Ability input.
+ * @return array Events-by-term result.
+ */
+function extrachill_events_add_events_by_term_taxonomy_context( array $result, array $input ): array {
+	unset( $input );
+
+	foreach ( array( 'upcoming', 'past' ) as $scope ) {
+		if ( empty( $result[ $scope ] ) || ! is_array( $result[ $scope ] ) ) {
+			continue;
+		}
+
+		foreach ( $result[ $scope ] as $index => $event ) {
+			$post_id = isset( $event['event_id'] ) ? (int) $event['event_id'] : 0;
+			if ( $post_id <= 0 ) {
+				continue;
+			}
+
+			$result[ $scope ][ $index ]['relationships'] = array(
+				'venue'    => extrachill_events_get_event_term_relationship( $post_id, 'venue' ),
+				'location' => extrachill_events_get_event_term_relationship( $post_id, 'location' ),
+				'festival' => extrachill_events_get_event_term_relationship( $post_id, 'festival' ),
+			);
+		}
+	}
+
+	return $result;
+}
+
+/**
+ * Return an event's assigned term as a portable archive relationship.
+ *
+ * Events currently assign one term per relationship taxonomy. The first term
+ * mirrors the existing venue-name response behavior without inferring data.
+ *
+ * @param int    $post_id Event post ID.
+ * @param string $taxonomy Relationship taxonomy.
+ * @return array|null Relationship data, or null when the event is unassigned.
+ */
+function extrachill_events_get_event_term_relationship( int $post_id, string $taxonomy ): ?array {
+	$terms = get_the_terms( $post_id, $taxonomy );
+	if ( empty( $terms ) || is_wp_error( $terms ) || ! isset( $terms[0] ) || ! ( $terms[0] instanceof WP_Term ) ) {
+		return null;
+	}
+
+	$term = $terms[0];
+	$url  = get_term_link( $term );
+	$data = array(
+		'name' => html_entity_decode( (string) $term->name, ENT_QUOTES, 'UTF-8' ),
+		'slug' => (string) $term->slug,
+		'url'  => is_wp_error( $url ) ? '' : (string) $url,
+	);
+
+	if ( 'location' !== $taxonomy || ! function_exists( 'extrachill_events_prepare_canonical_location' ) ) {
+		return $data;
+	}
+
+	$location = extrachill_events_prepare_canonical_location( $term );
+	if ( is_array( $location ) && isset( $location['hierarchy'] ) && is_array( $location['hierarchy'] ) ) {
+		$data['display']   = (string) ( $location['hierarchy']['label'] ?? $term->name );
+		$data['hierarchy'] = $location['hierarchy'];
+	} else {
+		$data['display']   = (string) $term->name;
+		$data['hierarchy'] = null;
+	}
+
+	return $data;
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,7 @@
 			<directory>tests/Unit/Core</directory>
 			<file>tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalLocationsAbilityTest.php</file>
+			<file>tests/Unit/Abilities/EventsByTermTaxonomyContextTest.php</file>
 			<file>tests/Unit/FestivalNotificationsTest.php</file>
 		</testsuite>
 	</testsuites>

--- a/tests/Unit/Abilities/EventsByTermTaxonomyContextTest.php
+++ b/tests/Unit/Abilities/EventsByTermTaxonomyContextTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Events-by-term taxonomy context tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+// phpcs:disable -- This isolated fixture intentionally declares WordPress test doubles.
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! class_exists( 'WP_Term' ) ) {
+	class WP_Term {
+		public int $term_id;
+		public string $name;
+		public string $slug;
+		public int $parent;
+
+		public function __construct( int $term_id, string $name, string $slug, int $parent = 0 ) {
+			$this->term_id = $term_id;
+			$this->name    = $name;
+			$this->slug    = $slug;
+			$this->parent  = $parent;
+		}
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter() {}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return false;
+	}
+}
+if ( ! function_exists( 'get_the_terms' ) ) {
+	function get_the_terms( $post_id, $taxonomy ) {
+		return $GLOBALS['ec_events_by_term_relationships'][ $post_id ][ $taxonomy ] ?? false;
+	}
+}
+if ( ! function_exists( 'get_term_link' ) ) {
+	function get_term_link( $term ) {
+		return $GLOBALS['ec_events_by_term_term_links'][ $term->term_id ] ?? 'https://events.example/location/' . $term->slug . '/';
+	}
+}
+
+require_once dirname( __DIR__, 3 ) . '/inc/core/events-by-term-taxonomy-context.php';
+
+final class EventsByTermTaxonomyContextTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['ec_events_by_term_relationships'] = array();
+	}
+
+	public function test_enriches_assigned_relationships_without_changing_existing_row_fields(): void {
+		$GLOBALS['ec_events_by_term_relationships'][123] = array(
+			'venue'    => array( new WP_Term( 10, 'The Royal American', 'royal-american' ) ),
+			'location' => array( new WP_Term( 11, 'Charleston', 'charleston-sc' ) ),
+			'festival' => array( new WP_Term( 12, 'High Water Festival', 'high-water-festival' ) ),
+		);
+		$result = extrachill_events_add_events_by_term_taxonomy_context(
+			array(
+				'upcoming' => array(
+					array(
+						'event_id'   => 123,
+						'title'      => 'A Show',
+						'venue_name' => 'The Royal American',
+					),
+				),
+				'past'     => array(),
+			),
+			array()
+		);
+
+		$row = $result['upcoming'][0];
+		$this->assertSame( 'A Show', $row['title'] );
+		$this->assertSame( 'The Royal American', $row['venue_name'] );
+		$this->assertSame(
+			array(
+				'name' => 'The Royal American',
+				'slug' => 'royal-american',
+				'url'  => 'https://events.example/location/royal-american/',
+			),
+			$row['relationships']['venue']
+		);
+		$this->assertSame( 'charleston-sc', $row['relationships']['location']['slug'] );
+		$this->assertSame( 'High Water Festival', $row['relationships']['festival']['name'] );
+	}
+
+	public function test_returns_null_relationships_when_event_has_no_assigned_terms(): void {
+		$result = extrachill_events_add_events_by_term_taxonomy_context(
+			array(
+				'upcoming' => array( array( 'event_id' => 456 ) ),
+				'past'     => array(),
+			),
+			array()
+		);
+
+		$this->assertSame(
+			array(
+				'venue'    => null,
+				'location' => null,
+				'festival' => null,
+			),
+			$result['upcoming'][0]['relationships']
+		);
+	}
+
+	public function test_declares_relationship_fields_for_both_result_scopes(): void {
+		$args = extrachill_events_add_events_by_term_taxonomy_schema(
+			array(
+				'output_schema' => array(
+					'properties' => array(
+						'upcoming' => array( 'items' => array( 'type' => 'object' ) ),
+						'past'     => array( 'items' => array( 'type' => 'object' ) ),
+					),
+				),
+			),
+			'data-machine-events/events-by-term'
+		);
+
+		$this->assertSame( array( 'object', 'null' ), $args['output_schema']['properties']['upcoming']['items']['properties']['relationships']['properties']['venue']['type'] );
+		$this->assertSame( 'string', $args['output_schema']['properties']['past']['items']['properties']['relationships']['properties']['location']['properties']['display']['type'] );
+	}
+}


### PR DESCRIPTION
## Summary
- compose Events-owned venue, location, and festival relationships onto `data-machine-events/events-by-term` rows
- declare the runtime response schema through the WordPress ability registration filter
- add assigned and missing-relationship coverage without changing existing row fields

## Dependency
- Requires Extra-Chill/data-machine-events#448 for the generic canonical-context result filter.

## Blog Consumer Shape
```json
{
  "event_id": 123,
  "title": "A Show",
  "permalink": "https://events.extrachill.com/event/a-show/",
  "venue_name": "The Royal American",
  "date_iso": "2026-07-13T00:00:00+00:00",
  "date_display": "July 13, 2026",
  "time_display": "8:00 pm",
  "timing": "upcoming",
  "relationships": {
    "venue": { "name": "The Royal American", "slug": "royal-american", "url": "https://events.extrachill.com/venue/royal-american/" },
    "location": { "name": "Charleston", "slug": "charleston-sc", "url": "https://events.extrachill.com/location/charleston-sc/", "display": "Charleston, South Carolina", "hierarchy": { "region": "USA", "state": "South Carolina", "label": "Charleston, South Carolina" } },
    "festival": { "name": "High Water Festival", "slug": "high-water-festival", "url": "https://events.extrachill.com/festival/high-water-festival/" }
  }
}
```
Unassigned relationships are `null`; a non-selectable location has its canonical name, slug, URL, display name, and `hierarchy: null`.

## Verification
- `php -l inc/core/events-by-term-taxonomy-context.php`
- `./vendor/bin/phpunit --testsuite=qualify-v2-unit --filter=EventsByTermTaxonomyContextTest`
- `./vendor/bin/phpcs --standard=WordPress inc/core/events-by-term-taxonomy-context.php tests/Unit/Abilities/EventsByTermTaxonomyContextTest.php`
- `git diff --check`

The full existing `qualify-v2-unit` suite remains red on six unrelated existing failures: four `QualifyRecheckHandlerTest` expectations and two `CanonicalLocationsAbilityTest` failures.