### PR TITLE
fix: make festival event notifications idempotent

### DIFF
--- a/inc/core/data-machine-events/festival-notifications.php
+++ b/inc/core/data-machine-events/festival-notifications.php
@@ -9,8 +9,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER = 'extrachill-events-festival-notifications';
+const EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER   = 'extrachill-events-festival-notifications';
 const EXTRACHILL_EVENTS_NEARBY_ARTIST_EVENT_NOTIFICATION = 'nearby_artist_event_published';
+const EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META  = '_extrachill_events_festival_notification_sent';
 
 /**
  * Register event entity notification hooks.
@@ -56,6 +57,10 @@ function extrachill_events_notify_festival_subscribers( $new_status, $old_status
 		return;
 	}
 
+	if ( get_post_meta( $post->ID, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META, true ) ) {
+		return;
+	}
+
 	if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify' ) ) {
 		return;
 	}
@@ -91,12 +96,21 @@ function extrachill_events_notify_festival_subscribers( $new_status, $old_status
 		return;
 	}
 
-	$artist_recipient_ids = array_values( array_unique( array_map( 'absint', $artist_recipient_ids ) ) );
-	$nearby_recipient_ids = extrachill_events_get_nearby_artist_event_recipients( $post, $artist_recipient_ids );
+	$artist_recipient_ids  = array_values( array_unique( array_map( 'absint', $artist_recipient_ids ) ) );
+	$nearby_recipient_ids  = extrachill_events_get_nearby_artist_event_recipients( $post, $artist_recipient_ids );
 	$general_recipient_ids = array_values( array_diff( $recipient_ids, $nearby_recipient_ids ) );
 
+	// Claim before delivery so concurrent publish hooks cannot duplicate notices.
+	if ( ! add_post_meta( $post->ID, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META, current_time( 'mysql', true ), true ) ) {
+		return;
+	}
+
+	$expected_deliveries = 0;
+	$delivered           = 0;
+
 	if ( ! empty( $general_recipient_ids ) ) {
-		ec_users_notify(
+		$expected_deliveries += count( $general_recipient_ids );
+		$delivered           += ec_users_notify(
 			$general_recipient_ids,
 			array(
 				'actor_id' => (int) $post->post_author,
@@ -110,10 +124,15 @@ function extrachill_events_notify_festival_subscribers( $new_status, $old_status
 	}
 
 	if ( empty( $nearby_recipient_ids ) ) {
+		if ( $delivered < $expected_deliveries ) {
+			delete_post_meta( $post->ID, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META );
+		}
+
 		return;
 	}
 
-	ec_users_notify(
+	$expected_deliveries += count( $nearby_recipient_ids );
+	$delivered           += ec_users_notify(
 		$nearby_recipient_ids,
 		array(
 			'actor_id' => (int) $post->post_author,
@@ -124,6 +143,10 @@ function extrachill_events_notify_festival_subscribers( $new_status, $old_status
 			'item_id'  => (int) $post->ID,
 		)
 	);
+
+	if ( $delivered < $expected_deliveries ) {
+		delete_post_meta( $post->ID, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META );
+	}
 }
 
 /**

--- a/tests/Unit/FestivalNotificationsTest.php
+++ b/tests/Unit/FestivalNotificationsTest.php
@@ -50,6 +50,36 @@ if ( ! function_exists( 'get_post_type' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_post_meta' ) ) {
+	function get_post_meta( $post_id, $key, $single = false ) {
+		$value = $GLOBALS['festival_notification_meta'][ $post_id ][ $key ] ?? '';
+
+		return $single ? $value : ( '' === $value ? array() : array( $value ) );
+	}
+}
+
+if ( ! function_exists( 'add_post_meta' ) ) {
+	function add_post_meta( $post_id, $key, $value, $unique = false ) {
+		if ( ! empty( $GLOBALS['festival_notification_claim_failure'] ) || ( $unique && isset( $GLOBALS['festival_notification_meta'][ $post_id ][ $key ] ) ) ) {
+			return false;
+		}
+
+		$GLOBALS['festival_notification_meta'][ $post_id ][ $key ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'delete_post_meta' ) ) {
+	function delete_post_meta( $post_id, $key ) {
+		if ( ! isset( $GLOBALS['festival_notification_meta'][ $post_id ][ $key ] ) ) {
+			return false;
+		}
+
+		unset( $GLOBALS['festival_notification_meta'][ $post_id ][ $key ] );
+		return true;
+	}
+}
+
 if ( ! function_exists( 'wp_get_post_terms' ) ) {
 	function wp_get_post_terms( $post_id, $taxonomy ) {
 		return $GLOBALS['festival_notification_terms'][ $taxonomy ] ?? array();
@@ -69,7 +99,8 @@ if ( ! function_exists( 'ec_users_notify' ) ) {
 			'user_ids' => $user_ids,
 			'data'     => $data,
 		);
-		return count( $user_ids );
+
+		return array_shift( $GLOBALS['festival_notification_delivery_results'] ) ?? count( $user_ids );
 	}
 }
 
@@ -118,14 +149,17 @@ require_once dirname( __DIR__, 2 ) . '/inc/core/data-machine-events/festival-not
 class FestivalNotificationsTest extends TestCase {
 
 	protected function setUp(): void {
-		$GLOBALS['festival_notification_terms']       = array(
+		$GLOBALS['festival_notification_terms']            = array(
 			'artist'   => array(),
 			'festival' => array(),
 		);
-		$GLOBALS['festival_notification_recipients']  = array();
-		$GLOBALS['festival_notification_resolutions'] = array();
-		$GLOBALS['festival_notification_calls']       = array();
-		$GLOBALS['festival_notification_scenes']      = array();
+		$GLOBALS['festival_notification_recipients']       = array();
+		$GLOBALS['festival_notification_resolutions']      = array();
+		$GLOBALS['festival_notification_calls']            = array();
+		$GLOBALS['festival_notification_scenes']           = array();
+		$GLOBALS['festival_notification_meta']             = array();
+		$GLOBALS['festival_notification_delivery_results'] = array();
+		$GLOBALS['festival_notification_claim_failure']    = false;
 	}
 
 	public function test_authorizes_only_event_entity_notification_resolution(): void {
@@ -213,7 +247,7 @@ class FestivalNotificationsTest extends TestCase {
 	}
 
 	public function test_notifies_nearby_artist_subscribers_with_a_distinct_notification(): void {
-		$GLOBALS['festival_notification_terms'] = array(
+		$GLOBALS['festival_notification_terms']      = array(
 			'artist'   => array( 'the-headliners' ),
 			'festival' => array( 'summer-jam' ),
 			'location' => array( 'charleston-sc' ),
@@ -222,12 +256,12 @@ class FestivalNotificationsTest extends TestCase {
 			'the-headliners' => array( 7, 9, 11 ),
 			'summer-jam'     => array( 11, 13 ),
 		);
-		$GLOBALS['festival_notification_scenes'] = array(
+		$GLOBALS['festival_notification_scenes']     = array(
 			7  => array( 'slug' => 'charleston-sc' ),
 			9  => array( 'slug' => 'austin-tx' ),
 			11 => null,
 		);
-		$post = new WP_Post(
+		$post                                        = new WP_Post(
 			array(
 				'ID'          => 42,
 				'post_author' => 3,
@@ -261,5 +295,93 @@ class FestivalNotificationsTest extends TestCase {
 
 		$this->assertSame( array(), $GLOBALS['festival_notification_resolutions'] );
 		$this->assertSame( array(), $GLOBALS['festival_notification_calls'] );
+	}
+
+	public function test_repeated_invocation_delivers_once_after_claiming_notification(): void {
+		$GLOBALS['festival_notification_terms']['festival'] = array( 'summer-jam' );
+		$GLOBALS['festival_notification_recipients']        = array(
+			'summer-jam' => array( 7 ),
+		);
+		$post = new WP_Post(
+			array(
+				'ID'          => 42,
+				'post_author' => 3,
+				'post_type'   => DATA_MACHINE_EVENTS_POST_TYPE,
+				'post_title'  => 'The Big Show',
+			)
+		);
+
+		extrachill_events_notify_festival_subscribers( 'publish', 'draft', $post );
+		extrachill_events_notify_festival_subscribers( 'publish', 'draft', $post );
+
+		$this->assertCount( 1, $GLOBALS['festival_notification_calls'] );
+		$this->assertCount( 1, $GLOBALS['festival_notification_resolutions'] );
+		$this->assertNotEmpty( $GLOBALS['festival_notification_meta'][42][ EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META ] );
+	}
+
+	public function test_existing_claim_skips_concurrent_invocation_before_recipient_resolution(): void {
+		$GLOBALS['festival_notification_terms']['festival'] = array( 'summer-jam' );
+		$GLOBALS['festival_notification_recipients']        = array(
+			'summer-jam' => array( 7 ),
+		);
+		$GLOBALS['festival_notification_meta'][42][ EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META ] = '2026-07-13 18:00:00';
+		$post = new WP_Post(
+			array(
+				'ID'          => 42,
+				'post_author' => 3,
+				'post_type'   => DATA_MACHINE_EVENTS_POST_TYPE,
+				'post_title'  => 'The Big Show',
+			)
+		);
+
+		extrachill_events_notify_festival_subscribers( 'publish', 'draft', $post );
+
+		$this->assertSame( array(), $GLOBALS['festival_notification_resolutions'] );
+		$this->assertSame( array(), $GLOBALS['festival_notification_calls'] );
+	}
+
+	public function test_losing_atomic_claim_race_skips_delivery(): void {
+		$GLOBALS['festival_notification_terms']['festival'] = array( 'summer-jam' );
+		$GLOBALS['festival_notification_recipients']        = array(
+			'summer-jam' => array( 7 ),
+		);
+		$GLOBALS['festival_notification_claim_failure']     = true;
+		$post = new WP_Post(
+			array(
+				'ID'          => 42,
+				'post_author' => 3,
+				'post_type'   => DATA_MACHINE_EVENTS_POST_TYPE,
+				'post_title'  => 'The Big Show',
+			)
+		);
+
+		extrachill_events_notify_festival_subscribers( 'publish', 'draft', $post );
+
+		$this->assertCount( 1, $GLOBALS['festival_notification_resolutions'] );
+		$this->assertSame( array(), $GLOBALS['festival_notification_calls'] );
+	}
+
+	public function test_failed_delivery_clears_claim_for_a_later_retry(): void {
+		$GLOBALS['festival_notification_terms']['festival'] = array( 'summer-jam' );
+		$GLOBALS['festival_notification_recipients']        = array(
+			'summer-jam' => array( 7 ),
+		);
+		$GLOBALS['festival_notification_delivery_results']  = array( 0, 1 );
+		$post = new WP_Post(
+			array(
+				'ID'          => 42,
+				'post_author' => 3,
+				'post_type'   => DATA_MACHINE_EVENTS_POST_TYPE,
+				'post_title'  => 'The Big Show',
+			)
+		);
+
+		extrachill_events_notify_festival_subscribers( 'publish', 'draft', $post );
+		$this->assertArrayNotHasKey( EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META, $GLOBALS['festival_notification_meta'][42] );
+
+		extrachill_events_notify_festival_subscribers( 'publish', 'draft', $post );
+
+		$this->assertCount( 2, $GLOBALS['festival_notification_calls'] );
+		$this->assertNotEmpty( $GLOBALS['festival_notification_meta'][42][ EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META ] );
 	}
 }


### PR DESCRIPTION
## Summary
- Add an event-owned `_extrachill_events_festival_notification_sent` post-meta claim before festival-event notification delivery. The existing marker check makes successful publication replays no-ops, while the unique `add_post_meta()` claim prevents a competing hook from delivering after it loses the claim.
- Resolve recipients before claiming so a publication with no currently resolvable recipients remains eligible for a later retry. If `ec_users_notify()` reports fewer inserted rows than intended, remove the claim so a subsequent replay can retry instead of silently losing the notification.
- Add repeat, existing-claim, claim-race, and failed-delivery retry coverage.

## Failure Behavior
`ec_users_notify()` returns only an aggregate inserted-row count and its notification table has no per-recipient idempotency constraint. A partial insert therefore clears the event claim to prefer retrying missing notifications; a retry can duplicate rows that were already inserted in that partial batch. Eliminating that remaining at-least-once edge case requires idempotency support in the owning Extra Chill Users notification API/schema, rather than a cross-plugin workaround here.

## Tests
- `./vendor/bin/phpunit tests/Unit/FestivalNotificationsTest.php` (9 tests, 29 assertions)
- `./vendor/bin/phpcs --standard=WordPress inc/core/data-machine-events/festival-notifications.php`
- `composer test` remains blocked by pre-existing failures in `QualifyRecheckHandlerTest` and `CanonicalLocationsAbilityTest` (5 failures, 1 error); the notification tests pass within that run.

Fixes #257