### PR TITLE
fix: render selected public concert history

### DIFF
--- a/blocks/concert-stats/render.php
+++ b/blocks/concert-stats/render.php
@@ -140,8 +140,9 @@ if ( ! $user_id ) {
 	$user_id = get_current_user_id();
 }
 
-$events_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'events' ) : home_url();
-$is_own     = is_user_logged_in() && get_current_user_id() === $user_id;
+$events_url     = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'events' ) : home_url();
+$is_own         = is_user_logged_in() && get_current_user_id() === $user_id;
+$public_date_to = $is_own ? '' : current_datetime()->modify( '-1 day' )->format( 'Y-m-d' );
 
 // #110: Calendar tab is owner-only, and the server-side filter callback
 // only activates on /my-shows/. Match both conditions before emitting
@@ -167,6 +168,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		data-user-id="<?php echo esc_attr( $user_id ); ?>"
 		data-events-url="<?php echo esc_attr( $events_url ); ?>"
 		data-is-own="<?php echo esc_attr( $is_own ? '1' : '0' ); ?>"
+		data-public-date-to="<?php echo esc_attr( $public_date_to ); ?>"
 		data-has-calendar="<?php echo esc_attr( $render_embedded_calendar ? '1' : '0' ); ?>"
 		data-has-map="<?php echo esc_attr( $render_embedded_map ? '1' : '0' ); ?>"
 	>

--- a/blocks/concert-stats/render.php
+++ b/blocks/concert-stats/render.php
@@ -32,7 +32,42 @@
  * @since 0.18.0
  */
 
-$user_id = ! empty( $attributes['userId'] ) ? (int) $attributes['userId'] : get_current_user_id();
+$on_my_shows = function_exists( 'is_page' ) && is_page( 'my-shows' );
+$user_id     = ! empty( $attributes['userId'] ) ? (int) $attributes['userId'] : get_current_user_id();
+
+// Public profile cards link to the canonical My Shows page with the profile
+// owner's network user ID. Resolve that selection before the anonymous
+// marketing fallback so every viewer sees the requested public history rather
+// than their own dashboard (or the logged-out marketing state).
+// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only public route selection.
+if ( $on_my_shows && isset( $_GET['user_id'] ) ) {
+	$requested_user_id = is_scalar( $_GET['user_id'] )
+		? absint( wp_unslash( $_GET['user_id'] ) )
+		: 0;
+
+	if ( $requested_user_id < 1 || ! get_userdata( $requested_user_id ) ) {
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class' => 'ec-concert-stats-shell ec-concert-stats-shell--invalid-user',
+			)
+		);
+		?>
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped via get_block_wrapper_attributes. ?>>
+			<div class="ec-block-shell ec-block-shell--depth-0 ec-mobile-full-width-panel">
+				<div class="ec-block-shell-inner ec-block-shell-inner--narrow">
+					<div class="ec-inline-status ec-inline-status--error" role="status">
+						<?php esc_html_e( 'This concert history could not be found.', 'extrachill-events' ); ?>
+					</div>
+				</div>
+			</div>
+		</div>
+		<?php
+		return;
+	}
+
+	$user_id = $requested_user_id;
+}
+// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 // #126: when there's no explicit `userId` attribute (the usual case
 // on /my-shows/) and the visitor is logged out, render a public
@@ -111,7 +146,6 @@ $is_own     = is_user_logged_in() && get_current_user_id() === $user_id;
 // #110: Calendar tab is owner-only, and the server-side filter callback
 // only activates on /my-shows/. Match both conditions before emitting
 // the embedded calendar block so we don't ship dead markup elsewhere.
-$on_my_shows              = function_exists( 'is_page' ) && is_page( 'my-shows' );
 $render_embedded_calendar = $is_own && $on_my_shows;
 
 // #111: Same gate for the Map tab. The events-map block in

--- a/blocks/concert-stats/src/components/PastTab.js
+++ b/blocks/concert-stats/src/components/PastTab.js
@@ -47,6 +47,7 @@ const PastTab = ( { userId, year, isOwn } ) => {
 				userId={ userId }
 				period="past"
 				year={ year }
+				isOwn={ isOwn }
 			/>
 		</div>
 	);

--- a/blocks/concert-stats/src/components/ShowList.js
+++ b/blocks/concert-stats/src/components/ShowList.js
@@ -20,7 +20,7 @@ import { ActionRow, InlineStatus } from '@extrachill/components';
 import ShowCard from './ShowCard';
 import useShows from '../hooks/useShows';
 
-const ShowList = ( { userId, period, year, eventsUrl } ) => {
+const ShowList = ( { userId, period, year, eventsUrl, isOwn = true } ) => {
 	const [ page, setPage ] = useState( 1 );
 
 	const { shows, total, pages, loading, error } = useShows( userId, {
@@ -51,8 +51,9 @@ const ShowList = ( { userId, period, year, eventsUrl } ) => {
 		}
 		return (
 			<InlineStatus tone="info">
-				No past shows tracked yet. Use the search above to find shows
-				you&rsquo;ve attended, or Import from setlist.fm/phish.net.
+				{ isOwn
+					? "No past shows tracked yet. Use the search above to find shows you've attended, or Import from setlist.fm/phish.net."
+					: 'No past shows tracked yet.' }
 			</InlineStatus>
 		);
 	}

--- a/blocks/concert-stats/src/hooks/useImportRuns.js
+++ b/blocks/concert-stats/src/hooks/useImportRuns.js
@@ -18,8 +18,10 @@ const ACTIVE_STATUSES = [ 'pending', 'running', 'paused' ];
 
 /**
  * Hook returning import sources + runs + actions.
+ *
+ * @param {boolean} enabled Whether owner-only import requests may run.
  */
-export default function useImportRuns() {
+export default function useImportRuns( enabled = true ) {
 	const [ sources, setSources ] = useState( [] );
 	const [ runs, setRuns ] = useState( [] );
 	const [ loading, setLoading ] = useState( true );
@@ -48,11 +50,16 @@ export default function useImportRuns() {
 	}, [] );
 
 	const refresh = useCallback( () => {
+		if ( ! enabled ) {
+			setLoading( false );
+			return Promise.resolve();
+		}
+
 		setLoading( true );
 		return Promise.all( [ fetchSources(), fetchRuns() ] ).finally( () =>
 			setLoading( false )
 		);
-	}, [ fetchSources, fetchRuns ] );
+	}, [ enabled, fetchSources, fetchRuns ] );
 
 	// Initial load.
 	useEffect( () => {
@@ -70,7 +77,7 @@ export default function useImportRuns() {
 			pollTimerRef.current = null;
 		}
 
-		if ( anyActive ) {
+		if ( enabled && anyActive ) {
 			pollTimerRef.current = setInterval( () => {
 				fetchRuns();
 			}, POLL_INTERVAL_MS );
@@ -82,7 +89,7 @@ export default function useImportRuns() {
 				pollTimerRef.current = null;
 			}
 		};
-	}, [ runs, fetchRuns ] );
+	}, [ enabled, runs, fetchRuns ] );
 
 	const preview = useCallback( ( source, username ) => {
 		return apiFetch( {

--- a/blocks/concert-stats/src/hooks/useShows.js
+++ b/blocks/concert-stats/src/hooks/useShows.js
@@ -12,7 +12,7 @@ import apiFetch from '@wordpress/api-fetch';
 
 /**
  * @param {number} userId
- * @param {Object} filters - { period, year, page, perPage }
+ * @param {Object} filters - { period, year, page, perPage, enabled }
  */
 export default function useShows( userId, filters = {} ) {
 	const [ shows, setShows ] = useState( [] );
@@ -21,10 +21,16 @@ export default function useShows( userId, filters = {} ) {
 	const [ loading, setLoading ] = useState( true );
 	const [ error, setError ] = useState( null );
 
-	const { period = 'all', year = 0, page = 1, perPage = 20 } = filters;
+	const {
+		period = 'all',
+		year = 0,
+		page = 1,
+		perPage = 20,
+		enabled = true,
+	} = filters;
 
 	const fetchShows = useCallback( () => {
-		if ( ! userId ) {
+		if ( ! userId || ! enabled ) {
 			setLoading( false );
 			return;
 		}
@@ -56,7 +62,7 @@ export default function useShows( userId, filters = {} ) {
 				setError( err.message || 'Failed to load shows.' );
 				setLoading( false );
 			} );
-	}, [ userId, period, year, page, perPage ] );
+	}, [ userId, period, year, page, perPage, enabled ] );
 
 	useEffect( () => {
 		fetchShows();

--- a/blocks/concert-stats/src/hooks/useStats.js
+++ b/blocks/concert-stats/src/hooks/useStats.js
@@ -12,14 +12,14 @@ import apiFetch from '@wordpress/api-fetch';
 
 /**
  * @param {number} userId
- * @param {Object} filters - { year }
+ * @param {Object} filters - { year, dateTo }
  */
 export default function useStats( userId, filters = {} ) {
 	const [ stats, setStats ] = useState( null );
 	const [ loading, setLoading ] = useState( true );
 	const [ error, setError ] = useState( null );
 
-	const { year = 0 } = filters;
+	const { year = 0, dateTo = '' } = filters;
 
 	const fetchStats = useCallback( () => {
 		if ( ! userId ) {
@@ -30,10 +30,17 @@ export default function useStats( userId, filters = {} ) {
 		setLoading( true );
 		setError( null );
 
-		let path = `/extrachill/v1/concert-tracking/user/${ userId }/stats`;
+		const params = new URLSearchParams();
 		if ( year ) {
-			path += `?year=${ year }`;
+			params.set( 'year', year );
 		}
+		if ( dateTo ) {
+			params.set( 'date_to', dateTo );
+		}
+		const query = params.toString();
+		const path = `/extrachill/v1/concert-tracking/user/${ userId }/stats${
+			query ? `?${ query }` : ''
+		}`;
 
 		apiFetch( { path } )
 			.then( ( response ) => {
@@ -44,7 +51,7 @@ export default function useStats( userId, filters = {} ) {
 				setError( err.message || 'Failed to load stats.' );
 				setLoading( false );
 			} );
-	}, [ userId, year ] );
+	}, [ userId, year, dateTo ] );
 
 	useEffect( () => {
 		fetchStats();

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -188,7 +188,7 @@ function ConcertStatsApp( {
 	// We hoist the hook to the parent and pass the full bag down to ImportTab
 	// so we don't double-fetch from two `useImportRuns()` sites on the same
 	// page. ImportTab consumes the props directly.
-	const importRunsBag = useImportRuns();
+	const importRunsBag = useImportRuns( isOwn );
 	const hasImports =
 		isOwn && importRunsBag.sources && importRunsBag.sources.length > 0;
 

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -38,10 +38,8 @@ import useShows from './hooks/useShows';
 import useImportRuns from './hooks/useImportRuns';
 
 /**
- * Whitelist of tab IDs that may appear in `?tab=` URL state. Anything
- * else falls back to the default ("upcoming"). Owner-only tabs are
- * still gated by `isOwn` inside the render — the whitelist just guards
- * against arbitrary strings becoming React state.
+ * Whitelist of tab IDs that may appear in `?tab=` URL state. Owners default
+ * to Upcoming; public viewers default to Past and can also open Stats.
  */
 const VALID_TAB_IDS = [
 	'upcoming',
@@ -74,19 +72,26 @@ const TAB_ALIASES = {
  * recognized (or aliased) tab so callers can apply their own default.
  *
  * @param {?string} requested Raw `tab` query param value.
+ * @param {boolean} isOwn     Whether owner-only tabs are available.
  * @return {?string} A valid tab ID, or null when unrecognized.
  */
-function resolveTabId( requested ) {
+function resolveTabId( requested, isOwn = true ) {
 	if ( ! requested ) {
 		return null;
 	}
 	const aliased = TAB_ALIASES[ requested ] || requested;
-	return VALID_TAB_IDS.includes( aliased ) ? aliased : null;
+	if ( ! VALID_TAB_IDS.includes( aliased ) ) {
+		return null;
+	}
+	return ! isOwn && ! [ 'past', 'stats' ].includes( aliased )
+		? 'past'
+		: aliased;
 }
 
 /**
  * Read the initial active tab from `?tab=` on first render. SSR-safe
- * (no-op when `window` is absent). Falls back to `'upcoming'`.
+ * (no-op when `window` is absent). Public viewers always land on a
+ * public tab, with unavailable owner-only links normalized to Past.
  *
  * #126: when `?tab=` is absent we default to `'upcoming'`. A
  * post-fetch effect inside the app swaps the default to `'past'`
@@ -103,14 +108,18 @@ function resolveTabId( requested ) {
  * #159: a legacy `?tab=add-past` deep link resolves to `'past'` via
  * resolveTabId()'s alias table.
  *
+ * @param {boolean} isOwn Whether owner-only tabs are available.
  * @return {string} Tab ID.
  */
-function readInitialTab() {
+function readInitialTab( isOwn ) {
 	if ( typeof window === 'undefined' ) {
-		return 'upcoming';
+		return isOwn ? 'upcoming' : 'past';
 	}
 	const params = new URLSearchParams( window.location.search );
-	return resolveTabId( params.get( 'tab' ) ) || 'upcoming';
+	return (
+		resolveTabId( params.get( 'tab' ), isOwn ) ||
+		( isOwn ? 'upcoming' : 'past' )
+	);
 }
 
 /**
@@ -120,14 +129,15 @@ function readInitialTab() {
  * including a legacy `?tab=add-past` link, which resolveTabId() maps to
  * `past` (#159).
  *
+ * @param {boolean} isOwn Whether owner-only tabs are available.
  * @return {boolean} True when the URL carries a recognized `?tab=` value.
  */
-function hasExplicitTabParam() {
+function hasExplicitTabParam( isOwn ) {
 	if ( typeof window === 'undefined' ) {
 		return false;
 	}
 	const params = new URLSearchParams( window.location.search );
-	return resolveTabId( params.get( 'tab' ) ) !== null;
+	return resolveTabId( params.get( 'tab' ), isOwn ) !== null;
 }
 
 /**
@@ -136,30 +146,41 @@ function hasExplicitTabParam() {
  * @param {number}  root0.userId       Profile owner's user ID.
  * @param {string}  root0.eventsUrl    Base URL for the events site.
  * @param {boolean} root0.isOwn        Whether the viewer owns this profile.
+ * @param {string}  root0.publicDateTo Last date included in public stats.
  * @param {boolean} root0.hasCalendar  Whether an embedded calendar sibling is present.
  * @param {boolean} root0.hasMap       Whether an embedded map sibling is present.
  * @param {Object}  root0.containerRef Ref object pointing at the React mount container.
  */
-function ConcertStatsApp( {
+export function ConcertStatsApp( {
 	userId,
 	eventsUrl,
 	isOwn,
+	publicDateTo,
 	hasCalendar,
 	hasMap,
 	containerRef,
 } ) {
 	const [ year, setYear ] = useState( 0 );
-	const [ activeTab, setActiveTab ] = useState( readInitialTab );
+	const [ activeTab, setActiveTab ] = useState( () =>
+		readInitialTab( isOwn )
+	);
 	// #126: tracks whether the user (or a deep link) has chosen a tab.
 	// Until then, the post-stats-fetch effect below is allowed to swap
 	// the default from 'upcoming' → 'past' when the owner has zero
 	// tracked shows. Once the user explicitly picks a tab via the tab
 	// strip, this flips to true and the auto-swap stops fighting them.
-	const [ userPickedTab, setUserPickedTab ] = useState( hasExplicitTabParam );
+	const [ userPickedTab, setUserPickedTab ] = useState( () =>
+		hasExplicitTabParam( isOwn )
+	);
 
-	const { stats, loading: statsLoading } = useStats( userId, { year } );
+	const { stats, loading: statsLoading } = useStats( userId, {
+		year,
+		dateTo: isOwn ? '' : publicDateTo,
+	} );
 
-	// Badge counts for the Upcoming / Past tabs. The aggregate stats
+	// Badge counts for the Upcoming / Past tabs. Public views disable the
+	// upcoming request entirely so the browser never receives itinerary data.
+	// The aggregate stats
 	// payload doesn't split tracked shows by period, so we read the
 	// accurate per-period `total` from the same paginated shows
 	// endpoint ShowList uses, but with `perPage: 1` so it's a cheap
@@ -170,6 +191,7 @@ function ConcertStatsApp( {
 		year,
 		page: 1,
 		perPage: 1,
+		enabled: isOwn,
 	} );
 	const { total: pastCount } = useShows( userId, {
 		period: 'past',
@@ -306,21 +328,25 @@ function ConcertStatsApp( {
 		}
 	}, [ activeTab, hasMap, containerRef ] );
 
-	// Tab order: Upcoming → Past → Calendar (owner, #110) → Map
+	// Owner tab order: Upcoming → Past → Calendar (#110) → Map
 	// (owner, #111) → Stats → Import (owner, #112). The Past tab now
 	// also hosts the owner-only "add a past show" search affordance
 	// (#159 folded the old standalone "Add Past Shows" tab into Past),
 	// so there's no separate growth tab in the strip anymore.
 	// Visualization tabs (Calendar, Map) sit alongside the history axes
 	// (Upcoming, Past); Stats stays second-to-last as the summary
-	// surface; Import is the remaining growth tab. Owner-only tabs exist
-	// because the underlying tracking table is per-user.
+	// surface; Import is the remaining growth tab. Public viewers receive only
+	// Past and past-derived Stats, never a centralized upcoming itinerary.
 	const tabs = [
-		{
-			id: 'upcoming',
-			label: 'Upcoming',
-			badge: upcomingCount,
-		},
+		...( isOwn
+			? [
+					{
+						id: 'upcoming',
+						label: 'Upcoming',
+						badge: upcomingCount,
+					},
+			  ]
+			: [] ),
 		{
 			id: 'past',
 			label: 'Past',
@@ -581,6 +607,7 @@ function init() {
 		const userId = parseInt( container.dataset.userId, 10 );
 		const eventsUrl = container.dataset.eventsUrl || '';
 		const isOwn = container.dataset.isOwn === '1';
+		const publicDateTo = container.dataset.publicDateTo || '';
 		const hasCalendar = container.dataset.hasCalendar === '1';
 		const hasMap = container.dataset.hasMap === '1';
 
@@ -590,6 +617,7 @@ function init() {
 				userId={ userId }
 				eventsUrl={ eventsUrl }
 				isOwn={ isOwn }
+				publicDateTo={ publicDateTo }
 				hasCalendar={ hasCalendar }
 				hasMap={ hasMap }
 				mountNode={ container }

--- a/blocks/concert-stats/src/view.test.js
+++ b/blocks/concert-stats/src/view.test.js
@@ -1,0 +1,213 @@
+/**
+ * Concert stats public/owner request boundaries.
+ */
+/* eslint-env jest */
+
+import { createRoot } from '@wordpress/element';
+import { act } from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import { ConcertStatsApp } from './view';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '@extrachill/components', () => {
+	const React = require( 'react' );
+	const Wrapper = ( { children } ) =>
+		React.createElement( 'div', null, children );
+
+	return {
+		ActionRow: Wrapper,
+		BlockShell: Wrapper,
+		BlockShellInner: Wrapper,
+		BlockShellHeader: ( { title } ) =>
+			React.createElement( 'h2', null, title ),
+		Grid: Wrapper,
+		InlineStatus: Wrapper,
+		ResponsiveTabs: ( { tabs, active, renderPanel } ) =>
+			React.createElement(
+				'div',
+				null,
+				tabs.map( ( tab ) =>
+					React.createElement( 'button', { key: tab.id }, tab.label )
+				),
+				renderPanel( active )
+			),
+		Section: Wrapper,
+		SearchBox: ( { value } ) =>
+			React.createElement( 'input', { value, readOnly: true } ),
+		StatGroup: Wrapper,
+		StatTile: ( { label, value } ) =>
+			React.createElement( 'span', null, `${ label }: ${ value }` ),
+	};
+} );
+
+const emptyStats = {
+	total_shows: 0,
+	unique_venues: 0,
+	unique_artists: 0,
+	unique_cities: 0,
+	top_artists: [],
+	top_venues: [],
+	top_cities: [],
+	shows_by_year: {},
+};
+
+function mockApi() {
+	apiFetch.mockImplementation( ( { path } ) => {
+		if ( path.includes( '/stats' ) ) {
+			return Promise.resolve( emptyStats );
+		}
+		if ( path.includes( '/shows' ) ) {
+			const upcoming = path.includes( 'period=upcoming' );
+			return Promise.resolve( {
+				shows: [
+					{
+						event_id: upcoming ? 99 : 11,
+						title: upcoming
+							? 'Secret Future Concert'
+							: 'Past Concert',
+						event_date: upcoming ? '2026-08-01' : '2026-01-01',
+						artists: [],
+					},
+				],
+				total: 1,
+				pages: 1,
+			} );
+		}
+		if ( path.includes( '/concert-import/sources' ) ) {
+			return Promise.resolve( { sources: [ { id: 'setlistfm' } ] } );
+		}
+		if ( path.includes( '/concert-import/status' ) ) {
+			return Promise.resolve( { runs: [] } );
+		}
+		if ( path.includes( '/concert-tracking/search' ) ) {
+			return Promise.resolve( { events: [], total: 0, pages: 0 } );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+async function renderApp( { isOwn, tab } ) {
+	window.history.replaceState(
+		{},
+		'',
+		`/my-shows/?user_id=34${ tab ? `&tab=${ tab }` : '' }`
+	);
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+
+	await act( async () => {
+		root.render(
+			<ConcertStatsApp
+				userId={ 34 }
+				eventsUrl="https://events.example"
+				isOwn={ isOwn }
+				publicDateTo="2026-07-18"
+				hasCalendar={ isOwn }
+				hasMap={ isOwn }
+				containerRef={ { current: container } }
+			/>
+		);
+		await Promise.resolve();
+	} );
+
+	return { container, root };
+}
+
+describe( 'ConcertStatsApp request boundaries', () => {
+	beforeAll( () => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+	} );
+
+	afterAll( () => {
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	} );
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		mockApi();
+		document.body.innerHTML = '';
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it.each( [
+		[ 'logged-out calendar link', 'calendar' ],
+		[ 'logged-in non-owner map link', 'map' ],
+		[ 'public import link', 'import' ],
+	] )( 'renders past-only for a %s', async ( label, tab ) => {
+		const { container, root } = await renderApp( { isOwn: false, tab } );
+		const paths = apiFetch.mock.calls.map(
+			( [ request ] ) => request.path
+		);
+
+		expect( window.location.search ).toContain( 'tab=past' );
+		expect( container.textContent ).toContain( 'Past' );
+		expect( container.textContent ).toContain( 'Past Concert' );
+		expect( container.textContent ).not.toContain( 'Upcoming' );
+		expect( container.textContent ).not.toContain(
+			'Secret Future Concert'
+		);
+		expect( paths ).toContain(
+			'/extrachill/v1/concert-tracking/user/34/stats?date_to=2026-07-18'
+		);
+		expect(
+			paths.some( ( path ) => path.includes( 'period=upcoming' ) )
+		).toBe( false );
+		expect( paths.some( ( path ) => path.includes( 'period=past' ) ) ).toBe(
+			true
+		);
+		expect(
+			paths.some( ( path ) => path.includes( '/concert-import/' ) )
+		).toBe( false );
+		expect(
+			paths.some( ( path ) =>
+				path.includes( '/concert-tracking/search' )
+			)
+		).toBe( false );
+
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'retains owner upcoming and write requests', async () => {
+		const { container, root } = await renderApp( {
+			isOwn: true,
+			tab: 'past',
+		} );
+
+		await act( async () => {
+			jest.runOnlyPendingTimers();
+			await Promise.resolve();
+		} );
+
+		const paths = apiFetch.mock.calls.map(
+			( [ request ] ) => request.path
+		);
+		expect( container.textContent ).toContain( 'Upcoming' );
+		expect( paths ).toContain(
+			'/extrachill/v1/concert-tracking/user/34/stats'
+		);
+		expect( paths.some( ( path ) => path.includes( 'date_to=' ) ) ).toBe(
+			false
+		);
+		expect(
+			paths.some( ( path ) => path.includes( 'period=upcoming' ) )
+		).toBe( true );
+		expect( paths ).toContain( '/extrachill/v1/concert-import/sources' );
+		expect( paths ).toContain( '/extrachill/v1/concert-import/status' );
+		expect(
+			paths.some( ( path ) =>
+				path.includes( '/concert-tracking/search' )
+			)
+		).toBe( true );
+
+		await act( async () => root.unmount() );
+	} );
+} );

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"copy:concert-stats": "cp blocks/concert-stats/block.json blocks/concert-stats/render.php build/concert-stats/",
 		"start": "wp-scripts start blocks/event-submission/src/index.js --output-path=build/event-submission",
 		"start:concert-stats": "wp-scripts start blocks/concert-stats/src/index.js blocks/concert-stats/src/view.js --output-path=build/concert-stats",
+		"test:js": "wp-scripts test-unit-js",
 		"lint:js": "wp-scripts lint-js",
 		"lint:js:fix": "wp-scripts lint-js --fix"
 	},

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,7 @@
 			<file>tests/Unit/Abilities/EventsByTermTaxonomyContextTest.php</file>
 			<file>tests/Unit/FestivalNotificationsTest.php</file>
 			<file>tests/Unit/SingleEventNetworkBridgeTest.php</file>
+			<file>tests/Unit/ConcertStatsPublicProfileRenderTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/Unit/ConcertStatsPublicProfileRenderTest.php
+++ b/tests/Unit/ConcertStatsPublicProfileRenderTest.php
@@ -98,6 +98,12 @@ if ( ! function_exists( 'do_blocks' ) ) {
 	}
 }
 
+if ( ! function_exists( 'current_datetime' ) ) {
+	function current_datetime() {
+		return new DateTimeImmutable( '2026-07-19 12:00:00' );
+	}
+}
+
 final class ConcertStatsPublicProfileRenderTest extends TestCase {
 	protected function setUp(): void {
 		$GLOBALS['ec_test_current_user_id']   = 0;
@@ -118,6 +124,7 @@ final class ConcertStatsPublicProfileRenderTest extends TestCase {
 
 		$this->assertStringContainsString( 'data-user-id="12"', $output );
 		$this->assertStringContainsString( 'data-is-own="1"', $output );
+		$this->assertStringContainsString( 'data-public-date-to=""', $output );
 		$this->assertStringContainsString( 'data-has-calendar="1"', $output );
 		$this->assertStringContainsString( 'data-has-map="1"', $output );
 		$this->assertStringContainsString( 'ec-concert-stats__embedded-calendar', $output );
@@ -133,6 +140,7 @@ final class ConcertStatsPublicProfileRenderTest extends TestCase {
 
 		$this->assertStringContainsString( 'data-user-id="34"', $output );
 		$this->assertStringContainsString( 'data-is-own="0"', $output );
+		$this->assertStringContainsString( 'data-public-date-to="2026-07-18"', $output );
 		$this->assertStringContainsString( 'data-has-calendar="0"', $output );
 		$this->assertStringContainsString( 'data-has-map="0"', $output );
 		$this->assertStringNotContainsString( 'ec-concert-stats__embedded-calendar', $output );
@@ -146,6 +154,7 @@ final class ConcertStatsPublicProfileRenderTest extends TestCase {
 
 		$this->assertStringContainsString( 'data-user-id="34"', $output );
 		$this->assertStringContainsString( 'data-is-own="0"', $output );
+		$this->assertStringContainsString( 'data-public-date-to="2026-07-18"', $output );
 		$this->assertStringNotContainsString( 'ec-concert-stats-shell--marketing', $output );
 	}
 
@@ -170,16 +179,6 @@ final class ConcertStatsPublicProfileRenderTest extends TestCase {
 
 		$this->assertStringContainsString( 'This concert history could not be found.', $output );
 		$this->assertStringNotContainsString( 'data-user-id="12"', $output );
-	}
-
-	public function test_client_write_controls_remain_owner_only(): void {
-		$root     = dirname( __DIR__, 2 );
-		$view     = (string) file_get_contents( $root . '/blocks/concert-stats/src/view.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local test fixture.
-		$past_tab = (string) file_get_contents( $root . '/blocks/concert-stats/src/components/PastTab.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local test fixture.
-
-		$this->assertStringContainsString( 'useImportRuns( isOwn )', $view );
-		$this->assertStringContainsString( 'isOwn && importRunsBag.sources', $view );
-		$this->assertStringContainsString( 'isOwn && <AddPastShows', $past_tab );
 	}
 
 	private function renderBlock(): string {

--- a/tests/Unit/ConcertStatsPublicProfileRenderTest.php
+++ b/tests/Unit/ConcertStatsPublicProfileRenderTest.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Concert stats public-profile render regression tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+// WordPress stubs intentionally share this test file with its test class.
+// phpcs:disable Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Universal.Files.SeparateFunctionsFromOO.Mixed, WordPress.Security.EscapeOutput.OutputNotEscaped
+
+if ( ! function_exists( 'is_page' ) ) {
+	function is_page( $slug ) {
+		return 'my-shows' === $slug;
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id() {
+		return $GLOBALS['ec_test_current_user_id'];
+	}
+}
+
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in() {
+		return $GLOBALS['ec_test_current_user_id'] > 0;
+	}
+}
+
+if ( ! function_exists( 'get_userdata' ) ) {
+	function get_userdata( $user_id ) {
+		return in_array( (int) $user_id, $GLOBALS['ec_test_existing_user_ids'], true ) ? (object) array( 'ID' => (int) $user_id ) : false;
+	}
+}
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+	function wp_unslash( $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ) {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! function_exists( 'get_block_wrapper_attributes' ) ) {
+	function get_block_wrapper_attributes( $attributes = array() ) {
+		$rendered = array();
+		foreach ( $attributes as $name => $value ) {
+			$rendered[] = $name . '="' . htmlspecialchars( (string) $value, ENT_QUOTES ) . '"';
+		}
+		return implode( ' ', $rendered );
+	}
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES );
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES );
+	}
+}
+
+if ( ! function_exists( 'esc_html_e' ) ) {
+	function esc_html_e( $text ) {
+		echo htmlspecialchars( (string) $text, ENT_QUOTES );
+	}
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return 'https://events.example' . $path;
+	}
+}
+
+if ( ! function_exists( 'wp_registration_url' ) ) {
+	function wp_registration_url() {
+		return 'https://events.example/register/';
+	}
+}
+
+if ( ! function_exists( 'wp_login_url' ) ) {
+	function wp_login_url() {
+		return 'https://events.example/login/';
+	}
+}
+
+if ( ! function_exists( 'do_blocks' ) ) {
+	function do_blocks( $content ) {
+		return '<div class="embedded-block">' . htmlspecialchars( $content, ENT_QUOTES ) . '</div>';
+	}
+}
+
+final class ConcertStatsPublicProfileRenderTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test_current_user_id']   = 0;
+		$GLOBALS['ec_test_existing_user_ids'] = array( 12, 34 );
+		$GLOBALS['test_is_user_logged_in']    = false;
+		$_GET                                 = array();
+	}
+
+	protected function tearDown(): void {
+		$_GET = array();
+	}
+
+	public function test_owner_gets_dashboard_and_owner_only_embeds(): void {
+		$GLOBALS['ec_test_current_user_id'] = 12;
+		$GLOBALS['test_is_user_logged_in']  = true;
+
+		$output = $this->renderBlock();
+
+		$this->assertStringContainsString( 'data-user-id="12"', $output );
+		$this->assertStringContainsString( 'data-is-own="1"', $output );
+		$this->assertStringContainsString( 'data-has-calendar="1"', $output );
+		$this->assertStringContainsString( 'data-has-map="1"', $output );
+		$this->assertStringContainsString( 'ec-concert-stats__embedded-calendar', $output );
+		$this->assertStringContainsString( 'ec-concert-stats__embedded-map', $output );
+	}
+
+	public function test_logged_in_viewer_gets_selected_users_public_history(): void {
+		$GLOBALS['ec_test_current_user_id'] = 12;
+		$GLOBALS['test_is_user_logged_in']  = true;
+		$_GET['user_id']                    = '34';
+
+		$output = $this->renderBlock();
+
+		$this->assertStringContainsString( 'data-user-id="34"', $output );
+		$this->assertStringContainsString( 'data-is-own="0"', $output );
+		$this->assertStringContainsString( 'data-has-calendar="0"', $output );
+		$this->assertStringContainsString( 'data-has-map="0"', $output );
+		$this->assertStringNotContainsString( 'ec-concert-stats__embedded-calendar', $output );
+		$this->assertStringNotContainsString( 'ec-concert-stats__embedded-map', $output );
+	}
+
+	public function test_logged_out_viewer_gets_selected_users_public_history(): void {
+		$_GET['user_id'] = '34';
+
+		$output = $this->renderBlock();
+
+		$this->assertStringContainsString( 'data-user-id="34"', $output );
+		$this->assertStringContainsString( 'data-is-own="0"', $output );
+		$this->assertStringNotContainsString( 'ec-concert-stats-shell--marketing', $output );
+	}
+
+	public function test_invalid_selection_does_not_fall_back_to_viewer(): void {
+		$GLOBALS['ec_test_current_user_id'] = 12;
+		$GLOBALS['test_is_user_logged_in']  = true;
+		$_GET['user_id']                    = '999';
+
+		$output = $this->renderBlock();
+
+		$this->assertStringContainsString( 'This concert history could not be found.', $output );
+		$this->assertStringNotContainsString( 'data-user-id="12"', $output );
+		$this->assertStringNotContainsString( 'class="ec-concert-stats"', $output );
+	}
+
+	public function test_malformed_selection_fails_safely(): void {
+		$GLOBALS['ec_test_current_user_id'] = 12;
+		$GLOBALS['test_is_user_logged_in']  = true;
+		$_GET['user_id']                    = array( '34' );
+
+		$output = $this->renderBlock();
+
+		$this->assertStringContainsString( 'This concert history could not be found.', $output );
+		$this->assertStringNotContainsString( 'data-user-id="12"', $output );
+	}
+
+	public function test_client_write_controls_remain_owner_only(): void {
+		$root     = dirname( __DIR__, 2 );
+		$view     = (string) file_get_contents( $root . '/blocks/concert-stats/src/view.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local test fixture.
+		$past_tab = (string) file_get_contents( $root . '/blocks/concert-stats/src/components/PastTab.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local test fixture.
+
+		$this->assertStringContainsString( 'useImportRuns( isOwn )', $view );
+		$this->assertStringContainsString( 'isOwn && importRunsBag.sources', $view );
+		$this->assertStringContainsString( 'isOwn && <AddPastShows', $past_tab );
+	}
+
+	private function renderBlock(): string {
+		$attributes = array();
+
+		ob_start();
+		include dirname( __DIR__, 2 ) . '/blocks/concert-stats/render.php';
+		return (string) ob_get_clean();
+	}
+}


### PR DESCRIPTION
## Summary
- resolve the canonical `/my-shows/?user_id=<id>` selection before owner or logged-out fallbacks
- expose only completed, past attendance to non-owners: public lists request `period=past`, and public aggregate stats use the matching site-timezone cutoff through the existing `date_to` API filter
- keep the owner dashboard unchanged with Upcoming, Past, Calendar, Map, Import, and add-past controls
- normalize public `tab=calendar`, `tab=map`, `tab=import`, and other unavailable tabs to `tab=past` instead of rendering a blank or unavailable panel
- fail safely for malformed or nonexistent users instead of showing the viewer's history

Public profiles intentionally exclude upcoming attendance because a centralized itinerary reveals future plans. This PR preserves the existing public-by-default contract for completed concert history only; individual event attendee strips and any broader privacy controls remain outside this change.

The Community profile link already uses the canonical route, so no Community code change is required.

Closes Extra-Chill/extrachill-community#222.

## Verification
- `npm run test:js -- --runInBand blocks/concert-stats/src/view.test.js` (4 tests)
- `./vendor/bin/phpunit --filter ConcertStatsPublicProfileRenderTest` (5 tests, 23 assertions)
- `npm run lint:js -- --no-cache`
- `./vendor/bin/phpcs --standard=WordPress blocks/concert-stats/render.php tests/Unit/ConcertStatsPublicProfileRenderTest.php`
- `npm run build`
- `git diff --check`

The executable client suite covers logged-out Calendar, logged-in non-owner Map, and public Import deep links. It proves public requests are past-only, future show identities are not rendered, import/search/upcoming APIs are not requested, and owner requests remain available.

## Existing suite failures
The complete configured `./vendor/bin/phpunit` suite retains six unrelated failures and one error in `QualifyRecheckHandlerTest` and `CanonicalLocationsAbilityTest`. The focused concert-history PHP and JavaScript suites pass independently.