### PR TITLE
feat: enforce public concert privacy

### DIFF
--- a/blocks/concert-stats/src/components/PastTab.js
+++ b/blocks/concert-stats/src/components/PastTab.js
@@ -30,7 +30,7 @@ import { useState, useCallback } from '@wordpress/element';
 import AddPastShows from './AddPastShows';
 import ShowList from './ShowList';
 
-const PastTab = ( { userId, year, isOwn } ) => {
+const PastTab = ( { userId, year, isOwn, enabled = true } ) => {
 	// Bumping this remounts ShowList, forcing a fresh fetch so a
 	// just-marked show shows up in the tracked-past list.
 	const [ refreshKey, setRefreshKey ] = useState( 0 );
@@ -48,6 +48,7 @@ const PastTab = ( { userId, year, isOwn } ) => {
 				period="past"
 				year={ year }
 				isOwn={ isOwn }
+				enabled={ enabled }
 			/>
 		</div>
 	);

--- a/blocks/concert-stats/src/components/ShowList.js
+++ b/blocks/concert-stats/src/components/ShowList.js
@@ -15,19 +15,31 @@ import { ActionRow, InlineStatus } from '@extrachill/components';
 import ShowCard from './ShowCard';
 import useShows from '../hooks/useShows';
 
-const ShowList = ( { userId, period, year, eventsUrl, isOwn = true } ) => {
+const ShowList = ( {
+	userId,
+	period,
+	year,
+	eventsUrl,
+	isOwn = true,
+	enabled = true,
+} ) => {
 	const { shows, total, pages, page, loading, error, loadMore } = useShows(
 		userId,
 		{
 			period,
 			year,
 			perPage: 20,
+			enabled,
 			queryScope: isOwn ? 'owner' : 'public',
 		}
 	);
 
 	if ( error ) {
-		return <InlineStatus tone="error">{ error }</InlineStatus>;
+		return (
+			<InlineStatus tone="error">
+				{ error.message || 'Failed to load shows.' }
+			</InlineStatus>
+		);
 	}
 
 	if ( ! loading && shows.length === 0 ) {

--- a/blocks/concert-stats/src/hooks/useShows.js
+++ b/blocks/concert-stats/src/hooks/useShows.js
@@ -130,7 +130,7 @@ export default function useShows( userId, filters = {} ) {
 					setResult( ( current ) => ( {
 						...current,
 						loading: false,
-						error: err.message || 'Failed to load shows.',
+						error: err,
 					} ) );
 				} );
 		},

--- a/blocks/concert-stats/src/hooks/useShows.test.js
+++ b/blocks/concert-stats/src/hooks/useShows.test.js
@@ -43,6 +43,10 @@ const ShowsHarness = ( { userId, filters } ) => {
 			<span data-testid="loading">
 				{ result.loading ? 'loading' : 'ready' }
 			</span>
+			<span data-testid="error-code">{ result.error?.code || '' }</span>
+			<span data-testid="error-status">
+				{ result.error?.data?.status || '' }
+			</span>
 			<button type="button" onClick={ result.loadMore }>
 				Load More
 			</button>
@@ -235,6 +239,26 @@ describe( 'useShows', () => {
 
 		expect( value( harness.container, 'shows' ) ).toBe( '1,2,3' );
 		expect( value( harness.container, 'total' ) ).toBe( '3' );
+		await act( async () => harness.root.unmount() );
+	} );
+
+	it( 'preserves canonical error code and status', async () => {
+		apiFetch.mockRejectedValue( {
+			code: 'concert_history_private',
+			message: 'Concert history is private.',
+			data: { status: 403 },
+		} );
+
+		const harness = await renderHarness( {
+			userId: 7,
+			filters: { period: 'past' },
+		} );
+
+		expect( value( harness.container, 'error-code' ) ).toBe(
+			'concert_history_private'
+		);
+		expect( value( harness.container, 'error-status' ) ).toBe( '403' );
+		expect( value( harness.container, 'shows' ) ).toBe( '' );
 		await act( async () => harness.root.unmount() );
 	} );
 

--- a/blocks/concert-stats/src/hooks/useStats.js
+++ b/blocks/concert-stats/src/hooks/useStats.js
@@ -7,28 +7,44 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+
+const emptyResult = ( queryKey, loading = true ) => ( {
+	queryKey,
+	stats: null,
+	loading,
+	error: null,
+} );
 
 /**
  * @param {number} userId
- * @param {Object} filters - { year, dateTo }
+ * @param {Object} filters - { year, dateTo, enabled }
  */
 export default function useStats( userId, filters = {} ) {
-	const [ stats, setStats ] = useState( null );
-	const [ loading, setLoading ] = useState( true );
-	const [ error, setError ] = useState( null );
-
-	const { year = 0, dateTo = '' } = filters;
+	const { year = 0, dateTo = '', enabled = true } = filters;
+	const queryKey = [ userId, year, dateTo, enabled ].join( ':' );
+	const activeQueryKey = useRef( queryKey );
+	activeQueryKey.current = queryKey;
+	const abortRef = useRef( null );
+	const generationRef = useRef( 0 );
+	const [ result, setResult ] = useState( () => emptyResult( queryKey ) );
 
 	const fetchStats = useCallback( () => {
-		if ( ! userId ) {
-			setLoading( false );
+		if ( abortRef.current ) {
+			abortRef.current.abort();
+		}
+
+		const generation = ++generationRef.current;
+		if ( ! userId || ! enabled ) {
+			abortRef.current = null;
+			setResult( emptyResult( queryKey, false ) );
 			return;
 		}
 
-		setLoading( true );
-		setError( null );
+		const controller = new AbortController();
+		abortRef.current = controller;
+		setResult( emptyResult( queryKey ) );
 
 		const params = new URLSearchParams();
 		if ( year ) {
@@ -42,20 +58,53 @@ export default function useStats( userId, filters = {} ) {
 			query ? `?${ query }` : ''
 		}`;
 
-		apiFetch( { path } )
+		apiFetch( { path, signal: controller.signal } )
 			.then( ( response ) => {
-				setStats( response );
-				setLoading( false );
+				if (
+					controller.signal.aborted ||
+					generationRef.current !== generation ||
+					activeQueryKey.current !== queryKey
+				) {
+					return;
+				}
+
+				setResult( {
+					queryKey,
+					stats: response,
+					loading: false,
+					error: null,
+				} );
 			} )
 			.catch( ( err ) => {
-				setError( err.message || 'Failed to load stats.' );
-				setLoading( false );
+				if (
+					( err && err.name === 'AbortError' ) ||
+					controller.signal.aborted ||
+					generationRef.current !== generation ||
+					activeQueryKey.current !== queryKey
+				) {
+					return;
+				}
+
+				setResult( {
+					queryKey,
+					stats: null,
+					loading: false,
+					error: err,
+				} );
 			} );
-	}, [ userId, year, dateTo ] );
+	}, [ userId, year, dateTo, enabled, queryKey ] );
 
 	useEffect( () => {
 		fetchStats();
+		return () => {
+			if ( abortRef.current ) {
+				abortRef.current.abort();
+			}
+		};
 	}, [ fetchStats ] );
 
-	return { stats, loading, error, refetch: fetchStats };
+	const activeResult =
+		result.queryKey === queryKey ? result : emptyResult( queryKey );
+
+	return { ...activeResult, refetch: fetchStats };
 }

--- a/blocks/concert-stats/src/hooks/useStats.test.js
+++ b/blocks/concert-stats/src/hooks/useStats.test.js
@@ -1,0 +1,157 @@
+/**
+ * useStats request isolation and authorization behavior.
+ */
+/* eslint-env jest */
+
+import { createRoot } from '@wordpress/element';
+import { act } from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import useStats from './useStats';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const privateError = {
+	code: 'concert_history_private',
+	message: 'Concert history is private.',
+	data: { status: 403 },
+};
+
+const deferred = () => {
+	let resolve;
+	let reject;
+	const promise = new Promise( ( done, fail ) => {
+		resolve = done;
+		reject = fail;
+	} );
+	return { promise, resolve, reject };
+};
+
+const StatsHarness = ( { userId, filters } ) => {
+	const result = useStats( userId, filters );
+	return (
+		<div>
+			<span data-testid="total">{ result.stats?.total_shows ?? '' }</span>
+			<span data-testid="loading">
+				{ result.loading ? 'loading' : 'ready' }
+			</span>
+			<span data-testid="error-code">{ result.error?.code || '' }</span>
+			<span data-testid="error-status">
+				{ result.error?.data?.status || '' }
+			</span>
+		</div>
+	);
+};
+
+const value = ( container, testId ) =>
+	container.querySelector( `[data-testid="${ testId }"]` ).textContent;
+
+async function renderHarness( props ) {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+
+	await act( async () => {
+		root.render( <StatsHarness { ...props } /> );
+		await Promise.resolve();
+	} );
+
+	return {
+		container,
+		root,
+		rerender: async ( nextProps ) => {
+			await act( async () => {
+				root.render( <StatsHarness { ...nextProps } /> );
+				await Promise.resolve();
+			} );
+		},
+	};
+}
+
+describe( 'useStats', () => {
+	beforeAll( () => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+	} );
+
+	afterAll( () => {
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	} );
+
+	beforeEach( () => {
+		apiFetch.mockReset();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'clears public stats when the next profile returns private', async () => {
+		const privateRequest = deferred();
+		apiFetch
+			.mockResolvedValueOnce( { total_shows: 12 } )
+			.mockImplementationOnce( () => privateRequest.promise );
+		const harness = await renderHarness( {
+			userId: 7,
+			filters: { dateTo: '2026-07-18' },
+		} );
+
+		expect( value( harness.container, 'total' ) ).toBe( '12' );
+		await harness.rerender( {
+			userId: 8,
+			filters: { dateTo: '2026-07-18' },
+		} );
+
+		expect( value( harness.container, 'total' ) ).toBe( '' );
+		expect( value( harness.container, 'error-code' ) ).toBe( '' );
+		expect( value( harness.container, 'loading' ) ).toBe( 'loading' );
+		await act( async () => privateRequest.reject( privateError ) );
+		expect( value( harness.container, 'error-code' ) ).toBe(
+			'concert_history_private'
+		);
+		expect( value( harness.container, 'error-status' ) ).toBe( '403' );
+		await act( async () => harness.root.unmount() );
+	} );
+
+	it( 'ignores out-of-order success from an aborted profile request', async () => {
+		const oldRequest = deferred();
+		const newRequest = deferred();
+		apiFetch
+			.mockImplementationOnce( () => oldRequest.promise )
+			.mockImplementationOnce( () => newRequest.promise );
+		const harness = await renderHarness( { userId: 7, filters: {} } );
+		const oldSignal = apiFetch.mock.calls[ 0 ][ 0 ].signal;
+
+		await harness.rerender( { userId: 8, filters: {} } );
+		expect( oldSignal.aborted ).toBe( true );
+		expect( value( harness.container, 'total' ) ).toBe( '' );
+
+		await act( async () => newRequest.reject( privateError ) );
+		await act( async () => oldRequest.resolve( { total_shows: 99 } ) );
+
+		expect( value( harness.container, 'total' ) ).toBe( '' );
+		expect( value( harness.container, 'error-code' ) ).toBe(
+			'concert_history_private'
+		);
+		await act( async () => harness.root.unmount() );
+	} );
+
+	it( 'aborts on query changes and exposes a clean disabled state', async () => {
+		const request = deferred();
+		apiFetch.mockImplementationOnce( () => request.promise );
+		const harness = await renderHarness( { userId: 7, filters: {} } );
+		const signal = apiFetch.mock.calls[ 0 ][ 0 ].signal;
+
+		await harness.rerender( {
+			userId: 7,
+			filters: { enabled: false },
+		} );
+
+		expect( signal.aborted ).toBe( true );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( value( harness.container, 'loading' ) ).toBe( 'ready' );
+		expect( value( harness.container, 'total' ) ).toBe( '' );
+		expect( value( harness.container, 'error-code' ) ).toBe( '' );
+		await act( async () => request.resolve( { total_shows: 99 } ) );
+		expect( value( harness.container, 'total' ) ).toBe( '' );
+		await act( async () => harness.root.unmount() );
+	} );
+} );

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -173,10 +173,15 @@ export function ConcertStatsApp( {
 		hasExplicitTabParam( isOwn )
 	);
 
-	const { stats, loading: statsLoading } = useStats( userId, {
+	const {
+		stats,
+		loading: statsLoading,
+		error: statsError,
+	} = useStats( userId, {
 		year,
 		dateTo: isOwn ? '' : publicDateTo,
 	} );
+	const publicHistoryAllowed = isOwn || ( ! statsLoading && !! stats );
 
 	// Badge counts for the Upcoming / Past tabs. Public views disable the
 	// upcoming request entirely so the browser never receives itinerary data.
@@ -197,6 +202,7 @@ export function ConcertStatsApp( {
 		period: 'past',
 		year,
 		perPage: 1,
+		enabled: publicHistoryAllowed,
 		queryScope: isOwn ? 'owner' : 'public',
 	} );
 
@@ -241,6 +247,10 @@ export function ConcertStatsApp( {
 	};
 
 	const hasAnyShows = !! stats && stats.total_shows > 0;
+	const isPrivateHistory =
+		! isOwn &&
+		statsError?.code === 'concert_history_private' &&
+		Number( statsError?.data?.status ?? statsError?.status ) === 403;
 
 	// Sync `?tab=` to URL whenever the active tab changes. Use
 	// replaceState to keep the back button useful — switching tabs
@@ -434,7 +444,12 @@ export function ConcertStatsApp( {
 				// composes the two and refetches the list when a show
 				// is marked so additions appear without a reload.
 				return (
-					<PastTab userId={ userId } year={ year } isOwn={ isOwn } />
+					<PastTab
+						userId={ userId }
+						year={ year }
+						isOwn={ isOwn }
+						enabled={ publicHistoryAllowed }
+					/>
 				);
 
 			case 'calendar':
@@ -521,6 +536,35 @@ export function ConcertStatsApp( {
 				return null;
 		}
 	};
+
+	if ( isPrivateHistory ) {
+		return (
+			<BlockShell>
+				<BlockShellInner maxWidth="narrow">
+					<BlockShellHeader title="Concert History" />
+					<InlineStatus tone="info">
+						This concert history is private.
+					</InlineStatus>
+				</BlockShellInner>
+			</BlockShell>
+		);
+	}
+
+	if ( statsError ) {
+		return (
+			<BlockShell>
+				<BlockShellInner maxWidth="narrow">
+					<BlockShellHeader
+						title={ isOwn ? 'My Shows' : 'Concert History' }
+					/>
+					<InlineStatus tone="error">
+						{ statsError.message ||
+							'This concert history could not be loaded.' }
+					</InlineStatus>
+				</BlockShellInner>
+			</BlockShell>
+		);
+	}
 
 	return (
 		<BlockShell>

--- a/blocks/concert-stats/src/view.test.js
+++ b/blocks/concert-stats/src/view.test.js
@@ -55,6 +55,16 @@ const emptyStats = {
 	shows_by_year: {},
 };
 
+const deferred = () => {
+	let resolve;
+	let reject;
+	const promise = new Promise( ( done, fail ) => {
+		resolve = done;
+		reject = fail;
+	} );
+	return { promise, resolve, reject };
+};
+
 function mockApi() {
 	apiFetch.mockImplementation( ( { path } ) => {
 		if ( path.includes( '/stats' ) ) {
@@ -90,7 +100,7 @@ function mockApi() {
 	} );
 }
 
-async function renderApp( { isOwn, tab } ) {
+async function renderApp( { isOwn, tab, userId = 34 } ) {
 	window.history.replaceState(
 		{},
 		'',
@@ -99,23 +109,33 @@ async function renderApp( { isOwn, tab } ) {
 	const container = document.createElement( 'div' );
 	document.body.appendChild( container );
 	const root = createRoot( container );
+	const render = ( nextUserId ) => (
+		<ConcertStatsApp
+			userId={ nextUserId }
+			eventsUrl="https://events.example"
+			isOwn={ isOwn }
+			publicDateTo="2026-07-18"
+			hasCalendar={ isOwn }
+			hasMap={ isOwn }
+			containerRef={ { current: container } }
+		/>
+	);
 
 	await act( async () => {
-		root.render(
-			<ConcertStatsApp
-				userId={ 34 }
-				eventsUrl="https://events.example"
-				isOwn={ isOwn }
-				publicDateTo="2026-07-18"
-				hasCalendar={ isOwn }
-				hasMap={ isOwn }
-				containerRef={ { current: container } }
-			/>
-		);
+		root.render( render( userId ) );
 		await Promise.resolve();
 	} );
 
-	return { container, root };
+	return {
+		container,
+		root,
+		rerenderUser: async ( nextUserId ) => {
+			await act( async () => {
+				root.render( render( nextUserId ) );
+				await Promise.resolve();
+			} );
+		},
+	};
 }
 
 describe( 'ConcertStatsApp request boundaries', () => {
@@ -207,6 +227,77 @@ describe( 'ConcertStatsApp request boundaries', () => {
 				path.includes( '/concert-tracking/search' )
 			)
 		).toBe( true );
+
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'renders private history without requesting or displaying shows', async () => {
+		apiFetch.mockImplementation( ( { path } ) => {
+			if ( path.includes( '/stats' ) ) {
+				return Promise.reject( {
+					code: 'concert_history_private',
+					message: 'Concert history is private.',
+					data: { status: 403 },
+				} );
+			}
+			return Promise.resolve( {} );
+		} );
+
+		const { container, root } = await renderApp( {
+			isOwn: false,
+			tab: 'past',
+		} );
+		const paths = apiFetch.mock.calls.map(
+			( [ request ] ) => request.path
+		);
+
+		expect( container.textContent ).toContain(
+			'This concert history is private.'
+		);
+		expect( container.textContent ).not.toContain( 'Past Concert' );
+		expect( paths.some( ( path ) => path.includes( '/shows' ) ) ).toBe(
+			false
+		);
+
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'does not authorize a new private profile from an old success', async () => {
+		const oldStats = deferred();
+		const newStats = deferred();
+		apiFetch
+			.mockImplementationOnce( () => oldStats.promise )
+			.mockImplementationOnce( () => newStats.promise );
+		const { container, root, rerenderUser } = await renderApp( {
+			isOwn: false,
+			tab: 'past',
+			userId: 34,
+		} );
+
+		expect(
+			apiFetch.mock.calls.some( ( [ request ] ) =>
+				request.path.includes( '/shows' )
+			)
+		).toBe( false );
+
+		await rerenderUser( 35 );
+		await act( async () =>
+			newStats.reject( {
+				code: 'concert_history_private',
+				message: 'Concert history is private.',
+				data: { status: 403 },
+			} )
+		);
+		await act( async () => oldStats.resolve( emptyStats ) );
+
+		expect( container.textContent ).toContain(
+			'This concert history is private.'
+		);
+		expect(
+			apiFetch.mock.calls.some( ( [ request ] ) =>
+				request.path.includes( '/shows' )
+			)
+		).toBe( false );
 
 		await act( async () => root.unmount() );
 	} );

--- a/tests/Unit/ConcertStatsPublicProfileRenderTest.php
+++ b/tests/Unit/ConcertStatsPublicProfileRenderTest.php
@@ -28,6 +28,12 @@ if ( ! function_exists( 'is_user_logged_in' ) ) {
 	}
 }
 
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( $capability ) {
+		return 'manage_network_options' === $capability && ! empty( $GLOBALS['ec_test_is_network_admin'] );
+	}
+}
+
 if ( ! function_exists( 'get_userdata' ) ) {
 	function get_userdata( $user_id ) {
 		return in_array( (int) $user_id, $GLOBALS['ec_test_existing_user_ids'], true ) ? (object) array( 'ID' => (int) $user_id ) : false;
@@ -108,6 +114,7 @@ final class ConcertStatsPublicProfileRenderTest extends TestCase {
 	protected function setUp(): void {
 		$GLOBALS['ec_test_current_user_id']   = 0;
 		$GLOBALS['ec_test_existing_user_ids'] = array( 12, 34 );
+		$GLOBALS['ec_test_is_network_admin']  = false;
 		$GLOBALS['test_is_user_logged_in']    = false;
 		$_GET                                 = array();
 	}
@@ -141,6 +148,21 @@ final class ConcertStatsPublicProfileRenderTest extends TestCase {
 		$this->assertStringContainsString( 'data-user-id="34"', $output );
 		$this->assertStringContainsString( 'data-is-own="0"', $output );
 		$this->assertStringContainsString( 'data-public-date-to="2026-07-18"', $output );
+		$this->assertStringContainsString( 'data-has-calendar="0"', $output );
+		$this->assertStringContainsString( 'data-has-map="0"', $output );
+		$this->assertStringNotContainsString( 'ec-concert-stats__embedded-calendar', $output );
+		$this->assertStringNotContainsString( 'ec-concert-stats__embedded-map', $output );
+	}
+
+	public function test_network_admin_does_not_receive_another_users_owner_ui(): void {
+		$GLOBALS['ec_test_current_user_id']  = 12;
+		$GLOBALS['ec_test_is_network_admin'] = true;
+		$_GET['user_id']                     = '34';
+
+		$output = $this->renderBlock();
+
+		$this->assertStringContainsString( 'data-user-id="34"', $output );
+		$this->assertStringContainsString( 'data-is-own="0"', $output );
 		$this->assertStringContainsString( 'data-has-calendar="0"', $output );
 		$this->assertStringContainsString( 'data-has-map="0"', $output );
 		$this->assertStringNotContainsString( 'ec-concert-stats__embedded-calendar', $output );


### PR DESCRIPTION
## Summary
- render canonical private-history and API error states
- authorize public show requests only after the latest stats request succeeds
- isolate and abort stale stats requests across profile transitions
- preserve exact-owner Calendar, Map, and Import behavior

## Verification
- 24 JS tests passed
- focused PHP tests passed with 29 assertions
- JS lint and production build passed
- final independent review: merge

Depends on the Extra Chill Users privacy contract.