### PR TITLE
refactor: own Data Machine Events configuration

### DIFF
--- a/inc/core/data-machine-events/configuration.php
+++ b/inc/core/data-machine-events/configuration.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Extra Chill configuration for Data Machine Events.
+ *
+ * @package ExtraChillEvents
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Point cross-site event queries at the canonical events site.
+ *
+ * @param int $blog_id Data Machine Events default blog ID.
+ * @return int Canonical events blog ID when available.
+ */
+function extrachill_events_configure_events_blog_id( int $blog_id ): int {
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return $blog_id;
+	}
+
+	$events_blog_id = (int) ec_get_blog_id( 'events' );
+	return $events_blog_id > 0 ? $events_blog_id : $blog_id;
+}
+add_filter( 'data_machine_events_events_blog_id', 'extrachill_events_configure_events_blog_id' );
+
+/**
+ * Attribute automated imports to the network bot account.
+ *
+ * @param int   $author_id      Data Machine Events fallback author ID.
+ * @param array $handler_config Event handler configuration.
+ * @param mixed $engine         Data Machine engine snapshot helper.
+ * @return int Network bot user ID when available.
+ */
+function extrachill_events_configure_import_author( int $author_id, array $handler_config, $engine ): int {
+	unset( $handler_config, $engine );
+
+	if ( ! function_exists( 'ec_get_network_bot_user_id' ) ) {
+		return $author_id;
+	}
+
+	$bot_user_id = (int) ec_get_network_bot_user_id();
+	return $bot_user_id > 0 ? $bot_user_id : $author_id;
+}
+add_filter( 'data_machine_events_fallback_author_id', 'extrachill_events_configure_import_author', 10, 3 );
+
+/**
+ * Keep high-volume events automation retention bounded.
+ *
+ * @param int $days Data Machine default retention period.
+ * @return int Retention period for the events workload.
+ */
+function extrachill_events_configure_action_retention( int $days ): int {
+	unset( $days );
+
+	return 2;
+}
+add_filter( 'datamachine_as_actions_max_age_days', 'extrachill_events_configure_action_retention' );
+add_filter( 'datamachine_log_max_age_days', 'extrachill_events_configure_action_retention' );
+
+/**
+ * Keep completed and failed event-job history for two weeks.
+ *
+ * @param int $days Data Machine default retention period.
+ * @return int Retention period for the events workload.
+ */
+function extrachill_events_configure_job_retention( int $days ): int {
+	unset( $days );
+
+	return 14;
+}
+add_filter( 'datamachine_completed_jobs_max_age_days', 'extrachill_events_configure_job_retention' );
+add_filter( 'datamachine_failed_jobs_max_age_days', 'extrachill_events_configure_job_retention' );
+add_filter( 'datamachine_processed_items_max_age_days', 'extrachill_events_configure_job_retention' );

--- a/inc/core/data-machine-events/init.php
+++ b/inc/core/data-machine-events/init.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/taxonomy-registration.php';
+require_once __DIR__ . '/configuration.php';
 require_once __DIR__ . '/badge-styling.php';
 require_once __DIR__ . '/button-styling.php';
 require_once __DIR__ . '/archive-title.php';

--- a/tests/Unit/Core/DataMachineEventsConfigurationTest.php
+++ b/tests/Unit/Core/DataMachineEventsConfigurationTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Data Machine Events configuration tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'ec_get_blog_id' ) ) {
+	function ec_get_blog_id( string $site ): int {
+		return 'events' === $site ? 7 : 0;
+	}
+}
+
+if ( ! function_exists( 'ec_get_network_bot_user_id' ) ) {
+	function ec_get_network_bot_user_id(): int {
+		return 42;
+	}
+}
+
+require_once dirname( __DIR__, 3 ) . '/inc/core/data-machine-events/configuration.php';
+
+final class DataMachineEventsConfigurationTest extends TestCase {
+	public function test_configures_canonical_events_site(): void {
+		$this->assertSame( 7, apply_filters( 'data_machine_events_events_blog_id', 1 ) );
+	}
+
+	public function test_configures_network_bot_for_automated_imports(): void {
+		$this->assertSame( 42, apply_filters( 'data_machine_events_fallback_author_id', 0, array(), null ) );
+	}
+
+	public function test_configures_events_retention_policy(): void {
+		$this->assertSame( 2, apply_filters( 'datamachine_as_actions_max_age_days', 7 ) );
+		$this->assertSame( 2, apply_filters( 'datamachine_log_max_age_days', 7 ) );
+		$this->assertSame( 14, apply_filters( 'datamachine_completed_jobs_max_age_days', 30 ) );
+		$this->assertSame( 14, apply_filters( 'datamachine_failed_jobs_max_age_days', 30 ) );
+		$this->assertSame( 14, apply_filters( 'datamachine_processed_items_max_age_days', 30 ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,8 +40,27 @@ if ( ! function_exists( 'wp_parse_url' ) ) {
 	}
 }
 
+if ( ! function_exists( 'add_filter' ) ) {
+	$GLOBALS['ec_test_filters'] = array();
+
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['ec_test_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+	}
+}
+
 if ( ! function_exists( 'apply_filters' ) ) {
 	function apply_filters( $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['ec_test_filters'][ $hook ] ) ) {
+			return $value;
+		}
+
+		ksort( $GLOBALS['ec_test_filters'][ $hook ] );
+		foreach ( $GLOBALS['ec_test_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				$value = call_user_func_array( $callback[0], array_slice( array_merge( array( $value ), $args ), 0, $callback[1] ) );
+			}
+		}
+
 		return $value;
 	}
 }


### PR DESCRIPTION
## Summary
- configure Data Machine Events from Extra Chill Events with the canonical events site and network bot author policy
- move the Extra Chill retention policy from the generic plugin into this consumer
- cover the consumer wiring with a focused pure-PHP regression test

## Dependency Direction and Contract
Extra Chill Events depends on Data Machine Events, never the reverse. It supplies `data_machine_events_events_blog_id` for cross-site queries and `data_machine_events_fallback_author_id` for automated imports. If this plugin is inactive, Data Machine Events remains functional on a standalone current-site installation with WordPress's normal author fallback.

## Companion PR
Generic-layer change: https://github.com/Extra-Chill/data-machine-events/pull/456

## Verification
- Direct filter exercise passed for canonical blog ID, network bot author, and all retention hooks.
- `php -l` passed for changed PHP files and `phpunit.xml.dist` parsed successfully.
- Focused PHPUnit and PHPCS could not run because this worktree has no `vendor/` directory.
- `homeboy review extrachill-events --changed-only --summary` was declined by Homeboy because the host is hot (load 145.1 across 8 CPUs).

Fixes #266