### PR TITLE
fix(discovery): preserve scoped request state

### DIFF
--- a/assets/js/discovery.js
+++ b/assets/js/discovery.js
@@ -14,10 +14,24 @@
 
 	/** Scope labels for title/H1 generation. */
 	const SCOPE_LABELS = {
+		today: 'Today',
 		tonight: 'Tonight',
 		'this-weekend': 'This Weekend',
 		'this-week': 'This Week',
 	};
+	const FILTER_QUERY_KEYS = [
+		'event_search',
+		'date_start',
+		'date_end',
+		'past',
+		'month',
+		'lat',
+		'lng',
+		'radius',
+		'radius_unit',
+	];
+	let activeRequest = null;
+	let requestSequence = 0;
 
 	document.addEventListener( 'DOMContentLoaded', init );
 
@@ -38,7 +52,7 @@
 			const scope = link.getAttribute( 'data-scope' );
 			const termId = nav.getAttribute( 'data-term-id' );
 			const termName = nav.getAttribute( 'data-term-name' );
-			const targetUrl = link.getAttribute( 'href' );
+			const targetUrl = buildScopeUrl( link.getAttribute( 'href' ) );
 
 			// Update active tab immediately for responsive feel.
 			updateActiveTab( nav, link );
@@ -50,33 +64,41 @@
 			updatePageText( termName, scope );
 
 			// Fetch calendar events for new scope.
-			fetchScopedCalendar( scope, termId );
+			fetchScopedCalendar( scope, termId, targetUrl.searchParams );
 		} );
 
 		// Handle browser back/forward navigation.
-		window.addEventListener( 'popstate', function ( e ) {
-			if ( e.state && typeof e.state.scope === 'string' ) {
-				const scope = e.state.scope;
-				const termId = nav.getAttribute( 'data-term-id' );
-				const termName = nav.getAttribute( 'data-term-name' );
-
-				// Find the matching tab link.
-				const tabLink = nav.querySelector(
-					'a[data-scope="' + scope + '"]'
-				);
-				if ( tabLink ) {
-					updateActiveTab( nav, tabLink );
-				}
-
-				updatePageText( termName, scope );
-				fetchScopedCalendar( scope, termId );
+		window.addEventListener( 'popstate', function () {
+			const tabLink = findTabForLocation( nav );
+			const scope = tabLink
+				? tabLink.getAttribute( 'data-scope' )
+				: findScopeForLocation();
+			if ( typeof scope !== 'string' ) {
+				return;
 			}
+
+			const termId = nav.getAttribute( 'data-term-id' );
+			const termName = nav.getAttribute( 'data-term-name' );
+
+			if ( tabLink ) {
+				updateActiveTab( nav, tabLink );
+			} else {
+				clearActiveTabs( nav );
+			}
+			updatePageText( termName, scope );
+			fetchScopedCalendar(
+				scope,
+				termId,
+				new URLSearchParams( window.location.search )
+			);
 		} );
 
 		// Set initial state for popstate support.
 		const activeLink = nav.querySelector( 'li.active a[data-scope]' );
-		if ( activeLink ) {
-			const initialScope = activeLink.getAttribute( 'data-scope' );
+		const initialScope = activeLink
+			? activeLink.getAttribute( 'data-scope' )
+			: findScopeForLocation();
+		if ( typeof initialScope === 'string' ) {
 			window.history.replaceState(
 				{ scope: initialScope },
 				'',
@@ -86,12 +108,98 @@
 	}
 
 	/**
+	 * Read a valid scope slug from the current URL path.
+	 * @return {string|undefined} Current scope, if represented by the path.
+	 */
+	function findScopeForLocation() {
+		const parts = normalizePath( window.location.pathname ).split( '/' );
+		const candidate = parts[ parts.length - 1 ];
+
+		return Object.prototype.hasOwnProperty.call( SCOPE_LABELS, candidate )
+			? candidate
+			: undefined;
+	}
+
+	/**
+	 * Build a scope destination without carrying REST-owned state or pagination.
+	 * @param {string} href Scope link destination.
+	 * @return {URL} Scope destination with current filters.
+	 */
+	function buildScopeUrl( href ) {
+		const targetUrl = new URL( href, window.location.href );
+		const currentParams = new URLSearchParams( window.location.search );
+
+		targetUrl.search = '';
+		FILTER_QUERY_KEYS.forEach( function ( key ) {
+			const value = currentParams.get( key );
+			if ( value ) {
+				targetUrl.searchParams.set( key, value );
+			}
+		} );
+
+		for ( const pair of currentParams.entries() ) {
+			if ( pair[ 0 ].indexOf( 'tax_filter[' ) === 0 ) {
+				targetUrl.searchParams.append( pair[ 0 ], pair[ 1 ] );
+			}
+		}
+
+		return targetUrl;
+	}
+
+	/**
+	 * Find the tab whose generated path represents the current location.
+	 * @param {Element} nav Scope-nav container element.
+	 * @return {Element|null} Matching tab link.
+	 */
+	function findTabForLocation( nav ) {
+		const links = nav.querySelectorAll( 'a[data-scope]' );
+		const currentPath = normalizePath( window.location.pathname );
+
+		for ( let i = 0; i < links.length; i++ ) {
+			const linkPath = normalizePath(
+				new URL(
+					links[ i ].getAttribute( 'href' ),
+					window.location.href
+				).pathname
+			);
+			if ( linkPath === currentPath ) {
+				return links[ i ];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Normalize trailing slashes for tab path comparisons.
+	 * @param {string} path URL path.
+	 * @return {string} Normalized path.
+	 */
+	function normalizePath( path ) {
+		return path.replace( /\/+$/, '' ) || '/';
+	}
+
+	/**
 	 * Update active tab styling.
 	 * @param {Element} nav        Scope-nav container element.
 	 * @param {Element} activeLink The tab link to mark active.
 	 */
 	function updateActiveTab( nav, activeLink ) {
-		// Remove active from all tabs.
+		clearActiveTabs( nav );
+
+		// Set new active tab.
+		const li = activeLink.closest( 'li' );
+		if ( li ) {
+			li.classList.add( 'active' );
+		}
+		activeLink.setAttribute( 'aria-current', 'page' );
+	}
+
+	/**
+	 * Clear scope tab styling when a valid scope has no corresponding tab.
+	 * @param {Element} nav Scope-nav container element.
+	 */
+	function clearActiveTabs( nav ) {
 		const items = nav.querySelectorAll( 'li' );
 		for ( let i = 0; i < items.length; i++ ) {
 			items[ i ].classList.remove( 'active' );
@@ -100,13 +208,6 @@
 				a.removeAttribute( 'aria-current' );
 			}
 		}
-
-		// Set new active tab.
-		const li = activeLink.closest( 'li' );
-		if ( li ) {
-			li.classList.add( 'active' );
-		}
-		activeLink.setAttribute( 'aria-current', 'page' );
 	}
 
 	/**
@@ -136,10 +237,11 @@
 
 	/**
 	 * Fetch scoped calendar events via REST API and swap DOM.
-	 * @param {string} scope  Scope slug (e.g. 'tonight', 'this-weekend').
-	 * @param {string} termId Location term ID to fetch events for.
+	 * @param {string}          scope     Scope slug (e.g. 'tonight', 'this-weekend').
+	 * @param {string}          termId    Location term ID to fetch events for.
+	 * @param {URLSearchParams} urlParams Filter state owned by this navigation.
 	 */
-	function fetchScopedCalendar( scope, termId ) {
+	function fetchScopedCalendar( scope, termId, urlParams ) {
 		const calendar = document.querySelector(
 			'.data-machine-events-calendar'
 		);
@@ -154,7 +256,14 @@
 			return;
 		}
 
-		// Show loading state.
+		if ( activeRequest ) {
+			activeRequest.controller.abort();
+		}
+
+		const requestId = ++requestSequence;
+		const controller = new AbortController();
+		activeRequest = { id: requestId, controller };
+
 		content.classList.add( 'loading' );
 
 		// Update the calendar's data-scope attribute.
@@ -172,10 +281,8 @@
 			params.set( 'scope', scope );
 		}
 
-		// Preserve search/filter params from current URL.
-		const urlParams = new URLSearchParams( window.location.search );
-		const passthroughKeys = [ 'event_search', 'date_start', 'date_end' ];
-		passthroughKeys.forEach( function ( key ) {
+		// Preserve user-owned filters from the navigation snapshot.
+		FILTER_QUERY_KEYS.forEach( function ( key ) {
 			const val = urlParams.get( key );
 			if ( val ) {
 				params.set( key, val );
@@ -189,12 +296,33 @@
 			}
 		}
 
+		// Archive context and opaque tokens are server-owned DOM state. Never
+		// trust query-string copies of either value.
+		const archiveTaxonomy = calendar.getAttribute(
+			'data-archive-taxonomy'
+		);
+		const archiveTermId = calendar.getAttribute( 'data-archive-term-id' );
+		if ( archiveTaxonomy && archiveTermId ) {
+			params.set( 'archive_taxonomy', archiveTaxonomy );
+			params.set( 'archive_term_id', archiveTermId );
+		}
+
+		const scopeToken = calendar.getAttribute( 'data-scope-token' );
+		if ( scopeToken ) {
+			params.set( 'scope_token', scopeToken );
+		}
+
 		const apiUrl =
 			'/wp-json/datamachine/v1/events/calendar?' + params.toString();
 
 		fetch( apiUrl, {
 			method: 'GET',
-			headers: { 'Content-Type': 'application/json' },
+			signal: controller.signal,
+			headers: {
+				'Content-Type': 'application/json',
+				Accept: 'application/json',
+				'X-Requested-With': 'XMLHttpRequest',
+			},
 		} )
 			.then( function ( response ) {
 				if ( ! response.ok ) {
@@ -203,6 +331,10 @@
 				return response.json();
 			} )
 			.then( function ( data ) {
+				if ( requestId !== requestSequence ) {
+					return;
+				}
+
 				if ( data.success ) {
 					// Swap events content.
 					content.innerHTML = data.html;
@@ -277,15 +409,60 @@
 
 					// Re-trigger lazy render for new content.
 					triggerLazyRender( calendar );
+				} else {
+					renderRequestError( content, scope, termId, urlParams );
 				}
 			} )
-			.catch( function () {
-				content.innerHTML =
-					'<div class="data-machine-events-error"><p>Error loading events. Please try again.</p></div>';
+			.catch( function ( error ) {
+				if (
+					error.name === 'AbortError' ||
+					requestId !== requestSequence
+				) {
+					return;
+				}
+
+				renderRequestError( content, scope, termId, urlParams );
 			} )
 			.finally( function () {
-				content.classList.remove( 'loading' );
+				if ( requestId === requestSequence ) {
+					content.classList.remove( 'loading' );
+					activeRequest = null;
+				}
 			} );
+	}
+
+	/**
+	 * Replace stale results with an explicit, retryable latest-request error.
+	 * @param {Element}         content   Calendar content element.
+	 * @param {string}          scope     Requested scope.
+	 * @param {string}          termId    Location term ID.
+	 * @param {URLSearchParams} urlParams Request filter snapshot.
+	 */
+	function renderRequestError( content, scope, termId, urlParams ) {
+		const calendar = content.closest( '.data-machine-events-calendar' );
+		if ( calendar ) {
+			calendar
+				.querySelectorAll(
+					'.data-machine-events-pagination, .data-machine-events-load-more-nav, .data-machine-events-results-counter, .data-machine-events-past-navigation'
+				)
+				.forEach( function ( element ) {
+					element.remove();
+				} );
+		}
+
+		content.innerHTML =
+			'<div class="data-machine-events-error"><p>Error loading events. Please try again.</p><button type="button" class="data-machine-events-retry">Try again</button></div>';
+
+		const retry = content.querySelector( '.data-machine-events-retry' );
+		if ( retry ) {
+			retry.addEventListener( 'click', function () {
+				fetchScopedCalendar(
+					scope,
+					termId,
+					new URLSearchParams( urlParams.toString() )
+				);
+			} );
+		}
 	}
 
 	/**

--- a/assets/js/discovery.test.js
+++ b/assets/js/discovery.test.js
@@ -1,0 +1,268 @@
+/**
+ * Discovery scope navigation request-state coverage.
+ */
+/* eslint-env jest */
+
+function deferred() {
+	let resolve;
+	let reject;
+	const promise = new Promise( ( promiseResolve, promiseReject ) => {
+		resolve = promiseResolve;
+		reject = promiseReject;
+	} );
+
+	return { promise, resolve, reject };
+}
+
+function response( html, success = true ) {
+	return {
+		ok: true,
+		json: () =>
+			Promise.resolve( {
+				success,
+				html,
+				pagination: null,
+				counter: null,
+				navigation: null,
+			} ),
+	};
+}
+
+async function flushPromises() {
+	await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+}
+
+function clickScope( scope ) {
+	document
+		.querySelector( `a[data-scope="${ scope }"]` )
+		.dispatchEvent(
+			new MouseEvent( 'click', { bubbles: true, cancelable: true } )
+		);
+}
+
+describe( 'discovery scope navigation', () => {
+	let nav;
+	let calendar;
+	let content;
+
+	beforeAll( () => {
+		document.body.innerHTML = `
+			<h1 class="page-title"></h1>
+			<nav class="discovery-scope-nav" data-term-id="44" data-term-name="Austin">
+				<ul></ul>
+			</nav>
+			<div class="data-machine-events-calendar"
+				data-archive-taxonomy="location"
+				data-archive-term-id="44"
+				data-scope-token="44.signed-token">
+				<div class="data-machine-events-content"></div>
+			</div>`;
+
+		nav = document.querySelector( '.discovery-scope-nav' );
+		calendar = document.querySelector( '.data-machine-events-calendar' );
+		content = document.querySelector( '.data-machine-events-content' );
+
+		require( './discovery' );
+		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+	} );
+
+	beforeEach( () => {
+		nav.querySelector( 'ul' ).innerHTML = `
+			<li class="active"><a href="/location/austin/tonight/" data-scope="tonight" aria-current="page">Tonight</a></li>
+			<li><a href="/location/austin/this-weekend/" data-scope="this-weekend">This Weekend</a></li>
+			<li><a href="/location/austin/this-week/" data-scope="this-week">This Week</a></li>
+			<li><a href="/location/austin/" data-scope="">All Shows</a></li>`;
+		content.className = 'data-machine-events-content';
+		content.innerHTML = '<p>Initial results</p>';
+		calendar.setAttribute( 'data-scope', 'tonight' );
+		window.history.replaceState(
+			{ scope: 'tonight' },
+			'',
+			'/location/austin/tonight/'
+		);
+		global.fetch = jest.fn();
+	} );
+
+	it( 'preserves filters while keeping scope-owned values authoritative', async () => {
+		window.history.replaceState(
+			{ scope: 'tonight' },
+			'',
+			'/location/austin/tonight/?event_search=jazz&date_start=2026-07-20&date_end=2026-07-21&past=1&tax_filter%5Bartist%5D%5B%5D=7&tax_filter%5Bartist%5D%5B%5D=9&lat=30.1&lng=-97.7&radius=40&radius_unit=mi&paged=3&scope=forged&archive_taxonomy=venue&archive_term_id=99&scope_token=forged'
+		);
+		fetch.mockResolvedValue( response( '<p>Weekend results</p>' ) );
+
+		clickScope( 'this-weekend' );
+		await flushPromises();
+
+		const browserParams = new URLSearchParams( window.location.search );
+		expect( window.location.pathname ).toBe(
+			'/location/austin/this-weekend/'
+		);
+		expect( browserParams.get( 'event_search' ) ).toBe( 'jazz' );
+		expect( browserParams.getAll( 'tax_filter[artist][]' ) ).toEqual( [
+			'7',
+			'9',
+		] );
+		expect( browserParams.get( 'lat' ) ).toBe( '30.1' );
+		expect( browserParams.has( 'paged' ) ).toBe( false );
+		expect( browserParams.has( 'scope' ) ).toBe( false );
+		expect( browserParams.has( 'archive_taxonomy' ) ).toBe( false );
+		expect( browserParams.has( 'scope_token' ) ).toBe( false );
+
+		const requestUrl = new URL(
+			fetch.mock.calls[ 0 ][ 0 ],
+			window.location
+		);
+		expect( requestUrl.searchParams.get( 'scope' ) ).toBe( 'this-weekend' );
+		expect( requestUrl.searchParams.getAll( 'scope' ) ).toHaveLength( 1 );
+		expect( requestUrl.searchParams.get( 'archive_taxonomy' ) ).toBe(
+			'location'
+		);
+		expect( requestUrl.searchParams.get( 'archive_term_id' ) ).toBe( '44' );
+		expect( requestUrl.searchParams.get( 'scope_token' ) ).toBe(
+			'44.signed-token'
+		);
+		expect( requestUrl.searchParams.getAll( 'scope_token' ) ).toHaveLength(
+			1
+		);
+		expect( requestUrl.searchParams.has( 'paged' ) ).toBe( false );
+		expect( content.innerHTML ).toBe( '<p>Weekend results</p>' );
+	} );
+
+	it( 'ignores an older response that resolves after the latest request', async () => {
+		const older = deferred();
+		const latest = deferred();
+		fetch
+			.mockImplementationOnce( () => older.promise )
+			.mockImplementationOnce( () => latest.promise );
+
+		clickScope( 'this-weekend' );
+		clickScope( 'this-week' );
+		latest.resolve( response( '<p>Latest week</p>' ) );
+		await flushPromises();
+		older.resolve( response( '<p>Stale weekend</p>' ) );
+		await flushPromises();
+
+		expect( content.innerHTML ).toBe( '<p>Latest week</p>' );
+		expect( window.location.pathname ).toBe(
+			'/location/austin/this-week/'
+		);
+		expect( calendar.getAttribute( 'data-scope' ) ).toBe( 'this-week' );
+	} );
+
+	it( 'aborts superseded requests without exposing an error or clearing loading', async () => {
+		const older = deferred();
+		const latest = deferred();
+		fetch
+			.mockImplementationOnce( () => older.promise )
+			.mockImplementationOnce( () => latest.promise );
+
+		clickScope( 'this-weekend' );
+		const olderSignal = fetch.mock.calls[ 0 ][ 1 ].signal;
+		clickScope( 'this-week' );
+
+		expect( olderSignal.aborted ).toBe( true );
+		expect( content.classList.contains( 'loading' ) ).toBe( true );
+
+		const abortError = new Error( 'Aborted' );
+		abortError.name = 'AbortError';
+		older.reject( abortError );
+		await flushPromises();
+		expect( content.classList.contains( 'loading' ) ).toBe( true );
+		expect(
+			content.querySelector( '.data-machine-events-error' )
+		).toBeNull();
+
+		latest.resolve( response( '<p>Latest week</p>' ) );
+		await flushPromises();
+		expect( content.classList.contains( 'loading' ) ).toBe( false );
+	} );
+
+	it( 'replaces stale HTML with a recoverable latest-request error', async () => {
+		content.insertAdjacentHTML(
+			'afterend',
+			'<nav class="data-machine-events-pagination">Stale pages</nav><div class="data-machine-events-results-counter">Stale count</div>'
+		);
+		fetch
+			.mockRejectedValueOnce( new Error( 'Offline' ) )
+			.mockResolvedValueOnce( response( '<p>Recovered week</p>' ) );
+
+		clickScope( 'this-week' );
+		await flushPromises();
+
+		expect( content.textContent ).not.toContain( 'Initial results' );
+		expect( content.textContent ).toContain( 'Error loading events' );
+		expect(
+			calendar.querySelector( '.data-machine-events-pagination' )
+		).toBeNull();
+		expect(
+			calendar.querySelector( '.data-machine-events-results-counter' )
+		).toBeNull();
+		expect(
+			content.querySelector( '.data-machine-events-retry' )
+		).not.toBeNull();
+
+		content
+			.querySelector( '.data-machine-events-retry' )
+			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		await flushPromises();
+
+		expect( content.innerHTML ).toBe( '<p>Recovered week</p>' );
+		expect( fetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'restores scope, filters, and results from popstate URL state', async () => {
+		fetch.mockResolvedValue( response( '<p>Back to weekend jazz</p>' ) );
+		window.history.replaceState(
+			null,
+			'',
+			'/location/austin/this-weekend/?event_search=jazz&tax_filter%5Bvenue%5D%5B%5D=12'
+		);
+
+		window.dispatchEvent(
+			new PopStateEvent( 'popstate', { state: null } )
+		);
+		await flushPromises();
+
+		expect(
+			document
+				.querySelector( 'a[data-scope="this-weekend"]' )
+				.getAttribute( 'aria-current' )
+		).toBe( 'page' );
+		expect( document.querySelector( '.page-title' ).textContent ).toBe(
+			'Live Music in Austin This Weekend'
+		);
+		expect( document.title ).toContain( 'Austin This Weekend' );
+		expect( content.innerHTML ).toBe( '<p>Back to weekend jazz</p>' );
+
+		const requestUrl = new URL(
+			fetch.mock.calls[ 0 ][ 0 ],
+			window.location
+		);
+		expect( requestUrl.searchParams.get( 'event_search' ) ).toBe( 'jazz' );
+		expect( requestUrl.searchParams.get( 'tax_filter[venue][]' ) ).toBe(
+			'12'
+		);
+	} );
+
+	it( 'restores a valid URL scope that has no navigation tab', async () => {
+		fetch.mockResolvedValue( response( '<p>Today results</p>' ) );
+		window.history.replaceState( null, '', '/location/austin/today/' );
+
+		window.dispatchEvent(
+			new PopStateEvent( 'popstate', { state: null } )
+		);
+		await flushPromises();
+
+		expect( nav.querySelector( 'li.active' ) ).toBeNull();
+		expect( document.querySelector( '.page-title' ).textContent ).toBe(
+			'Live Music in Austin Today'
+		);
+		const requestUrl = new URL(
+			fetch.mock.calls[ 0 ][ 0 ],
+			window.location
+		);
+		expect( requestUrl.searchParams.get( 'scope' ) ).toBe( 'today' );
+		expect( content.innerHTML ).toBe( '<p>Today results</p>' );
+	} );
+} );

--- a/inc/core/discovery-pages.php
+++ b/inc/core/discovery-pages.php
@@ -419,6 +419,7 @@ function extrachill_events_render_scope_nav( \WP_Term $term, string $current, st
 		'this-week'    => 'This Week',
 		''             => 'All Shows',
 	);
+	$query_args = extrachill_events_scope_nav_query_args();
 
 	$nav_class = 'discovery-scope-nav';
 	if ( '' !== trim( $extra_class ) ) {
@@ -443,6 +444,9 @@ function extrachill_events_render_scope_nav( \WP_Term $term, string $current, st
 		} else {
 			$url = trailingslashit( $term_link ) . $scope_slug . '/';
 		}
+		if ( ! empty( $query_args ) ) {
+			$url = add_query_arg( $query_args, $url );
+		}
 
 		printf(
 			'<li%s><a href="%s" data-scope="%s"%s>%s</a></li>',
@@ -456,4 +460,37 @@ function extrachill_events_render_scope_nav( \WP_Term $term, string $current, st
 
 	echo '</ul>';
 	echo '</nav>';
+}
+
+/**
+ * Return user-facing calendar filters that survive a scope switch.
+ *
+ * Pagination resets, while scope, archive context, and opaque scope tokens are
+ * intentionally excluded because the destination path and calendar DOM own
+ * those values.
+ *
+ * @return array<string, mixed> Supported query arguments.
+ */
+function extrachill_events_scope_nav_query_args(): array {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only public filter state.
+	$request = wp_unslash( $_GET );
+	$args    = array();
+
+	foreach ( array( 'event_search', 'date_start', 'date_end', 'past', 'month', 'lat', 'lng', 'radius', 'radius_unit' ) as $key ) {
+		if ( isset( $request[ $key ] ) && is_scalar( $request[ $key ] ) && '' !== (string) $request[ $key ] ) {
+			$args[ $key ] = sanitize_text_field( (string) $request[ $key ] );
+		}
+	}
+
+	if ( ! empty( $request['tax_filter'] ) && is_array( $request['tax_filter'] ) ) {
+		foreach ( $request['tax_filter'] as $taxonomy => $term_ids ) {
+			$taxonomy = sanitize_key( (string) $taxonomy );
+			$term_ids = array_values( array_filter( array_map( 'absint', (array) $term_ids ) ) );
+			if ( $taxonomy && $term_ids ) {
+				$args['tax_filter'][ $taxonomy ] = $term_ids;
+			}
+		}
+	}
+
+	return $args;
 }


### PR DESCRIPTION
## Summary
- preserve supported search, date, taxonomy, archive, and geo state across discovery scope URLs and calendar requests while resetting pagination
- keep path-owned scope plus server-rendered archive context and opaque scope tokens authoritative
- abort superseded requests, guard every DOM update by latest-request ownership, and provide a retryable coherent error state
- restore URL-derived scope and filters on back/forward navigation, including valid scopes without a visible tab
- add executable Jest coverage for query preservation, out-of-order responses, aborts, failures/retries, and popstate

## Verification
- `npm run lint:js`
- `npm run test:js -- --runInBand` (10 tests passed)
- `npm run build`
- `php -l inc/core/discovery-pages.php`
- `git diff --check`

PHPUnit/PHPCS dependencies are not installed in this worktree. Homeboy's changed-file review was attempted but declined execution under its hot-machine resource policy.

Closes #271
