### PR TITLE
refactor: retire datamachine/v1 artist import aliases

### DIFF
--- a/inc/Api/ArtistUrlImportRoutes.php
+++ b/inc/Api/ArtistUrlImportRoutes.php
@@ -6,14 +6,11 @@
  * `extrachill/v1` namespace (matching `extrachill/v1/event-submissions`).
  * Migrated out of data-machine-events in extrachill-events#200.
  *
- * Compatibility (extrachill-events#200): the event-submission block
- * historically called these under the data-machine-events REST namespace
- * `datamachine/v1/artist-url/*`. To avoid breaking any cached page markup
- * or third-party consumer mid-deploy, the old `datamachine/v1` routes are
- * ALSO registered here as deprecated aliases for one release. The block's
- * own render.php is repointed to the new `extrachill/v1` paths in this same
- * change; the aliases are belt-and-braces and should be removed in a
- * follow-up once no traffic hits them.
+ * The one-release `datamachine/v1/artist-url/*` compatibility aliases that
+ * shipped with the #200 migration were retired in extrachill-events#256: the
+ * event-submission block was repointed to the canonical `extrachill/v1`
+ * paths in the same #201 change, no in-repo consumer referenced the aliases,
+ * and the compat window is closed. Only the canonical namespace is served.
  *
  * @package ExtraChillEvents\Api
  * @since   0.35.0
@@ -25,8 +22,7 @@ use ExtraChillEvents\Api\Controllers\ArtistUrlImport;
 
 defined( 'ABSPATH' ) || exit;
 
-const ARTIST_URL_NAMESPACE            = 'extrachill/v1';
-const ARTIST_URL_NAMESPACE_DEPRECATED = 'datamachine/v1';
+const ARTIST_URL_NAMESPACE = 'extrachill/v1';
 
 /**
  * Register the artist-url routes for a given namespace.
@@ -133,25 +129,13 @@ function register_artist_url_routes_for( string $route_namespace ): void {
 /**
  * Register all artist-url routes on rest_api_init.
  *
- * Registers under the canonical `extrachill/v1` namespace plus the
- * deprecated `datamachine/v1` namespace (one-release compat alias).
+ * Only the canonical `extrachill/v1` namespace is registered; the
+ * `datamachine/v1` one-release aliases were retired in extrachill-events#256.
  *
  * @return void
  */
 function register_artist_url_routes(): void {
 	register_artist_url_routes_for( ARTIST_URL_NAMESPACE );
-
-	/**
-	 * Filter whether to keep registering the deprecated `datamachine/v1`
-	 * artist-url route aliases. Defaults to true for one release so cached
-	 * page markup keeps working through a deploy. Set to false (or remove
-	 * the routes in a follow-up) once no traffic hits the old paths.
-	 *
-	 * @param bool $enabled Whether the deprecated aliases are registered.
-	 */
-	if ( (bool) apply_filters( 'extrachill_events_artist_url_legacy_routes', true ) ) {
-		register_artist_url_routes_for( ARTIST_URL_NAMESPACE_DEPRECATED );
-	}
 }
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\\register_artist_url_routes' );


### PR DESCRIPTION
Fixes #256

## Summary

Retires the one-release `datamachine/v1/artist-url/*` compatibility aliases that shipped with the #200/#201 layer-purity migration. They remained enabled by default via the `extrachill_events_artist_url_legacy_routes` filter (default `true`), so the migration never completed and the stale public surface was maintained indefinitely. This drops the deprecated namespace constant, the legacy-routes filter, and the conditional second registration. Only the canonical `extrachill/v1` namespace is served. No new route abstraction is introduced — the existing `register_artist_url_routes_for()` helper is reused unchanged for the single canonical registration.

## Compatibility evidence checked

- **In-repo consumers:** grepped the whole repo for `datamachine/v1`, `ARTIST_URL_NAMESPACE_DEPRECATED`, and `extrachill_events_artist_url_legacy_routes`. The event-submission block — the only client of these routes — was repointed to the canonical `extrachill/v1/artist-url/*` paths in the **same** #201 change (`blocks/event-submission/render.php:29-30`, `blocks/event-submission/view.js:121`). No PHP/JS file calls the deprecated aliases.
- **Unrelated match:** the only other `datamachine/v1` hit is `assets/js/discovery.js:193` → `datamachine/v1/events/calendar`, a different route (calendar), not in scope.
- **Tests/docs:** no unit test encodes the deprecated-alias default. The sole docs hit is `docs/CHANGELOG.md:100` (immutable changelog; not edited). No other doc references the aliases.
- **History:** the file was introduced in #201 (adopt) and only touched by a lint pass in #219 — at least one release has passed since the one-release window opened, so the cutoff is overdue.

## Route behavior

**Before**
```
POST extrachill/v1/artist-url/preview            (canonical)
POST extrachill/v1/artist-url/submit             (canonical)
POST extrachill/v1/artist-url/{id}/approve       (canonical)
POST extrachill/v1/artist-url/{id}/reject        (canonical)
POST datamachine/v1/artist-url/preview           (deprecated alias, enabled by default)
POST datamachine/v1/artist-url/submit            (deprecated alias, enabled by default)
POST datamachine/v1/artist-url/{id}/approve      (deprecated alias, enabled by default)
POST datamachine/v1/artist-url/{id}/reject       (deprecated alias, enabled by default)
```

**After**
```
POST extrachill/v1/artist-url/preview            (canonical)
POST extrachill/v1/artist-url/submit             (canonical)
POST extrachill/v1/artist-url/{id}/approve       (canonical)
POST extrachill/v1/artist-url/{id}/reject        (canonical)
```
The four `datamachine/v1/artist-url/*` aliases and the `extrachill_events_artist_url_legacy_routes` filter are removed. The canonical controller (`ExtraChillEvents\Api\Controllers\ArtistUrlImport`) and all four canonical routes are unchanged.

## Tests / lint

- `php -l inc/Api/ArtistUrlImportRoutes.php` → clean.
- `phpcs --standard=WordPress inc/Api/ArtistUrlImportRoutes.php` → one pre-existing filename-casing notice (`ArtistUrlImportRoutes.php` vs expected lowercase) present on `main`, **not** introduced here; renaming is out of scope (would break includes).
- The repo's PHPUnit suite does not cover REST route registration (minimal bootstrap, no WP REST framework), so no test encoded the old default to update. No behavioral logic was added — only deprecated registration code was deleted.

## Notes

- Did not edit `CHANGELOG.md` and did not bump any version string (homeboy owns both).
- Conventional commit `refactor:`; PR only — no merge, release, or deploy.