### PR TITLE
fix(concert-stats): isolate paginated show queries

### DIFF
--- a/blocks/concert-stats/src/components/ShowList.js
+++ b/blocks/concert-stats/src/components/ShowList.js
@@ -7,11 +7,6 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
-
-/**
- * External dependencies
- */
 import { ActionRow, InlineStatus } from '@extrachill/components';
 
 /**
@@ -21,14 +16,15 @@ import ShowCard from './ShowCard';
 import useShows from '../hooks/useShows';
 
 const ShowList = ( { userId, period, year, eventsUrl, isOwn = true } ) => {
-	const [ page, setPage ] = useState( 1 );
-
-	const { shows, total, pages, loading, error } = useShows( userId, {
-		period,
-		year,
-		page,
-		perPage: 20,
-	} );
+	const { shows, total, pages, page, loading, error, loadMore } = useShows(
+		userId,
+		{
+			period,
+			year,
+			perPage: 20,
+			queryScope: isOwn ? 'owner' : 'public',
+		}
+	);
 
 	if ( error ) {
 		return <InlineStatus tone="error">{ error }</InlineStatus>;
@@ -70,10 +66,11 @@ const ShowList = ( { userId, period, year, eventsUrl, isOwn = true } ) => {
 				<ActionRow align="center">
 					<button
 						className="button-2 button-medium"
-						onClick={ () => setPage( ( p ) => p + 1 ) }
+						onClick={ loadMore }
 						type="button"
 					>
-						Load More ({ total - shows.length } remaining)
+						Load More ({ Math.max( 0, total - shows.length ) }{ ' ' }
+						remaining)
 					</button>
 				</ActionRow>
 			) }

--- a/blocks/concert-stats/src/components/ShowList.test.js
+++ b/blocks/concert-stats/src/components/ShowList.test.js
@@ -1,0 +1,76 @@
+/**
+ * ShowList load-more behavior.
+ */
+/* eslint-env jest */
+
+import { createRoot } from '@wordpress/element';
+import { act } from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import ShowList from './ShowList';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '@extrachill/components', () => {
+	const React = require( 'react' );
+	const Wrapper = ( { children } ) =>
+		React.createElement( 'div', null, children );
+	return { ActionRow: Wrapper, InlineStatus: Wrapper };
+} );
+
+jest.mock( './ShowCard', () => ( { show } ) => <div>{ show.title }</div> );
+
+describe( 'ShowList', () => {
+	beforeAll( () => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+	} );
+
+	afterAll( () => {
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	} );
+
+	beforeEach( () => {
+		apiFetch.mockReset();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'appends Upcoming pages and keeps remaining state active', async () => {
+		apiFetch.mockImplementation( ( { path } ) => {
+			const page = Number(
+				new URLSearchParams( path.split( '?' )[ 1 ] ).get( 'page' )
+			);
+			return Promise.resolve( {
+				shows: [ { event_id: page, title: `Upcoming ${ page }` } ],
+				total: 2,
+				pages: 2,
+				page,
+			} );
+		} );
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const root = createRoot( container );
+
+		await act( async () => {
+			root.render(
+				<ShowList userId={ 7 } period="upcoming" year={ 0 } />
+			);
+			await Promise.resolve();
+		} );
+		expect( container.textContent ).toContain( 'Upcoming 1' );
+		expect( container.textContent ).toContain( 'Load More (1 remaining)' );
+
+		await act( async () => {
+			container
+				.querySelector( 'button' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+			await Promise.resolve();
+		} );
+
+		expect( container.textContent ).toContain( 'Upcoming 1' );
+		expect( container.textContent ).toContain( 'Upcoming 2' );
+		expect( container.textContent ).not.toContain( 'Load More' );
+		await act( async () => root.unmount() );
+	} );
+} );

--- a/blocks/concert-stats/src/hooks/useShows.js
+++ b/blocks/concert-stats/src/hooks/useShows.js
@@ -7,66 +7,163 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+
+const emptyResult = ( queryKey ) => ( {
+	queryKey,
+	shows: [],
+	total: 0,
+	pages: 0,
+	page: 1,
+	loading: true,
+	error: null,
+} );
+
+const dedupeShows = ( shows ) => [
+	...new Map( shows.map( ( show ) => [ show.event_id, show ] ) ).values(),
+];
 
 /**
  * @param {number} userId
- * @param {Object} filters - { period, year, page, perPage, enabled }
+ * @param {Object} filters - { period, year, perPage, enabled, queryScope }
  */
 export default function useShows( userId, filters = {} ) {
-	const [ shows, setShows ] = useState( [] );
-	const [ total, setTotal ] = useState( 0 );
-	const [ pages, setPages ] = useState( 0 );
-	const [ loading, setLoading ] = useState( true );
-	const [ error, setError ] = useState( null );
-
 	const {
 		period = 'all',
 		year = 0,
-		page = 1,
 		perPage = 20,
 		enabled = true,
+		queryScope = 'default',
 	} = filters;
+	const queryKey = [
+		userId,
+		queryScope,
+		period,
+		year,
+		perPage,
+		enabled,
+	].join( ':' );
+	const activeQueryKey = useRef( queryKey );
+	activeQueryKey.current = queryKey;
+	const abortRef = useRef( null );
+	const [ result, setResult ] = useState( () => emptyResult( queryKey ) );
 
-	const fetchShows = useCallback( () => {
-		if ( ! userId || ! enabled ) {
-			setLoading( false );
-			return;
-		}
+	const fetchShows = useCallback(
+		( requestedPage = 1 ) => {
+			if ( abortRef.current ) {
+				abortRef.current.abort();
+			}
 
-		setLoading( true );
-		setError( null );
+			if ( ! userId || ! enabled ) {
+				setResult( {
+					...emptyResult( queryKey ),
+					loading: false,
+				} );
+				return;
+			}
 
-		let path = `/extrachill/v1/concert-tracking/user/${ userId }/shows?period=${ period }&page=${ page }&per_page=${ perPage }`;
-		if ( year ) {
-			path += `&year=${ year }`;
-		}
+			const controller = new AbortController();
+			abortRef.current = controller;
+			setResult( ( current ) => ( {
+				...( current.queryKey === queryKey
+					? current
+					: emptyResult( queryKey ) ),
+				loading: true,
+				error: null,
+			} ) );
 
-		apiFetch( { path } )
-			.then( ( response ) => {
-				if ( page > 1 && period === 'past' ) {
-					// Append for load-more behavior on past shows.
-					setShows( ( prev ) => [
-						...prev,
-						...( response.shows || [] ),
-					] );
-				} else {
-					setShows( response.shows || [] );
+			const requestPage = ( page ) => {
+				let path = `/extrachill/v1/concert-tracking/user/${ userId }/shows?period=${ period }&page=${ page }&per_page=${ perPage }`;
+				if ( year ) {
+					path += `&year=${ year }`;
 				}
-				setTotal( response.total || 0 );
-				setPages( response.pages || 0 );
-				setLoading( false );
-			} )
-			.catch( ( err ) => {
-				setError( err.message || 'Failed to load shows.' );
-				setLoading( false );
-			} );
-	}, [ userId, period, year, page, perPage, enabled ] );
+				return apiFetch( { path, signal: controller.signal } );
+			};
+
+			requestPage( requestedPage )
+				.then( async ( response ) => {
+					const responsePage =
+						Number( response.page ) || requestedPage;
+					if ( requestedPage > 1 && responsePage !== requestedPage ) {
+						return requestPage( 1 );
+					}
+					return response;
+				} )
+				.then( ( response ) => {
+					if (
+						controller.signal.aborted ||
+						activeQueryKey.current !== queryKey
+					) {
+						return;
+					}
+
+					const responsePage = Number( response.page ) || 1;
+					const incoming = response.shows || [];
+					setResult( ( current ) => {
+						if ( current.queryKey !== queryKey ) {
+							return current;
+						}
+						return {
+							queryKey,
+							shows: dedupeShows(
+								responsePage > 1
+									? [ ...current.shows, ...incoming ]
+									: incoming
+							),
+							total: response.total || 0,
+							pages: response.pages || 0,
+							page: responsePage,
+							loading: false,
+							error: null,
+						};
+					} );
+				} )
+				.catch( ( err ) => {
+					if (
+						( err && err.name === 'AbortError' ) ||
+						controller.signal.aborted ||
+						activeQueryKey.current !== queryKey
+					) {
+						return;
+					}
+					setResult( ( current ) => ( {
+						...current,
+						loading: false,
+						error: err.message || 'Failed to load shows.',
+					} ) );
+				} );
+		},
+		[ userId, period, year, perPage, enabled, queryKey ]
+	);
 
 	useEffect( () => {
-		fetchShows();
-	}, [ fetchShows ] );
+		setResult( emptyResult( queryKey ) );
+		fetchShows( 1 );
+		return () => {
+			if ( abortRef.current ) {
+				abortRef.current.abort();
+			}
+		};
+	}, [ fetchShows, queryKey ] );
 
-	return { shows, total, pages, loading, error, refetch: fetchShows };
+	const activeResult =
+		result.queryKey === queryKey ? result : emptyResult( queryKey );
+	const loadMore = useCallback( () => {
+		if ( activeResult.loading || activeResult.page >= activeResult.pages ) {
+			return;
+		}
+		fetchShows( activeResult.page + 1 );
+	}, [
+		activeResult.loading,
+		activeResult.page,
+		activeResult.pages,
+		fetchShows,
+	] );
+
+	return {
+		...activeResult,
+		loadMore,
+		refetch: () => fetchShows( 1 ),
+	};
 }

--- a/blocks/concert-stats/src/hooks/useShows.test.js
+++ b/blocks/concert-stats/src/hooks/useShows.test.js
@@ -1,0 +1,282 @@
+/**
+ * useShows pagination and query identity behavior.
+ */
+/* eslint-env jest */
+
+import { createRoot } from '@wordpress/element';
+import { act } from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import useShows from './useShows';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const response = ( shows, total, pages, page ) => ( {
+	shows: shows.map( ( eventId ) => ( {
+		event_id: eventId,
+		title: `Show ${ eventId }`,
+	} ) ),
+	total,
+	pages,
+	page,
+} );
+
+const deferred = () => {
+	let resolve;
+	const promise = new Promise( ( done ) => {
+		resolve = done;
+	} );
+	return { promise, resolve };
+};
+
+const ShowsHarness = ( { userId, filters } ) => {
+	const result = useShows( userId, filters );
+	return (
+		<div>
+			<span data-testid="shows">
+				{ result.shows.map( ( show ) => show.event_id ).join( ',' ) }
+			</span>
+			<span data-testid="page">{ result.page }</span>
+			<span data-testid="total">{ result.total }</span>
+			<span data-testid="loading">
+				{ result.loading ? 'loading' : 'ready' }
+			</span>
+			<button type="button" onClick={ result.loadMore }>
+				Load More
+			</button>
+		</div>
+	);
+};
+
+const value = ( container, testId ) =>
+	container.querySelector( `[data-testid="${ testId }"]` ).textContent;
+
+async function renderHarness( props ) {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+
+	await act( async () => {
+		root.render( <ShowsHarness { ...props } /> );
+		await Promise.resolve();
+	} );
+
+	return {
+		container,
+		root,
+		rerender: async ( nextProps ) => {
+			await act( async () => {
+				root.render( <ShowsHarness { ...nextProps } /> );
+				await Promise.resolve();
+			} );
+		},
+		loadMore: async () => {
+			await act( async () => {
+				container
+					.querySelector( 'button' )
+					.dispatchEvent(
+						new MouseEvent( 'click', { bubbles: true } )
+					);
+				await Promise.resolve();
+			} );
+		},
+	};
+}
+
+describe( 'useShows', () => {
+	beforeAll( () => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+	} );
+
+	afterAll( () => {
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	} );
+
+	beforeEach( () => {
+		apiFetch.mockReset();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'starts a selected year at page one after multiple pages', async () => {
+		apiFetch.mockImplementation( ( { path } ) => {
+			const page = Number(
+				new URLSearchParams( path.split( '?' )[ 1 ] ).get( 'page' )
+			);
+			if ( path.includes( 'year=2025' ) ) {
+				return Promise.resolve( response( [ 25 ], 1, 1, 1 ) );
+			}
+			return Promise.resolve( response( [ page ], 3, 3, page ) );
+		} );
+		const initial = {
+			userId: 7,
+			filters: { period: 'past', year: 0, perPage: 1 },
+		};
+		const harness = await renderHarness( initial );
+
+		await harness.loadMore();
+		await harness.loadMore();
+		expect( value( harness.container, 'shows' ) ).toBe( '1,2,3' );
+
+		await harness.rerender( {
+			...initial,
+			filters: { ...initial.filters, year: 2025 },
+		} );
+
+		expect( value( harness.container, 'shows' ) ).toBe( '25' );
+		expect( value( harness.container, 'page' ) ).toBe( '1' );
+		expect( apiFetch.mock.calls.at( -1 )[ 0 ].path ).toContain( 'page=1' );
+		await act( async () => harness.root.unmount() );
+	} );
+
+	it( 'resets rows when the user changes', async () => {
+		apiFetch.mockImplementation( ( { path } ) =>
+			Promise.resolve(
+				path.includes( '/user/8/' )
+					? response( [ 80 ], 1, 1, 1 )
+					: response( [ 70 ], 1, 1, 1 )
+			)
+		);
+		const filters = { period: 'past', year: 0 };
+		const harness = await renderHarness( { userId: 7, filters } );
+
+		await harness.rerender( { userId: 8, filters } );
+
+		expect( value( harness.container, 'shows' ) ).toBe( '80' );
+		expect( value( harness.container, 'total' ) ).toBe( '1' );
+		await act( async () => harness.root.unmount() );
+	} );
+
+	it( 'resets rows when period, visibility scope, or page size changes', async () => {
+		apiFetch
+			.mockResolvedValueOnce( response( [ 1 ], 1, 1, 1 ) )
+			.mockResolvedValueOnce( response( [ 4 ], 1, 1, 1 ) )
+			.mockResolvedValueOnce( response( [ 2 ], 1, 1, 1 ) )
+			.mockResolvedValueOnce( response( [ 3 ], 1, 1, 1 ) );
+		const harness = await renderHarness( {
+			userId: 7,
+			filters: {
+				period: 'past',
+				perPage: 20,
+				queryScope: 'owner',
+			},
+		} );
+
+		await harness.rerender( {
+			userId: 7,
+			filters: {
+				period: 'past',
+				perPage: 20,
+				queryScope: 'public',
+			},
+		} );
+		expect( value( harness.container, 'shows' ) ).toBe( '4' );
+
+		await harness.rerender( {
+			userId: 7,
+			filters: {
+				period: 'upcoming',
+				perPage: 20,
+				queryScope: 'public',
+			},
+		} );
+		expect( value( harness.container, 'shows' ) ).toBe( '2' );
+
+		await harness.rerender( {
+			userId: 7,
+			filters: {
+				period: 'upcoming',
+				perPage: 10,
+				queryScope: 'public',
+			},
+		} );
+		expect( value( harness.container, 'shows' ) ).toBe( '3' );
+		await act( async () => harness.root.unmount() );
+	} );
+
+	it( 'ignores an overlapping response from the previous query', async () => {
+		const oldRequest = deferred();
+		const newRequest = deferred();
+		apiFetch
+			.mockImplementationOnce( () => oldRequest.promise )
+			.mockImplementationOnce( () => newRequest.promise );
+		const harness = await renderHarness( {
+			userId: 7,
+			filters: { period: 'past', year: 2024 },
+		} );
+
+		await harness.rerender( {
+			userId: 7,
+			filters: { period: 'past', year: 2025 },
+		} );
+		await act( async () =>
+			newRequest.resolve( response( [ 25 ], 1, 1, 1 ) )
+		);
+		expect( value( harness.container, 'shows' ) ).toBe( '25' );
+
+		await act( async () =>
+			oldRequest.resolve( response( [ 24 ], 1, 1, 1 ) )
+		);
+		expect( value( harness.container, 'shows' ) ).toBe( '25' );
+		await act( async () => harness.root.unmount() );
+	} );
+
+	it( 'deduplicates rows across retries and pages', async () => {
+		apiFetch
+			.mockResolvedValueOnce( response( [ 1, 2, 2 ], 3, 2, 1 ) )
+			.mockResolvedValueOnce( response( [ 2, 3, 3 ], 3, 2, 2 ) );
+		const harness = await renderHarness( {
+			userId: 7,
+			filters: { period: 'past' },
+		} );
+
+		await harness.loadMore();
+
+		expect( value( harness.container, 'shows' ) ).toBe( '1,2,3' );
+		expect( value( harness.container, 'total' ) ).toBe( '3' );
+		await act( async () => harness.root.unmount() );
+	} );
+
+	it( 'clears accumulated rows for an empty year', async () => {
+		apiFetch.mockImplementation( ( { path } ) =>
+			Promise.resolve(
+				path.includes( 'year=2023' )
+					? response( [], 0, 0, 1 )
+					: response( [ 1 ], 1, 1, 1 )
+			)
+		);
+		const harness = await renderHarness( {
+			userId: 7,
+			filters: { period: 'past', year: 0 },
+		} );
+
+		await harness.rerender( {
+			userId: 7,
+			filters: { period: 'past', year: 2023 },
+		} );
+
+		expect( value( harness.container, 'shows' ) ).toBe( '' );
+		expect( value( harness.container, 'total' ) ).toBe( '0' );
+		expect( value( harness.container, 'page' ) ).toBe( '1' );
+		await act( async () => harness.root.unmount() );
+	} );
+
+	it( 'recovers a server-clamped page at page one', async () => {
+		apiFetch
+			.mockResolvedValueOnce( response( [ 1 ], 2, 2, 1 ) )
+			.mockResolvedValueOnce( response( [ 2 ], 1, 1, 1 ) )
+			.mockResolvedValueOnce( response( [ 9 ], 1, 1, 1 ) );
+		const harness = await renderHarness( {
+			userId: 7,
+			filters: { period: 'past' },
+		} );
+
+		await harness.loadMore();
+
+		expect( apiFetch.mock.calls.at( -1 )[ 0 ].path ).toContain( 'page=1' );
+		expect( value( harness.container, 'shows' ) ).toBe( '9' );
+		expect( value( harness.container, 'page' ) ).toBe( '1' );
+		await act( async () => harness.root.unmount() );
+	} );
+} );

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -189,15 +189,15 @@ export function ConcertStatsApp( {
 	const { total: upcomingCount } = useShows( userId, {
 		period: 'upcoming',
 		year,
-		page: 1,
 		perPage: 1,
 		enabled: isOwn,
+		queryScope: isOwn ? 'owner' : 'public',
 	} );
 	const { total: pastCount } = useShows( userId, {
 		period: 'past',
 		year,
-		page: 1,
 		perPage: 1,
+		queryScope: isOwn ? 'owner' : 'public',
 	} );
 
 	// Pull the configured source list at the parent level so the Import tab


### PR DESCRIPTION
## Summary
- make `useShows` own page accumulation under an authoritative user/mode/period/year/page-size query key
- abort and ignore stale requests, deduplicate event rows, and recover server-clamped pages from page one
- make Upcoming use the same append contract as Past and keep remaining/button state scoped to the active query
- add hook and component regressions for multi-page year changes, user/mode/period/page-size changes, overlapping responses, duplicates, empty years, clamped pages, and Upcoming load-more

## Verification
- `npm run test:js -- --runInBand` (18 tests passed)
- `npm run lint:js`
- `npm run build`
- `git diff --check`
- PHP checks not run because no PHP files changed

Closes #272