### PR TITLE
fix: anchor My Shows map to Local Scene

### DIFF
--- a/inc/core/my-shows-map-filter.php
+++ b/inc/core/my-shows-map-filter.php
@@ -76,6 +76,40 @@ function ec_events_my_shows_emit_map_scope_token( $scope_token, $context = array
 add_filter( 'data_machine_events_map_scope_token', 'ec_events_my_shows_emit_map_scope_token', 10, 2 );
 
 /**
+ * Anchor the owner My Shows map to the account's canonical Local Scene.
+ *
+ * Extra Chill Users owns this private preference. The account-market resolver
+ * consumes its public Ability contract and returns canonical location-term
+ * coordinates; this integration only passes those coordinates into the
+ * generic map center seam.
+ *
+ * @param mixed $center  Existing map center.
+ * @param array $context Map render context from Data Machine Events.
+ * @return mixed Existing center or Local Scene coordinates.
+ */
+function ec_events_my_shows_map_account_center( $center, array $context = array() ) {
+	$is_route_map = ! empty( $context['attributes']['chronologicalRouteMode'] );
+	if ( null !== $center || ! $is_route_map || ! is_page( 'my-shows' ) || get_current_user_id() < 1 ) {
+		return $center;
+	}
+
+	if ( ! function_exists( 'extrachill_events_get_account_market' ) ) {
+		return $center;
+	}
+
+	$market = extrachill_events_get_account_market();
+	if ( null === $market || null === $market['lat'] || null === $market['lon'] ) {
+		return $center;
+	}
+
+	return array(
+		'lat' => $market['lat'],
+		'lon' => $market['lon'],
+	);
+}
+add_filter( 'data_machine_events_map_center', 'ec_events_my_shows_map_account_center', 20, 2 );
+
+/**
  * Restrict events-map venue lookup to venues of the token owner's
  * tracked shows.
  *

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -101,6 +101,18 @@ if ( ! function_exists( 'is_front_page' ) ) {
 	}
 }
 
+if ( ! function_exists( 'is_page' ) ) {
+	function is_page( $slug = '' ) {
+		return ( $GLOBALS['test_page_slug'] ?? '' ) === $slug;
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id() {
+		return (int) ( $GLOBALS['test_current_user_id'] ?? 0 );
+	}
+}
+
 if ( ! function_exists( 'is_admin' ) ) {
 	function is_admin() {
 		return false;
@@ -281,6 +293,7 @@ if ( ! function_exists( 'wp_verify_nonce' ) ) {
 
 require_once dirname( __DIR__, 3 ) . '/inc/core/router-pages.php';
 require_once dirname( __DIR__, 3 ) . '/inc/core/account-market.php';
+require_once dirname( __DIR__, 3 ) . '/inc/core/my-shows-map-filter.php';
 
 /**
  * Verifies the account preference integration and its precedence gates.
@@ -478,6 +491,57 @@ final class AccountMarketTest extends TestCase {
 
 		$GLOBALS['test_is_near_me_page'] = false;
 		$this->assertFalse( extrachill_events_supports_account_market() );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_my_shows_route_map_uses_account_market_center(): void {
+		$GLOBALS['test_is_user_logged_in']      = true;
+		$GLOBALS['test_current_user_id']        = 42;
+		$GLOBALS['test_page_slug']              = 'my-shows';
+		$GLOBALS['test_account_market_ability'] = new class() {
+			public function execute(): array {
+				return array(
+					'local_scene' => array(
+						'slug'        => 'charleston',
+						'term_id'     => 1618,
+						'coordinates' => array(
+							'lat' => 32.7765,
+							'lon' => -79.9311,
+						),
+					),
+				);
+			}
+		};
+		$context                                = array(
+			'attributes' => array( 'chronologicalRouteMode' => true ),
+		);
+
+		$this->assertSame(
+			array(
+				'lat' => 32.7765,
+				'lon' => -79.9311,
+			),
+			ec_events_my_shows_map_account_center( null, $context )
+		);
+	}
+
+	public function test_my_shows_center_preserves_stronger_context_and_other_maps(): void {
+		$existing = array(
+			'lat' => 40.7128,
+			'lon' => -74.0060,
+		);
+
+		$this->assertSame(
+			$existing,
+			ec_events_my_shows_map_account_center(
+				$existing,
+				array( 'attributes' => array( 'chronologicalRouteMode' => true ) )
+			)
+		);
+		$this->assertNull( ec_events_my_shows_map_account_center( null, array() ) );
 	}
 
 	public function test_location_directory_is_enabled_by_default(): void {


### PR DESCRIPTION
## Summary

- resolve the signed-in owner's canonical Local Scene through the existing account-market integration
- pass its location-term coordinates to Data Machine Events' generic map-center seam
- scope the behavior to the owner My Shows chronological-route map
- preserve any stronger center and fail open when the preference or coordinates are missing

## Architecture

Extra Chill Users remains the source of truth through `extrachill/get-user-settings`. Extra Chill Events owns the consumer integration. Data Machine Events remains generic and only honors the supplied center while fitting route bounds in Extra-Chill/data-machine-events#505.

No `user_location` marker is emitted because Local Scene is a configured market, not the user's current physical position.

## Verification

- `AccountMarketTest`: 24 tests, 67 assertions passed
- PHP syntax checks passed
- changed runtime file passes PHPCS
- `git diff --check`

The test harness retains its pre-existing standalone-stub PHPCS baseline.

Depends on Extra-Chill/data-machine-events#505.

Closes #288