### PR TITLE
fix: route paginated all-events archives

### DIFF
--- a/inc/core/router-pages.php
+++ b/inc/core/router-pages.php
@@ -35,6 +35,7 @@ function extrachill_events_router_rewrite_rules() {
 
 	add_rewrite_tag( '%ec_events_router%', '(all)' );
 	add_rewrite_rule( '^all/?$', 'index.php?ec_events_router=all', 'top' );
+	add_rewrite_rule( '^all/page/([0-9]{1,})/?$', 'index.php?ec_events_router=all&paged=$matches[1]', 'top' );
 
 	if ( extrachill_events_location_directory_enabled() ) {
 		add_rewrite_tag( '%ec_events_location_index%', '(1)' );
@@ -66,7 +67,7 @@ function extrachill_events_location_directory_enabled(): bool {
  * Flush rewrites once when the public location directory route is introduced.
  */
 function extrachill_events_maybe_flush_router_rewrites(): void {
-	$rewrite_version = '2';
+	$rewrite_version = '3';
 	if ( get_option( 'extrachill_events_router_rewrite_version' ) === $rewrite_version ) {
 		return;
 	}

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -19,6 +19,25 @@ if ( ! function_exists( 'add_action' ) ) {
 	}
 }
 
+if ( ! function_exists( 'add_rewrite_tag' ) ) {
+	function add_rewrite_tag( $tag, $regex ) {
+		$GLOBALS['test_rewrite_tags'][] = array(
+			'tag'   => $tag,
+			'regex' => $regex,
+		);
+	}
+}
+
+if ( ! function_exists( 'add_rewrite_rule' ) ) {
+	function add_rewrite_rule( $regex, $query, $after ) {
+		$GLOBALS['test_rewrite_rules'][] = array(
+			'regex' => $regex,
+			'query' => $query,
+			'after' => $after,
+		);
+	}
+}
+
 if ( ! function_exists( 'is_user_logged_in' ) ) {
 	function is_user_logged_in() {
 		return (bool) ( $GLOBALS['test_is_user_logged_in'] ?? false );
@@ -463,6 +482,40 @@ final class AccountMarketTest extends TestCase {
 
 	public function test_location_directory_is_enabled_by_default(): void {
 		$this->assertTrue( extrachill_events_location_directory_enabled() );
+	}
+
+	public function test_all_events_pagination_rewrite_routes_upcoming_page_two(): void {
+		$GLOBALS['test_rewrite_rules'] = array();
+
+		extrachill_events_router_rewrite_rules();
+
+		$this->assertContains(
+			array(
+				'regex' => '^all/page/([0-9]{1,})/?$',
+				'query' => 'index.php?ec_events_router=all&paged=$matches[1]',
+				'after' => 'top',
+			),
+			$GLOBALS['test_rewrite_rules']
+		);
+	}
+
+	public function test_all_events_pagination_rewrite_keeps_past_requests_on_router_page(): void {
+		$GLOBALS['test_rewrite_rules'] = array();
+
+		extrachill_events_router_rewrite_rules();
+
+		$pagination_rule = array_values(
+			array_filter(
+				$GLOBALS['test_rewrite_rules'],
+				static function ( array $rule ): bool {
+					return '^all/page/([0-9]{1,})/?$' === $rule['regex'];
+				}
+			)
+		);
+
+		$this->assertCount( 1, $pagination_rule );
+		$this->assertSame( 'index.php?ec_events_router=all&paged=$matches[1]', $pagination_rule[0]['query'] );
+		$this->assertSame( 'past=1', (string) wp_parse_url( 'https://events.example/all/page/2/?past=1', PHP_URL_QUERY ) );
 	}
 
 	public function test_router_query_flags_use_the_query_being_parsed(): void {


### PR DESCRIPTION
## Summary
- register `/all/page/<number>/` as the paginated all-events virtual archive
- pass the captured page number into WordPress while preserving query parameters such as `past=1`
- advance the internal rewrite schema version so production refreshes the new rule
- add focused route-registration coverage for upcoming and past page-two requests

## Testing
- changed-file Homeboy lint passed
- `php -l inc/core/router-pages.php`
- `php -l tests/Unit/Core/AccountMarketTest.php`
- `git diff --check`
- isolated Homeboy/Codebox test was attempted but did not return from runtime preparation; no test failure was reported

Fixes #264