### PR TITLE
chore: clear release-blocking location lint

### DIFF
--- a/inc/Core/LocationIntegrityAuditor.php
+++ b/inc/Core/LocationIntegrityAuditor.php
@@ -115,15 +115,15 @@ class LocationIntegrityAuditor {
 
 	private static function finding( string $issue, string $reason, array $candidate, array $canonical ): array {
 		return array(
-			'issue'          => $issue,
-			'reason'         => $reason,
-			'candidate_id'   => (int) $candidate['term_id'],
-			'candidate_name' => (string) $candidate['name'],
-			'candidate_slug' => (string) $candidate['slug'],
+			'issue'           => $issue,
+			'reason'          => $reason,
+			'candidate_id'    => (int) $candidate['term_id'],
+			'candidate_name'  => (string) $candidate['name'],
+			'candidate_slug'  => (string) $candidate['slug'],
 			'candidate_count' => (int) ( $candidate['count'] ?? 0 ),
-			'canonical_id'   => (int) $canonical['term_id'],
-			'canonical_name' => (string) $canonical['name'],
-			'canonical_slug' => (string) $canonical['slug'],
+			'canonical_id'    => (int) $canonical['term_id'],
+			'canonical_name'  => (string) $canonical['name'],
+			'canonical_slug'  => (string) $canonical['slug'],
 			'canonical_count' => (int) ( $canonical['count'] ?? 0 ),
 		);
 	}


### PR DESCRIPTION
## Summary
- align `LocationIntegrityAuditor` finding array arrows
- clear the eight auto-fixable PHPCS warnings blocking the v0.46.1 release

## Verification
- direct PHPCS no longer reports the array-alignment warnings
- `git diff --check`
- no behavioral code changed

Fixes #261