### PR TITLE
fix: distinguish unsupported qualification sources

### DIFF
--- a/inc/Abilities/QualifyDigestAbilities.php
+++ b/inc/Abilities/QualifyDigestAbilities.php
@@ -258,7 +258,8 @@ class QualifyDigestAbilities {
 
 		// Newly-qualified venues this week — count of QUALIFIED_STRUCTURED
 		// verdict rows in the window.
-		$new_qualified = 0;
+		$new_qualified       = 0;
+		$unsupported_sources = 0;
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table name is a trusted internal identifier built from $wpdb->prefix.
 		if ( $wpdb->get_var( "SHOW TABLES LIKE '" . $verdicts_table . "'" ) === $verdicts_table ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -267,6 +268,16 @@ class QualifyDigestAbilities {
 					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a trusted internal identifier built from $wpdb->prefix.
 					"SELECT COUNT(*) FROM {$verdicts_table} WHERE verdict = %s AND qualified_at >= %s AND qualified_at <= %s",
 					QualifyVerdict::QUALIFIED_STRUCTURED,
+					$start,
+					$end
+				)
+			);
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$unsupported_sources = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a trusted internal identifier built from $wpdb->prefix.
+					"SELECT COUNT(*) FROM {$verdicts_table} WHERE verdict = %s AND qualified_at >= %s AND qualified_at <= %s",
+					QualifyVerdict::UNSUPPORTED_SOURCE,
 					$start,
 					$end
 				)
@@ -305,6 +316,7 @@ class QualifyDigestAbilities {
 			'paused_total'        => array_sum( $paused_by_verdict ),
 			'resumed_total'       => $resumed_count,
 			'new_qualified_total' => $new_qualified,
+			'unsupported_total'   => $unsupported_sources,
 			'stale_total'         => count( $stale_flows ),
 		);
 
@@ -339,6 +351,7 @@ class QualifyDigestAbilities {
 		$h .= '<tr><td>Flows paused this week</td><td class="count">' . (int) $data['counts']['paused_total'] . '</td></tr>';
 		$h .= '<tr><td>Flows auto-resumed this week</td><td class="count">' . (int) $data['counts']['resumed_total'] . '</td></tr>';
 		$h .= '<tr><td>New venues qualified</td><td class="count">' . (int) $data['counts']['new_qualified_total'] . '</td></tr>';
+		$h .= '<tr><td>Unsupported sources identified</td><td class="count">' . (int) ( $data['counts']['unsupported_total'] ?? 0 ) . '</td></tr>';
 		$h .= '<tr><td>Stale paused flows (need review)</td><td class="count">' . (int) $data['counts']['stale_total'] . '</td></tr>';
 		$h .= '</table>';
 
@@ -415,6 +428,7 @@ class QualifyDigestAbilities {
 		$lines[] = sprintf( 'Paused this week:        %d flows', (int) $data['counts']['paused_total'] );
 		$lines[] = sprintf( 'Auto-resumed this week:  %d flows', (int) $data['counts']['resumed_total'] );
 		$lines[] = sprintf( 'New venues qualified:    %d', (int) $data['counts']['new_qualified_total'] );
+		$lines[] = sprintf( 'Unsupported sources:     %d', (int) ( $data['counts']['unsupported_total'] ?? 0 ) );
 		$lines[] = sprintf( 'Stale paused flows:      %d', (int) $data['counts']['stale_total'] );
 		$lines[] = '';
 

--- a/inc/Abilities/QualifyDigestAbilities.php
+++ b/inc/Abilities/QualifyDigestAbilities.php
@@ -211,16 +211,14 @@ class QualifyDigestAbilities {
 			if ( ! is_array( $cfg ) ) {
 				continue;
 			}
-			$paused_at_str = (string) ( $cfg['paused_at'] ?? '' );
-			$paused_at_ts  = '' !== $paused_at_str ? strtotime( $paused_at_str . ' UTC' ) : false;
-			if ( $paused_at_ts && $paused_at_ts >= $start_ts && $paused_at_ts <= $end_ts ) {
+			$paused_at_ts = self::site_datetime_timestamp( (string) ( $cfg['paused_at'] ?? '' ), $timezone );
+			if ( null !== $paused_at_ts && $paused_at_ts >= $start_ts && $paused_at_ts < $end_ts ) {
 				$verdict                       = (string) ( $cfg['paused_reason'] ?? 'unknown' );
 				$paused_by_verdict[ $verdict ] = ( $paused_by_verdict[ $verdict ] ?? 0 ) + 1;
 			}
 
-			$resumed_at_str = (string) ( $cfg['resumed_at'] ?? '' );
-			$resumed_at_ts  = '' !== $resumed_at_str ? strtotime( $resumed_at_str . ' UTC' ) : false;
-			if ( $resumed_at_ts && $resumed_at_ts >= $start_ts && $resumed_at_ts <= $end_ts && ! empty( $cfg['resumed_by_qualify'] ) ) {
+			$resumed_at_ts = self::site_datetime_timestamp( (string) ( $cfg['resumed_at'] ?? '' ), $timezone );
+			if ( null !== $resumed_at_ts && $resumed_at_ts >= $start_ts && $resumed_at_ts < $end_ts && ! empty( $cfg['resumed_by_qualify'] ) ) {
 				++$resumed_count;
 			}
 
@@ -267,7 +265,7 @@ class QualifyDigestAbilities {
 			$new_qualified = (int) $wpdb->get_var(
 				$wpdb->prepare(
 					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a trusted internal identifier built from $wpdb->prefix.
-					"SELECT COUNT(*) FROM {$verdicts_table} WHERE verdict = %s AND qualified_at >= %s AND qualified_at <= %s",
+					"SELECT COUNT(*) FROM {$verdicts_table} WHERE verdict = %s AND qualified_at >= %s AND qualified_at < %s",
 					QualifyVerdict::QUALIFIED_STRUCTURED,
 					$start,
 					$end
@@ -291,7 +289,7 @@ class QualifyDigestAbilities {
 				$wpdb->prepare(
 					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a trusted internal identifier built from $wpdb->prefix.
 					"SELECT improvement_hint, COUNT(*) AS c FROM {$verdicts_table}
-					 WHERE verdict = %s AND qualified_at >= %s AND qualified_at <= %s
+					 WHERE verdict = %s AND qualified_at >= %s AND qualified_at < %s
 					 GROUP BY improvement_hint
 					 ORDER BY c DESC LIMIT 3",
 					QualifyVerdict::EXTRACTION_GAP,
@@ -472,5 +470,21 @@ class QualifyDigestAbilities {
 		$lines[] = 'Run: wp extrachill venues qualify-stats   for the full breakdown.';
 
 		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Parse a DATETIME stored by current_time( 'mysql' ) in the site timezone.
+	 *
+	 * @param string        $value    Stored local DATETIME value.
+	 * @param \DateTimeZone $timezone Site timezone.
+	 * @return int|null Unix timestamp, or null for an invalid value.
+	 */
+	private static function site_datetime_timestamp( string $value, \DateTimeZone $timezone ): ?int {
+		if ( '' === $value ) {
+			return null;
+		}
+
+		$date = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $value, $timezone );
+		return false === $date ? null : $date->getTimestamp();
 	}
 }

--- a/inc/Abilities/QualifyDigestAbilities.php
+++ b/inc/Abilities/QualifyDigestAbilities.php
@@ -274,13 +274,20 @@ class QualifyDigestAbilities {
 			);
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$unsupported_sources = (int) $wpdb->get_var(
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a trusted internal identifier built from $wpdb->prefix.
 				$wpdb->prepare(
-					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a trusted internal identifier built from $wpdb->prefix.
-					"SELECT COUNT(*) FROM {$verdicts_table} WHERE verdict = %s AND qualified_at >= %s AND qualified_at <= %s",
+					"SELECT COUNT(*) FROM {$verdicts_table} v
+					 INNER JOIN (
+						 SELECT url_hash, MAX(id) AS max_id
+						 FROM {$verdicts_table}
+						 GROUP BY url_hash
+					 ) latest ON latest.max_id = v.id
+					 WHERE v.verdict = %s AND v.qualified_at >= %s AND v.qualified_at <= %s",
 					QualifyVerdict::UNSUPPORTED_SOURCE,
 					$start,
 					$end
 				)
+				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			);
 		}
 

--- a/inc/Abilities/QualifyDigestAbilities.php
+++ b/inc/Abilities/QualifyDigestAbilities.php
@@ -182,8 +182,9 @@ class QualifyDigestAbilities {
 	public function gather_data( int $start_ts, int $end_ts ): array {
 		global $wpdb;
 
-		$start = gmdate( 'Y-m-d H:i:s', $start_ts );
-		$end   = gmdate( 'Y-m-d H:i:s', $end_ts );
+		$timezone = wp_timezone();
+		$start    = wp_date( 'Y-m-d H:i:s', $start_ts, $timezone );
+		$end      = wp_date( 'Y-m-d H:i:s', $end_ts, $timezone );
 
 		$verdicts_table = QualifyVerdictsTable::table_name();
 		$flows_table    = $wpdb->prefix . 'datamachine_flows';
@@ -272,22 +273,10 @@ class QualifyDigestAbilities {
 					$end
 				)
 			);
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$unsupported_sources = (int) $wpdb->get_var(
-				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a trusted internal identifier built from $wpdb->prefix.
-				$wpdb->prepare(
-					"SELECT COUNT(*) FROM {$verdicts_table} v
-					 INNER JOIN (
-						 SELECT url_hash, MAX(id) AS max_id
-						 FROM {$verdicts_table}
-						 GROUP BY url_hash
-					 ) latest ON latest.max_id = v.id
-					 WHERE v.verdict = %s AND v.qualified_at >= %s AND v.qualified_at <= %s",
-					QualifyVerdict::UNSUPPORTED_SOURCE,
-					$start,
-					$end
-				)
-				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$unsupported_sources = QualifyVerdictsTable::count_latest_verdicts_in_window(
+				QualifyVerdict::UNSUPPORTED_SOURCE,
+				$start,
+				$end
 			);
 		}
 

--- a/inc/Cli/RequalifyFlowCommand.php
+++ b/inc/Cli/RequalifyFlowCommand.php
@@ -145,7 +145,7 @@ class RequalifyFlowCommand {
 				$row['action'] = 'review_recommended';
 			} elseif ( $auto ) {
 				// Not qualified anymore and --auto-pause is set — pause the flow.
-				$ok            = $this->pause_flow_by_verdict( $flow['flow_id'], $row['new_verdict'] );
+				$ok            = $this->pause_requalified_flow( $flow, $row['new_verdict'] );
 				$row['action'] = $ok ? 'paused' : 'pause_failed';
 			} else {
 				// Not qualified anymore — recommend pause without acting.
@@ -176,5 +176,16 @@ class RequalifyFlowCommand {
 			\WP_CLI::log( '' );
 			\WP_CLI::warning( sprintf( '%d flow(s) recommend pausing. Re-run with --auto-pause to apply.', count( $recommended ) ) );
 		}
+	}
+
+	/**
+	 * Pause a requalified flow while preserving the URL needed by rechecks.
+	 *
+	 * @param array  $flow    Flow metadata from FlowHelpers.
+	 * @param string $verdict New qualification verdict.
+	 * @return bool True when the flow was paused.
+	 */
+	protected function pause_requalified_flow( array $flow, string $verdict ): bool {
+		return $this->pause_flow_by_verdict( $flow['flow_id'], $verdict, $flow['source_url'] );
 	}
 }

--- a/inc/Core/QualifyVerdict.php
+++ b/inc/Core/QualifyVerdict.php
@@ -41,6 +41,9 @@ final class QualifyVerdict {
 	/** Page reachable, structured data present, but our extractors do not cover it. Fixable. */
 	public const EXTRACTION_GAP = 'extraction_gap';
 
+	/** Page reachable, but no evidence identifies actionable extractor work. */
+	public const UNSUPPORTED_SOURCE = 'unsupported_source';
+
 	/** Reservation-only platform (OpenTable/Resy/Tock). Permanently disqualify. */
 	public const RESERVATION_ONLY = 'reservation_only';
 
@@ -97,6 +100,7 @@ final class QualifyVerdict {
 			self::QUALIFIED_STRUCTURED,
 			self::QUALIFIED_FOR_FLYER,
 			self::EXTRACTION_GAP,
+			self::UNSUPPORTED_SOURCE,
 			self::RESERVATION_ONLY,
 			self::BOT_BLOCKED,
 			self::UNREACHABLE,
@@ -136,6 +140,8 @@ final class QualifyVerdict {
 
 	public const GUIDANCE_EXTRACTION_GAP = 'Page is reachable and contains structured data, but our extractors did not parse it. Fetch the URL via WebFetch and inspect the HTML. If you can identify a predictable pattern (JSON-LD shape, platform-specific markup, etc.), file an issue against data-machine-events suggesting the extractor fix. DO NOT recommend wiring this venue until the extractor lands.';
 
+	public const GUIDANCE_UNSUPPORTED_SOURCE = 'Page is reachable, but the fingerprint contains no structured event data or detected platform with a missing extractor. Do NOT treat this as extractor work or recommend wiring. Re-qualify only if the source changes or relevant platform support lands.';
+
 	public const GUIDANCE_BOT_BLOCKED = 'HTTP 403/429 — venue origin is blocking our scraper. No code-level fix is possible without proxy support. Park the URL; revisit when proxy support lands. Do NOT recommend wiring.';
 
 	public const GUIDANCE_RESERVATION_ONLY = 'Venue uses OpenTable/Resy/Tock for reservations only and does not publish event listings. Permanently disqualified. Do NOT recommend wiring. Do NOT file an extractor issue.';
@@ -159,6 +165,8 @@ final class QualifyVerdict {
 				return self::GUIDANCE_QUALIFIED_FOR_FLYER;
 			case self::EXTRACTION_GAP:
 				return self::GUIDANCE_EXTRACTION_GAP;
+			case self::UNSUPPORTED_SOURCE:
+				return self::GUIDANCE_UNSUPPORTED_SOURCE;
 			case self::BOT_BLOCKED:
 				return self::GUIDANCE_BOT_BLOCKED;
 			case self::RESERVATION_ONLY:
@@ -173,7 +181,8 @@ final class QualifyVerdict {
 	}
 
 	/**
-	 * Whether a verdict is fixable by shipping a new/improved extractor.
+	 * Whether a verdict can change through source recovery, source updates, or
+	 * new/improved extractor support.
 	 *
 	 * Used by requalify-pending to decide which verdicts to consider
 	 * candidates for automatic re-qualification when a new extractor lands.
@@ -184,7 +193,7 @@ final class QualifyVerdict {
 	public static function is_requalifiable( string $verdict ): bool {
 		return in_array(
 			$verdict,
-			array( self::EXTRACTION_GAP, self::BOT_BLOCKED, self::UNREACHABLE ),
+			array( self::EXTRACTION_GAP, self::UNSUPPORTED_SOURCE, self::BOT_BLOCKED, self::UNREACHABLE ),
 			true
 		);
 	}
@@ -204,6 +213,8 @@ final class QualifyVerdict {
 	// QUALIFIED_STRUCTURED / QUALIFIED_FOR_FLYER: never auto-paused.
 	// EXTRACTION_GAP: 2 verdicts over ≥48h — extractor gaps don't fix
 	// themselves between consecutive audit runs.
+	// UNSUPPORTED_SOURCE: 2 verdicts over ≥48h — require confirmation before
+	// pausing a source that may have temporarily stopped exposing events.
 	// BOT_BLOCKED / UNREACHABLE: 3 verdicts over ≥7 days — Cloudflare rules
 	// flip; DNS/timeout/5xx is often transient.
 	// RESERVATION_ONLY / COVERED_ELSEWHERE: single verdict — these are
@@ -218,6 +229,10 @@ final class QualifyVerdict {
 		self::QUALIFIED_STRUCTURED => null,
 		self::QUALIFIED_FOR_FLYER  => null,
 		self::EXTRACTION_GAP       => array(
+			'verdicts' => 2,
+			'hours'    => 48,
+		),
+		self::UNSUPPORTED_SOURCE   => array(
 			'verdicts' => 2,
 			'hours'    => 48,
 		),
@@ -261,6 +276,7 @@ final class QualifyVerdict {
 	// to the digest after 6 consecutive failures).
 	//
 	// EXTRACTION_GAP: 14d — extractor coverage usually ships in batches.
+	// UNSUPPORTED_SOURCE: 30d — sources may change or gain platform support.
 	// BOT_BLOCKED:    7d  — Cloudflare rules can flip.
 	// UNREACHABLE:    3d  — DNS/timeout/5xx is often short-lived.
 	// QUALIFIED_FOR_FLYER: 21d — operator-review state; long cadence.
@@ -273,6 +289,7 @@ final class QualifyVerdict {
 	 */
 	public const RECHECK_INTERVALS = array(
 		self::EXTRACTION_GAP      => 14 * DAY_IN_SECONDS,
+		self::UNSUPPORTED_SOURCE  => 30 * DAY_IN_SECONDS,
 		self::BOT_BLOCKED         => 7 * DAY_IN_SECONDS,
 		self::UNREACHABLE         => 3 * DAY_IN_SECONDS,
 		self::QUALIFIED_FOR_FLYER => 21 * DAY_IN_SECONDS,

--- a/inc/Core/QualifyVerdictResolver.php
+++ b/inc/Core/QualifyVerdictResolver.php
@@ -16,7 +16,7 @@
  *  7. JSON-LD/microdata present but 0 events extracted  → EXTRACTION_GAP
  *  8. platform detected but no extractor exists for it  → EXTRACTION_GAP
  *  9. reservation-only platform and no other platforms  → RESERVATION_ONLY
- * 10. default                                           → EXTRACTION_GAP
+ * 10. default                                           → UNSUPPORTED_SOURCE
  *
  * @package ExtraChillEvents\Core
  * @since   0.20.0
@@ -212,9 +212,9 @@ class QualifyVerdictResolver {
 
 		// ---- 10. Default fallback. ----
 		return self::bundle(
-			QualifyVerdict::EXTRACTION_GAP,
+			QualifyVerdict::UNSUPPORTED_SOURCE,
 			'',
-			'Scraper could not extract events from any discovered URL. Manual investigation recommended.',
+			'Reachable source contains no structured event data or detected platform requiring a missing extractor.',
 			0
 		);
 	}

--- a/inc/Core/QualifyVerdictsTable.php
+++ b/inc/Core/QualifyVerdictsTable.php
@@ -207,6 +207,58 @@ class QualifyVerdictsTable {
 	}
 
 	/**
+	 * Count URLs whose canonical latest verdict matches inside a local-time window.
+	 *
+	 * Verdict timestamps are stored with current_time( 'mysql' ), so callers must
+	 * pass site-local DATETIME bounds. The window is half-open [start, end).
+	 * Canonical latest ordering matches latest_for_url_hash(): qualified_at DESC,
+	 * then id DESC. This remains correct for backfilled rows whose IDs do not
+	 * reflect event time and makes timestamp ties deterministic.
+	 *
+	 * Keep this query as the shared latest-window semantic for digest/cohort
+	 * consumers; do not replace it with MAX(id) grouping.
+	 *
+	 * @param string $verdict    Verdict to count.
+	 * @param string $start_local Inclusive site-local DATETIME bound.
+	 * @param string $end_local   Exclusive site-local DATETIME bound.
+	 * @return int Distinct canonical URLs matching the verdict.
+	 */
+	public static function count_latest_verdicts_in_window( string $verdict, string $start_local, string $end_local ): int {
+		global $wpdb;
+		$table = self::table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$count = $wpdb->get_var(
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a trusted internal identifier built from $wpdb->prefix.
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT current_verdict.url_hash)
+				 FROM {$table} current_verdict
+				 WHERE current_verdict.verdict = %s
+				   AND current_verdict.qualified_at >= %s
+				   AND current_verdict.qualified_at < %s
+				   AND NOT EXISTS (
+					 SELECT 1
+					 FROM {$table} newer_verdict
+					 WHERE newer_verdict.url_hash = current_verdict.url_hash
+					   AND (
+						 newer_verdict.qualified_at > current_verdict.qualified_at
+						 OR (
+							 newer_verdict.qualified_at = current_verdict.qualified_at
+							 AND newer_verdict.id > current_verdict.id
+						 )
+					   )
+				   )",
+				$verdict,
+				$start_local,
+				$end_local
+			)
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+
+		return (int) $count;
+	}
+
+	/**
 	 * Fetch the N most recent verdict rows for a URL hash, newest first.
 	 *
 	 * Used by meets_pause_confirmation() to inspect verdict history when

--- a/tests/Unit/Core/QualifyConfirmationRulesTest.php
+++ b/tests/Unit/Core/QualifyConfirmationRulesTest.php
@@ -33,6 +33,13 @@ class QualifyConfirmationRulesTest extends TestCase {
 		$this->assertSame( 168, $rule['hours'] );
 	}
 
+	public function test_unsupported_source_requires_two_verdicts_over_48h(): void {
+		$rule = QualifyVerdict::confirmation_for( QualifyVerdict::UNSUPPORTED_SOURCE );
+		$this->assertIsArray( $rule );
+		$this->assertSame( 2, $rule['verdicts'] );
+		$this->assertSame( 48, $rule['hours'] );
+	}
+
 	public function test_unreachable_requires_three_verdicts_over_7_days(): void {
 		$rule = QualifyVerdict::confirmation_for( QualifyVerdict::UNREACHABLE );
 		$this->assertIsArray( $rule );
@@ -64,6 +71,10 @@ class QualifyConfirmationRulesTest extends TestCase {
 
 	public function test_bot_blocked_recheck_interval_is_7_days(): void {
 		$this->assertSame( 7 * DAY_IN_SECONDS, QualifyVerdict::recheck_interval_for( QualifyVerdict::BOT_BLOCKED ) );
+	}
+
+	public function test_unsupported_source_recheck_interval_is_30_days(): void {
+		$this->assertSame( 30 * DAY_IN_SECONDS, QualifyVerdict::recheck_interval_for( QualifyVerdict::UNSUPPORTED_SOURCE ) );
 	}
 
 	public function test_unreachable_recheck_interval_is_3_days(): void {

--- a/tests/Unit/Core/QualifyDigestAbilityTest.php
+++ b/tests/Unit/Core/QualifyDigestAbilityTest.php
@@ -16,12 +16,14 @@ use ExtraChillEvents\Core\QualifyVerdict;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Stubs/digest-stubs.php';
+require_once __DIR__ . '/Stubs/class-qualifydigestwpdbstub.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Core/QualifyVerdictsTable.php';
 require_once dirname( __DIR__, 3 ) . '/inc/Abilities/QualifyDigestAbilities.php';
 
 class QualifyDigestAbilityTest extends TestCase {
 
 	protected function tearDown(): void {
-		unset( $GLOBALS['wpdb'] );
+		unset( $GLOBALS['wpdb'], $GLOBALS['ec_digest_timezone'] );
 		parent::tearDown();
 	}
 
@@ -147,9 +149,13 @@ class QualifyDigestAbilityTest extends TestCase {
 		$this->assertStringContainsString( '9', $body, 'unsupported source total' );
 	}
 
-	public function test_digest_counts_only_latest_unsupported_urls_in_window(): void {
-		$start = strtotime( '2026-07-01 00:00:00 UTC' );
-		$end   = strtotime( '2026-07-08 00:00:00 UTC' );
+	/**
+	 * Digest boundaries use site-local time and canonical latest-row ordering.
+	 */
+	public function test_digest_uses_canonical_latest_unsupported_rows_in_local_half_open_window(): void {
+		$start                         = strtotime( '2026-07-01 04:00:00 UTC' );
+		$end                           = strtotime( '2026-07-08 04:00:00 UTC' );
+		$GLOBALS['ec_digest_timezone'] = 'America/New_York';
 
 		$wpdb            = new QualifyDigestWpdbStub(
 			array(
@@ -178,79 +184,167 @@ class QualifyDigestAbilityTest extends TestCase {
 					'qualified_at' => '2026-07-05 00:00:00',
 				),
 				array(
-					'id'           => 5,
-					'url_hash'     => 'old',
+					'id'           => 100,
+					'url_hash'     => 'backfill',
 					'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
-					'qualified_at' => '2026-06-15 00:00:00',
+					'qualified_at' => '2026-07-02 00:00:00',
+				),
+				array(
+					'id'           => 5,
+					'url_hash'     => 'backfill',
+					'verdict'      => QualifyVerdict::QUALIFIED_STRUCTURED,
+					'qualified_at' => '2026-07-06 00:00:00',
+				),
+				array(
+					'id'           => 10,
+					'url_hash'     => 'timestamp-tie',
+					'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+					'qualified_at' => '2026-07-06 12:00:00',
+				),
+				array(
+					'id'           => 11,
+					'url_hash'     => 'timestamp-tie',
+					'verdict'      => QualifyVerdict::QUALIFIED_STRUCTURED,
+					'qualified_at' => '2026-07-06 12:00:00',
+				),
+				array(
+					'id'           => 12,
+					'url_hash'     => 'end-boundary',
+					'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+					'qualified_at' => '2026-07-08 00:00:00',
 				),
 				array(
 					'id'           => 6,
 					'url_hash'     => 'current',
 					'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
-					'qualified_at' => '2026-07-06 00:00:00',
+					'qualified_at' => '2026-07-07 00:00:00',
 				),
 			)
 		);
-		$GLOBALS['wpdb'] = $wpdb;
+		$GLOBALS['wpdb'] = $wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test installs an isolated database stub.
 
 		$data = ( new QualifyDigestAbilities() )->gather_data( $start, $end );
 
 		$this->assertSame( 2, $data['counts']['unsupported_total'] );
-		$this->assertStringContainsString( 'MAX(id) AS max_id', $wpdb->unsupported_query );
-		$this->assertStringContainsString( 'GROUP BY url_hash', $wpdb->unsupported_query );
-		$this->assertStringContainsString( 'latest.max_id = v.id', $wpdb->unsupported_query );
-	}
-}
-
-class QualifyDigestWpdbStub {
-
-	public string $prefix            = 'c8c_';
-	public string $unsupported_query = '';
-	private array $verdict_rows;
-	private array $prepared_args = array();
-
-	public function __construct( array $verdict_rows ) {
-		$this->verdict_rows = $verdict_rows;
+		$this->assertSame( array( QualifyVerdict::UNSUPPORTED_SOURCE, '2026-07-01 00:00:00', '2026-07-08 00:00:00' ), $wpdb->unsupported_args );
+		$this->assertStringContainsString( 'COUNT(DISTINCT current_verdict.url_hash)', $wpdb->unsupported_query );
+		$this->assertStringContainsString( 'current_verdict.qualified_at <', $wpdb->unsupported_query );
+		$this->assertStringContainsString( 'newer_verdict.qualified_at > current_verdict.qualified_at', $wpdb->unsupported_query );
+		$this->assertStringContainsString( 'newer_verdict.id > current_verdict.id', $wpdb->unsupported_query );
+		$this->assertStringNotContainsString( 'MAX(id)', $wpdb->unsupported_query );
 	}
 
-	public function prepare( string $sql, ...$args ): string {
-		foreach ( $args as $arg ) {
-			$sql = preg_replace( '/%[sd]/', is_string( $arg ) ? "'{$arg}'" : (string) $arg, $sql, 1 );
-		}
-		$this->prepared_args[ $sql ] = $args;
-		return $sql;
+	/**
+	 * Verify each edge case in the canonical latest unsupported contract.
+	 *
+	 * @param array<int,array<string,mixed>> $rows     Verdict history.
+	 * @param int                            $expected Expected URL count.
+	 *
+	 * @dataProvider latestUnsupportedContractProvider
+	 */
+	public function test_latest_unsupported_count_contract( array $rows, int $expected ): void {
+		$GLOBALS['wpdb'] = new QualifyDigestWpdbStub( $rows ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test installs an isolated database stub.
+
+		$data = ( new QualifyDigestAbilities() )->gather_data(
+			strtotime( '2026-07-01 00:00:00 UTC' ),
+			strtotime( '2026-07-08 00:00:00 UTC' )
+		);
+
+		$this->assertSame( $expected, $data['counts']['unsupported_total'] );
 	}
 
-	public function get_results( string $sql, $output = ARRAY_A ): array {
-		return array();
-	}
-
-	public function get_var( string $sql ) {
-		if ( 0 === strpos( $sql, 'SHOW TABLES LIKE' ) ) {
-			return $this->prefix . 'dme_qualify_verdicts';
-		}
-		if ( false === strpos( $sql, "v.verdict = '" . QualifyVerdict::UNSUPPORTED_SOURCE . "'" ) ) {
-			return 0;
-		}
-
-		$this->unsupported_query = $sql;
-		$args                    = $this->prepared_args[ $sql ];
-		$latest                  = array();
-		foreach ( $this->verdict_rows as $row ) {
-			$hash = $row['url_hash'];
-			if ( ! isset( $latest[ $hash ] ) || $row['id'] > $latest[ $hash ]['id'] ) {
-				$latest[ $hash ] = $row;
-			}
-		}
-
-		$count = 0;
-		foreach ( $latest as $row ) {
-			if ( QualifyVerdict::UNSUPPORTED_SOURCE === $row['verdict']
-				&& $row['qualified_at'] >= $args[1]
-				&& $row['qualified_at'] <= $args[2] ) {
-				++$count;
-			}
-		}
-		return $count;
+	/**
+	 * Edge cases required by the latest unsupported contract.
+	 *
+	 * @return array<string,array{0:array<int,array<string,mixed>>,1:int}>
+	 */
+	public static function latestUnsupportedContractProvider(): array {
+		return array(
+			'backfilled higher id does not override newer timestamp' => array(
+				array(
+					array(
+						'id'           => 100,
+						'url_hash'     => 'backfill',
+						'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+						'qualified_at' => '2026-07-02 00:00:00',
+					),
+					array(
+						'id'           => 5,
+						'url_hash'     => 'backfill',
+						'verdict'      => QualifyVerdict::QUALIFIED_STRUCTURED,
+						'qualified_at' => '2026-07-03 00:00:00',
+					),
+				),
+				0,
+			),
+			'timestamp tie uses higher id'    => array(
+				array(
+					array(
+						'id'           => 10,
+						'url_hash'     => 'tie',
+						'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+						'qualified_at' => '2026-07-03 00:00:00',
+					),
+					array(
+						'id'           => 11,
+						'url_hash'     => 'tie',
+						'verdict'      => QualifyVerdict::QUALIFIED_STRUCTURED,
+						'qualified_at' => '2026-07-03 00:00:00',
+					),
+				),
+				0,
+			),
+			'end boundary is excluded'        => array(
+				array(
+					array(
+						'id'           => 1,
+						'url_hash'     => 'boundary',
+						'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+						'qualified_at' => '2026-07-08 00:00:00',
+					),
+				),
+				0,
+			),
+			'recovered URL is excluded'       => array(
+				array(
+					array(
+						'id'           => 1,
+						'url_hash'     => 'recovered',
+						'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+						'qualified_at' => '2026-07-02 00:00:00',
+					),
+					array(
+						'id'           => 2,
+						'url_hash'     => 'recovered',
+						'verdict'      => QualifyVerdict::QUALIFIED_STRUCTURED,
+						'qualified_at' => '2026-07-04 00:00:00',
+					),
+				),
+				0,
+			),
+			'repeated rechecks count one URL' => array(
+				array(
+					array(
+						'id'           => 1,
+						'url_hash'     => 'repeat',
+						'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+						'qualified_at' => '2026-07-02 00:00:00',
+					),
+					array(
+						'id'           => 2,
+						'url_hash'     => 'repeat',
+						'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+						'qualified_at' => '2026-07-03 00:00:00',
+					),
+					array(
+						'id'           => 3,
+						'url_hash'     => 'repeat',
+						'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+						'qualified_at' => '2026-07-04 00:00:00',
+					),
+				),
+				1,
+			),
+		);
 	}
 }

--- a/tests/Unit/Core/QualifyDigestAbilityTest.php
+++ b/tests/Unit/Core/QualifyDigestAbilityTest.php
@@ -235,6 +235,120 @@ class QualifyDigestAbilityTest extends TestCase {
 	}
 
 	/**
+	 * Every digest event section uses the same site-local half-open window.
+	 */
+	public function test_all_digest_sections_exclude_exact_end_boundary_in_site_timezone(): void {
+		$GLOBALS['ec_digest_timezone'] = 'America/New_York';
+		$verdict_rows                  = array(
+			array(
+				'id'           => 1,
+				'url_hash'     => 'qualified-start',
+				'verdict'      => QualifyVerdict::QUALIFIED_STRUCTURED,
+				'qualified_at' => '2026-07-01 00:00:00',
+			),
+			array(
+				'id'           => 2,
+				'url_hash'     => 'qualified-end',
+				'verdict'      => QualifyVerdict::QUALIFIED_STRUCTURED,
+				'qualified_at' => '2026-07-08 00:00:00',
+			),
+			array(
+				'id'               => 3,
+				'url_hash'         => 'gap-start',
+				'verdict'          => QualifyVerdict::EXTRACTION_GAP,
+				'qualified_at'     => '2026-07-01 00:00:00',
+				'improvement_hint' => 'inside gap',
+			),
+			array(
+				'id'               => 4,
+				'url_hash'         => 'gap-end',
+				'verdict'          => QualifyVerdict::EXTRACTION_GAP,
+				'qualified_at'     => '2026-07-08 00:00:00',
+				'improvement_hint' => 'excluded gap',
+			),
+			array(
+				'id'           => 5,
+				'url_hash'     => 'unsupported-start',
+				'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+				'qualified_at' => '2026-07-01 00:00:00',
+			),
+			array(
+				'id'           => 6,
+				'url_hash'     => 'unsupported-end',
+				'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+				'qualified_at' => '2026-07-08 00:00:00',
+			),
+		);
+		$flow_rows                     = array(
+			array(
+				'flow_id'           => 1,
+				'flow_name'         => 'Paused Start',
+				'scheduling_config' => wp_json_encode(
+					array(
+						'paused_at'     => '2026-07-01 00:00:00',
+						'paused_reason' => QualifyVerdict::EXTRACTION_GAP,
+					)
+				),
+			),
+			array(
+				'flow_id'           => 2,
+				'flow_name'         => 'Paused End',
+				'scheduling_config' => wp_json_encode(
+					array(
+						'paused_at'     => '2026-07-08 00:00:00',
+						'paused_reason' => QualifyVerdict::UNSUPPORTED_SOURCE,
+					)
+				),
+			),
+			array(
+				'flow_id'           => 3,
+				'flow_name'         => 'Resumed Start',
+				'scheduling_config' => wp_json_encode(
+					array(
+						'resumed_at'         => '2026-07-01 00:00:00',
+						'resumed_by_qualify' => true,
+					)
+				),
+			),
+			array(
+				'flow_id'           => 4,
+				'flow_name'         => 'Resumed End',
+				'scheduling_config' => wp_json_encode(
+					array(
+						'resumed_at'         => '2026-07-08 00:00:00',
+						'resumed_by_qualify' => true,
+					)
+				),
+			),
+		);
+		$wpdb                          = new QualifyDigestWpdbStub( $verdict_rows, $flow_rows );
+		$GLOBALS['wpdb']               = $wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test installs an isolated database stub.
+
+		$data = ( new QualifyDigestAbilities() )->gather_data(
+			strtotime( '2026-07-01 04:00:00 UTC' ),
+			strtotime( '2026-07-08 04:00:00 UTC' )
+		);
+
+		$this->assertSame( array( QualifyVerdict::EXTRACTION_GAP => 1 ), $data['paused_by_verdict'] );
+		$this->assertSame( 1, $data['counts']['resumed_total'] );
+		$this->assertSame( 1, $data['counts']['new_qualified_total'] );
+		$this->assertSame( 1, $data['counts']['unsupported_total'] );
+		$this->assertSame(
+			array(
+				array(
+					'hint'  => 'inside gap',
+					'count' => 1,
+				),
+			),
+			$data['top_extraction_gap']
+		);
+		$this->assertStringContainsString( 'qualified_at <', $wpdb->qualified_query );
+		$this->assertStringNotContainsString( 'qualified_at <=', $wpdb->qualified_query );
+		$this->assertStringContainsString( 'qualified_at <', $wpdb->gap_query );
+		$this->assertStringNotContainsString( 'qualified_at <=', $wpdb->gap_query );
+	}
+
+	/**
 	 * Verify each edge case in the canonical latest unsupported contract.
 	 *
 	 * @param array<int,array<string,mixed>> $rows     Verdict history.

--- a/tests/Unit/Core/QualifyDigestAbilityTest.php
+++ b/tests/Unit/Core/QualifyDigestAbilityTest.php
@@ -26,6 +26,7 @@ class QualifyDigestAbilityTest extends TestCase {
 				'paused_total'        => 4,
 				'resumed_total'       => 12,
 				'new_qualified_total' => 18,
+				'unsupported_total'   => 9,
 				'stale_total'         => 1,
 			),
 			'paused_by_verdict'  => array(
@@ -72,6 +73,7 @@ class QualifyDigestAbilityTest extends TestCase {
 		$this->assertStringContainsString( 'Paused this week:        4 flows', $body );
 		$this->assertStringContainsString( 'Auto-resumed this week:  12 flows', $body );
 		$this->assertStringContainsString( 'New venues qualified:    18', $body );
+		$this->assertStringContainsString( 'Unsupported sources:     9', $body );
 		$this->assertStringContainsString( 'Stale paused flows:      1', $body );
 	}
 
@@ -113,6 +115,7 @@ class QualifyDigestAbilityTest extends TestCase {
 				'paused_total'        => 0,
 				'resumed_total'       => 0,
 				'new_qualified_total' => 0,
+				'unsupported_total'   => 0,
 				'stale_total'         => 0,
 			),
 			'paused_by_verdict'  => array(),
@@ -136,5 +139,6 @@ class QualifyDigestAbilityTest extends TestCase {
 		$this->assertStringContainsString( '147', $body, 'standing inventory active:daily count' );
 		$this->assertStringContainsString( '22', $body, 'paused extraction_gap count' );
 		$this->assertStringContainsString( '18', $body, 'new qualified total' );
+		$this->assertStringContainsString( '9', $body, 'unsupported source total' );
 	}
 }

--- a/tests/Unit/Core/QualifyDigestAbilityTest.php
+++ b/tests/Unit/Core/QualifyDigestAbilityTest.php
@@ -20,6 +20,11 @@ require_once dirname( __DIR__, 3 ) . '/inc/Abilities/QualifyDigestAbilities.php'
 
 class QualifyDigestAbilityTest extends TestCase {
 
+	protected function tearDown(): void {
+		unset( $GLOBALS['wpdb'] );
+		parent::tearDown();
+	}
+
 	private function seed_data(): array {
 		return array(
 			'counts'             => array(
@@ -140,5 +145,112 @@ class QualifyDigestAbilityTest extends TestCase {
 		$this->assertStringContainsString( '22', $body, 'paused extraction_gap count' );
 		$this->assertStringContainsString( '18', $body, 'new qualified total' );
 		$this->assertStringContainsString( '9', $body, 'unsupported source total' );
+	}
+
+	public function test_digest_counts_only_latest_unsupported_urls_in_window(): void {
+		$start = strtotime( '2026-07-01 00:00:00 UTC' );
+		$end   = strtotime( '2026-07-08 00:00:00 UTC' );
+
+		$wpdb            = new QualifyDigestWpdbStub(
+			array(
+				array(
+					'id'           => 1,
+					'url_hash'     => 'repeat',
+					'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+					'qualified_at' => '2026-07-02 00:00:00',
+				),
+				array(
+					'id'           => 2,
+					'url_hash'     => 'repeat',
+					'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+					'qualified_at' => '2026-07-03 00:00:00',
+				),
+				array(
+					'id'           => 3,
+					'url_hash'     => 'recovered',
+					'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+					'qualified_at' => '2026-07-04 00:00:00',
+				),
+				array(
+					'id'           => 4,
+					'url_hash'     => 'recovered',
+					'verdict'      => QualifyVerdict::QUALIFIED_STRUCTURED,
+					'qualified_at' => '2026-07-05 00:00:00',
+				),
+				array(
+					'id'           => 5,
+					'url_hash'     => 'old',
+					'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+					'qualified_at' => '2026-06-15 00:00:00',
+				),
+				array(
+					'id'           => 6,
+					'url_hash'     => 'current',
+					'verdict'      => QualifyVerdict::UNSUPPORTED_SOURCE,
+					'qualified_at' => '2026-07-06 00:00:00',
+				),
+			)
+		);
+		$GLOBALS['wpdb'] = $wpdb;
+
+		$data = ( new QualifyDigestAbilities() )->gather_data( $start, $end );
+
+		$this->assertSame( 2, $data['counts']['unsupported_total'] );
+		$this->assertStringContainsString( 'MAX(id) AS max_id', $wpdb->unsupported_query );
+		$this->assertStringContainsString( 'GROUP BY url_hash', $wpdb->unsupported_query );
+		$this->assertStringContainsString( 'latest.max_id = v.id', $wpdb->unsupported_query );
+	}
+}
+
+class QualifyDigestWpdbStub {
+
+	public string $prefix            = 'c8c_';
+	public string $unsupported_query = '';
+	private array $verdict_rows;
+	private array $prepared_args = array();
+
+	public function __construct( array $verdict_rows ) {
+		$this->verdict_rows = $verdict_rows;
+	}
+
+	public function prepare( string $sql, ...$args ): string {
+		foreach ( $args as $arg ) {
+			$sql = preg_replace( '/%[sd]/', is_string( $arg ) ? "'{$arg}'" : (string) $arg, $sql, 1 );
+		}
+		$this->prepared_args[ $sql ] = $args;
+		return $sql;
+	}
+
+	public function get_results( string $sql, $output = ARRAY_A ): array {
+		return array();
+	}
+
+	public function get_var( string $sql ) {
+		if ( 0 === strpos( $sql, 'SHOW TABLES LIKE' ) ) {
+			return $this->prefix . 'dme_qualify_verdicts';
+		}
+		if ( false === strpos( $sql, "v.verdict = '" . QualifyVerdict::UNSUPPORTED_SOURCE . "'" ) ) {
+			return 0;
+		}
+
+		$this->unsupported_query = $sql;
+		$args                    = $this->prepared_args[ $sql ];
+		$latest                  = array();
+		foreach ( $this->verdict_rows as $row ) {
+			$hash = $row['url_hash'];
+			if ( ! isset( $latest[ $hash ] ) || $row['id'] > $latest[ $hash ]['id'] ) {
+				$latest[ $hash ] = $row;
+			}
+		}
+
+		$count = 0;
+		foreach ( $latest as $row ) {
+			if ( QualifyVerdict::UNSUPPORTED_SOURCE === $row['verdict']
+				&& $row['qualified_at'] >= $args[1]
+				&& $row['qualified_at'] <= $args[2] ) {
+				++$count;
+			}
+		}
+		return $count;
 	}
 }

--- a/tests/Unit/Core/QualifyVerdictResolverTest.php
+++ b/tests/Unit/Core/QualifyVerdictResolverTest.php
@@ -392,9 +392,10 @@ class QualifyVerdictResolverTest extends TestCase {
 		$this->assertNotSame( QualifyVerdict::RESERVATION_ONLY, $verdict['verdict'] );
 	}
 
-	public function test_default_fallback_is_extraction_gap(): void {
+	public function test_reachable_page_without_event_evidence_is_unsupported_source(): void {
 		$fingerprint = array(
 			'http_status'        => 200,
+			'final_url'          => 'https://example.com/about',
 			'platforms_detected' => array(),
 			'structured_data'    => array(),
 			'extractor_attempts' => array(),
@@ -402,8 +403,28 @@ class QualifyVerdictResolverTest extends TestCase {
 
 		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
 
-		$this->assertSame( QualifyVerdict::EXTRACTION_GAP, $verdict['verdict'] );
-		$this->assertSame( QualifyVerdict::GUIDANCE_EXTRACTION_GAP, $verdict['agent_guidance'] );
+		$this->assertSame( QualifyVerdict::UNSUPPORTED_SOURCE, $verdict['verdict'] );
+		$this->assertSame( QualifyVerdict::GUIDANCE_UNSUPPORTED_SOURCE, $verdict['agent_guidance'] );
+	}
+
+	public function test_facebook_login_wall_is_unsupported_source(): void {
+		$fingerprint = array(
+			'http_status'        => 200,
+			'final_url'          => 'https://www.facebook.com/login/?next=%2Freggiesnc',
+			'redirects'          => array( 'https://facebook.com/reggiesnc → https://www.facebook.com/login/?next=%2Freggiesnc' ),
+			'platforms_detected' => array(),
+			'structured_data'    => array(
+				'jsonld_events'              => 0,
+				'jsonld_event_graph_present' => false,
+				'microdata_events'           => 0,
+			),
+			'extractor_attempts' => array(),
+		);
+
+		$verdict = QualifyVerdictResolver::resolve( $fingerprint );
+
+		$this->assertSame( QualifyVerdict::UNSUPPORTED_SOURCE, $verdict['verdict'] );
+		$this->assertNotSame( QualifyVerdict::EXTRACTION_GAP, $verdict['verdict'] );
 	}
 
 	/**
@@ -421,6 +442,7 @@ class QualifyVerdictResolverTest extends TestCase {
 			'qualified_structured' => array( QualifyVerdict::QUALIFIED_STRUCTURED, 'Safe to promote to a live flow. Recommend the operator wire it via wp extrachill venues add.' ),
 			'qualified_for_flyer'  => array( QualifyVerdict::QUALIFIED_FOR_FLYER, 'Vision detected a likely flyer image, but no structured events were extracted. Fetch the source_url directly. Verify the image is actually an event flyer (not a logo, decoration, or stale ad). If it is a genuine flyer, recommend the operator wire it with the event_flyer handler, NOT universal_web_scraper. If it is noise, recommend pausing and filing the URL for re-qualification when extractor coverage improves.' ),
 			'extraction_gap'       => array( QualifyVerdict::EXTRACTION_GAP, 'Page is reachable and contains structured data, but our extractors did not parse it. Fetch the URL via WebFetch and inspect the HTML. If you can identify a predictable pattern (JSON-LD shape, platform-specific markup, etc.), file an issue against data-machine-events suggesting the extractor fix. DO NOT recommend wiring this venue until the extractor lands.' ),
+			'unsupported_source'   => array( QualifyVerdict::UNSUPPORTED_SOURCE, 'Page is reachable, but the fingerprint contains no structured event data or detected platform with a missing extractor. Do NOT treat this as extractor work or recommend wiring. Re-qualify only if the source changes or relevant platform support lands.' ),
 			'bot_blocked'          => array( QualifyVerdict::BOT_BLOCKED, 'HTTP 403/429 — venue origin is blocking our scraper. No code-level fix is possible without proxy support. Park the URL; revisit when proxy support lands. Do NOT recommend wiring.' ),
 			'reservation_only'     => array( QualifyVerdict::RESERVATION_ONLY, 'Venue uses OpenTable/Resy/Tock for reservations only and does not publish event listings. Permanently disqualified. Do NOT recommend wiring. Do NOT file an extractor issue.' ),
 			'unreachable'          => array( QualifyVerdict::UNREACHABLE, 'Site DNS/timeout/5xx. Could be transient. Requeue for re-qualification in 7 days. If still unreachable then, permanently disqualify.' ),
@@ -441,11 +463,17 @@ class QualifyVerdictResolverTest extends TestCase {
 
 	public function test_is_requalifiable_helper(): void {
 		$this->assertTrue( QualifyVerdict::is_requalifiable( QualifyVerdict::EXTRACTION_GAP ) );
+		$this->assertTrue( QualifyVerdict::is_requalifiable( QualifyVerdict::UNSUPPORTED_SOURCE ) );
 		$this->assertTrue( QualifyVerdict::is_requalifiable( QualifyVerdict::BOT_BLOCKED ) );
 		$this->assertTrue( QualifyVerdict::is_requalifiable( QualifyVerdict::UNREACHABLE ) );
 		$this->assertFalse( QualifyVerdict::is_requalifiable( QualifyVerdict::COVERED_ELSEWHERE ) );
 		$this->assertFalse( QualifyVerdict::is_requalifiable( QualifyVerdict::RESERVATION_ONLY ) );
 		$this->assertFalse( QualifyVerdict::is_requalifiable( QualifyVerdict::QUALIFIED_STRUCTURED ) );
+	}
+
+	public function test_taxonomy_preserves_extraction_gap_and_adds_unsupported_source(): void {
+		$this->assertContains( QualifyVerdict::EXTRACTION_GAP, QualifyVerdict::all() );
+		$this->assertContains( QualifyVerdict::UNSUPPORTED_SOURCE, QualifyVerdict::all() );
 	}
 
 	public function test_min_events_thresholds_are_distinct(): void {

--- a/tests/Unit/Core/QualifyVerdictResolverTest.php
+++ b/tests/Unit/Core/QualifyVerdictResolverTest.php
@@ -476,6 +476,12 @@ class QualifyVerdictResolverTest extends TestCase {
 		$this->assertContains( QualifyVerdict::UNSUPPORTED_SOURCE, QualifyVerdict::all() );
 	}
 
+	public function test_unsupported_source_is_not_an_actionable_extractor_cohort(): void {
+		$this->assertNotSame( QualifyVerdict::EXTRACTION_GAP, QualifyVerdict::UNSUPPORTED_SOURCE );
+		$this->assertFalse( QualifyVerdict::is_qualified( QualifyVerdict::UNSUPPORTED_SOURCE ) );
+		$this->assertStringContainsString( 'Do NOT treat this as extractor work', QualifyVerdict::guidance_for( QualifyVerdict::UNSUPPORTED_SOURCE ) );
+	}
+
 	public function test_min_events_thresholds_are_distinct(): void {
 		// Listing-page threshold MUST stay at 2 — the existing guard against
 		// stray-snippet false positives. Detail-page threshold relaxes to 1

--- a/tests/Unit/Core/RequalifyFlowCommandTest.php
+++ b/tests/Unit/Core/RequalifyFlowCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Tests for the requalify-flow CLI path.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use ExtraChillEvents\Cli\RequalifyFlowCommand;
+use ExtraChillEvents\Core\QualifyVerdict;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__, 3 ) . '/inc/Cli/FlowHelpers.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Cli/RequalifyFlowCommand.php';
+
+class RequalifyFlowCommandTest extends TestCase {
+
+	public function test_auto_pause_passes_flow_source_url_for_recheck_scheduling(): void {
+		$flow = array(
+			'flow_id'    => 42,
+			'source_url' => 'https://venue.example/events',
+		);
+
+		$command = new class() extends RequalifyFlowCommand {
+			public array $paused = array();
+
+			public function pause_from_requalification( array $flow, string $verdict ): bool {
+				return $this->pause_requalified_flow( $flow, $verdict );
+			}
+
+			protected function pause_flow_by_verdict( int $flow_id, string $verdict, string $source_url = '' ): bool {
+				$this->paused = compact( 'flow_id', 'verdict', 'source_url' );
+				return true;
+			}
+		};
+		$command->pause_from_requalification( $flow, QualifyVerdict::UNSUPPORTED_SOURCE );
+
+		$this->assertSame(
+			array(
+				'flow_id'    => 42,
+				'verdict'    => QualifyVerdict::UNSUPPORTED_SOURCE,
+				'source_url' => 'https://venue.example/events',
+			),
+			$command->paused
+		);
+	}
+}

--- a/tests/Unit/Core/Stubs/class-qualifydigestwpdbstub.php
+++ b/tests/Unit/Core/Stubs/class-qualifydigestwpdbstub.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Database stub for qualify digest latest-verdict tests.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use ExtraChillEvents\Core\QualifyVerdict;
+
+/**
+ * Emulates canonical latest-row selection independently from production SQL.
+ */
+class QualifyDigestWpdbStub {
+
+	/**
+	 * WordPress site table prefix.
+	 *
+	 * @var string
+	 */
+	public string $prefix = 'c8c_';
+
+	/**
+	 * Prepared arguments for the unsupported query.
+	 *
+	 * @var array<int,mixed>
+	 */
+	public array $unsupported_args = array();
+
+	/**
+	 * Captured unsupported query.
+	 *
+	 * @var string
+	 */
+	public string $unsupported_query = '';
+
+	/**
+	 * Seeded verdict history.
+	 *
+	 * @var array<int,array<string,mixed>>
+	 */
+	private array $verdict_rows;
+
+	/**
+	 * Arguments keyed by prepared SQL.
+	 *
+	 * @var array<string,array<int,mixed>>
+	 */
+	private array $prepared_args = array();
+
+	/**
+	 * Seed verdict history.
+	 *
+	 * @param array<int,array<string,mixed>> $verdict_rows Seeded verdict rows.
+	 */
+	public function __construct( array $verdict_rows ) {
+		$this->verdict_rows = $verdict_rows;
+	}
+
+	/**
+	 * Naively interpolate placeholders and retain their original arguments.
+	 *
+	 * @param string $sql  SQL template.
+	 * @param mixed  ...$args Placeholder values.
+	 * @return string Interpolated SQL.
+	 */
+	public function prepare( string $sql, ...$args ): string {
+		foreach ( $args as $arg ) {
+			$sql = preg_replace( '/%[sd]/', is_string( $arg ) ? "'{$arg}'" : (string) $arg, $sql, 1 );
+		}
+		$this->prepared_args[ $sql ] = $args;
+		return $sql;
+	}
+
+	/**
+	 * Return no flow or extraction-gap rows for digest setup queries.
+	 *
+	 * @param string $sql    SQL query.
+	 * @param mixed  $output Output mode.
+	 * @return array Empty rows.
+	 */
+	public function get_results( string $sql, $output = ARRAY_A ): array {
+		unset( $sql, $output );
+		return array();
+	}
+
+	/**
+	 * Resolve table checks and emulate the latest-verdict count contract.
+	 *
+	 * @param string $sql Prepared SQL.
+	 * @return int|string Query result.
+	 */
+	public function get_var( string $sql ) {
+		if ( 0 === strpos( $sql, 'SHOW TABLES LIKE' ) ) {
+			return $this->prefix . 'dme_qualify_verdicts';
+		}
+		if ( false === strpos( $sql, "current_verdict.verdict = '" . QualifyVerdict::UNSUPPORTED_SOURCE . "'" ) ) {
+			return 0;
+		}
+
+		$this->unsupported_query = $sql;
+		$args                    = $this->prepared_args[ $sql ];
+		$this->unsupported_args  = $args;
+		$latest                  = array();
+		foreach ( $this->verdict_rows as $row ) {
+			$hash = $row['url_hash'];
+			if ( ! isset( $latest[ $hash ] )
+				|| $row['qualified_at'] > $latest[ $hash ]['qualified_at']
+				|| ( $row['qualified_at'] === $latest[ $hash ]['qualified_at'] && $row['id'] > $latest[ $hash ]['id'] ) ) {
+				$latest[ $hash ] = $row;
+			}
+		}
+
+		$count = 0;
+		foreach ( $latest as $row ) {
+			if ( QualifyVerdict::UNSUPPORTED_SOURCE === $row['verdict']
+				&& $row['qualified_at'] >= $args[1]
+				&& $row['qualified_at'] < $args[2] ) {
+				++$count;
+			}
+		}
+		return $count;
+	}
+}

--- a/tests/Unit/Core/Stubs/class-qualifydigestwpdbstub.php
+++ b/tests/Unit/Core/Stubs/class-qualifydigestwpdbstub.php
@@ -36,11 +36,32 @@ class QualifyDigestWpdbStub {
 	public string $unsupported_query = '';
 
 	/**
+	 * Captured newly-qualified query.
+	 *
+	 * @var string
+	 */
+	public string $qualified_query = '';
+
+	/**
+	 * Captured extraction-gap query.
+	 *
+	 * @var string
+	 */
+	public string $gap_query = '';
+
+	/**
 	 * Seeded verdict history.
 	 *
 	 * @var array<int,array<string,mixed>>
 	 */
 	private array $verdict_rows;
+
+	/**
+	 * Seeded flow rows.
+	 *
+	 * @var array<int,array<string,mixed>>
+	 */
+	private array $flow_rows;
 
 	/**
 	 * Arguments keyed by prepared SQL.
@@ -53,9 +74,11 @@ class QualifyDigestWpdbStub {
 	 * Seed verdict history.
 	 *
 	 * @param array<int,array<string,mixed>> $verdict_rows Seeded verdict rows.
+	 * @param array<int,array<string,mixed>> $flow_rows    Seeded flow rows.
 	 */
-	public function __construct( array $verdict_rows ) {
+	public function __construct( array $verdict_rows, array $flow_rows = array() ) {
 		$this->verdict_rows = $verdict_rows;
+		$this->flow_rows    = $flow_rows;
 	}
 
 	/**
@@ -74,14 +97,38 @@ class QualifyDigestWpdbStub {
 	}
 
 	/**
-	 * Return no flow or extraction-gap rows for digest setup queries.
+	 * Return seeded flow rows and grouped extraction-gap rows.
 	 *
 	 * @param string $sql    SQL query.
 	 * @param mixed  $output Output mode.
 	 * @return array Empty rows.
 	 */
 	public function get_results( string $sql, $output = ARRAY_A ): array {
-		unset( $sql, $output );
+		unset( $output );
+		if ( false !== strpos( $sql, 'SELECT flow_id, flow_name, scheduling_config' ) ) {
+			return $this->flow_rows;
+		}
+		if ( false !== strpos( $sql, "verdict = '" . QualifyVerdict::EXTRACTION_GAP . "'" ) ) {
+			$this->gap_query = $sql;
+			$args            = $this->prepared_args[ $sql ];
+			$counts          = array();
+			foreach ( $this->verdict_rows as $row ) {
+				if ( QualifyVerdict::EXTRACTION_GAP === $row['verdict']
+					&& $row['qualified_at'] >= $args[1]
+					&& $row['qualified_at'] < $args[2] ) {
+					$hint            = $row['improvement_hint'] ?? '';
+					$counts[ $hint ] = ( $counts[ $hint ] ?? 0 ) + 1;
+				}
+			}
+			$rows = array();
+			foreach ( $counts as $hint => $count ) {
+				$rows[] = array(
+					'improvement_hint' => $hint,
+					'c'                => $count,
+				);
+			}
+			return $rows;
+		}
 		return array();
 	}
 
@@ -94,6 +141,19 @@ class QualifyDigestWpdbStub {
 	public function get_var( string $sql ) {
 		if ( 0 === strpos( $sql, 'SHOW TABLES LIKE' ) ) {
 			return $this->prefix . 'dme_qualify_verdicts';
+		}
+		if ( false !== strpos( $sql, "verdict = '" . QualifyVerdict::QUALIFIED_STRUCTURED . "'" ) ) {
+			$this->qualified_query = $sql;
+			$args                  = $this->prepared_args[ $sql ];
+			$count                 = 0;
+			foreach ( $this->verdict_rows as $row ) {
+				if ( QualifyVerdict::QUALIFIED_STRUCTURED === $row['verdict']
+					&& $row['qualified_at'] >= $args[1]
+					&& $row['qualified_at'] < $args[2] ) {
+					++$count;
+				}
+			}
+			return $count;
 		}
 		if ( false === strpos( $sql, "current_verdict.verdict = '" . QualifyVerdict::UNSUPPORTED_SOURCE . "'" ) ) {
 			return 0;

--- a/tests/Unit/Core/Stubs/digest-stubs.php
+++ b/tests/Unit/Core/Stubs/digest-stubs.php
@@ -37,3 +37,27 @@ if ( ! function_exists( 'did_action' ) ) {
 		return false;
 	}
 }
+
+if ( ! function_exists( 'wp_timezone' ) ) {
+	/**
+	 * Return the timezone configured by the current digest test.
+	 */
+	function wp_timezone(): \DateTimeZone {
+		return new \DateTimeZone( $GLOBALS['ec_digest_timezone'] ?? 'UTC' );
+	}
+}
+
+if ( ! function_exists( 'wp_date' ) ) {
+	/**
+	 * Format a timestamp in the supplied WordPress site timezone.
+	 *
+	 * @param string             $format    Date format.
+	 * @param int|null           $timestamp Unix timestamp.
+	 * @param \DateTimeZone|null $timezone  Output timezone.
+	 * @return string Formatted local date.
+	 */
+	function wp_date( string $format, ?int $timestamp = null, ?\DateTimeZone $timezone = null ): string {
+		$date = new \DateTimeImmutable( '@' . ( $timestamp ?? time() ) );
+		return $date->setTimezone( $timezone ?? wp_timezone() )->format( $format );
+	}
+}


### PR DESCRIPTION
## Summary
- add an `unsupported_source` verdict for reachable pages without structured event evidence or a detected missing extractor
- keep true JSON-LD parse failures and detected missing extractors classified as `extraction_gap`
- integrate guidance, pause confirmation, 30-day rechecks, stats taxonomy, and weekly digest reporting without changing persistence
- preserve existing verdict rows so requalification appends a new latest verdict and naturally removes corrected URLs from `--verdict=extraction_gap`

## Verification
- `vendor/bin/phpunit --filter 'Qualify(VerdictResolver|ConfirmationRules|DigestAbility)Test'` (56 tests, 131 assertions)
- PHP syntax checks passed for all changed files
- `git diff --check` passed
- full `composer test` executed: issue-specific tests passed; repository baseline has 19 unrelated failures and 2 errors in recheck stubs, canonical adapters, festival notifications, and concert-profile rendering
- full WordPress PHPCS executed: baseline naming/docblock/direct-query violations remain; no issue-specific lint defect retained
- Homeboy PR audit executed: reported existing structural/convention outliers, with no new qualification architecture introduced

Fixes #301