### PR TITLE
feat: resolve canonical artist identity at Events boundary

### DIFF
--- a/inc/abilities/events-by-artist.php
+++ b/inc/abilities/events-by-artist.php
@@ -1,0 +1,429 @@
+<?php
+/**
+ * Canonical artist to Events-site artist adapter.
+ *
+ * @package ExtraChillEvents
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+const EXTRACHILL_EVENTS_ARTIST_TERM_META       = '_extrachill_events_artist_term_id';
+const EXTRACHILL_EVENTS_ARTIST_BACKFILL_OPTION = 'extrachill_events_artist_identity_backfill_1';
+
+add_action( 'wp_abilities_api_init', 'extrachill_events_register_events_by_artist_ability' );
+add_action( 'admin_init', 'extrachill_events_maybe_backfill_artist_identity' );
+
+/**
+ * Register the Extra Chill artist-specific event lookup adapter.
+ */
+function extrachill_events_register_events_by_artist_ability(): void {
+	wp_register_ability(
+		'extrachill-events/events-by-artist',
+		array(
+			'label'               => __( 'Events By Canonical Artist', 'extrachill-events' ),
+			'description'         => __( 'Resolve a canonical Extra Chill artist to its Events-site artist term and return the artist events.', 'extrachill-events' ),
+			'category'            => 'extrachill-events',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'artist_term_id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Canonical main-site artist term ID.', 'extrachill-events' ),
+					),
+					'term_slug'      => array(
+						'type'        => 'string',
+						'description' => __( 'Legacy Events-site artist slug used during migration.', 'extrachill-events' ),
+					),
+					'scope'          => array(
+						'type' => 'string',
+						'enum' => array( 'upcoming', 'past', 'all' ),
+					),
+					'limit'          => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'taxonomy'  => array( 'type' => 'string' ),
+					'term_id'   => array( 'type' => 'integer' ),
+					'term_slug' => array( 'type' => 'string' ),
+					'found'     => array( 'type' => 'boolean' ),
+					'upcoming'  => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'object' ),
+					),
+					'past'      => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'object' ),
+					),
+				),
+			),
+			'execute_callback'    => 'extrachill_events_ability_events_by_artist',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Resolve a canonical artist and delegate its event lookup to Data Machine Events.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_events_ability_events_by_artist( array $input ) {
+	$artist_term_id = absint( $input['artist_term_id'] ?? 0 );
+	$legacy_slug    = sanitize_title( $input['term_slug'] ?? '' );
+	if ( $artist_term_id < 1 && '' === $legacy_slug ) {
+		return new WP_Error( 'missing_artist_identity', __( 'A canonical artist_term_id or legacy term_slug is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+	}
+
+	$resolved = extrachill_events_resolve_artist_term( $artist_term_id, $legacy_slug );
+	if ( is_wp_error( $resolved ) ) {
+		return $resolved;
+	}
+
+	$ability = wp_get_ability( 'data-machine-events/events-by-term' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_unavailable', __( 'The events-by-term ability is not available.', 'extrachill-events' ), array( 'status' => 500 ) );
+	}
+
+	$delegate_input = array(
+		'taxonomy'  => 'artist',
+		'term_id'   => $resolved['term_id'],
+		'term_slug' => $resolved['term_slug'],
+	);
+	if ( isset( $input['scope'] ) ) {
+		$delegate_input['scope'] = sanitize_key( $input['scope'] );
+	}
+	if ( isset( $input['limit'] ) ) {
+		$delegate_input['limit'] = absint( $input['limit'] );
+	}
+
+	$events_blog_id = extrachill_events_artist_blog_id( 'events' );
+	if ( $events_blog_id < 1 ) {
+		return new WP_Error( 'events_site_unresolved', __( 'Could not resolve the Events site.', 'extrachill-events' ), array( 'status' => 500 ) );
+	}
+
+	switch_to_blog( $events_blog_id );
+	try {
+		return $ability->execute( $delegate_input );
+	} finally {
+		restore_current_blog();
+	}
+}
+
+/**
+ * Resolve a canonical main-site artist term to a validated local Events term.
+ *
+ * @param int    $artist_term_id Canonical main-site artist term ID, or zero for legacy lookup.
+ * @param string $legacy_slug    Optional legacy local slug.
+ * @return array{term_id:int,term_slug:string}|WP_Error
+ */
+function extrachill_events_resolve_artist_term( int $artist_term_id, string $legacy_slug = '' ) {
+	$main_blog_id   = extrachill_events_artist_blog_id( 'main' );
+	$events_blog_id = extrachill_events_artist_blog_id( 'events' );
+	if ( $main_blog_id < 1 || $events_blog_id < 1 ) {
+		return new WP_Error( 'artist_sites_unresolved', __( 'Could not resolve the main and Events sites.', 'extrachill-events' ), array( 'status' => 500 ) );
+	}
+
+	$mapped_term_id = 0;
+	$canonical_slug = '';
+	if ( $artist_term_id > 0 ) {
+		switch_to_blog( $main_blog_id );
+		try {
+			$canonical = get_term( $artist_term_id, 'artist' );
+			if ( ! $canonical || is_wp_error( $canonical ) || 'artist' !== $canonical->taxonomy ) {
+				return new WP_Error( 'invalid_canonical_artist', __( 'The canonical artist term is missing or invalid.', 'extrachill-events' ), array( 'status' => 404 ) );
+			}
+
+			$canonical_slug = (string) $canonical->slug;
+			$mapped_term_id = absint( get_term_meta( $artist_term_id, EXTRACHILL_EVENTS_ARTIST_TERM_META, true ) );
+			if ( $mapped_term_id > 0 ) {
+				$claims = extrachill_events_find_artist_mapping_claims( $mapped_term_id );
+				if ( count( $claims ) > 1 ) {
+					return new WP_Error( 'duplicate_artist_mapping', __( 'Multiple canonical artists claim the same Events artist term.', 'extrachill-events' ), array( 'status' => 409 ) );
+				}
+			}
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	$lookup_slug = '' !== $legacy_slug ? $legacy_slug : $canonical_slug;
+	switch_to_blog( $events_blog_id );
+	try {
+		if ( $mapped_term_id > 0 ) {
+			$local = get_term( $mapped_term_id, 'artist' );
+			if ( ! $local || is_wp_error( $local ) || 'artist' !== $local->taxonomy ) {
+				return new WP_Error( 'stale_artist_mapping', __( 'The mapped Events artist term is missing or has the wrong taxonomy.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+		} else {
+			$local = '' !== $lookup_slug ? get_term_by( 'slug', $lookup_slug, 'artist' ) : false;
+			if ( ! $local || is_wp_error( $local ) ) {
+				return new WP_Error( 'artist_mapping_missing', __( 'No Events artist mapping or legacy slug match exists.', 'extrachill-events' ), array( 'status' => 404 ) );
+			}
+		}
+
+		return array(
+			'term_id'   => (int) $local->term_id,
+			'term_slug' => (string) $local->slug,
+		);
+	} finally {
+		restore_current_blog();
+	}
+}
+
+/**
+ * Find canonical main-site artists that claim a local Events artist term.
+ *
+ * Must be called in main-site context.
+ *
+ * @param int $events_term_id Events-site artist term ID.
+ * @return int[] Canonical artist term IDs.
+ */
+function extrachill_events_find_artist_mapping_claims( int $events_term_id ): array {
+	// A single indexed metadata value bounds this duplicate-claim check.
+	// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+	$claims = get_terms(
+		array(
+			'taxonomy'   => 'artist',
+			'hide_empty' => false,
+			'fields'     => 'ids',
+			'meta_key'   => EXTRACHILL_EVENTS_ARTIST_TERM_META,
+			'meta_value' => $events_term_id,
+		)
+	);
+	// phpcs:enable
+
+	return is_wp_error( $claims ) ? array() : array_map( 'intval', (array) $claims );
+}
+
+/**
+ * Resolve one of the network's known blog IDs.
+ *
+ * @param string $site Site key.
+ * @return int Blog ID, or zero.
+ */
+function extrachill_events_artist_blog_id( string $site ): int {
+	return function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( $site ) : 0;
+}
+
+/**
+ * Run the bounded one-time exact-slug artist mapping backfill.
+ */
+function extrachill_events_maybe_backfill_artist_identity(): void {
+	$events_blog_id = extrachill_events_artist_blog_id( 'events' );
+	if ( $events_blog_id < 1 ) {
+		return;
+	}
+
+	switch_to_blog( $events_blog_id );
+	try {
+		if ( get_option( EXTRACHILL_EVENTS_ARTIST_BACKFILL_OPTION, false ) ) {
+			return;
+		}
+	} finally {
+		restore_current_blog();
+	}
+
+	$report = extrachill_events_backfill_artist_identity();
+	if ( is_wp_error( $report ) ) {
+		return;
+	}
+
+	switch_to_blog( $events_blog_id );
+	try {
+		update_option( EXTRACHILL_EVENTS_ARTIST_BACKFILL_OPTION, $report, false );
+	} finally {
+		restore_current_blog();
+	}
+}
+
+/**
+ * Map bound canonical artists to unclaimed local artist terms by exact slug.
+ *
+ * @return array|WP_Error Audit report.
+ */
+function extrachill_events_backfill_artist_identity() {
+	$main_blog_id   = extrachill_events_artist_blog_id( 'main' );
+	$events_blog_id = extrachill_events_artist_blog_id( 'events' );
+	if ( $main_blog_id < 1 || $events_blog_id < 1 ) {
+		return new WP_Error( 'artist_sites_unresolved', __( 'Could not resolve the main and Events sites.', 'extrachill-events' ) );
+	}
+
+	$report = array(
+		'version'         => 1,
+		'mapped'          => array(),
+		'existing'        => array(),
+		'missing'         => array(),
+		'unmatched_local' => array(),
+		'stale'           => array(),
+		'ambiguous'       => array(),
+		'collisions'      => array(),
+	);
+
+	switch_to_blog( $main_blog_id );
+	try {
+		$canonical_terms = get_terms(
+			array(
+				'taxonomy'   => 'artist',
+				'hide_empty' => false,
+			)
+		);
+		if ( is_wp_error( $canonical_terms ) ) {
+			return $canonical_terms;
+		}
+
+		$canonical_terms = array_values(
+			array_filter(
+				$canonical_terms,
+				static function ( $term ): bool {
+					return absint( get_term_meta( $term->term_id, '_artist_profile_id', true ) ) > 0;
+				}
+			)
+		);
+		$mappings        = array();
+		foreach ( $canonical_terms as $term ) {
+			$mappings[ (int) $term->term_id ] = absint( get_term_meta( $term->term_id, EXTRACHILL_EVENTS_ARTIST_TERM_META, true ) );
+		}
+	} finally {
+		restore_current_blog();
+	}
+
+	switch_to_blog( $events_blog_id );
+	try {
+		$local_terms = get_terms(
+			array(
+				'taxonomy'   => 'artist',
+				'hide_empty' => false,
+			)
+		);
+		if ( is_wp_error( $local_terms ) ) {
+			return $local_terms;
+		}
+	} finally {
+		restore_current_blog();
+	}
+
+	$local_by_id   = array();
+	$local_by_slug = array();
+	foreach ( $local_terms as $term ) {
+		$local_by_id[ (int) $term->term_id ]     = $term;
+		$local_by_slug[ (string) $term->slug ][] = $term;
+	}
+
+	$claims = array();
+	foreach ( $mappings as $canonical_id => $local_id ) {
+		if ( $local_id < 1 ) {
+			continue;
+		}
+		if ( ! isset( $local_by_id[ $local_id ] ) ) {
+			$report['stale'][] = array(
+				'artist_term_id' => $canonical_id,
+				'events_term_id' => $local_id,
+			);
+			continue;
+		}
+		$claims[ $local_id ][] = $canonical_id;
+	}
+
+	foreach ( $claims as $local_id => $canonical_ids ) {
+		if ( count( $canonical_ids ) > 1 ) {
+			$report['collisions'][] = array(
+				'events_term_id'  => $local_id,
+				'artist_term_ids' => $canonical_ids,
+			);
+			continue;
+		}
+		$report['existing'][] = array(
+			'artist_term_id' => $canonical_ids[0],
+			'events_term_id' => $local_id,
+		);
+	}
+
+	$canonical_by_slug = array();
+	foreach ( $canonical_terms as $term ) {
+		$canonical_by_slug[ (string) $term->slug ][] = $term;
+	}
+
+	foreach ( $canonical_terms as $term ) {
+		$canonical_id = (int) $term->term_id;
+		if ( $mappings[ $canonical_id ] > 0 ) {
+			continue;
+		}
+		if ( count( $canonical_by_slug[ (string) $term->slug ] ) > 1 ) {
+			$report['ambiguous'][] = array(
+				'artist_term_id' => $canonical_id,
+				'slug'           => (string) $term->slug,
+			);
+			continue;
+		}
+
+		$candidates = $local_by_slug[ (string) $term->slug ] ?? array();
+		if ( empty( $candidates ) ) {
+			$report['missing'][] = array(
+				'artist_term_id' => $canonical_id,
+				'slug'           => (string) $term->slug,
+			);
+			continue;
+		}
+		if ( count( $candidates ) > 1 ) {
+			$report['ambiguous'][] = array(
+				'artist_term_id' => $canonical_id,
+				'slug'           => (string) $term->slug,
+			);
+			continue;
+		}
+
+		$local_id = (int) $candidates[0]->term_id;
+		if ( ! empty( $claims[ $local_id ] ) ) {
+			$report['collisions'][] = array(
+				'events_term_id'  => $local_id,
+				'artist_term_ids' => array_merge( $claims[ $local_id ], array( $canonical_id ) ),
+			);
+			continue;
+		}
+
+		switch_to_blog( $main_blog_id );
+		try {
+			update_term_meta( $canonical_id, EXTRACHILL_EVENTS_ARTIST_TERM_META, $local_id );
+		} finally {
+			restore_current_blog();
+		}
+		$claims[ $local_id ] = array( $canonical_id );
+		$report['mapped'][]  = array(
+			'artist_term_id' => $canonical_id,
+			'events_term_id' => $local_id,
+		);
+	}
+
+	foreach ( $local_terms as $term ) {
+		$slug = (string) $term->slug;
+		if ( empty( $canonical_by_slug[ $slug ] ) ) {
+			$report['unmatched_local'][] = array(
+				'events_term_id' => (int) $term->term_id,
+				'slug'           => $slug,
+			);
+		} elseif ( count( $canonical_by_slug[ $slug ] ) > 1 ) {
+			$report['ambiguous'][] = array(
+				'events_term_id' => (int) $term->term_id,
+				'slug'           => $slug,
+			);
+		}
+	}
+
+	return $report;
+}

--- a/inc/abilities/events-by-artist.php
+++ b/inc/abilities/events-by-artist.php
@@ -27,6 +27,10 @@ function extrachill_events_register_events_by_artist_ability(): void {
 			'category'            => 'extrachill-events',
 			'input_schema'        => array(
 				'type'       => 'object',
+				'anyOf'      => array(
+					array( 'required' => array( 'artist_term_id' ) ),
+					array( 'required' => array( 'term_slug' ) ),
+				),
 				'properties' => array(
 					'artist_term_id' => array(
 						'type'        => 'integer',
@@ -162,7 +166,7 @@ function extrachill_events_resolve_artist_term( int $artist_term_id, string $leg
 		}
 	}
 
-	$lookup_slug = '' !== $legacy_slug ? $legacy_slug : $canonical_slug;
+	$lookup_slug = $artist_term_id > 0 ? $canonical_slug : $legacy_slug;
 	switch_to_blog( $events_blog_id );
 	try {
 		if ( $mapped_term_id > 0 ) {
@@ -174,6 +178,18 @@ function extrachill_events_resolve_artist_term( int $artist_term_id, string $leg
 			$local = '' !== $lookup_slug ? get_term_by( 'slug', $lookup_slug, 'artist' ) : false;
 			if ( ! $local || is_wp_error( $local ) ) {
 				return new WP_Error( 'artist_mapping_missing', __( 'No Events artist mapping or legacy slug match exists.', 'extrachill-events' ), array( 'status' => 404 ) );
+			}
+
+			if ( $artist_term_id > 0 ) {
+				switch_to_blog( $main_blog_id );
+				try {
+					$claims = extrachill_events_find_artist_mapping_claims( (int) $local->term_id );
+					if ( ! empty( $claims ) ) {
+						return new WP_Error( 'duplicate_artist_mapping', __( 'The matched Events artist term is already claimed by another canonical artist.', 'extrachill-events' ), array( 'status' => 409 ) );
+					}
+				} finally {
+					restore_current_blog();
+				}
 			}
 		}
 
@@ -232,7 +248,8 @@ function extrachill_events_maybe_backfill_artist_identity(): void {
 
 	switch_to_blog( $events_blog_id );
 	try {
-		if ( get_option( EXTRACHILL_EVENTS_ARTIST_BACKFILL_OPTION, false ) ) {
+		$existing_report = get_option( EXTRACHILL_EVENTS_ARTIST_BACKFILL_OPTION, false );
+		if ( is_array( $existing_report ) && ! empty( $existing_report['complete'] ) ) {
 			return;
 		}
 	} finally {
@@ -266,6 +283,7 @@ function extrachill_events_backfill_artist_identity() {
 
 	$report = array(
 		'version'         => 1,
+		'complete'        => true,
 		'mapped'          => array(),
 		'existing'        => array(),
 		'missing'         => array(),
@@ -273,6 +291,7 @@ function extrachill_events_backfill_artist_identity() {
 		'stale'           => array(),
 		'ambiguous'       => array(),
 		'collisions'      => array(),
+		'write_failures'  => array(),
 	);
 
 	switch_to_blog( $main_blog_id );
@@ -287,16 +306,17 @@ function extrachill_events_backfill_artist_identity() {
 			return $canonical_terms;
 		}
 
-		$canonical_terms = array_values(
+		$all_canonical_terms = $canonical_terms;
+		$canonical_terms     = array_values(
 			array_filter(
-				$canonical_terms,
+				$all_canonical_terms,
 				static function ( $term ): bool {
 					return absint( get_term_meta( $term->term_id, '_artist_profile_id', true ) ) > 0;
 				}
 			)
 		);
-		$mappings        = array();
-		foreach ( $canonical_terms as $term ) {
+		$mappings            = array();
+		foreach ( $all_canonical_terms as $term ) {
 			$mappings[ (int) $term->term_id ] = absint( get_term_meta( $term->term_id, EXTRACHILL_EVENTS_ARTIST_TERM_META, true ) );
 		}
 	} finally {
@@ -355,7 +375,7 @@ function extrachill_events_backfill_artist_identity() {
 	}
 
 	$canonical_by_slug = array();
-	foreach ( $canonical_terms as $term ) {
+	foreach ( $all_canonical_terms as $term ) {
 		$canonical_by_slug[ (string) $term->slug ][] = $term;
 	}
 
@@ -399,9 +419,17 @@ function extrachill_events_backfill_artist_identity() {
 
 		switch_to_blog( $main_blog_id );
 		try {
-			update_term_meta( $canonical_id, EXTRACHILL_EVENTS_ARTIST_TERM_META, $local_id );
+			$updated = update_term_meta( $canonical_id, EXTRACHILL_EVENTS_ARTIST_TERM_META, $local_id );
 		} finally {
 			restore_current_blog();
+		}
+		if ( false === $updated || is_wp_error( $updated ) ) {
+			$report['complete']         = false;
+			$report['write_failures'][] = array(
+				'artist_term_id' => $canonical_id,
+				'events_term_id' => $local_id,
+			);
+			continue;
 		}
 		$claims[ $local_id ] = array( $canonical_id );
 		$report['mapped'][]  = array(

--- a/inc/abilities/register.php
+++ b/inc/abilities/register.php
@@ -52,3 +52,4 @@ require_once __DIR__ . '/events-upcoming-counts.php';
 require_once __DIR__ . '/events-list-venues.php';
 require_once __DIR__ . '/events-get-venue.php';
 require_once __DIR__ . '/events-check-venue-duplicate.php';
+require_once __DIR__ . '/events-by-artist.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,7 @@
 			<file>tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalLocationsAbilityTest.php</file>
 			<file>tests/Unit/Abilities/EventsByTermTaxonomyContextTest.php</file>
+			<file>tests/Unit/Abilities/EventsByArtistAbilityTest.php</file>
 			<file>tests/Unit/FestivalNotificationsTest.php</file>
 			<file>tests/Unit/SingleEventNetworkBridgeTest.php</file>
 			<file>tests/Unit/ConcertStatsPublicProfileRenderTest.php</file>

--- a/tests/Unit/Abilities/EventsByArtistAbilityTest.php
+++ b/tests/Unit/Abilities/EventsByArtistAbilityTest.php
@@ -93,8 +93,16 @@ if ( ! function_exists( 'get_term_meta' ) ) {
 }
 if ( ! function_exists( 'update_term_meta' ) ) {
 	function update_term_meta( $term_id, $key, $value ) {
+		if ( ! empty( $GLOBALS['ec_artist_test']['fail_updates'][ $term_id ] ) ) {
+			return false;
+		}
 		$GLOBALS['ec_artist_test']['meta'][ get_current_blog_id() ][ $term_id ][ $key ] = $value;
 		return true;
+	}
+}
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( $name, $args ) {
+		$GLOBALS['ec_artist_test']['registered'][ $name ] = $args;
 	}
 }
 if ( ! function_exists( 'get_terms' ) ) {
@@ -144,6 +152,8 @@ final class EventsByArtistAbilityTest extends TestCase {
 			'meta'    => array( 1 => array(), 7 => array() ),
 			'options' => array( 1 => array(), 7 => array() ),
 			'events'  => array( 44 => array( 'artists' => array() ) ),
+			'fail_updates' => array(),
+			'registered'   => array(),
 		);
 		$GLOBALS['ec_artist_test']['ability'] = new class() {
 			public function execute( array $input ): array {
@@ -190,6 +200,32 @@ final class EventsByArtistAbilityTest extends TestCase {
 		$result = extrachill_events_ability_events_by_artist( array( 'artist_term_id' => 101 ) );
 
 		$this->assertSame( 'artist_mapping_missing', $result->get_error_code() );
+		$this->assertSame( 4, get_current_blog_id() );
+	}
+
+	public function test_canonical_identity_cannot_be_overridden_by_legacy_slug(): void {
+		$this->addTerm( 1, 101, 'canonical-band' );
+		$this->addTerm( 7, 501, 'other-band' );
+
+		$result = extrachill_events_ability_events_by_artist(
+			array(
+				'artist_term_id' => 101,
+				'term_slug'      => 'other-band',
+			)
+		);
+
+		$this->assertSame( 'artist_mapping_missing', $result->get_error_code() );
+	}
+
+	public function test_canonical_slug_fallback_rejects_a_term_claimed_by_another_artist(): void {
+		$this->addTerm( 1, 101, 'shared-band' );
+		$this->addTerm( 1, 102, 'other-name' );
+		$this->addTerm( 7, 501, 'shared-band' );
+		$GLOBALS['ec_artist_test']['meta'][1][102][ EXTRACHILL_EVENTS_ARTIST_TERM_META ] = 501;
+
+		$result = extrachill_events_ability_events_by_artist( array( 'artist_term_id' => 101 ) );
+
+		$this->assertSame( 'duplicate_artist_mapping', $result->get_error_code() );
 		$this->assertSame( 4, get_current_blog_id() );
 	}
 
@@ -278,5 +314,46 @@ final class EventsByArtistAbilityTest extends TestCase {
 		$this->assertArrayNotHasKey( EXTRACHILL_EVENTS_ARTIST_TERM_META, $GLOBALS['ec_artist_test']['meta'][1][101] );
 		$this->assertArrayNotHasKey( EXTRACHILL_EVENTS_ARTIST_TERM_META, $GLOBALS['ec_artist_test']['meta'][1][102] );
 		$this->assertSame( 4, get_current_blog_id() );
+	}
+
+	public function test_backfill_counts_unbound_artist_mappings_as_claims(): void {
+		$this->addTerm( 1, 101, 'candidate' );
+		$this->addTerm( 1, 102, 'unbound-owner' );
+		$this->bindProfile( 101, 1101 );
+		$this->addTerm( 7, 501, 'candidate' );
+		$GLOBALS['ec_artist_test']['meta'][1][102][ EXTRACHILL_EVENTS_ARTIST_TERM_META ] = 501;
+
+		$report = extrachill_events_backfill_artist_identity();
+
+		$this->assertCount( 0, $report['mapped'] );
+		$this->assertCount( 1, $report['collisions'] );
+		$this->assertArrayNotHasKey( EXTRACHILL_EVENTS_ARTIST_TERM_META, $GLOBALS['ec_artist_test']['meta'][1][101] );
+	}
+
+	public function test_failed_mapping_write_is_reported_and_remains_retryable(): void {
+		$this->addTerm( 1, 101, 'candidate' );
+		$this->bindProfile( 101, 1101 );
+		$this->addTerm( 7, 501, 'candidate' );
+		$GLOBALS['ec_artist_test']['fail_updates'][101] = true;
+
+		$report = extrachill_events_backfill_artist_identity();
+
+		$this->assertFalse( $report['complete'] );
+		$this->assertCount( 0, $report['mapped'] );
+		$this->assertCount( 1, $report['write_failures'] );
+		$this->assertArrayNotHasKey( EXTRACHILL_EVENTS_ARTIST_TERM_META, $GLOBALS['ec_artist_test']['meta'][1][101] );
+	}
+
+	public function test_input_schema_requires_a_canonical_id_or_legacy_slug(): void {
+		extrachill_events_register_events_by_artist_ability();
+
+		$schema = $GLOBALS['ec_artist_test']['registered']['extrachill-events/events-by-artist']['input_schema'];
+		$this->assertSame(
+			array(
+				array( 'required' => array( 'artist_term_id' ) ),
+				array( 'required' => array( 'term_slug' ) ),
+			),
+			$schema['anyOf']
+		);
 	}
 }

--- a/tests/Unit/Abilities/EventsByArtistAbilityTest.php
+++ b/tests/Unit/Abilities/EventsByArtistAbilityTest.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * Canonical artist identity adapter tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+// phpcs:disable -- Isolated WordPress test doubles.
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		public function __construct( string $code, string $message = '', array $data = array() ) {
+			unset( $message, $data );
+			$this->code = $code;
+		}
+		public function get_error_code(): string {
+			return $this->code;
+		}
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action() {}
+}
+if ( ! function_exists( '__' ) ) {
+	function __( $text ) {
+		return $text;
+	}
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ) {
+		return abs( (int) $value );
+	}
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $value ) {
+		return strtolower( trim( (string) $value ) );
+	}
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $value ) {
+		return strtolower( trim( (string) $value ) );
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error;
+	}
+}
+if ( ! function_exists( 'ec_get_blog_id' ) ) {
+	function ec_get_blog_id( $site ) {
+		return array( 'main' => 1, 'events' => 7 )[ $site ] ?? 0;
+	}
+}
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id() {
+		return $GLOBALS['ec_artist_test']['blog_id'];
+	}
+}
+if ( ! function_exists( 'switch_to_blog' ) ) {
+	function switch_to_blog( $blog_id ) {
+		$GLOBALS['ec_artist_test']['stack'][] = $GLOBALS['ec_artist_test']['blog_id'];
+		$GLOBALS['ec_artist_test']['blog_id'] = (int) $blog_id;
+	}
+}
+if ( ! function_exists( 'restore_current_blog' ) ) {
+	function restore_current_blog() {
+		$GLOBALS['ec_artist_test']['blog_id'] = array_pop( $GLOBALS['ec_artist_test']['stack'] );
+	}
+}
+if ( ! function_exists( 'get_term' ) ) {
+	function get_term( $term_id, $taxonomy = '' ) {
+		$term = $GLOBALS['ec_artist_test']['terms'][ get_current_blog_id() ][ $term_id ] ?? null;
+		return $term && ( '' === $taxonomy || $taxonomy === $term->taxonomy ) ? $term : null;
+	}
+}
+if ( ! function_exists( 'get_term_by' ) ) {
+	function get_term_by( $field, $value, $taxonomy ) {
+		foreach ( $GLOBALS['ec_artist_test']['terms'][ get_current_blog_id() ] ?? array() as $term ) {
+			if ( $taxonomy === $term->taxonomy && $value === $term->{$field} ) {
+				return $term;
+			}
+		}
+		return false;
+	}
+}
+if ( ! function_exists( 'get_term_meta' ) ) {
+	function get_term_meta( $term_id, $key ) {
+		return $GLOBALS['ec_artist_test']['meta'][ get_current_blog_id() ][ $term_id ][ $key ] ?? '';
+	}
+}
+if ( ! function_exists( 'update_term_meta' ) ) {
+	function update_term_meta( $term_id, $key, $value ) {
+		$GLOBALS['ec_artist_test']['meta'][ get_current_blog_id() ][ $term_id ][ $key ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'get_terms' ) ) {
+	function get_terms( $args ) {
+		$terms = array_values( $GLOBALS['ec_artist_test']['terms'][ get_current_blog_id() ] ?? array() );
+		$terms = array_values( array_filter( $terms, static fn( $term ) => $term->taxonomy === $args['taxonomy'] ) );
+		if ( isset( $args['meta_key'] ) ) {
+			$terms = array_values(
+				array_filter(
+					$terms,
+					static fn( $term ) => (int) get_term_meta( $term->term_id, $args['meta_key'], true ) === (int) $args['meta_value']
+				)
+			);
+		}
+		return 'ids' === ( $args['fields'] ?? '' ) ? array_map( static fn( $term ) => $term->term_id, $terms ) : $terms;
+	}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $key, $default = false ) {
+		return $GLOBALS['ec_artist_test']['options'][ get_current_blog_id() ][ $key ] ?? $default;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $key, $value ) {
+		$GLOBALS['ec_artist_test']['options'][ get_current_blog_id() ][ $key ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability() {
+		return $GLOBALS['ec_artist_test']['ability'];
+	}
+}
+
+require_once dirname( __DIR__, 3 ) . '/inc/abilities/events-by-artist.php';
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class EventsByArtistAbilityTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id' => 4,
+			'stack'   => array(),
+			'terms'   => array( 1 => array(), 7 => array() ),
+			'meta'    => array( 1 => array(), 7 => array() ),
+			'options' => array( 1 => array(), 7 => array() ),
+			'events'  => array( 44 => array( 'artists' => array() ) ),
+		);
+		$GLOBALS['ec_artist_test']['ability'] = new class() {
+			public function execute( array $input ): array {
+				$GLOBALS['ec_artist_test']['delegated'] = $input;
+				return array(
+					'taxonomy'  => 'artist',
+					'term_id'   => $input['term_id'],
+					'term_slug' => $input['term_slug'],
+					'found'     => true,
+					'upcoming'  => array(),
+					'past'      => array(),
+				);
+			}
+		};
+	}
+
+	private function addTerm( int $blog_id, int $term_id, string $slug, string $taxonomy = 'artist' ): void {
+		$GLOBALS['ec_artist_test']['terms'][ $blog_id ][ $term_id ] = (object) array(
+			'term_id'  => $term_id,
+			'slug'     => $slug,
+			'taxonomy' => $taxonomy,
+		);
+	}
+
+	private function bindProfile( int $canonical_id, int $profile_id = 10 ): void {
+		$GLOBALS['ec_artist_test']['meta'][1][ $canonical_id ]['_artist_profile_id'] = $profile_id;
+	}
+
+	public function test_canonical_mapping_survives_renamed_slugs(): void {
+		$this->addTerm( 1, 101, 'renamed-main' );
+		$this->addTerm( 7, 501, 'renamed-events' );
+		$GLOBALS['ec_artist_test']['meta'][1][101][ EXTRACHILL_EVENTS_ARTIST_TERM_META ] = 501;
+
+		$result = extrachill_events_ability_events_by_artist( array( 'artist_term_id' => 101 ) );
+
+		$this->assertSame( 501, $result['term_id'] );
+		$this->assertSame( 'renamed-events', $GLOBALS['ec_artist_test']['delegated']['term_slug'] );
+		$this->assertSame( 4, get_current_blog_id() );
+	}
+
+	public function test_missing_mapping_fails_closed_when_no_slug_matches(): void {
+		$this->addTerm( 1, 101, 'main-only' );
+
+		$result = extrachill_events_ability_events_by_artist( array( 'artist_term_id' => 101 ) );
+
+		$this->assertSame( 'artist_mapping_missing', $result->get_error_code() );
+		$this->assertSame( 4, get_current_blog_id() );
+	}
+
+	public function test_deleted_or_wrong_taxonomy_local_terms_are_stale(): void {
+		$this->addTerm( 1, 101, 'band' );
+		$GLOBALS['ec_artist_test']['meta'][1][101][ EXTRACHILL_EVENTS_ARTIST_TERM_META ] = 501;
+		$this->assertSame( 'stale_artist_mapping', extrachill_events_ability_events_by_artist( array( 'artist_term_id' => 101 ) )->get_error_code() );
+
+		$this->addTerm( 7, 501, 'band', 'festival' );
+		$this->assertSame( 'stale_artist_mapping', extrachill_events_ability_events_by_artist( array( 'artist_term_id' => 101 ) )->get_error_code() );
+		$this->assertSame( 4, get_current_blog_id() );
+	}
+
+	public function test_deleted_or_wrong_taxonomy_canonical_terms_are_rejected(): void {
+		$result = extrachill_events_ability_events_by_artist( array( 'artist_term_id' => 101, 'term_slug' => 'legacy-band' ) );
+		$this->assertSame( 'invalid_canonical_artist', $result->get_error_code() );
+
+		$this->addTerm( 1, 101, 'band', 'festival' );
+		$result = extrachill_events_ability_events_by_artist( array( 'artist_term_id' => 101, 'term_slug' => 'legacy-band' ) );
+		$this->assertSame( 'invalid_canonical_artist', $result->get_error_code() );
+		$this->assertSame( 4, get_current_blog_id() );
+	}
+
+	public function test_duplicate_local_claims_are_rejected(): void {
+		$this->addTerm( 1, 101, 'one' );
+		$this->addTerm( 1, 102, 'two' );
+		$this->addTerm( 7, 501, 'local' );
+		$GLOBALS['ec_artist_test']['meta'][1][101][ EXTRACHILL_EVENTS_ARTIST_TERM_META ] = 501;
+		$GLOBALS['ec_artist_test']['meta'][1][102][ EXTRACHILL_EVENTS_ARTIST_TERM_META ] = 501;
+
+		$result = extrachill_events_ability_events_by_artist( array( 'artist_term_id' => 101 ) );
+
+		$this->assertSame( 'duplicate_artist_mapping', $result->get_error_code() );
+		$this->assertSame( 4, get_current_blog_id() );
+	}
+
+	public function test_legacy_slug_lookup_remains_available(): void {
+		$this->addTerm( 7, 501, 'legacy-band' );
+
+		$result = extrachill_events_ability_events_by_artist( array( 'term_slug' => 'legacy-band' ) );
+
+		$this->assertSame( 501, $result['term_id'] );
+		$this->assertSame( 501, $GLOBALS['ec_artist_test']['delegated']['term_id'] );
+	}
+
+	public function test_backfill_maps_only_bound_exact_unclaimed_pairs_and_reports_failures(): void {
+		$this->addTerm( 1, 101, 'mapped' );
+		$this->addTerm( 1, 102, 'missing' );
+		$this->addTerm( 1, 103, 'stale' );
+		$this->addTerm( 1, 104, 'collision' );
+		$this->addTerm( 1, 105, 'collision-two' );
+		foreach ( range( 101, 105 ) as $canonical_id ) {
+			$this->bindProfile( $canonical_id, $canonical_id + 1000 );
+		}
+		$this->addTerm( 7, 501, 'mapped' );
+		$this->addTerm( 7, 504, 'collision' );
+		$this->addTerm( 7, 599, 'local-only' );
+		$GLOBALS['ec_artist_test']['meta'][1][103][ EXTRACHILL_EVENTS_ARTIST_TERM_META ] = 999;
+		$GLOBALS['ec_artist_test']['meta'][1][104][ EXTRACHILL_EVENTS_ARTIST_TERM_META ] = 504;
+		$GLOBALS['ec_artist_test']['meta'][1][105][ EXTRACHILL_EVENTS_ARTIST_TERM_META ] = 504;
+		$events_before = $GLOBALS['ec_artist_test']['events'];
+
+		$report = extrachill_events_backfill_artist_identity();
+
+		$this->assertSame( 501, $GLOBALS['ec_artist_test']['meta'][1][101][ EXTRACHILL_EVENTS_ARTIST_TERM_META ] );
+		$this->assertCount( 1, $report['mapped'] );
+		$this->assertCount( 1, $report['missing'] );
+		$this->assertCount( 1, $report['stale'] );
+		$this->assertCount( 1, $report['collisions'] );
+		$this->assertCount( 1, $report['unmatched_local'] );
+		$this->assertSame( $events_before, $GLOBALS['ec_artist_test']['events'] );
+		$this->assertSame( 4, get_current_blog_id() );
+	}
+
+	public function test_backfill_reports_ambiguous_slugs_without_mapping_them(): void {
+		$this->addTerm( 1, 101, 'duplicate' );
+		$this->addTerm( 1, 102, 'duplicate' );
+		$this->bindProfile( 101, 1101 );
+		$this->bindProfile( 102, 1102 );
+		$this->addTerm( 7, 501, 'duplicate' );
+
+		$report = extrachill_events_backfill_artist_identity();
+
+		$this->assertCount( 0, $report['mapped'] );
+		$this->assertCount( 3, $report['ambiguous'] );
+		$this->assertArrayNotHasKey( EXTRACHILL_EVENTS_ARTIST_TERM_META, $GLOBALS['ec_artist_test']['meta'][1][101] );
+		$this->assertArrayNotHasKey( EXTRACHILL_EVENTS_ARTIST_TERM_META, $GLOBALS['ec_artist_test']['meta'][1][102] );
+		$this->assertSame( 4, get_current_blog_id() );
+	}
+}


### PR DESCRIPTION
## Summary
- expose `extrachill-events/events-by-artist` as the Extra Chill-owned adapter from canonical main-site artist terms to validated local Events artist terms
- store the local Events term ID on the canonical artist term, reject stale or duplicate claims, preserve exact-slug fallback during migration, and delegate the final query through DME's generic local taxonomy/`term_id` contract
- run a bounded one-time exact-slug backfill for Artist Platform-bound canonical terms with mapped, existing, missing, unmatched-local, stale, ambiguous, and collision reporting

## Boundary
Artist identity remains entirely in Extra Chill Events. Data Machine Events receives only `taxonomy=artist`, a positive local Events `term_id`, the current local `term_slug`, and generic scope/limit values. DME does not inspect main-site terms, Artist Platform profiles, Extra Chill mapping metadata, or migration state.

The adapter consumes the stable Artist Platform profile -> canonical main-site artist term established by Extra-Chill/extrachill-artist-platform#140. It does not create a generic cross-site identity framework.

## Dependency
Depends on Extra-Chill/data-machine-events#494 and its implementation PR Extra-Chill/data-machine-events#495. This branch targets the proposed contract: local `taxonomy`, authoritative positive `term_id`, optional `term_slug`, and resolved `term_id`/`term_slug` in the response. The adapter should not ship before #495. If that contract changes materially, update this dependency rather than adding artist semantics or a compatibility workaround to DME.

## Migration
- Canonical main-site `artist` terms store the local Events artist term ID in `_extrachill_events_artist_term_id`.
- The one-time `extrachill_events_artist_identity_backfill_1` report is stored on the Events site.
- Only canonical terms carrying Artist Platform's `_artist_profile_id` binding participate.
- Only exact, one-to-one, currently unclaimed slug pairs are written.
- Existing mappings are validated and never silently replaced.
- Missing, unmatched local, stale, ambiguous, and collision cases are reported for review.
- Legacy slug lookup remains available through the adapter during cutover.
- Events and event taxonomy relationships are never mutated, so artistless events are unaffected.

## Rollback
- Keep Artist Platform on its existing slug request until this dependency and report are reviewed.
- Remove `_extrachill_events_artist_term_id` from canonical main-site artist terms to remove mappings.
- Delete the Events-site `extrachill_events_artist_identity_backfill_1` option only when intentionally rerunning the migration after correcting source data.
- No profile binding, term ID, term slug, event, or event relationship is changed by rollback.

## Tests
Passing:
- `./vendor/bin/phpunit --filter EventsByArtistAbilityTest` (8 tests, 28 assertions)
- changed-file WordPress PHPCS for the adapter, registration, and test files
- `php -l` on the adapter and focused test
- `git diff --check`

Covered:
- canonical mappings after independent slug renames
- missing mappings and legacy slug compatibility
- deleted and wrong-taxonomy canonical/local terms
- duplicate local claims
- exact unclaimed backfill, stale mappings, missing pairs, collisions, unmatched local terms, and ambiguous slugs
- artistless event data remaining untouched
- blog restoration on success and failure paths

Homeboy 0.298.0 focused and full test runs were attempted but failed before running any tests because the WordPress extension's packaged Composer autoloader cannot load `Composer\\Autoload\\ClassLoader` (runs `a548cc36-4e7a-46d4-86a2-8d67789ca724` and `1dfe9488-2651-4128-8871-46459d8fa6d4`; known extension issue Extra-Chill/homeboy-extensions#2233). Homeboy full lint hit the same extension infrastructure failure (`3ddcc9cd-0063-475e-b88d-6a5832a12224`), while the repository-local PHPCS installation passes the changed files.

The local full configured suite runs 196 tests but has 1 error and 5 failures in unrelated shared global doubles used by `QualifyRecheckHandlerTest` and `CanonicalLocationsAbilityTest`; tracked in #280. The new focused suite passes independently and in the full run.

Fixes #279