### PR TITLE
feat: make event exploration contextual

### DIFF
--- a/assets/css/single-event.css
+++ b/assets/css/single-event.css
@@ -61,6 +61,36 @@
 }
 
 /*
+ * Contextual exploration follows the conversion actions as its own full row.
+ * The shared network bridge still owns link markup and instrumentation; this
+ * consumer only composes it into the Event Details surface.
+ */
+.data-machine-event-details .event-action-buttons > .network-bridge-section {
+    flex: 1 0 100%;
+    width: 100%;
+    margin: var(--spacing-md, 1rem) 0 0;
+    text-align: left;
+}
+
+.data-machine-event-details .event-action-buttons > .network-bridge-section .network-bridge-header {
+    margin: 0 0 var(--spacing-sm, 0.5rem);
+}
+
+.data-machine-event-details .event-action-buttons > .network-bridge-section .network-bridge-links {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+    gap: var(--spacing-sm, 0.5rem);
+}
+
+.data-machine-event-details .event-action-buttons > .network-bridge-section .event-exploration-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+    text-align: center;
+}
+
+/*
  * Force the actual button/anchor inside each wrapper to fill its wrapper, so
  * the wrapper's width is driven by the button (not the reverse). Every button
  * already carries .button-medium, so once widths agree the heights agree too.
@@ -128,6 +158,10 @@
     .data-machine-event-details .event-action-buttons > .share-dropdown {
         flex: 0 0 auto;
         width: 100%;
+    }
+
+    .data-machine-event-details .event-action-buttons > .network-bridge-section .network-bridge-links {
+        grid-template-columns: 1fr;
     }
 
     /*

--- a/inc/single-event/network-bridge.php
+++ b/inc/single-event/network-bridge.php
@@ -1,23 +1,23 @@
 <?php
 /**
- * From Around the Extra Chill Network — Single Event Bridge (thin consumer)
+ * Contextual single-event exploration bridge.
  *
  * The reverse bridge on the single-event page: events.extrachill.com is a large
  * attention pool whose single-event template otherwise dead-ends with zero
  * outbound links to the rest of the network. This bridge gives the reader a
- * contextual path OUTWARD — blog coverage, a wire story, a community entry
- * point — driven by the event's own artist/festival terms.
+ * contextual path OUTWARD — an artist profile, nearby shows, editorial
+ * coverage, or a real community discussion — driven by the event's own terms.
  *
  * The bridge itself — terms resolution, transient caching, slot assembly, UTM
  * tagging, and render markup — lives in the shared primitive
  * `extrachill_render_network_bridge()` in extrachill-multisite (and the shared
- * stylesheet is registered there too). This file is a thin hook that decides
- * WHEN to render (single `data_machine_events` views on the events site) and
- * passes the events per-site arguments.
+ * stylesheet is registered there too). This file decides WHEN to render
+ * (inside the single event action composition), orders the resolved cards, and
+ * supplies event-specific labels. The shared primitive remains responsible for
+ * cross-site URL resolution, caching, and analytics tags.
  *
- * NOTE: same-site event→event relevance is already handled by
- * inc/single-event/related-events.php. This bridge is STRICTLY the cross-SITE
- * outward links.
+ * Full same-site event cards remain in inc/single-event/related-events.php;
+ * this compact module adds only one canonical location-archive path.
  *
  * @package ExtraChillEvents
  * @since 0.28.0
@@ -28,18 +28,118 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Render the "From Around the Extra Chill Network" section on single events.
+ * Build shared bridge arguments for an event.
  *
- * Hooked on `extrachill_after_post_content` (single events route through the
- * theme's single-post template). Guarded to single `data_machine_events` views
- * on the events site; both guards stay HERE in the consumer, not in the shared
- * primitive (layer purity — the primitive knows nothing about post types/sites).
+ * Upcoming and ongoing events lead with the artist profile. Past events lead
+ * with coverage. Both paths remain bounded to three real destinations.
  *
- * Renders NOTHING when the event carries no artist/festival terms or when no
- * cross-site content matches (no empty box) — that behavior lives in the
- * shared primitive.
+ * @param int    $post_id Event post ID.
+ * @param string $timing  Event timing state.
+ * @return array
  */
-function ec_events_network_bridge() {
+function ec_events_network_bridge_args( $post_id, $timing ) {
+	$is_past = 'past' === $timing;
+
+	return array(
+		'post_id'           => (int) $post_id,
+		'taxonomies'        => array( 'artist', 'festival' ),
+		'allowed_site_keys' => array( 'artist', 'main', 'community' ),
+		'slot_order'        => $is_past
+			? array( 'main', 'artist', 'community', 'events' )
+			: array( 'artist', 'events', 'community', 'main' ),
+		'utm_source'        => 'extrachill_events',
+		'cache_prefix'      => 'ec_events_network_bridge_v2_' . ( $is_past ? 'past_' : 'current_' ),
+		'heading_id'        => 'events-network-bridge-header-' . (int) $post_id,
+		'heading_text'      => __( 'Keep Exploring', 'extrachill-events' ),
+	);
+}
+
+/**
+ * Build at most three contextual cards from canonical destinations.
+ *
+ * Cross-site resolution and caching stay in the shared network primitive. This
+ * consumer changes labels only on the returned copies, avoiding pollution of
+ * the shared term-link cache. Upcoming events also add the canonical location
+ * archive as a same-site discovery path.
+ *
+ * @param array $args Bridge arguments from ec_events_network_bridge_args().
+ * @return array
+ */
+function ec_events_network_bridge_cards( $args ) {
+	$cards = extrachill_network_bridge_get_cards(
+		$args['post_id'],
+		$args['taxonomies'],
+		$args['allowed_site_keys'],
+		$args['allowed_site_keys'],
+		$args['utm_source'],
+		$args['cache_prefix']
+	);
+
+	$labels  = array(
+		'artist'    => __( 'Profile', 'extrachill-events' ),
+		'main'      => __( 'Coverage', 'extrachill-events' ),
+		'community' => __( 'Discussions', 'extrachill-events' ),
+	);
+	$by_site = array();
+
+	foreach ( $cards as $card ) {
+		$site_key = isset( $card['site_key'] ) ? $card['site_key'] : '';
+		if ( ! isset( $labels[ $site_key ] ) ) {
+			continue;
+		}
+
+		$card['label']        = $labels[ $site_key ];
+		$by_site[ $site_key ] = $card;
+	}
+
+	if ( 'events' === $args['slot_order'][1] ) {
+		$locations = get_the_terms( $args['post_id'], 'location' );
+		if ( $locations && ! is_wp_error( $locations ) ) {
+			$location     = reset( $locations );
+			$location_url = get_term_link( $location );
+
+			if ( ! is_wp_error( $location_url ) ) {
+				$by_site['events'] = array(
+					'site_key'     => 'events',
+					'url'          => $location_url,
+					'label'        => __( 'More Shows', 'extrachill-events' ),
+					'term_name'    => $location->name,
+					'is_same_site' => true,
+				);
+			}
+		}
+	}
+
+	$ordered = array();
+	foreach ( $args['slot_order'] as $site_key ) {
+		if ( isset( $by_site[ $site_key ] ) ) {
+			$ordered[] = $by_site[ $site_key ];
+		}
+
+		if ( 3 === count( $ordered ) ) {
+			break;
+		}
+	}
+
+	return $ordered;
+}
+
+/**
+ * Render contextual exploration links beneath the event's primary actions.
+ *
+ * Hooked inside the Event Details action composition after tickets,
+ * attendance, calendar, and sharing. The CSS gives the bridge its own full
+ * row, so the primary conversion actions remain visually distinct.
+ *
+ * @param int    $post_id    Event post ID.
+ * @param string $ticket_url Ticket URL (unused).
+ * @param string $timing     Event timing state.
+ */
+function ec_events_network_bridge( $post_id, $ticket_url = '', $timing = '' ) {
+	static $rendered_post_ids = array();
+
+	unset( $ticket_url );
+
 	if ( ! is_singular( 'data_machine_events' ) ) {
 		return;
 	}
@@ -48,20 +148,33 @@ function ec_events_network_bridge() {
 		return;
 	}
 
-	if ( ! function_exists( 'extrachill_render_network_bridge' ) ) {
+	if ( ! function_exists( 'extrachill_network_bridge_get_cards' )
+		|| ! function_exists( 'extrachill_network_bridge_tag_url' )
+		|| ! function_exists( 'extrachill_cross_site_link_button' ) ) {
 		return;
 	}
 
-	extrachill_render_network_bridge(
-		array(
-			'post_id'           => get_the_ID(),
-			'taxonomies'        => array( 'artist', 'festival' ),
-			'allowed_site_keys' => array( 'main', 'wire', 'community' ),
-			'slot_order'        => array( 'main', 'wire', 'community' ),
-			'utm_source'        => 'extrachill_events',
-			'cache_prefix'      => 'ec_events_network_bridge_',
-			'heading_id'        => 'events-network-bridge-header',
-		)
-	);
+	$args  = ec_events_network_bridge_args( $post_id, $timing );
+	$cards = ec_events_network_bridge_cards( $args );
+	if ( empty( $cards ) || isset( $rendered_post_ids[ $post_id ] ) ) {
+		return;
+	}
+	$rendered_post_ids[ $post_id ] = true;
+
+	wp_enqueue_style( 'extrachill-network-bridge' );
+	?>
+	<div class="network-bridge-section related-tax-section" aria-labelledby="<?php echo esc_attr( $args['heading_id'] ); ?>">
+		<h3 class="network-bridge-header related-tax-header" id="<?php echo esc_attr( $args['heading_id'] ); ?>"><?php echo esc_html( $args['heading_text'] ); ?></h3>
+		<div class="network-bridge-links ec-cross-site-links">
+			<?php foreach ( $cards as $card ) : ?>
+				<?php if ( ! empty( $card['is_same_site'] ) ) : ?>
+					<a href="<?php echo esc_url( $card['url'] ); ?>" class="button-3 button-small event-exploration-link"><?php echo esc_html( $card['term_name'] . ' ' . $card['label'] ); ?></a>
+				<?php else : ?>
+					<?php extrachill_cross_site_link_button( $card, 'network-bridge-link event-exploration-link' ); ?>
+				<?php endif; ?>
+			<?php endforeach; ?>
+		</div>
+	</div>
+	<?php
 }
-add_action( 'extrachill_after_post_content', 'ec_events_network_bridge', 6 );
+add_action( 'data_machine_events_action_buttons', 'ec_events_network_bridge', 30, 3 );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
 			<file>tests/Unit/Abilities/CanonicalLocationsAbilityTest.php</file>
 			<file>tests/Unit/Abilities/EventsByTermTaxonomyContextTest.php</file>
 			<file>tests/Unit/FestivalNotificationsTest.php</file>
+			<file>tests/Unit/SingleEventNetworkBridgeTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/Unit/SingleEventNetworkBridgeTest.php
+++ b/tests/Unit/SingleEventNetworkBridgeTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Single-event contextual bridge tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+// phpcs:disable -- This isolated fixture intentionally declares WordPress test doubles.
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action() {}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return false;
+	}
+}
+if ( ! function_exists( 'get_the_terms' ) ) {
+	function get_the_terms( $post_id, $taxonomy ) {
+		return $GLOBALS['ec_events_bridge_terms'][ $post_id ][ $taxonomy ] ?? false;
+	}
+}
+if ( ! function_exists( 'get_term_link' ) ) {
+	function get_term_link( $term ) {
+		return 'https://events.example/location/' . $term->slug . '/';
+	}
+}
+if ( ! function_exists( 'extrachill_network_bridge_get_cards' ) ) {
+	function extrachill_network_bridge_get_cards() {
+		return $GLOBALS['ec_events_bridge_cross_site_cards'];
+	}
+}
+if ( ! function_exists( 'extrachill_network_bridge_tag_url' ) ) {
+	function extrachill_network_bridge_tag_url( $url, $site_key, $source ) {
+		return $url . '?utm_source=' . $source . '&utm_campaign=' . $site_key;
+	}
+}
+
+require_once dirname( __DIR__, 2 ) . '/inc/single-event/network-bridge.php';
+
+final class SingleEventNetworkBridgeTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['ec_events_bridge_terms']            = array();
+		$GLOBALS['ec_events_bridge_cross_site_cards'] = array();
+		$GLOBALS['ec_events_by_term_relationships']   = array();
+	}
+
+	public function test_upcoming_events_prioritize_profile_then_discussion_then_coverage(): void {
+		$args = ec_events_network_bridge_args( 123, 'upcoming' );
+
+		$this->assertSame( 123, $args['post_id'] );
+		$this->assertSame( array( 'artist', 'main', 'community' ), $args['allowed_site_keys'] );
+		$this->assertSame( array( 'artist', 'events', 'community', 'main' ), $args['slot_order'] );
+		$this->assertSame( 'Keep Exploring', $args['heading_text'] );
+		$this->assertSame( 'ec_events_network_bridge_v2_current_', $args['cache_prefix'] );
+	}
+
+	public function test_past_events_prioritize_coverage_then_profile_then_discussion(): void {
+		$args = ec_events_network_bridge_args( 456, 'past' );
+
+		$this->assertSame( array( 'main', 'artist', 'community', 'events' ), $args['slot_order'] );
+		$this->assertSame( 'ec_events_network_bridge_v2_past_', $args['cache_prefix'] );
+	}
+
+	public function test_upcoming_cards_include_nearby_shows_and_are_bounded_to_three(): void {
+		$GLOBALS['ec_events_bridge_cross_site_cards'] = array(
+			array( 'site_key' => 'main', 'label' => 'Blog Posts', 'url' => 'https://example.com/coverage' ),
+			array( 'site_key' => 'artist', 'label' => 'Artist Platform', 'url' => 'https://artist.example/band' ),
+			array( 'site_key' => 'community', 'label' => 'Forum Discussions', 'url' => 'https://community.example/band' ),
+		);
+		$GLOBALS['ec_events_bridge_terms'][123]['location'] = array(
+			(object) array(
+				'name' => 'Charleston',
+				'slug' => 'charleston-sc',
+			),
+		);
+		$GLOBALS['ec_events_by_term_relationships'][123]['location'] = $GLOBALS['ec_events_bridge_terms'][123]['location'];
+
+		$cards = ec_events_network_bridge_cards( ec_events_network_bridge_args( 123, 'upcoming' ) );
+
+		$this->assertCount( 3, $cards );
+		$this->assertSame( array( 'artist', 'events', 'community' ), array_column( $cards, 'site_key' ) );
+		$this->assertSame( 'Profile', $cards[0]['label'] );
+		$this->assertSame( 'More Shows', $cards[1]['label'] );
+		$this->assertSame( 'Charleston', $cards[1]['term_name'] );
+		$this->assertSame( 'https://events.example/location/charleston-sc/', $cards[1]['url'] );
+		$this->assertTrue( $cards[1]['is_same_site'] );
+	}
+
+	public function test_past_cards_do_not_add_nearby_shows_and_prioritize_coverage(): void {
+		$GLOBALS['ec_events_bridge_cross_site_cards'] = array(
+			array( 'site_key' => 'community', 'label' => 'Forum Discussions', 'url' => 'https://community.example/band' ),
+			array( 'site_key' => 'artist', 'label' => 'Artist Platform', 'url' => 'https://artist.example/band' ),
+			array( 'site_key' => 'main', 'label' => 'Blog Posts', 'url' => 'https://example.com/coverage' ),
+		);
+
+		$cards = ec_events_network_bridge_cards( ec_events_network_bridge_args( 456, 'past' ) );
+
+		$this->assertCount( 3, $cards );
+		$this->assertSame( array( 'main', 'artist', 'community' ), array_column( $cards, 'site_key' ) );
+		$this->assertSame( array( 'Coverage', 'Profile', 'Discussions' ), array_column( $cards, 'label' ) );
+	}
+}


### PR DESCRIPTION
## Summary
- Move the event network bridge into the Event Details action composition as a responsive `Keep Exploring` row.
- Prioritize artist profiles, nearby location archives, real community discussions, and editorial coverage by event tense, capped at three destinations.
- Preserve canonical shared resolution and cross-site analytics while keeping the same-site `More Shows` path out of cross-site traversal metrics.
- Add focused coverage for upcoming/past ordering, contextual labels, nearby-show composition, and the three-card bound.

## Why
Events is the network's fastest-growing acquisition surface, but event-entry journeys remain shallow. This turns the existing bridge primitive into an immediate, contextual continuation path without adding storage, recommendation infrastructure, copied content, or synthetic search URLs.

Fixes #262
Refs Extra-Chill/extrachill-network#88

## Verification
- `./vendor/bin/phpunit --filter SingleEventNetworkBridgeTest` (4 tests, 17 assertions)
- `./vendor/bin/phpcs --standard=WordPress inc/single-event/network-bridge.php tests/Unit/SingleEventNetworkBridgeTest.php`
- `php -l inc/single-event/network-bridge.php`
- `php -l tests/Unit/SingleEventNetworkBridgeTest.php`
- `npm run build`
- `git diff --check`

## Known Baseline
- Full `./vendor/bin/phpunit` reaches 177 tests but retains five unrelated failures and one error in `QualifyRecheckHandlerTest` and `CanonicalLocationsAbilityTest`.
- `homeboy review ... lint/test` was refused by the hot-host resource policy because no Lab runner was eligible; targeted lint/tests above passed.