### PR TITLE
feat: turn My Shows into an onboarding surface

### DIFF
--- a/blocks/concert-stats/render.php
+++ b/blocks/concert-stats/render.php
@@ -92,6 +92,9 @@ if ( ! $user_id ) {
 		$login_url  = function_exists( 'ec_get_site_url' )
 			? trailingslashit( ec_get_site_url( 'events' ) ) . 'login/?redirect_to=' . rawurlencode( home_url( '/my-shows/' ) )
 			: wp_login_url( home_url( '/my-shows/' ) );
+		$docs_url   = function_exists( 'ec_get_site_url' )
+			? trailingslashit( ec_get_site_url( 'docs' ) ) . 'events-calendar/'
+			: 'https://docs.extrachill.com/events-calendar/';
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
@@ -101,36 +104,94 @@ if ( ! $user_id ) {
 		?>
 		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped via get_block_wrapper_attributes. ?>>
 			<div class="ec-block-shell ec-block-shell--depth-0 ec-mobile-full-width-panel">
-				<div class="ec-block-shell-inner ec-block-shell-inner--narrow">
-					<div class="ec-block-shell-header">
-						<div class="ec-block-shell-header__main">
-							<div class="ec-block-shell-header__title">
-								<?php esc_html_e( 'Your concert history, in one place', 'extrachill-events' ); ?>
+				<div class="ec-block-shell-inner">
+					<section class="ec-concert-stats-marketing__hero">
+						<div class="ec-concert-stats-marketing__hero-copy">
+							<p class="ec-concert-stats-marketing__eyebrow"><?php esc_html_e( 'Your live music life', 'extrachill-events' ); ?></p>
+							<h1><?php esc_html_e( 'Every show has a story. Keep yours.', 'extrachill-events' ); ?></h1>
+							<p class="ec-concert-stats-marketing__lede">
+								<?php esc_html_e( 'My Shows turns the concerts you have seen and the ones still ahead into a personal archive you can explore by date, artist, venue, city, and route.', 'extrachill-events' ); ?>
+							</p>
+							<div class="ec-action-row">
+								<a href="<?php echo esc_url( $signup_url ); ?>" class="button-1 button-large">
+									<?php esc_html_e( 'Start My Shows', 'extrachill-events' ); ?>
+								</a>
+								<a href="#how-it-works" class="button-2 button-large">
+									<?php esc_html_e( 'See How It Works', 'extrachill-events' ); ?>
+								</a>
 							</div>
-							<div class="ec-block-shell-header__description">
-								<?php esc_html_e( 'My Shows lets you track every concert you\'ve been to and every one you\'re going to.', 'extrachill-events' ); ?>
+							<p class="ec-concert-stats-marketing__assurance">
+								<?php esc_html_e( 'Free Extra Chill account. You control what other people can see.', 'extrachill-events' ); ?>
+							</p>
+						</div>
+						<div class="ec-concert-stats-marketing__preview" aria-label="<?php esc_attr_e( 'Example concert archive', 'extrachill-events' ); ?>">
+							<div class="ec-concert-stats-marketing__preview-header">
+								<span><?php esc_html_e( 'Your concert trail', 'extrachill-events' ); ?></span>
+								<span class="ec-concert-stats-marketing__preview-status"><?php esc_html_e( 'Always growing', 'extrachill-events' ); ?></span>
+							</div>
+							<ol class="ec-concert-stats-marketing__trail">
+								<li><span>2018</span><div class="ec-concert-stats-marketing__trail-copy"><?php esc_html_e( 'The first one you remember', 'extrachill-events' ); ?></div></li>
+								<li><span>2023</span><div class="ec-concert-stats-marketing__trail-copy"><?php esc_html_e( 'The set you still talk about', 'extrachill-events' ); ?></div></li>
+								<li><span><?php esc_html_e( 'Next', 'extrachill-events' ); ?></span><div class="ec-concert-stats-marketing__trail-copy"><?php esc_html_e( 'The show already on your calendar', 'extrachill-events' ); ?></div></li>
+							</ol>
+							<div class="ec-concert-stats-marketing__preview-tabs" aria-hidden="true">
+								<span><?php esc_html_e( 'History', 'extrachill-events' ); ?></span>
+								<span><?php esc_html_e( 'Calendar', 'extrachill-events' ); ?></span>
+								<span><?php esc_html_e( 'Map', 'extrachill-events' ); ?></span>
+								<span><?php esc_html_e( 'Stats', 'extrachill-events' ); ?></span>
 							</div>
 						</div>
-					</div>
-					<div class="ec-panel ec-panel--depth-1">
-						<div class="ec-section ec-section--depth-2">
-							<h3><?php esc_html_e( 'What you can do', 'extrachill-events' ); ?></h3>
-							<ul>
-								<li><?php esc_html_e( 'Mark events as \'Going\' or \'I Was There\' — across decades of past shows', 'extrachill-events' ); ?></li>
-								<li><?php esc_html_e( 'See your concert history on a calendar and a map, with chronological tour routes for the artists you\'ve followed', 'extrachill-events' ); ?></li>
-								<li><?php esc_html_e( 'Import your full history from setlist.fm or phish.net', 'extrachill-events' ); ?></li>
-								<li><?php esc_html_e( 'Stats: shows, venues, artists, cities', 'extrachill-events' ); ?></li>
-							</ul>
+					</section>
+
+					<section id="how-it-works" class="ec-concert-stats-marketing__section">
+						<p class="ec-concert-stats-marketing__eyebrow"><?php esc_html_e( 'Three simple moves', 'extrachill-events' ); ?></p>
+						<h2><?php esc_html_e( 'Build an archive that gets better with every show', 'extrachill-events' ); ?></h2>
+						<div class="ec-concert-stats-marketing__steps">
+							<article><span>1</span><h3><?php esc_html_e( 'Find a show', 'extrachill-events' ); ?></h3><p><?php esc_html_e( 'Browse upcoming events or search decades of past concerts.', 'extrachill-events' ); ?></p></article>
+							<article><span>2</span><h3><?php esc_html_e( 'Mark your place', 'extrachill-events' ); ?></h3><p><?php esc_html_e( 'Choose Going for what is ahead or I Was There for the nights already lived.', 'extrachill-events' ); ?></p></article>
+							<article><span>3</span><h3><?php esc_html_e( 'Explore your history', 'extrachill-events' ); ?></h3><p><?php esc_html_e( 'Watch your calendar, map, route, and personal stats take shape.', 'extrachill-events' ); ?></p></article>
 						</div>
+					</section>
+
+					<section class="ec-concert-stats-marketing__section ec-concert-stats-marketing__feature-grid">
+						<article><p class="ec-concert-stats-marketing__feature-label"><?php esc_html_e( 'Remember', 'extrachill-events' ); ?></p><h3><?php esc_html_e( 'A chronological concert archive', 'extrachill-events' ); ?></h3><p><?php esc_html_e( 'Keep upcoming plans and past memories together without losing the details.', 'extrachill-events' ); ?></p></article>
+						<article><p class="ec-concert-stats-marketing__feature-label"><?php esc_html_e( 'See', 'extrachill-events' ); ?></p><h3><?php esc_html_e( 'Calendar and map views', 'extrachill-events' ); ?></h3><p><?php esc_html_e( 'Move through years of shows and trace the cities and venues that shaped your route.', 'extrachill-events' ); ?></p></article>
+						<article><p class="ec-concert-stats-marketing__feature-label"><?php esc_html_e( 'Learn', 'extrachill-events' ); ?></p><h3><?php esc_html_e( 'Stats with a human pulse', 'extrachill-events' ); ?></h3><p><?php esc_html_e( 'Discover your most-seen artists, most-visited venues, cities, and milestones.', 'extrachill-events' ); ?></p></article>
+						<article><p class="ec-concert-stats-marketing__feature-label"><?php esc_html_e( 'Return', 'extrachill-events' ); ?></p><h3><?php esc_html_e( 'A home for what comes next', 'extrachill-events' ); ?></h3><p><?php esc_html_e( 'Keep upcoming shows close and receive an Extra Chill reminder before showtime.', 'extrachill-events' ); ?></p></article>
+					</section>
+
+					<section class="ec-concert-stats-marketing__section ec-concert-stats-marketing__split">
+						<article class="ec-panel ec-panel--depth-1">
+							<p class="ec-concert-stats-marketing__eyebrow"><?php esc_html_e( 'Already have a history?', 'extrachill-events' ); ?></p>
+							<h2><?php esc_html_e( 'Bring the whole archive with you', 'extrachill-events' ); ?></h2>
+							<p><?php esc_html_e( 'Import attended shows from setlist.fm or phish.net. My Shows matches what it can and adds missing events so the story does not start today.', 'extrachill-events' ); ?></p>
+							<a href="<?php echo esc_url( $docs_url . 'importing-concert-history/' ); ?>"><?php esc_html_e( 'How concert imports work', 'extrachill-events' ); ?> &rarr;</a>
+						</article>
+						<article class="ec-panel ec-panel--depth-1">
+							<p class="ec-concert-stats-marketing__eyebrow"><?php esc_html_e( 'Your history, your call', 'extrachill-events' ); ?></p>
+							<h2><?php esc_html_e( 'Private by default for new accounts', 'extrachill-events' ); ?></h2>
+							<p><?php esc_html_e( 'Choose whether people can view your past concert history and whether your identity appears on event attendee lists. Upcoming plans stay owner-only.', 'extrachill-events' ); ?></p>
+							<a href="<?php echo esc_url( $docs_url . 'concert-history-privacy/' ); ?>"><?php esc_html_e( 'Understand privacy controls', 'extrachill-events' ); ?> &rarr;</a>
+						</article>
+					</section>
+
+					<section class="ec-concert-stats-marketing__section ec-concert-stats-marketing__docs">
+						<div>
+							<p class="ec-concert-stats-marketing__eyebrow"><?php esc_html_e( 'No guesswork', 'extrachill-events' ); ?></p>
+							<h2><?php esc_html_e( 'Start with the full My Shows guide', 'extrachill-events' ); ?></h2>
+							<p><?php esc_html_e( 'Learn how marking, search, imports, public histories, and each dashboard view fit together.', 'extrachill-events' ); ?></p>
+						</div>
+						<a href="<?php echo esc_url( $docs_url . 'getting-started-with-my-shows/' ); ?>" class="button-2 button-large"><?php esc_html_e( 'Read the Guide', 'extrachill-events' ); ?></a>
+					</section>
+
+					<section class="ec-concert-stats-marketing__closing">
+						<h2><?php esc_html_e( 'Your next favorite show belongs here.', 'extrachill-events' ); ?></h2>
+						<p><?php esc_html_e( 'Start with one concert. The archive grows from there.', 'extrachill-events' ); ?></p>
 						<div class="ec-action-row ec-action-row--center">
-							<a href="<?php echo esc_url( $signup_url ); ?>" class="button-1 button-large">
-								<?php esc_html_e( 'Sign Up', 'extrachill-events' ); ?>
-							</a>
-							<a href="<?php echo esc_url( $login_url ); ?>" class="button-2 button-large">
-								<?php esc_html_e( 'Log In', 'extrachill-events' ); ?>
-							</a>
+							<a href="<?php echo esc_url( $signup_url ); ?>" class="button-1 button-large"><?php esc_html_e( 'Create Free Account', 'extrachill-events' ); ?></a>
+							<a href="<?php echo esc_url( $login_url ); ?>" class="button-2 button-large"><?php esc_html_e( 'Log In', 'extrachill-events' ); ?></a>
 						</div>
-					</div>
+					</section>
 				</div>
 			</div>
 		</div>

--- a/blocks/concert-stats/src/style.scss
+++ b/blocks/concert-stats/src/style.scss
@@ -27,6 +27,274 @@
 	justify-content: center;
 }
 
+/* ─── Anonymous My Shows landing page ─────────────────────────────────── */
+
+/* stylelint-disable no-descending-specificity */
+.ec-concert-stats-shell--marketing {
+
+	.ec-block-shell-inner {
+		max-width: 1120px;
+	}
+
+	h1,
+	h2,
+	h3,
+	p {
+		margin-top: 0;
+	}
+}
+
+.ec-concert-stats-marketing__hero {
+	display: grid;
+	grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+	align-items: center;
+	gap: clamp(2rem, 6vw, 5rem);
+	padding: clamp(2.5rem, 7vw, 6rem) 0;
+}
+
+.ec-concert-stats-marketing__hero-copy h1 {
+	max-width: 720px;
+	margin-bottom: var(--spacing-lg, 1.5rem);
+	font-size: clamp(2.5rem, 6vw, 5.5rem);
+	line-height: 0.98;
+	letter-spacing: -0.045em;
+}
+
+.ec-concert-stats-marketing__lede {
+	max-width: 680px;
+	margin-bottom: var(--spacing-xl, 2rem);
+	font-size: clamp(1.05rem, 2vw, 1.3rem);
+	line-height: 1.65;
+	color: var(--muted-text, #6b7280);
+}
+
+.ec-concert-stats-marketing__eyebrow,
+.ec-concert-stats-marketing__feature-label {
+	margin-bottom: var(--spacing-sm, 0.5rem);
+	font-size: var(--font-size-xs, 0.75rem);
+	font-weight: 700;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--accent-color, #53940b);
+}
+
+.ec-concert-stats-marketing__assurance {
+	margin: var(--spacing-md, 1rem) 0 0;
+	font-size: var(--font-size-sm, 0.875rem);
+	color: var(--muted-text, #6b7280);
+}
+
+.ec-concert-stats-marketing__preview {
+	position: relative;
+	padding: clamp(1.25rem, 3vw, 2rem);
+	overflow: hidden;
+	background:
+		radial-gradient(circle at 90% 5%, rgba(83, 148, 11, 0.2), transparent 34%),
+		var(--card-background, #f9fafb);
+	border: 1px solid var(--border-color, #e5e7eb);
+	border-radius: var(--border-radius-lg, 16px);
+	box-shadow: var(--card-shadow, 0 18px 48px rgba(0, 0, 0, 0.1));
+}
+
+.ec-concert-stats-marketing__preview-header {
+	display: flex;
+	justify-content: space-between;
+	gap: var(--spacing-md, 1rem);
+	padding-bottom: var(--spacing-md, 1rem);
+	font-weight: 700;
+	border-bottom: 1px solid var(--border-color, #e5e7eb);
+}
+
+.ec-concert-stats-marketing__preview-status {
+	font-size: var(--font-size-xs, 0.75rem);
+	font-weight: 600;
+	color: var(--accent-color, #53940b);
+}
+
+.ec-concert-stats-marketing__trail {
+	position: relative;
+	padding: var(--spacing-lg, 1.5rem) 0;
+	margin: 0;
+	list-style: none;
+}
+
+.ec-concert-stats-marketing__trail::before {
+	position: absolute;
+	top: 2rem;
+	bottom: 2rem;
+	left: 2.2rem;
+	width: 2px;
+	content: "";
+	background: var(--accent-color, #53940b);
+	opacity: 0.35;
+}
+
+.ec-concert-stats-marketing__trail li {
+	position: relative;
+	display: grid;
+	grid-template-columns: 4.5rem 1fr;
+	gap: var(--spacing-md, 1rem);
+	align-items: center;
+	min-height: 4.5rem;
+}
+
+.ec-concert-stats-marketing__trail li span {
+	z-index: 1;
+	display: grid;
+	width: 4.5rem;
+	height: 2rem;
+	place-items: center;
+	font-size: var(--font-size-xs, 0.75rem);
+	font-weight: 700;
+	background: var(--background-color, #fff);
+	border: 1px solid var(--accent-color, #53940b);
+	border-radius: 999px;
+}
+
+.ec-concert-stats-marketing__trail-copy {
+	font-size: var(--font-size-sm, 0.875rem);
+	font-weight: 700;
+}
+
+.ec-concert-stats-marketing__preview-tabs {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--spacing-xs, 0.25rem);
+}
+
+.ec-concert-stats-marketing__preview-tabs span {
+	padding: var(--spacing-xs, 0.25rem) var(--spacing-sm, 0.5rem);
+	font-size: var(--font-size-xs, 0.75rem);
+	color: var(--muted-text, #6b7280);
+	background: var(--background-color, #fff);
+	border: 1px solid var(--border-color, #e5e7eb);
+	border-radius: 999px;
+}
+
+.ec-concert-stats-marketing__section {
+	padding: clamp(2.5rem, 6vw, 5rem) 0;
+	border-top: 1px solid var(--border-color, #e5e7eb);
+}
+
+.ec-concert-stats-marketing__section > h2 {
+	max-width: 760px;
+	margin-bottom: clamp(2rem, 4vw, 3rem);
+	font-size: clamp(1.8rem, 4vw, 3.25rem);
+	line-height: 1.12;
+	letter-spacing: -0.025em;
+}
+
+.ec-concert-stats-marketing__steps,
+.ec-concert-stats-marketing__feature-grid,
+.ec-concert-stats-marketing__split {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: var(--spacing-xl, 2rem);
+}
+
+.ec-concert-stats-marketing__steps article span {
+	display: grid;
+	width: 2.5rem;
+	height: 2.5rem;
+	margin-bottom: var(--spacing-md, 1rem);
+	place-items: center;
+	font-weight: 700;
+	color: var(--background-color, #fff);
+	background: var(--accent-color, #53940b);
+	border-radius: 999px;
+}
+
+.ec-concert-stats-marketing__steps h3,
+.ec-concert-stats-marketing__feature-grid h3 {
+	margin-bottom: var(--spacing-sm, 0.5rem);
+}
+
+.ec-concert-stats-marketing__steps p,
+.ec-concert-stats-marketing__feature-grid article > p:last-child,
+.ec-concert-stats-marketing__split article > p:not(.ec-concert-stats-marketing__eyebrow),
+.ec-concert-stats-marketing__docs p {
+	color: var(--muted-text, #6b7280);
+}
+
+.ec-concert-stats-marketing__feature-grid {
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.ec-concert-stats-marketing__feature-grid article {
+	padding: clamp(1.25rem, 3vw, 2rem);
+	background: var(--card-background, #f9fafb);
+	border-left: 3px solid var(--accent-color, #53940b);
+}
+
+.ec-concert-stats-marketing__split {
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.ec-concert-stats-marketing__split article {
+	padding: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.ec-concert-stats-marketing__split article > a {
+	display: inline-block;
+	margin-top: var(--spacing-md, 1rem);
+	font-weight: 700;
+}
+
+.ec-concert-stats-marketing__docs {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--spacing-xl, 2rem);
+}
+
+.ec-concert-stats-marketing__docs > div {
+	max-width: 680px;
+}
+
+.ec-concert-stats-marketing__docs h2 {
+	margin-bottom: var(--spacing-sm, 0.5rem);
+}
+
+.ec-concert-stats-marketing__closing {
+	padding: clamp(3rem, 8vw, 6rem) clamp(1.25rem, 5vw, 4rem);
+	text-align: center;
+	background: var(--card-background, #f9fafb);
+	border: 1px solid var(--border-color, #e5e7eb);
+	border-radius: var(--border-radius-lg, 16px);
+}
+
+.ec-concert-stats-marketing__closing h2 {
+	margin-bottom: var(--spacing-sm, 0.5rem);
+	font-size: clamp(2rem, 5vw, 4rem);
+	line-height: 1.05;
+	letter-spacing: -0.035em;
+}
+
+.ec-concert-stats-marketing__closing p {
+	margin-bottom: var(--spacing-xl, 2rem);
+	color: var(--muted-text, #6b7280);
+}
+
+@media (max-width: 780px) {
+
+	.ec-concert-stats-marketing__hero,
+	.ec-concert-stats-marketing__steps,
+	.ec-concert-stats-marketing__feature-grid,
+	.ec-concert-stats-marketing__split {
+		grid-template-columns: 1fr;
+	}
+
+	.ec-concert-stats-marketing__hero {
+		padding-top: var(--spacing-xl, 2rem);
+	}
+
+	.ec-concert-stats-marketing__docs {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+}
+/* stylelint-enable no-descending-specificity */
+
 /* ─── Stats Bar (canonical StatGroup / StatTile primitives) ─────────────── */
 
 /*

--- a/docs/user/concert-history-privacy.md
+++ b/docs/user/concert-history-privacy.md
@@ -1,0 +1,35 @@
+# Concert History Privacy
+
+My Shows separates two privacy decisions so you can share a concert archive without automatically appearing on every event's attendee list.
+
+## Concert History Visibility
+
+This setting controls whether another person can open your past concert history and aggregate stats.
+
+- **Private** keeps the history available only to you and authorized administrators.
+- **Public** allows other people to view past shows and stats connected to your profile.
+
+Upcoming shows remain owner-only even when the history is public.
+
+## Event Attendance Visibility
+
+This setting controls whether your identity may appear in the attendee list on an individual event.
+
+- **Private** keeps your mark counted without exposing your identity publicly.
+- **Public** allows your profile identity to appear with the event's other visible attendees.
+
+Changing this setting does not add or remove any shows from My Shows.
+
+## Defaults
+
+New Extra Chill accounts receive private defaults for both settings. Older accounts created before these controls were introduced may retain their previous public behavior until changed.
+
+## Change Your Settings
+
+Open your account menu, choose **Settings**, and find the privacy controls for concert history and event attendance. Save each choice after reviewing it.
+
+Privacy changes apply to the network, not only the site where you changed them.
+
+## What Is Never Public
+
+Public concert-history readers cannot use your owner controls, edit attendance, run imports, or view your Upcoming tab, calendar, or personal route map.

--- a/docs/user/exploring-concert-history.md
+++ b/docs/user/exploring-concert-history.md
@@ -1,0 +1,40 @@
+# Exploring Your Concert History
+
+My Shows turns marked events into several views. Each view answers a different question about your live music life.
+
+## Upcoming
+
+Upcoming is your private concert itinerary. It contains future shows you marked Going and provides a direct path back to each event.
+
+Other people cannot view this tab when looking at your concert history.
+
+## Past
+
+Past is your chronological archive. Use the year control to focus on one part of your history. The same tab includes search so you can add another concert without leaving the page.
+
+## Calendar
+
+Calendar places your tracked shows on a month grid. Move between months to revisit busy stretches, festival weekends, and quieter years.
+
+## Map
+
+Map plots tracked venues and connects them in chronological order. A venue can contain multiple dates when you returned for more than one show.
+
+## Stats
+
+Stats summarizes:
+
+- Total shows
+- Unique artists
+- Unique venues
+- Unique cities
+- Most-seen artists
+- Most-visited venues and cities
+
+Select a summary number to jump to the view that explains it.
+
+## Public Views
+
+When concert-history visibility is public, other people can see past shows and aggregate stats. They do not receive your upcoming itinerary, owner controls, imports, calendar, or route map.
+
+Read [Concert History Privacy](https://docs.extrachill.com/events-calendar/concert-history-privacy/) before sharing your history.

--- a/docs/user/finding-live-music.md
+++ b/docs/user/finding-live-music.md
@@ -1,0 +1,23 @@
+# Finding Live Music
+
+Extra Chill Events helps you move from a broad question like “what is happening tonight?” to the right show, artist, venue, or city.
+
+## Start Near You
+
+Open [Live Music Near Me](https://events.extrachill.com/near-me/) and allow location access when prompted. Extra Chill uses your location to find relevant event markets without changing your saved profile location.
+
+## Browse a City
+
+Location pages collect upcoming shows for a city or region. They are useful for planning a night out, checking a destination before traveling, or following a scene outside your hometown.
+
+## Search the Network
+
+Use site search to look for an artist, venue, festival, or event title. Choose **This site** when you only want Events results or **Entire network** when you also want articles and community discussions.
+
+## Explore Artists and Venues
+
+Artist pages show known upcoming appearances. Venue pages provide a calendar for that room. Select taxonomy links on an event to keep exploring related listings.
+
+## Save What Matters
+
+When you find the right event, mark it Going. It will appear in [My Shows](https://events.extrachill.com/my-shows/) with your other plans and can trigger an in-app reminder before showtime.

--- a/docs/user/getting-started-with-my-shows.md
+++ b/docs/user/getting-started-with-my-shows.md
@@ -1,0 +1,44 @@
+# Getting Started with My Shows
+
+My Shows is your personal concert archive on Extra Chill. It keeps the shows you have attended and the shows you plan to attend in one place, then turns that history into a calendar, map, and personal music stats.
+
+## Start Your Archive
+
+1. Sign in to your Extra Chill account.
+2. Visit [My Shows](https://events.extrachill.com/my-shows/).
+3. Open the **Past** tab to search for a concert you attended, or browse the Events Calendar for an upcoming show.
+4. Mark the event. The button says **Going**, **Check In**, or **I Was There** based on when the show happens.
+
+Your marked event appears in My Shows immediately.
+
+## What You Can Explore
+
+- **Upcoming** keeps future plans together.
+- **Past** is your chronological concert history and includes search for older shows.
+- **Calendar** lays your tracked shows out month by month.
+- **Map** connects your concert history across cities and venues.
+- **Stats** shows your most-seen artists, venues, cities, and total shows.
+- **Import** brings in an existing setlist.fm or phish.net history when an import source is available.
+
+## Add Shows from Event Pages
+
+You do not have to begin in My Shows. Every event page includes an attendance control. Mark an upcoming event as Going or a past event as I Was There, and it joins your archive automatically.
+
+## Share Only What You Want
+
+New accounts begin with private concert-history and attendee-identity settings. You can independently choose whether other people may see your past concert history and whether your identity appears in an event's attendee list.
+
+Upcoming plans remain owner-only when another person views a concert history.
+
+Read [Concert History Privacy](https://docs.extrachill.com/events-calendar/concert-history-privacy/) for the complete behavior.
+
+## Next Steps
+
+- [Marking Shows](https://docs.extrachill.com/events-calendar/marking-shows/)
+- [Importing Your Concert History](https://docs.extrachill.com/events-calendar/importing-concert-history/)
+- [Exploring Your Concert History](https://docs.extrachill.com/events-calendar/exploring-concert-history/)
+- [Show Reminders and Milestones](https://docs.extrachill.com/events-calendar/show-reminders-and-milestones/)
+
+## Support
+
+If a show is missing or something does not look right, read [Troubleshooting My Shows](https://docs.extrachill.com/events-calendar/troubleshooting-my-shows/) or visit the [Tech Support Forum](https://community.extrachill.com/r/tech-support).

--- a/docs/user/importing-concert-history.md
+++ b/docs/user/importing-concert-history.md
@@ -1,0 +1,33 @@
+# Importing Your Concert History
+
+If you already track concerts on setlist.fm or phish.net, My Shows can bring that history into Extra Chill without making you mark every show again.
+
+## Before You Begin
+
+- Sign in to the Extra Chill account that should own the history.
+- Make sure the username you enter belongs to the source account you want to import.
+- Open the **Import** tab in [My Shows](https://events.extrachill.com/my-shows/?tab=import).
+
+Only import sources currently available to your account appear in the tab.
+
+## Preview the Import
+
+Choose a source and enter the requested username. Previewing lets you review the source and estimated work before starting the full import.
+
+## What Extra Chill Does
+
+For every imported attendance record, Extra Chill attempts to match the show to an event already in the Events Calendar. When a show is missing, the importer can add the event so your history stays complete.
+
+Matched and created events are marked as attended and become part of your calendar, map, and stats.
+
+## While an Import Runs
+
+Large histories take time. My Shows displays import progress and keeps a record of recent runs. You can leave the page and return later.
+
+The importer only handles historical attendance. It does not create upcoming Going marks or schedule reminders for imported past shows.
+
+## Avoiding Duplicates
+
+My Shows stores one mark per person and event. Importing a show you already marked does not create a second attendance entry.
+
+If one real-world concert appears twice because the source data matched two different event records, report both event links in the [Tech Support Forum](https://community.extrachill.com/r/tech-support).

--- a/docs/user/marking-shows.md
+++ b/docs/user/marking-shows.md
@@ -1,0 +1,39 @@
+# Marking Shows
+
+Marking an event adds it to My Shows. Extra Chill uses one simple attendance record and changes the label based on the event's timing.
+
+## What the Labels Mean
+
+- **Going** means the show is upcoming.
+- **Check In** appears while the show is happening.
+- **I Was There** means the show has passed.
+
+The label changes automatically. You never need to update a Going mark after the event ends.
+
+## Mark an Upcoming Show
+
+1. Open an event on [Extra Chill Events](https://events.extrachill.com/).
+2. Select **Going**.
+3. Sign in or create an account if prompted.
+4. Return to My Shows to find it under **Upcoming**.
+
+Upcoming marks can schedule an in-app reminder before showtime.
+
+## Mark a Past Show
+
+You can mark a past event directly from its event page. You can also:
+
+1. Open [My Shows](https://events.extrachill.com/my-shows/).
+2. Choose **Past**.
+3. Search by artist, event, or venue.
+4. Select **I Was There** on the correct result.
+
+The show joins your Past list, calendar, map, and stats.
+
+## Remove a Mark
+
+Select the marked attendance button again to remove the show. Removing an upcoming mark also cancels its pending reminder.
+
+## If You Cannot Find a Past Show
+
+Try a shorter artist or venue search. If you already track your history elsewhere, [import your concert history](https://docs.extrachill.com/events-calendar/importing-concert-history/). For other cases, see [Troubleshooting My Shows](https://docs.extrachill.com/events-calendar/troubleshooting-my-shows/).

--- a/docs/user/show-reminders-and-milestones.md
+++ b/docs/user/show-reminders-and-milestones.md
@@ -1,0 +1,32 @@
+# Show Reminders and Milestones
+
+My Shows uses in-app notifications to bring you back at useful moments without turning a historical import into a flood of alerts.
+
+## Upcoming Show Reminders
+
+When you mark an upcoming event Going, Extra Chill schedules one reminder for approximately two days before the show.
+
+If the show is already less than two days away but still has enough lead time, the reminder is scheduled soon instead. Shows that have started do not receive an upcoming reminder.
+
+Removing the Going mark cancels the pending reminder.
+
+## Historical Shows
+
+Past shows and ongoing check-ins do not schedule reminders. Imports also do not schedule reminders because imported records represent historical attendance.
+
+## Milestones
+
+Extra Chill celebrates tracked-show totals at:
+
+- Your first show
+- 10 shows
+- 25 shows
+- 50 shows
+- 100 shows
+- Every additional 100 shows
+
+Milestones appear as in-app notifications and link back to My Shows.
+
+## Finding Notifications
+
+Open the notification bell while signed in. Unread reminders remain there until viewed or until the event passes, when stale reminders are automatically resolved.

--- a/docs/user/submitting-an-event.md
+++ b/docs/user/submitting-an-event.md
@@ -1,0 +1,35 @@
+# How to Submit an Event
+
+Artists, venues, promoters, and community members can send a public live music event to the Extra Chill Events Calendar.
+
+## Before You Submit
+
+Gather the most reliable version of:
+
+- Event title
+- Start date and local time
+- Venue name and location
+- Artist lineup
+- Official ticket or information link
+- Event flyer
+- Contact information for follow-up
+
+Use the organizer's official source whenever possible.
+
+## Submit the Event
+
+1. Open [Submit Event](https://events.extrachill.com/submit/).
+2. Complete the required event and contact fields.
+3. Upload a clear flyer when one is available.
+4. Review the date, time, venue, and link.
+5. Complete the verification challenge and submit.
+
+## What Happens Next
+
+Submission does not guarantee immediate publication. Extra Chill reviews and processes the information before it becomes a public event listing.
+
+Avoid submitting the same event repeatedly. If you need to correct a pending or published listing, send the existing event URL and corrected information through the [Tech Support Forum](https://community.extrachill.com/r/tech-support).
+
+## After Publication
+
+Share the event page with your audience. Signed-in users can mark the show Going, add it to My Shows, and receive an in-app reminder before the event.

--- a/docs/user/troubleshooting-my-shows.md
+++ b/docs/user/troubleshooting-my-shows.md
@@ -1,0 +1,37 @@
+# Troubleshooting My Shows
+
+Use these checks when a concert is missing, an import does not match, or a public history behaves differently than expected.
+
+## A Show Is Missing from Search
+
+- Try the artist name without the venue or tour name.
+- Search for the venue instead of the artist.
+- Confirm that you are searching the Past tab for a past event.
+- Check the event date in case the listing uses a neighboring calendar day because of its local timezone.
+
+If the event is not in Extra Chill, use [Submit Event](https://events.extrachill.com/submit/) or import an existing history so the importer can create supported missing events.
+
+## A Mark Does Not Appear
+
+- Confirm you are signed into the intended Extra Chill account.
+- Reload My Shows after marking from another browser tab.
+- Check the correct Upcoming or Past section based on the event's current timing.
+- Clear the year filter if one is active.
+
+## An Import Is Missing Shows
+
+Review the import run status and source username. Source records without enough date, artist, or venue information may not produce a confident match.
+
+## A Concert Appears Twice
+
+My Shows prevents duplicate marks on the same Extra Chill event. Two entries usually mean the real-world concert exists as two separate event records. Send both event links to support so they can be reconciled.
+
+## Another Person Cannot See My History
+
+Check **Concert History Visibility** in account settings. Event Attendance Visibility is a separate control and does not make the full history public.
+
+See [Concert History Privacy](https://docs.extrachill.com/events-calendar/concert-history-privacy/) for details.
+
+## Get Help
+
+Post the event URL, expected date, and what you already tried in the [Tech Support Forum](https://community.extrachill.com/r/tech-support). Do not include passwords or private source-account credentials.

--- a/docs/user/using-calendar-filters.md
+++ b/docs/user/using-calendar-filters.md
@@ -1,0 +1,35 @@
+# Using Calendar Filters
+
+The Extra Chill Events Calendar covers shows across many cities and markets. Filters help narrow the full calendar to the artists, venues, festivals, dates, and locations that matter to you.
+
+## Apply Filters
+
+1. Visit [Extra Chill Events](https://events.extrachill.com/).
+2. Open the calendar filters.
+3. Choose a location, artist, venue, festival, or date range.
+4. Apply additional filters when you need a more specific result.
+
+The calendar updates to match the active choices.
+
+## Use Search
+
+Calendar search works well when you already know part of an artist, event, or venue name. Filters are better for browsing a category or place.
+
+## Filtered Pages
+
+Many links open a calendar that is already scoped for you:
+
+- Location pages show events in that city or region.
+- Venue pages show events at that room.
+- Artist pages show appearances by that performer.
+- Festival pages group related dates and listings.
+
+You can continue refining results from these pages.
+
+## Clear Filters
+
+Use the reset control to return to the complete upcoming calendar. If a copied URL keeps restoring an old filter, return to the [Events homepage](https://events.extrachill.com/) before beginning another search.
+
+## Save an Event
+
+Open an event and mark it Going to keep it in [My Shows](https://events.extrachill.com/my-shows/).

--- a/tests/Unit/ConcertStatsPublicProfileRenderTest.php
+++ b/tests/Unit/ConcertStatsPublicProfileRenderTest.php
@@ -98,6 +98,24 @@ if ( ! function_exists( 'wp_login_url' ) ) {
 	}
 }
 
+if ( ! function_exists( 'ec_get_site_url' ) ) {
+	function ec_get_site_url( $site ) {
+		return 'https://' . $site . '.example';
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $value ) {
+		return rtrim( $value, '/' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'esc_attr_e' ) ) {
+	function esc_attr_e( $text ) {
+		echo htmlspecialchars( (string) $text, ENT_QUOTES );
+	}
+}
+
 if ( ! function_exists( 'do_blocks' ) ) {
 	function do_blocks( $content ) {
 		return '<div class="embedded-block">' . htmlspecialchars( $content, ENT_QUOTES ) . '</div>';
@@ -178,6 +196,19 @@ final class ConcertStatsPublicProfileRenderTest extends TestCase {
 		$this->assertStringContainsString( 'data-is-own="0"', $output );
 		$this->assertStringContainsString( 'data-public-date-to="2026-07-18"', $output );
 		$this->assertStringNotContainsString( 'ec-concert-stats-shell--marketing', $output );
+	}
+
+	public function test_logged_out_visitor_gets_complete_marketing_and_docs_surface(): void {
+		$output = $this->renderBlock();
+
+		$this->assertStringContainsString( 'ec-concert-stats-shell--marketing', $output );
+		$this->assertStringContainsString( 'Every show has a story. Keep yours.', $output );
+		$this->assertStringContainsString( 'id="how-it-works"', $output );
+		$this->assertStringContainsString( 'https://community.example/register/', $output );
+		$this->assertStringContainsString( '/events-calendar/getting-started-with-my-shows/', $output );
+		$this->assertStringContainsString( '/events-calendar/importing-concert-history/', $output );
+		$this->assertStringContainsString( '/events-calendar/concert-history-privacy/', $output );
+		$this->assertStringNotContainsString( 'class="ec-concert-stats"', $output );
 	}
 
 	public function test_invalid_selection_does_not_fall_back_to_viewer(): void {


### PR DESCRIPTION
## Summary

- replace the anonymous My Shows utility card with a responsive acquisition page that explains the workflow, previews the archive, and foregrounds imports and privacy
- add direct contextual links into the Events documentation collection
- establish ten canonical `docs/user/` guides covering My Shows, discovery, filtering, submission, imports, privacy, reminders, and troubleshooting
- add server-render regression coverage for the anonymous page and documentation paths

## Why

My Shows is receiving early exploration but not converting that interest into attendance marks. The current anonymous state names features without showing how the product fits into a fan's live music life, while the Docs site has no My Shows coverage and still describes an old Charleston/Austin-only Events product.

The docs are placed in this owning repository so the Git-backed Docs sync remains the source of truth. Production sync repair is tracked separately in Extra-Chill/extrachill-docs#51; the landing page should deploy together with, or after, those destination pages become available.

## Verification

- `npm run build`
- `npm run test:js -- --runInBand` (24 tests passed)
- `npm run lint:js`
- isolated PHP render suite (7 tests, 37 assertions passed)
- PHPCS on changed PHP files
- `git diff --check`

The complete configured PHP suite retains the existing shared-test-double failures tracked in #280: 196 pass, five failures and one error in QualifyRecheckHandler/CanonicalLocations. The changed render suite passes in isolation and in the full run.

Stylelint on `concert-stats/src/style.scss` retains 11 pre-existing violations outside this change, tracked in #285. The production Sass build succeeds.

Closes #284