### PR TITLE
feat: add venue booking storage foundation

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -233,6 +233,10 @@ class ExtraChillEvents {
 		// Moderation-queue table + REST controller/routes. The abilities load in
 		// init_abilities(); the admin screen instantiates in init_admin().
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ArtistUrlSubmissionsTable.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingSchema.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingConfig.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/ArtistUrlImport.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/ArtistUrlImportRoutes.php';
 
@@ -374,6 +378,9 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ArtistUrlSubmissionsTable.php';
 		\ExtraChillEvents\Core\ArtistUrlSubmissionsTable::create_table();
 
+		// Private, site-scoped venue booking tables.
+		\ExtraChillEvents\Core\BookingSchema::install();
+
 		flush_rewrite_rules();
 	}
 
@@ -397,6 +404,10 @@ class ExtraChillEvents {
 		// data-machine-events in #200). Network-scoped; idempotent install.
 		if ( class_exists( '\\ExtraChillEvents\\Core\\ArtistUrlSubmissionsTable' ) ) {
 			\ExtraChillEvents\Core\ArtistUrlSubmissionsTable::maybe_install();
+		}
+
+		if ( class_exists( '\\ExtraChillEvents\\Core\\BookingSchema' ) ) {
+			\ExtraChillEvents\Core\BookingSchema::maybe_install();
 		}
 	}
 

--- a/inc/Core/BookingActivityRepository.php
+++ b/inc/Core/BookingActivityRepository.php
@@ -2,10 +2,12 @@
 /**
  * Append-only booking activity repository.
  *
+ * Queries use the current Events site's `$wpdb->prefix`; callers must preserve
+ * Events-site route affinity.
+ *
  * @package ExtraChillEvents\Core
  */
 
-// phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag,Squiz.Commenting.FunctionComment.Missing -- Concise internal helpers are typed and named by purpose.
 namespace ExtraChillEvents\Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -15,78 +17,161 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Stores immutable operational activity records. */
 class BookingActivityRepository {
 
-	/** Append one activity record. */
+	private const PAYLOAD_VERSION = 1;
+
+	/** Append one activity record, returning an idempotent prior record when found. */
 	public function append( array $data ) {
 		global $wpdb;
 
-		$booking_id = absint( $data['booking_id'] ?? 0 );
-		$kind       = sanitize_key( (string) ( $data['kind'] ?? '' ) );
-		if ( $booking_id < 1 || '' === $kind ) {
-			return new \WP_Error( 'invalid_booking_activity', __( 'Booking activity requires a booking and kind.', 'extrachill-events' ) );
+		$booking_id = $this->positive_id( $data['booking_id'] ?? null, 'booking_id', false );
+		if ( is_wp_error( $booking_id ) ) {
+			return $booking_id;
+		}
+		$booking = ( new BookingRepository() )->get( $booking_id );
+		if ( is_wp_error( $booking ) ) {
+			return new \WP_Error( 'booking_activity_booking_read_failed', __( 'The activity booking could not be verified.', 'extrachill-events' ), $booking->get_error_data() );
+		}
+		if ( null === $booking ) {
+			return new \WP_Error( 'booking_activity_orphan', __( 'Activity cannot be appended to a missing booking.', 'extrachill-events' ) );
 		}
 
-		$payload  = wp_json_encode(
+		$kind = mb_substr( sanitize_key( (string) ( $data['kind'] ?? '' ) ), 0, 64 );
+		if ( '' === $kind ) {
+			return new \WP_Error( 'invalid_booking_activity_kind', __( 'Booking activity requires a kind.', 'extrachill-events' ) );
+		}
+		$idempotency_key = $this->nullable_text( $data['idempotency_key'] ?? null, 191 );
+		if ( null !== $idempotency_key ) {
+			$existing = $this->find_by_idempotency( $booking_id, $idempotency_key );
+			if ( is_wp_error( $existing ) || is_array( $existing ) ) {
+				return $existing;
+			}
+		}
+
+		$payload = wp_json_encode(
 			array(
-				'version' => 1,
+				'version' => self::PAYLOAD_VERSION,
 				'data'    => $data['payload'] ?? array(),
 			)
 		);
-		$now      = gmdate( 'Y-m-d H:i:s' );
-		$actor_id = absint( $data['actor_id'] ?? 0 );
-		$row      = array(
-			'booking_id'      => $booking_id,
-			'kind'            => mb_substr( $kind, 0, 64 ),
-			'actor_type'      => mb_substr( sanitize_key( (string) ( $data['actor_type'] ?? 'system' ) ), 0, 32 ),
-			'actor_id'        => 0 < $actor_id ? $actor_id : null,
-			'direction'       => $this->nullable_key( $data['direction'] ?? null, 16 ),
-			'channel'         => $this->nullable_key( $data['channel'] ?? null, 32 ),
-			'payload'         => false === $payload ? '{"version":1,"data":{}}' : $payload,
-			'external_id'     => $this->nullable_text( $data['external_id'] ?? null, 191 ),
-			'idempotency_key' => $this->nullable_text( $data['idempotency_key'] ?? null, 191 ),
-			'occurred_at'     => $this->datetime( $data['occurred_at'] ?? $now ),
-			'created_at'      => $now,
-		);
-		if ( is_wp_error( $row['occurred_at'] ) ) {
-			return $row['occurred_at'];
+		if ( false === $payload ) {
+			return new \WP_Error( 'booking_activity_payload_encode_failed', __( 'Activity payload JSON encoding failed.', 'extrachill-events' ), array( 'json_error' => json_last_error_msg() ) );
+		}
+		$occurred_at = $this->datetime( $data['occurred_at'] ?? gmdate( 'Y-m-d H:i:s' ) );
+		if ( is_wp_error( $occurred_at ) ) {
+			return $occurred_at;
+		}
+		$actor_id = $this->positive_id( $data['actor_id'] ?? null, 'actor_id', true );
+		if ( is_wp_error( $actor_id ) ) {
+			return $actor_id;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = array(
+			'booking_id'      => $booking_id,
+			'kind'            => $kind,
+			'actor_type'      => mb_substr( sanitize_key( (string) ( $data['actor_type'] ?? 'system' ) ), 0, 32 ),
+			'actor_id'        => $actor_id,
+			'direction'       => $this->nullable_key( $data['direction'] ?? null, 16 ),
+			'channel'         => $this->nullable_key( $data['channel'] ?? null, 32 ),
+			'payload'         => $payload,
+			'external_id'     => $this->nullable_text( $data['external_id'] ?? null, 191 ),
+			'idempotency_key' => $idempotency_key,
+			'occurred_at'     => $occurred_at,
+			'created_at'      => gmdate( 'Y-m-d H:i:s' ),
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private append-only table write.
 		if ( false === $wpdb->insert( BookingSchema::activity_table(), $row ) ) {
-			return new \WP_Error( 'booking_activity_create_failed', __( 'The booking activity could not be recorded.', 'extrachill-events' ) );
+			if ( null !== $idempotency_key ) {
+				$existing = $this->find_by_idempotency( $booking_id, $idempotency_key );
+				if ( is_wp_error( $existing ) || is_array( $existing ) ) {
+					return $existing;
+				}
+			}
+			return new \WP_Error( 'booking_activity_write_failed', __( 'The booking activity could not be recorded.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
 		return $this->get( (int) $wpdb->insert_id );
 	}
 
 	/** Get one activity record by ID. */
-	public function get( int $id ): ?array {
+	public function get( int $id ) {
 		global $wpdb;
+		$id = $this->positive_id( $id, 'activity_id', false );
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
 		$table = BookingSchema::activity_table();
-		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1", $id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private operational table query.
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1", $id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted current-prefix table.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_activity_read_failed', __( 'The booking activity could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
 		return is_array( $row ) ? $this->hydrate( $row ) : null;
 	}
 
 	/** List recent activity for one booking. */
-	public function list_for_booking( int $booking_id, int $limit = 100, int $offset = 0 ): array {
+	public function list_for_booking( int $booking_id, int $limit = 100, int $offset = 0 ) {
 		global $wpdb;
+		$booking_id = $this->positive_id( $booking_id, 'booking_id', false );
+		if ( is_wp_error( $booking_id ) ) {
+			return $booking_id;
+		}
 		$table  = BookingSchema::activity_table();
 		$limit  = max( 1, min( 200, $limit ) );
 		$offset = max( 0, $offset );
-		$rows   = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d ORDER BY occurred_at DESC, id DESC LIMIT %d OFFSET %d", $booking_id, $limit, $offset ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private operational table query.
-		return array_map( array( $this, 'hydrate' ), is_array( $rows ) ? $rows : array() );
+		$rows   = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d ORDER BY occurred_at DESC, id DESC LIMIT %d OFFSET %d", $booking_id, $limit, $offset ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted current-prefix table.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_activity_list_failed', __( 'Booking activity could not be listed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		$hydrated = array();
+		foreach ( (array) $rows as $row ) {
+			$item = $this->hydrate( $row );
+			if ( is_wp_error( $item ) ) {
+				return $item;
+			}
+			$hydrated[] = $item;
+		}
+		return $hydrated;
 	}
 
-	/** Hydrate one activity row. */
-	public function hydrate( array $row ): array {
+	/** Find an existing booking-scoped idempotent activity. */
+	private function find_by_idempotency( int $booking_id, string $key ) {
+		global $wpdb;
+		$table = BookingSchema::activity_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND idempotency_key = %s LIMIT 1", $booking_id, $key ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted current-prefix table.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_activity_read_failed', __( 'Booking activity idempotency could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return is_array( $row ) ? $this->hydrate( $row ) : null;
+	}
+
+	/** Hydrate one validated activity row. */
+	public function hydrate( array $row ) {
+		$decoded = json_decode( (string) ( $row['payload'] ?? '' ), true );
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) || ! array_key_exists( 'version', $decoded ) || ! array_key_exists( 'data', $decoded ) ) {
+			return new \WP_Error( 'booking_activity_payload_invalid_json', __( 'Stored activity payload JSON is malformed.', 'extrachill-events' ), array( 'json_error' => json_last_error_msg() ) );
+		}
+		if ( ! is_int( $decoded['version'] ) || self::PAYLOAD_VERSION !== $decoded['version'] ) {
+			return new \WP_Error( 'booking_activity_payload_version_unsupported', __( 'Stored activity payload version is unsupported.', 'extrachill-events' ), array( 'version' => $decoded['version'] ) );
+		}
 		$row['id']         = (int) $row['id'];
 		$row['booking_id'] = (int) $row['booking_id'];
 		$row['actor_id']   = isset( $row['actor_id'] ) ? (int) $row['actor_id'] : null;
-		$row['payload']    = json_decode( (string) $row['payload'], true );
+		$row['payload']    = $decoded;
 		return $row;
 	}
 
+	private function positive_id( $value, string $field, bool $nullable ) {
+		if ( null === $value || '' === $value || 0 === $value || '0' === $value ) {
+			return $nullable ? null : new \WP_Error( 'invalid_booking_activity_id', __( 'A positive identifier is required.', 'extrachill-events' ), array( 'field' => $field ) );
+		}
+		if ( ( ! is_int( $value ) && ! ( is_string( $value ) && ctype_digit( $value ) ) ) || (int) $value < 1 ) {
+			return new \WP_Error( 'invalid_booking_activity_id', __( 'Identifiers must be positive integers.', 'extrachill-events' ), array( 'field' => $field ) );
+		}
+		return (int) $value;
+	}
+
 	private function nullable_key( $value, int $length ): ?string {
-		$value = sanitize_key( (string) $value );
-		return '' === $value ? null : mb_substr( $value, 0, $length );
+		$value = mb_substr( sanitize_key( (string) $value ), 0, $length );
+		return '' === $value ? null : $value;
 	}
 
 	private function nullable_text( $value, int $length ): ?string {

--- a/inc/Core/BookingActivityRepository.php
+++ b/inc/Core/BookingActivityRepository.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Append-only booking activity repository.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+// phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag,Squiz.Commenting.FunctionComment.Missing -- Concise internal helpers are typed and named by purpose.
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Stores immutable operational activity records. */
+class BookingActivityRepository {
+
+	/** Append one activity record. */
+	public function append( array $data ) {
+		global $wpdb;
+
+		$booking_id = absint( $data['booking_id'] ?? 0 );
+		$kind       = sanitize_key( (string) ( $data['kind'] ?? '' ) );
+		if ( $booking_id < 1 || '' === $kind ) {
+			return new \WP_Error( 'invalid_booking_activity', __( 'Booking activity requires a booking and kind.', 'extrachill-events' ) );
+		}
+
+		$payload  = wp_json_encode(
+			array(
+				'version' => 1,
+				'data'    => $data['payload'] ?? array(),
+			)
+		);
+		$now      = gmdate( 'Y-m-d H:i:s' );
+		$actor_id = absint( $data['actor_id'] ?? 0 );
+		$row      = array(
+			'booking_id'      => $booking_id,
+			'kind'            => mb_substr( $kind, 0, 64 ),
+			'actor_type'      => mb_substr( sanitize_key( (string) ( $data['actor_type'] ?? 'system' ) ), 0, 32 ),
+			'actor_id'        => 0 < $actor_id ? $actor_id : null,
+			'direction'       => $this->nullable_key( $data['direction'] ?? null, 16 ),
+			'channel'         => $this->nullable_key( $data['channel'] ?? null, 32 ),
+			'payload'         => false === $payload ? '{"version":1,"data":{}}' : $payload,
+			'external_id'     => $this->nullable_text( $data['external_id'] ?? null, 191 ),
+			'idempotency_key' => $this->nullable_text( $data['idempotency_key'] ?? null, 191 ),
+			'occurred_at'     => $this->datetime( $data['occurred_at'] ?? $now ),
+			'created_at'      => $now,
+		);
+		if ( is_wp_error( $row['occurred_at'] ) ) {
+			return $row['occurred_at'];
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( false === $wpdb->insert( BookingSchema::activity_table(), $row ) ) {
+			return new \WP_Error( 'booking_activity_create_failed', __( 'The booking activity could not be recorded.', 'extrachill-events' ) );
+		}
+		return $this->get( (int) $wpdb->insert_id );
+	}
+
+	/** Get one activity record by ID. */
+	public function get( int $id ): ?array {
+		global $wpdb;
+		$table = BookingSchema::activity_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1", $id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private operational table query.
+		return is_array( $row ) ? $this->hydrate( $row ) : null;
+	}
+
+	/** List recent activity for one booking. */
+	public function list_for_booking( int $booking_id, int $limit = 100, int $offset = 0 ): array {
+		global $wpdb;
+		$table  = BookingSchema::activity_table();
+		$limit  = max( 1, min( 200, $limit ) );
+		$offset = max( 0, $offset );
+		$rows   = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d ORDER BY occurred_at DESC, id DESC LIMIT %d OFFSET %d", $booking_id, $limit, $offset ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private operational table query.
+		return array_map( array( $this, 'hydrate' ), is_array( $rows ) ? $rows : array() );
+	}
+
+	/** Hydrate one activity row. */
+	public function hydrate( array $row ): array {
+		$row['id']         = (int) $row['id'];
+		$row['booking_id'] = (int) $row['booking_id'];
+		$row['actor_id']   = isset( $row['actor_id'] ) ? (int) $row['actor_id'] : null;
+		$row['payload']    = json_decode( (string) $row['payload'], true );
+		return $row;
+	}
+
+	private function nullable_key( $value, int $length ): ?string {
+		$value = sanitize_key( (string) $value );
+		return '' === $value ? null : mb_substr( $value, 0, $length );
+	}
+
+	private function nullable_text( $value, int $length ): ?string {
+		$value = sanitize_text_field( (string) $value );
+		return '' === $value ? null : mb_substr( $value, 0, $length );
+	}
+
+	private function datetime( $value ) {
+		$date = \DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', (string) $value, new \DateTimeZone( 'UTC' ) );
+		return $date && $date->format( 'Y-m-d H:i:s' ) === $value
+			? $date->format( 'Y-m-d H:i:s' )
+			: new \WP_Error( 'invalid_booking_activity_datetime', __( 'Activity timestamps must use UTC Y-m-d H:i:s format.', 'extrachill-events' ) );
+	}
+}

--- a/inc/Core/BookingRepository.php
+++ b/inc/Core/BookingRepository.php
@@ -2,10 +2,13 @@
 /**
  * Private venue booking repository.
  *
+ * Queries are intentionally scoped by the current site's `$wpdb->prefix`.
+ * Callers must invoke this repository on the Events-site route; identity
+ * validation switches only while reading canonical artist records.
+ *
  * @package ExtraChillEvents\Core
  */
 
-// phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag,Squiz.Commenting.FunctionComment.Missing -- Concise internal helpers are typed and named by purpose.
 namespace ExtraChillEvents\Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -17,22 +20,59 @@ class BookingRepository {
 
 	private const PAYLOAD_VERSION = 1;
 
-	/** Create a booking. */
+	/** Create a booking without an event handoff. */
 	public function create( array $data ) {
 		global $wpdb;
+
+		$venue_term_id = $this->positive_id( $data['venue_term_id'] ?? null, 'venue_term_id', false );
+		if ( is_wp_error( $venue_term_id ) ) {
+			return $venue_term_id;
+		}
+		$venue = get_term( $venue_term_id, 'venue' );
+		if ( ! $venue || is_wp_error( $venue ) || 'venue' !== $venue->taxonomy ) {
+			return new \WP_Error( 'invalid_booking_venue', __( 'A valid Events venue term is required.', 'extrachill-events' ) );
+		}
 
 		$identity = $this->validate_identity( $data );
 		if ( is_wp_error( $identity ) ) {
 			return $identity;
 		}
-		$venue_term_id = absint( $data['venue_term_id'] ?? 0 );
-		$venue         = get_term( $venue_term_id, 'venue' );
-		if ( $venue_term_id < 1 || ! $venue || is_wp_error( $venue ) || 'venue' !== $venue->taxonomy ) {
-			return new \WP_Error( 'invalid_booking_venue', __( 'A valid Events venue term is required.', 'extrachill-events' ) );
+		$artist_name_input = sanitize_text_field( (string) ( $data['artist_name'] ?? '' ) );
+		$artist_name       = $this->required_text( '' !== $artist_name_input ? $artist_name_input : $identity['artist_name'], 'artist_name', 255 );
+		if ( is_wp_error( $artist_name ) ) {
+			return $artist_name;
 		}
-		$artist_name = sanitize_text_field( (string) ( $data['artist_name'] ?? $identity['artist_name'] ) );
-		if ( '' === $artist_name ) {
-			return new \WP_Error( 'missing_booking_artist_name', __( 'An artist name is required.', 'extrachill-events' ) );
+
+		$ids = array();
+		foreach ( array( 'submitter_user_id', 'assignee_user_id' ) as $field ) {
+			$ids[ $field ] = $this->positive_id( $data[ $field ] ?? null, $field, true );
+			if ( is_wp_error( $ids[ $field ] ) ) {
+				return $ids[ $field ];
+			}
+		}
+
+		$start = $this->datetime( $data['requested_start_at'] ?? null, 'requested_start_at' );
+		$end   = $this->datetime( $data['requested_end_at'] ?? null, 'requested_end_at' );
+		$dates = $this->validate_date_range( $start, $end );
+		if ( is_wp_error( $dates ) ) {
+			return $dates;
+		}
+
+		$intake = $this->encode_payload( $data['intake'] ?? array(), 'intake' );
+		if ( is_wp_error( $intake ) ) {
+			return $intake;
+		}
+		$deal = null;
+		if ( array_key_exists( 'deal', $data ) ) {
+			$deal = $this->encode_payload( $data['deal'], 'deal' );
+			if ( is_wp_error( $deal ) ) {
+				return $deal;
+			}
+		}
+
+		$status = $this->status( $data['status'] ?? 'inquiry' );
+		if ( is_wp_error( $status ) ) {
+			return $status;
 		}
 
 		$now = gmdate( 'Y-m-d H:i:s' );
@@ -41,93 +81,136 @@ class BookingRepository {
 			'venue_term_id'      => $venue_term_id,
 			'artist_term_id'     => $identity['artist_term_id'],
 			'artist_profile_id'  => $identity['artist_profile_id'],
-			'artist_name'        => mb_substr( $artist_name, 0, 255 ),
-			'submitter_user_id'  => $this->nullable_id( $data['submitter_user_id'] ?? null ),
+			'artist_name'        => $artist_name,
+			'submitter_user_id'  => $ids['submitter_user_id'],
 			'contact_name'       => $this->nullable_text( $data['contact_name'] ?? null, 255 ),
 			'contact_email'      => $this->nullable_email( $data['contact_email'] ?? null ),
 			'contact_phone'      => $this->nullable_text( $data['contact_phone'] ?? null, 64 ),
-			'space_key'          => $this->nullable_key( $data['space_key'] ?? null ),
-			'status'             => $this->bounded_key( $data['status'] ?? 'inquiry', 32, 'inquiry' ),
+			'space_key'          => $this->nullable_key( $data['space_key'] ?? null, 64 ),
+			'status'             => $status,
 			'version'            => 1,
-			'assignee_user_id'   => $this->nullable_id( $data['assignee_user_id'] ?? null ),
-			'requested_start_at' => $this->nullable_datetime( $data['requested_start_at'] ?? null ),
-			'requested_end_at'   => $this->nullable_datetime( $data['requested_end_at'] ?? null ),
-			'intake_payload'     => $this->encode_payload( $data['intake'] ?? array() ),
-			'deal_payload'       => array_key_exists( 'deal', $data ) ? $this->encode_payload( $data['deal'] ) : null,
-			'event_id'           => $this->nullable_id( $data['event_id'] ?? null ),
+			'assignee_user_id'   => $ids['assignee_user_id'],
+			'requested_start_at' => $start,
+			'requested_end_at'   => $end,
+			'intake_payload'     => $intake,
+			'deal_payload'       => $deal,
+			'event_id'           => null,
 			'created_at'         => $now,
 			'updated_at'         => $now,
 		);
-		if ( is_wp_error( $row['requested_start_at'] ) || is_wp_error( $row['requested_end_at'] ) ) {
-			return is_wp_error( $row['requested_start_at'] ) ? $row['requested_start_at'] : $row['requested_end_at'];
-		}
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private operational table write.
 		if ( false === $wpdb->insert( BookingSchema::bookings_table(), $row ) ) {
-			return new \WP_Error( 'booking_create_failed', __( 'The booking could not be created.', 'extrachill-events' ) );
+			return new \WP_Error( 'booking_create_failed', __( 'The booking could not be created.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
 		return $this->get( (int) $wpdb->insert_id );
 	}
 
 	/** Get a booking by numeric ID or UUID public reference. */
-	public function get( $identifier ): ?array {
+	public function get( $identifier ) {
 		global $wpdb;
 		$table = BookingSchema::bookings_table();
-		if ( is_numeric( $identifier ) && (int) $identifier > 0 ) {
-			$sql = $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1", (int) $identifier ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		if ( is_int( $identifier ) || ( is_string( $identifier ) && ctype_digit( $identifier ) ) ) {
+			$id = $this->positive_id( $identifier, 'booking_id', false );
+			if ( is_wp_error( $id ) ) {
+				return $id;
+			}
+			$sql = $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1", $id ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Trusted current-prefix table.
 		} else {
-			$sql = $wpdb->prepare( "SELECT * FROM {$table} WHERE public_id = %s LIMIT 1", (string) $identifier ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$sql = $wpdb->prepare( "SELECT * FROM {$table} WHERE public_id = %s LIMIT 1", (string) $identifier ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Trusted current-prefix table.
 		}
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
-		$row = $wpdb->get_row( $sql, ARRAY_A );
+		$row = $wpdb->get_row( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Query prepared above.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_read_failed', __( 'The booking could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
 		return is_array( $row ) ? $this->hydrate( $row ) : null;
 	}
 
 	/** List bookings for one venue with bounded optional filters. */
 	public function list( array $filters ) {
 		global $wpdb;
-		$venue_term_id = absint( $filters['venue_term_id'] ?? 0 );
-		if ( $venue_term_id < 1 ) {
-			return new \WP_Error( 'missing_booking_venue_filter', __( 'A venue filter is required.', 'extrachill-events' ) );
+
+		$venue_term_id = $this->positive_id( $filters['venue_term_id'] ?? null, 'venue_term_id', false );
+		if ( is_wp_error( $venue_term_id ) ) {
+			return $venue_term_id;
 		}
 		$table  = BookingSchema::bookings_table();
 		$where  = array( 'venue_term_id = %d' );
 		$values = array( $venue_term_id );
-		$keys   = array(
-			'status'             => '%s',
-			'artist_term_id'     => '%d',
-			'artist_profile_id'  => '%d',
-			'assignee_user_id'   => '%d',
-			'requested_start_at' => '%s',
-		);
-		foreach ( $keys as $key => $placeholder ) {
-			if ( ! isset( $filters[ $key ] ) || '' === $filters[ $key ] ) {
+
+		if ( isset( $filters['status'] ) && '' !== $filters['status'] ) {
+			$status = $this->status( $filters['status'] );
+			if ( is_wp_error( $status ) ) {
+				return $status;
+			}
+			$where[]  = 'status = %s';
+			$values[] = $status;
+		}
+		foreach ( array( 'artist_term_id', 'artist_profile_id', 'assignee_user_id' ) as $field ) {
+			if ( ! array_key_exists( $field, $filters ) || null === $filters[ $field ] || '' === $filters[ $field ] ) {
 				continue;
 			}
-			$operator = 'requested_start_at' === $key ? '>=' : '=';
-			$where[]  = "{$key} {$operator} {$placeholder}";
-			$values[] = '%d' === $placeholder ? absint( $filters[ $key ] ) : (string) $filters[ $key ];
+			$id = $this->positive_id( $filters[ $field ], $field, false );
+			if ( is_wp_error( $id ) ) {
+				return $id;
+			}
+			$where[]  = "{$field} = %d";
+			$values[] = $id;
 		}
+		$date_filters = array(
+			'requested_start_at' => '>=',
+			'requested_end_at'   => '<=',
+		);
+		foreach ( $date_filters as $field => $operator ) {
+			if ( empty( $filters[ $field ] ) ) {
+				continue;
+			}
+			$date = $this->datetime( $filters[ $field ], $field );
+			if ( is_wp_error( $date ) ) {
+				return $date;
+			}
+			$where[]  = "{$field} {$operator} %s";
+			$values[] = $date;
+		}
+
 		$limit    = max( 1, min( 100, absint( $filters['limit'] ?? 50 ) ) );
 		$offset   = max( 0, absint( $filters['offset'] ?? 0 ) );
 		$values[] = $limit;
 		$values[] = $offset;
-		$query    = "SELECT * FROM {$table} WHERE " . implode( ' AND ', $where ) . ' ORDER BY created_at DESC, id DESC LIMIT %d OFFSET %d'; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
-		$rows = $wpdb->get_results( $wpdb->prepare( $query, $values ), ARRAY_A );
-		return array_map( array( $this, 'hydrate' ), is_array( $rows ) ? $rows : array() );
+		$query    = "SELECT * FROM {$table} WHERE " . implode( ' AND ', $where ) . ' ORDER BY created_at DESC, id DESC LIMIT %d OFFSET %d'; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Trusted current-prefix table and fixed clauses.
+		$rows     = $wpdb->get_results( $wpdb->prepare( $query, $values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Dynamic values are prepared.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_list_failed', __( 'Bookings could not be listed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		$hydrated = array();
+		foreach ( (array) $rows as $row ) {
+			$item = $this->hydrate( $row );
+			if ( is_wp_error( $item ) ) {
+				return $item;
+			}
+			$hydrated[] = $item;
+		}
+		return $hydrated;
 	}
 
-	/** Conditionally update a booking at an expected version. */
+	/** Conditionally update mutable booking fields at an expected version. */
 	public function update( int $id, array $changes, int $expected_version ) {
 		global $wpdb;
-		if ( $id < 1 || $expected_version < 1 ) {
-			return new \WP_Error( 'invalid_booking_update', __( 'A booking ID and expected version are required.', 'extrachill-events' ) );
+
+		$id       = $this->positive_id( $id, 'booking_id', false );
+		$expected = $this->positive_id( $expected_version, 'expected_version', false );
+		if ( is_wp_error( $id ) || is_wp_error( $expected ) ) {
+			return is_wp_error( $id ) ? $id : $expected;
 		}
+		$current = $this->get( $id );
+		if ( is_wp_error( $current ) ) {
+			return $current;
+		}
+		if ( null === $current ) {
+			return new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
+
 		if ( array_key_exists( 'artist_term_id', $changes ) || array_key_exists( 'artist_profile_id', $changes ) ) {
-			$current = $this->get( $id );
-			if ( ! $current ) {
-				return new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
-			}
 			$identity = $this->validate_identity( array_merge( $current, $changes ) );
 			if ( is_wp_error( $identity ) ) {
 				return $identity;
@@ -135,48 +218,108 @@ class BookingRepository {
 			$changes['artist_term_id']    = $identity['artist_term_id'];
 			$changes['artist_profile_id'] = $identity['artist_profile_id'];
 		}
-		$allowed = array(
-			'artist_term_id',
-			'artist_profile_id',
-			'artist_name',
-			'contact_name',
-			'contact_email',
-			'contact_phone',
-			'space_key',
-			'status',
-			'assignee_user_id',
-			'requested_start_at',
-			'requested_end_at',
-			'intake',
-			'deal',
-			'event_id',
-		);
+
+		$allowed = array( 'artist_term_id', 'artist_profile_id', 'artist_name', 'contact_name', 'contact_email', 'contact_phone', 'space_key', 'status', 'assignee_user_id', 'requested_start_at', 'requested_end_at', 'intake', 'deal' );
 		$changes = array_intersect_key( $changes, array_flip( $allowed ) );
 		if ( empty( $changes ) ) {
 			return new \WP_Error( 'empty_booking_update', __( 'No supported booking fields were supplied.', 'extrachill-events' ) );
 		}
 
-		$set    = array();
-		$values = array();
+		$normalized = array();
 		foreach ( $changes as $key => $value ) {
-			$column = $key;
 			if ( 'intake' === $key || 'deal' === $key ) {
-				$column = $key . '_payload';
-				$value  = $this->encode_payload( $value );
-			} elseif ( in_array( $key, array( 'artist_term_id', 'artist_profile_id', 'assignee_user_id', 'event_id' ), true ) ) {
-				$value = $this->nullable_id( $value );
+				$value = $this->encode_payload( $value, $key );
+			} elseif ( in_array( $key, array( 'artist_term_id', 'artist_profile_id', 'assignee_user_id' ), true ) ) {
+				$value = $this->positive_id( $value, $key, true );
 			} elseif ( in_array( $key, array( 'requested_start_at', 'requested_end_at' ), true ) ) {
-				$value = $this->nullable_datetime( $value );
-				if ( is_wp_error( $value ) ) {
-					return $value;
-				}
+				$value = $this->datetime( $value, $key );
+			} elseif ( 'artist_name' === $key ) {
+				$value = $this->required_text( $value, $key, 255 );
+			} elseif ( 'contact_name' === $key ) {
+				$value = $this->nullable_text( $value, 255 );
 			} elseif ( 'contact_email' === $key ) {
 				$value = $this->nullable_email( $value );
+			} elseif ( 'contact_phone' === $key ) {
+				$value = $this->nullable_text( $value, 64 );
 			} elseif ( 'space_key' === $key ) {
-				$value = $this->nullable_key( $value );
-			} else {
-				$value = sanitize_text_field( (string) $value );
+				$value = $this->nullable_key( $value, 64 );
+			} elseif ( 'status' === $key ) {
+				$value = $this->status( $value );
 			}
+			if ( is_wp_error( $value ) ) {
+				return $value;
+			}
+			$normalized[ 'intake' === $key || 'deal' === $key ? $key . '_payload' : $key ] = $value;
+		}
+
+		$start = array_key_exists( 'requested_start_at', $normalized ) ? $normalized['requested_start_at'] : $current['requested_start_at'];
+		$end   = array_key_exists( 'requested_end_at', $normalized ) ? $normalized['requested_end_at'] : $current['requested_end_at'];
+		$dates = $this->validate_date_range( $start, $end );
+		if ( is_wp_error( $dates ) ) {
+			return $dates;
+		}
+
+		$result = $this->conditional_update( $id, $expected, $normalized, '' );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		return $this->get( $id );
+	}
+
+	/** Atomically claim one site-local Data Machine event handoff. */
+	public function claim_event( int $id, int $event_id, int $expected_version ) {
+		$id       = $this->positive_id( $id, 'booking_id', false );
+		$event_id = $this->positive_id( $event_id, 'event_id', false );
+		$expected = $this->positive_id( $expected_version, 'expected_version', false );
+		foreach ( array( $id, $event_id, $expected ) as $validated ) {
+			if ( is_wp_error( $validated ) ) {
+				return $validated;
+			}
+		}
+
+		$current = $this->get( $id );
+		if ( is_wp_error( $current ) ) {
+			return $current;
+		}
+		if ( null === $current ) {
+			return new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
+		if ( $event_id === $current['event_id'] ) {
+			return $current;
+		}
+		if ( null !== $current['event_id'] ) {
+			return new \WP_Error( 'booking_event_already_linked', __( 'The booking is already linked to a different event.', 'extrachill-events' ), array( 'event_id' => $current['event_id'] ) );
+		}
+
+		$event     = get_post( $event_id );
+		$post_type = defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events';
+		if ( ! $event || $post_type !== $event->post_type ) {
+			return new \WP_Error( 'invalid_booking_event', __( 'A valid site-local event is required.', 'extrachill-events' ) );
+		}
+
+		$result = $this->conditional_update( $id, $expected, array( 'event_id' => $event_id ), ' AND event_id IS NULL' );
+		if ( is_wp_error( $result ) && 'booking_version_conflict' === $result->get_error_code() ) {
+			$latest = $this->get( $id );
+			if ( is_wp_error( $latest ) ) {
+				return $latest;
+			}
+			if ( is_array( $latest ) && $event_id === $latest['event_id'] ) {
+				return $latest;
+			}
+			if ( is_array( $latest ) && null !== $latest['event_id'] ) {
+				return new \WP_Error( 'booking_event_already_linked', __( 'The booking is already linked to a different event.', 'extrachill-events' ), array( 'event_id' => $latest['event_id'] ) );
+			}
+		}
+		return is_wp_error( $result ) ? $result : $this->get( $id );
+	}
+
+	/** Execute an optimistic update and distinguish disappearance from conflict. */
+	private function conditional_update( int $id, int $expected, array $changes, string $extra_where ) {
+		global $wpdb;
+
+		$set    = array();
+		$values = array();
+		foreach ( $changes as $column => $value ) {
 			if ( null === $value ) {
 				$set[] = "{$column} = NULL";
 			} elseif ( is_int( $value ) ) {
@@ -191,56 +334,90 @@ class BookingRepository {
 		$set[]    = 'updated_at = %s';
 		$values[] = gmdate( 'Y-m-d H:i:s' );
 		$values[] = $id;
-		$values[] = $expected_version;
+		$values[] = $expected;
 		$table    = BookingSchema::bookings_table();
-		$query    = "UPDATE {$table} SET " . implode( ', ', $set ) . ' WHERE id = %d AND version = %d'; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
-		$result = $wpdb->query( $wpdb->prepare( $query, $values ) );
+		$query    = "UPDATE {$table} SET " . implode( ', ', $set ) . " WHERE id = %d AND version = %d{$extra_where}"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Columns and suffix are internal constants.
+		$result   = $wpdb->query( $wpdb->prepare( $query, $values ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Values are prepared.
 		if ( false === $result ) {
-			return new \WP_Error( 'booking_update_failed', __( 'The booking could not be updated.', 'extrachill-events' ) );
+			return new \WP_Error( 'booking_update_failed', __( 'The booking could not be updated.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
 		if ( 0 === $result ) {
-			return new \WP_Error( 'booking_version_conflict', __( 'The booking changed since it was read.', 'extrachill-events' ), array( 'status' => 409 ) );
+			$current = $this->get( $id );
+			if ( is_wp_error( $current ) ) {
+				return $current;
+			}
+			return null === $current
+				? new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) )
+				: new \WP_Error(
+					'booking_version_conflict',
+					__( 'The booking changed since it was read.', 'extrachill-events' ),
+					array(
+						'status'          => 409,
+						'current_version' => $current['version'],
+					)
+				);
 		}
-		return $this->get( $id );
+		return true;
 	}
 
-	/** Validate optional canonical artist identities without creating mappings. */
+	/** Validate canonical/profile identities and their bidirectional binding. */
 	private function validate_identity( array $data ) {
-		$term_id    = $this->nullable_id( $data['artist_term_id'] ?? null );
-		$profile_id = $this->nullable_id( $data['artist_profile_id'] ?? null );
-		$name       = '';
-		if ( $term_id ) {
-			$main_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'main' ) : 0;
-			if ( $main_blog_id < 1 ) {
-				return new \WP_Error( 'artist_site_unresolved', __( 'The canonical artist site could not be resolved.', 'extrachill-events' ) );
-			}
-			switch_to_blog( $main_blog_id );
-			$term             = get_term( $term_id, 'artist' );
-			$bound_profile_id = $term && ! is_wp_error( $term ) ? absint( get_term_meta( $term_id, '_artist_profile_id', true ) ) : 0;
-			restore_current_blog();
-			if ( ! $term || is_wp_error( $term ) || 'artist' !== $term->taxonomy ) {
-				return new \WP_Error( 'invalid_booking_artist_term', __( 'The canonical artist term is invalid.', 'extrachill-events' ) );
-			}
-			$name = (string) $term->name;
-			if ( $profile_id && $bound_profile_id !== $profile_id ) {
-				return new \WP_Error( 'booking_artist_identity_mismatch', __( 'The artist term and profile are not bound.', 'extrachill-events' ) );
-			}
+		$term_id    = $this->positive_id( $data['artist_term_id'] ?? null, 'artist_term_id', true );
+		$profile_id = $this->positive_id( $data['artist_profile_id'] ?? null, 'artist_profile_id', true );
+		if ( is_wp_error( $term_id ) || is_wp_error( $profile_id ) ) {
+			return is_wp_error( $term_id ) ? $term_id : $profile_id;
 		}
+		$name            = '';
+		$profile_term_id = null;
+
 		if ( $profile_id ) {
 			$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : 0;
 			if ( $artist_blog_id < 1 ) {
 				return new \WP_Error( 'artist_platform_unresolved', __( 'The Artist Platform could not be resolved.', 'extrachill-events' ) );
 			}
 			switch_to_blog( $artist_blog_id );
-			$profile = get_post( $profile_id );
-			restore_current_blog();
-			if ( ! $profile || 'artist_profile' !== $profile->post_type ) {
-				return new \WP_Error( 'invalid_booking_artist_profile', __( 'The artist profile is invalid.', 'extrachill-events' ) );
+			try {
+				$profile         = get_post( $profile_id );
+				$profile_term_id = $profile ? $this->positive_id( get_post_meta( $profile_id, '_artist_term_id', true ), 'profile_artist_term_id', true ) : null;
+			} finally {
+				restore_current_blog();
 			}
-			if ( '' === $name ) {
-				$name = (string) $profile->post_title;
+			if ( ! $profile || 'artist_profile' !== $profile->post_type || 'publish' !== $profile->post_status ) {
+				return new \WP_Error( 'invalid_booking_artist_profile', __( 'The artist profile must exist and be published.', 'extrachill-events' ) );
 			}
+			if ( is_wp_error( $profile_term_id ) ) {
+				return $profile_term_id;
+			}
+			$name = (string) $profile->post_title;
+			if ( null === $term_id && $profile_term_id ) {
+				$term_id = $profile_term_id;
+			}
+		}
+
+		$bound_profile_id = null;
+		if ( $term_id ) {
+			$main_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'main' ) : 0;
+			if ( $main_blog_id < 1 ) {
+				return new \WP_Error( 'artist_site_unresolved', __( 'The canonical artist site could not be resolved.', 'extrachill-events' ) );
+			}
+			switch_to_blog( $main_blog_id );
+			try {
+				$term             = get_term( $term_id, 'artist' );
+				$bound_profile_id = $term && ! is_wp_error( $term ) ? $this->positive_id( get_term_meta( $term_id, '_artist_profile_id', true ), 'term_artist_profile_id', true ) : null;
+			} finally {
+				restore_current_blog();
+			}
+			if ( ! $term || is_wp_error( $term ) || 'artist' !== $term->taxonomy ) {
+				return new \WP_Error( 'invalid_booking_artist_term', __( 'The canonical artist term is invalid.', 'extrachill-events' ) );
+			}
+			if ( is_wp_error( $bound_profile_id ) ) {
+				return $bound_profile_id;
+			}
+			$name = (string) $term->name;
+		}
+
+		if ( $profile_id && $term_id && ( $profile_term_id !== $term_id || $bound_profile_id !== $profile_id ) ) {
+			return new \WP_Error( 'booking_artist_identity_mismatch', __( 'The artist term and profile bindings do not agree.', 'extrachill-events' ) );
 		}
 		return array(
 			'artist_term_id'    => $term_id,
@@ -249,33 +426,87 @@ class BookingRepository {
 		);
 	}
 
-	/** Encode flexible data in a versioned JSON envelope. */
-	private function encode_payload( $data ): string {
+	/** Encode flexible data without silently losing invalid structures. */
+	private function encode_payload( $data, string $field ) {
 		$encoded = wp_json_encode(
 			array(
 				'version' => self::PAYLOAD_VERSION,
 				'data'    => $data,
 			)
 		);
-		return false === $encoded ? '{"version":1,"data":{}}' : $encoded;
+		if ( false === $encoded ) {
+			return new \WP_Error(
+				'booking_payload_encode_failed',
+				__( 'Booking payload JSON encoding failed.', 'extrachill-events' ),
+				array(
+					'field'      => $field,
+					'json_error' => json_last_error_msg(),
+				)
+			);
+		}
+		return $encoded;
 	}
 
-	/** Hydrate scalar IDs and JSON payloads. */
-	public function hydrate( array $row ): array {
+	/** Hydrate scalar IDs and validated JSON envelopes. */
+	public function hydrate( array $row ) {
 		foreach ( array( 'id', 'venue_term_id', 'artist_term_id', 'artist_profile_id', 'submitter_user_id', 'version', 'assignee_user_id', 'event_id' ) as $key ) {
 			$row[ $key ] = isset( $row[ $key ] ) ? (int) $row[ $key ] : null;
 		}
-		foreach ( array( 'intake', 'deal' ) as $key ) {
-			$decoded     = json_decode( (string) ( $row[ $key . '_payload' ] ?? '' ), true );
-			$row[ $key ] = is_array( $decoded ) ? $decoded : null;
+		foreach ( array(
+			'intake' => false,
+			'deal'   => true,
+		) as $key => $nullable ) {
+			$decoded = $this->decode_payload( $row[ $key . '_payload' ] ?? null, $key, $nullable );
+			if ( is_wp_error( $decoded ) ) {
+				return $decoded;
+			}
+			$row[ $key ] = $decoded;
 			unset( $row[ $key . '_payload' ] );
 		}
 		return $row;
 	}
 
-	private function nullable_id( $value ): ?int {
-		$value = absint( $value );
-		return $value > 0 ? $value : null;
+	private function decode_payload( $json, string $field, bool $nullable ) {
+		if ( null === $json && $nullable ) {
+			return null;
+		}
+		$decoded = json_decode( (string) $json, true );
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) || ! array_key_exists( 'version', $decoded ) || ! array_key_exists( 'data', $decoded ) ) {
+			return new \WP_Error(
+				'booking_payload_invalid_json',
+				__( 'Stored booking payload JSON is malformed.', 'extrachill-events' ),
+				array(
+					'field'      => $field,
+					'json_error' => json_last_error_msg(),
+				)
+			);
+		}
+		if ( ! is_int( $decoded['version'] ) || self::PAYLOAD_VERSION !== $decoded['version'] ) {
+			return new \WP_Error(
+				'booking_payload_version_unsupported',
+				__( 'Stored booking payload version is unsupported.', 'extrachill-events' ),
+				array(
+					'field'   => $field,
+					'version' => $decoded['version'],
+				)
+			);
+		}
+		return $decoded;
+	}
+
+	private function positive_id( $value, string $field, bool $nullable ) {
+		if ( null === $value || '' === $value || 0 === $value || '0' === $value ) {
+			return $nullable ? null : new \WP_Error( 'invalid_booking_id', __( 'A positive identifier is required.', 'extrachill-events' ), array( 'field' => $field ) );
+		}
+		if ( ( ! is_int( $value ) && ! ( is_string( $value ) && ctype_digit( $value ) ) ) || (int) $value < 1 ) {
+			return new \WP_Error( 'invalid_booking_id', __( 'Identifiers must be positive integers.', 'extrachill-events' ), array( 'field' => $field ) );
+		}
+		return (int) $value;
+	}
+
+	private function required_text( $value, string $field, int $length ) {
+		$value = sanitize_text_field( (string) $value );
+		return '' === $value ? new \WP_Error( 'missing_booking_field', __( 'A required booking field is missing.', 'extrachill-events' ), array( 'field' => $field ) ) : mb_substr( $value, 0, $length );
 	}
 
 	private function nullable_text( $value, int $length ): ?string {
@@ -288,24 +519,34 @@ class BookingRepository {
 		return '' === $value ? null : mb_substr( $value, 0, 255 );
 	}
 
-	private function nullable_key( $value ): ?string {
-		$value = sanitize_key( (string) $value );
-		return '' === $value ? null : mb_substr( $value, 0, 64 );
+	private function nullable_key( $value, int $length ): ?string {
+		$value = mb_substr( sanitize_key( (string) $value ), 0, $length );
+		return '' === $value ? null : $value;
 	}
 
-	private function bounded_key( $value, int $length, string $fallback ): string {
-		$value = sanitize_key( (string) $value );
-		return '' === $value ? $fallback : mb_substr( $value, 0, $length );
+	private function status( $value ) {
+		$value = mb_substr( sanitize_key( (string) $value ), 0, 32 );
+		return '' === $value ? new \WP_Error( 'invalid_booking_status', __( 'A valid booking status is required.', 'extrachill-events' ) ) : $value;
 	}
 
-	private function nullable_datetime( $value ) {
+	private function datetime( $value, string $field ) {
 		if ( null === $value || '' === $value ) {
 			return null;
 		}
 		$date = \DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', (string) $value, new \DateTimeZone( 'UTC' ) );
 		if ( ! $date || $date->format( 'Y-m-d H:i:s' ) !== $value ) {
-			return new \WP_Error( 'invalid_booking_datetime', __( 'Booking datetimes must use UTC Y-m-d H:i:s format.', 'extrachill-events' ) );
+			return new \WP_Error( 'invalid_booking_datetime', __( 'Booking datetimes must use UTC Y-m-d H:i:s format.', 'extrachill-events' ), array( 'field' => $field ) );
 		}
 		return $date->format( 'Y-m-d H:i:s' );
+	}
+
+	private function validate_date_range( $start, $end ) {
+		if ( is_wp_error( $start ) || is_wp_error( $end ) ) {
+			return is_wp_error( $start ) ? $start : $end;
+		}
+		if ( null !== $start && null !== $end && $end < $start ) {
+			return new \WP_Error( 'invalid_booking_date_range', __( 'The requested end must not precede the requested start.', 'extrachill-events' ) );
+		}
+		return true;
 	}
 }

--- a/inc/Core/BookingRepository.php
+++ b/inc/Core/BookingRepository.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Private venue booking repository.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+// phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag,Squiz.Commenting.FunctionComment.Missing -- Concise internal helpers are typed and named by purpose.
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Provides bounded access to operational booking records. */
+class BookingRepository {
+
+	private const PAYLOAD_VERSION = 1;
+
+	/** Create a booking. */
+	public function create( array $data ) {
+		global $wpdb;
+
+		$identity = $this->validate_identity( $data );
+		if ( is_wp_error( $identity ) ) {
+			return $identity;
+		}
+		$venue_term_id = absint( $data['venue_term_id'] ?? 0 );
+		$venue         = get_term( $venue_term_id, 'venue' );
+		if ( $venue_term_id < 1 || ! $venue || is_wp_error( $venue ) || 'venue' !== $venue->taxonomy ) {
+			return new \WP_Error( 'invalid_booking_venue', __( 'A valid Events venue term is required.', 'extrachill-events' ) );
+		}
+		$artist_name = sanitize_text_field( (string) ( $data['artist_name'] ?? $identity['artist_name'] ) );
+		if ( '' === $artist_name ) {
+			return new \WP_Error( 'missing_booking_artist_name', __( 'An artist name is required.', 'extrachill-events' ) );
+		}
+
+		$now = gmdate( 'Y-m-d H:i:s' );
+		$row = array(
+			'public_id'          => wp_generate_uuid4(),
+			'venue_term_id'      => $venue_term_id,
+			'artist_term_id'     => $identity['artist_term_id'],
+			'artist_profile_id'  => $identity['artist_profile_id'],
+			'artist_name'        => mb_substr( $artist_name, 0, 255 ),
+			'submitter_user_id'  => $this->nullable_id( $data['submitter_user_id'] ?? null ),
+			'contact_name'       => $this->nullable_text( $data['contact_name'] ?? null, 255 ),
+			'contact_email'      => $this->nullable_email( $data['contact_email'] ?? null ),
+			'contact_phone'      => $this->nullable_text( $data['contact_phone'] ?? null, 64 ),
+			'space_key'          => $this->nullable_key( $data['space_key'] ?? null ),
+			'status'             => $this->bounded_key( $data['status'] ?? 'inquiry', 32, 'inquiry' ),
+			'version'            => 1,
+			'assignee_user_id'   => $this->nullable_id( $data['assignee_user_id'] ?? null ),
+			'requested_start_at' => $this->nullable_datetime( $data['requested_start_at'] ?? null ),
+			'requested_end_at'   => $this->nullable_datetime( $data['requested_end_at'] ?? null ),
+			'intake_payload'     => $this->encode_payload( $data['intake'] ?? array() ),
+			'deal_payload'       => array_key_exists( 'deal', $data ) ? $this->encode_payload( $data['deal'] ) : null,
+			'event_id'           => $this->nullable_id( $data['event_id'] ?? null ),
+			'created_at'         => $now,
+			'updated_at'         => $now,
+		);
+		if ( is_wp_error( $row['requested_start_at'] ) || is_wp_error( $row['requested_end_at'] ) ) {
+			return is_wp_error( $row['requested_start_at'] ) ? $row['requested_start_at'] : $row['requested_end_at'];
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+		if ( false === $wpdb->insert( BookingSchema::bookings_table(), $row ) ) {
+			return new \WP_Error( 'booking_create_failed', __( 'The booking could not be created.', 'extrachill-events' ) );
+		}
+		return $this->get( (int) $wpdb->insert_id );
+	}
+
+	/** Get a booking by numeric ID or UUID public reference. */
+	public function get( $identifier ): ?array {
+		global $wpdb;
+		$table = BookingSchema::bookings_table();
+		if ( is_numeric( $identifier ) && (int) $identifier > 0 ) {
+			$sql = $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1", (int) $identifier ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		} else {
+			$sql = $wpdb->prepare( "SELECT * FROM {$table} WHERE public_id = %s LIMIT 1", (string) $identifier ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+		$row = $wpdb->get_row( $sql, ARRAY_A );
+		return is_array( $row ) ? $this->hydrate( $row ) : null;
+	}
+
+	/** List bookings for one venue with bounded optional filters. */
+	public function list( array $filters ) {
+		global $wpdb;
+		$venue_term_id = absint( $filters['venue_term_id'] ?? 0 );
+		if ( $venue_term_id < 1 ) {
+			return new \WP_Error( 'missing_booking_venue_filter', __( 'A venue filter is required.', 'extrachill-events' ) );
+		}
+		$table  = BookingSchema::bookings_table();
+		$where  = array( 'venue_term_id = %d' );
+		$values = array( $venue_term_id );
+		$keys   = array(
+			'status'             => '%s',
+			'artist_term_id'     => '%d',
+			'artist_profile_id'  => '%d',
+			'assignee_user_id'   => '%d',
+			'requested_start_at' => '%s',
+		);
+		foreach ( $keys as $key => $placeholder ) {
+			if ( ! isset( $filters[ $key ] ) || '' === $filters[ $key ] ) {
+				continue;
+			}
+			$operator = 'requested_start_at' === $key ? '>=' : '=';
+			$where[]  = "{$key} {$operator} {$placeholder}";
+			$values[] = '%d' === $placeholder ? absint( $filters[ $key ] ) : (string) $filters[ $key ];
+		}
+		$limit    = max( 1, min( 100, absint( $filters['limit'] ?? 50 ) ) );
+		$offset   = max( 0, absint( $filters['offset'] ?? 0 ) );
+		$values[] = $limit;
+		$values[] = $offset;
+		$query    = "SELECT * FROM {$table} WHERE " . implode( ' AND ', $where ) . ' ORDER BY created_at DESC, id DESC LIMIT %d OFFSET %d'; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+		$rows = $wpdb->get_results( $wpdb->prepare( $query, $values ), ARRAY_A );
+		return array_map( array( $this, 'hydrate' ), is_array( $rows ) ? $rows : array() );
+	}
+
+	/** Conditionally update a booking at an expected version. */
+	public function update( int $id, array $changes, int $expected_version ) {
+		global $wpdb;
+		if ( $id < 1 || $expected_version < 1 ) {
+			return new \WP_Error( 'invalid_booking_update', __( 'A booking ID and expected version are required.', 'extrachill-events' ) );
+		}
+		if ( array_key_exists( 'artist_term_id', $changes ) || array_key_exists( 'artist_profile_id', $changes ) ) {
+			$current = $this->get( $id );
+			if ( ! $current ) {
+				return new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+			}
+			$identity = $this->validate_identity( array_merge( $current, $changes ) );
+			if ( is_wp_error( $identity ) ) {
+				return $identity;
+			}
+			$changes['artist_term_id']    = $identity['artist_term_id'];
+			$changes['artist_profile_id'] = $identity['artist_profile_id'];
+		}
+		$allowed = array(
+			'artist_term_id',
+			'artist_profile_id',
+			'artist_name',
+			'contact_name',
+			'contact_email',
+			'contact_phone',
+			'space_key',
+			'status',
+			'assignee_user_id',
+			'requested_start_at',
+			'requested_end_at',
+			'intake',
+			'deal',
+			'event_id',
+		);
+		$changes = array_intersect_key( $changes, array_flip( $allowed ) );
+		if ( empty( $changes ) ) {
+			return new \WP_Error( 'empty_booking_update', __( 'No supported booking fields were supplied.', 'extrachill-events' ) );
+		}
+
+		$set    = array();
+		$values = array();
+		foreach ( $changes as $key => $value ) {
+			$column = $key;
+			if ( 'intake' === $key || 'deal' === $key ) {
+				$column = $key . '_payload';
+				$value  = $this->encode_payload( $value );
+			} elseif ( in_array( $key, array( 'artist_term_id', 'artist_profile_id', 'assignee_user_id', 'event_id' ), true ) ) {
+				$value = $this->nullable_id( $value );
+			} elseif ( in_array( $key, array( 'requested_start_at', 'requested_end_at' ), true ) ) {
+				$value = $this->nullable_datetime( $value );
+				if ( is_wp_error( $value ) ) {
+					return $value;
+				}
+			} elseif ( 'contact_email' === $key ) {
+				$value = $this->nullable_email( $value );
+			} elseif ( 'space_key' === $key ) {
+				$value = $this->nullable_key( $value );
+			} else {
+				$value = sanitize_text_field( (string) $value );
+			}
+			if ( null === $value ) {
+				$set[] = "{$column} = NULL";
+			} elseif ( is_int( $value ) ) {
+				$set[]    = "{$column} = %d";
+				$values[] = $value;
+			} else {
+				$set[]    = "{$column} = %s";
+				$values[] = $value;
+			}
+		}
+		$set[]    = 'version = version + 1';
+		$set[]    = 'updated_at = %s';
+		$values[] = gmdate( 'Y-m-d H:i:s' );
+		$values[] = $id;
+		$values[] = $expected_version;
+		$table    = BookingSchema::bookings_table();
+		$query    = "UPDATE {$table} SET " . implode( ', ', $set ) . ' WHERE id = %d AND version = %d'; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+		$result = $wpdb->query( $wpdb->prepare( $query, $values ) );
+		if ( false === $result ) {
+			return new \WP_Error( 'booking_update_failed', __( 'The booking could not be updated.', 'extrachill-events' ) );
+		}
+		if ( 0 === $result ) {
+			return new \WP_Error( 'booking_version_conflict', __( 'The booking changed since it was read.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return $this->get( $id );
+	}
+
+	/** Validate optional canonical artist identities without creating mappings. */
+	private function validate_identity( array $data ) {
+		$term_id    = $this->nullable_id( $data['artist_term_id'] ?? null );
+		$profile_id = $this->nullable_id( $data['artist_profile_id'] ?? null );
+		$name       = '';
+		if ( $term_id ) {
+			$main_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'main' ) : 0;
+			if ( $main_blog_id < 1 ) {
+				return new \WP_Error( 'artist_site_unresolved', __( 'The canonical artist site could not be resolved.', 'extrachill-events' ) );
+			}
+			switch_to_blog( $main_blog_id );
+			$term             = get_term( $term_id, 'artist' );
+			$bound_profile_id = $term && ! is_wp_error( $term ) ? absint( get_term_meta( $term_id, '_artist_profile_id', true ) ) : 0;
+			restore_current_blog();
+			if ( ! $term || is_wp_error( $term ) || 'artist' !== $term->taxonomy ) {
+				return new \WP_Error( 'invalid_booking_artist_term', __( 'The canonical artist term is invalid.', 'extrachill-events' ) );
+			}
+			$name = (string) $term->name;
+			if ( $profile_id && $bound_profile_id !== $profile_id ) {
+				return new \WP_Error( 'booking_artist_identity_mismatch', __( 'The artist term and profile are not bound.', 'extrachill-events' ) );
+			}
+		}
+		if ( $profile_id ) {
+			$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : 0;
+			if ( $artist_blog_id < 1 ) {
+				return new \WP_Error( 'artist_platform_unresolved', __( 'The Artist Platform could not be resolved.', 'extrachill-events' ) );
+			}
+			switch_to_blog( $artist_blog_id );
+			$profile = get_post( $profile_id );
+			restore_current_blog();
+			if ( ! $profile || 'artist_profile' !== $profile->post_type ) {
+				return new \WP_Error( 'invalid_booking_artist_profile', __( 'The artist profile is invalid.', 'extrachill-events' ) );
+			}
+			if ( '' === $name ) {
+				$name = (string) $profile->post_title;
+			}
+		}
+		return array(
+			'artist_term_id'    => $term_id,
+			'artist_profile_id' => $profile_id,
+			'artist_name'       => $name,
+		);
+	}
+
+	/** Encode flexible data in a versioned JSON envelope. */
+	private function encode_payload( $data ): string {
+		$encoded = wp_json_encode(
+			array(
+				'version' => self::PAYLOAD_VERSION,
+				'data'    => $data,
+			)
+		);
+		return false === $encoded ? '{"version":1,"data":{}}' : $encoded;
+	}
+
+	/** Hydrate scalar IDs and JSON payloads. */
+	public function hydrate( array $row ): array {
+		foreach ( array( 'id', 'venue_term_id', 'artist_term_id', 'artist_profile_id', 'submitter_user_id', 'version', 'assignee_user_id', 'event_id' ) as $key ) {
+			$row[ $key ] = isset( $row[ $key ] ) ? (int) $row[ $key ] : null;
+		}
+		foreach ( array( 'intake', 'deal' ) as $key ) {
+			$decoded     = json_decode( (string) ( $row[ $key . '_payload' ] ?? '' ), true );
+			$row[ $key ] = is_array( $decoded ) ? $decoded : null;
+			unset( $row[ $key . '_payload' ] );
+		}
+		return $row;
+	}
+
+	private function nullable_id( $value ): ?int {
+		$value = absint( $value );
+		return $value > 0 ? $value : null;
+	}
+
+	private function nullable_text( $value, int $length ): ?string {
+		$value = sanitize_text_field( (string) $value );
+		return '' === $value ? null : mb_substr( $value, 0, $length );
+	}
+
+	private function nullable_email( $value ): ?string {
+		$value = sanitize_email( (string) $value );
+		return '' === $value ? null : mb_substr( $value, 0, 255 );
+	}
+
+	private function nullable_key( $value ): ?string {
+		$value = sanitize_key( (string) $value );
+		return '' === $value ? null : mb_substr( $value, 0, 64 );
+	}
+
+	private function bounded_key( $value, int $length, string $fallback ): string {
+		$value = sanitize_key( (string) $value );
+		return '' === $value ? $fallback : mb_substr( $value, 0, $length );
+	}
+
+	private function nullable_datetime( $value ) {
+		if ( null === $value || '' === $value ) {
+			return null;
+		}
+		$date = \DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', (string) $value, new \DateTimeZone( 'UTC' ) );
+		if ( ! $date || $date->format( 'Y-m-d H:i:s' ) !== $value ) {
+			return new \WP_Error( 'invalid_booking_datetime', __( 'Booking datetimes must use UTC Y-m-d H:i:s format.', 'extrachill-events' ) );
+		}
+		return $date->format( 'Y-m-d H:i:s' );
+	}
+}

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -55,7 +55,7 @@ class BookingSchema {
 			contact_phone VARCHAR(64) NULL,
 			space_key VARCHAR(64) NULL,
 			status VARCHAR(32) NOT NULL DEFAULT 'inquiry',
-			version BIGINT UNSIGNED NOT NULL DEFAULT 1,
+			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
 			assignee_user_id BIGINT UNSIGNED NULL,
 			requested_start_at DATETIME NULL,
 			requested_end_at DATETIME NULL,
@@ -95,23 +95,33 @@ class BookingSchema {
 			KEY channel_external (channel, external_id)
 		) ENGINE=InnoDB {$charset};";
 
+		$repair = self::drop_conflicting_indexes();
+		if ( is_wp_error( $repair ) ) {
+			self::record_failure( $repair );
+			return $repair;
+		}
+
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $bookings_sql );
+		$bookings_error = (string) $wpdb->last_error;
 		dbDelta( $activity_sql );
+		$activity_error = (string) $wpdb->last_error;
+		if ( '' !== $bookings_error || '' !== $activity_error ) {
+			$error = new \WP_Error(
+				'booking_schema_dbdelta_failed',
+				__( 'The booking schema could not be reconciled.', 'extrachill-events' ),
+				array(
+					'bookings_error' => $bookings_error,
+					'activity_error' => $activity_error,
+				)
+			);
+			self::record_failure( $error );
+			return $error;
+		}
 
 		$health = self::health();
 		if ( is_wp_error( $health ) ) {
-			update_option(
-				self::FAILURE_OPTION,
-				array(
-					'code'        => $health->get_error_code(),
-					'message'     => $health->get_error_message(),
-					'data'        => $health->get_error_data(),
-					'failed_at'   => gmdate( 'Y-m-d H:i:s' ),
-					'site_prefix' => $wpdb->prefix,
-				),
-				false
-			);
+			self::record_failure( $health );
 			return $health;
 		}
 
@@ -120,77 +130,23 @@ class BookingSchema {
 		return true;
 	}
 
-	/** Install when the version is stale or verified schema health is incomplete. */
+	/** Install only when the stored schema version is stale. */
 	public static function maybe_install() {
 		if ( self::SCHEMA_VERSION === (string) get_option( self::VERSION_OPTION, '' ) ) {
-			$health = self::health();
-			if ( true === $health ) {
-				return true;
-			}
+			return true;
 		}
 		return self::install();
 	}
 
-	/** Verify tables, critical columns, indexes, and uniqueness contracts. */
+	/** Verify tables, column attributes, indexes, and uniqueness contracts. */
 	public static function health() {
 		global $wpdb;
 
-		$contracts = array(
-			self::bookings_table() => array(
-				'columns' => array( 'id', 'public_id', 'venue_term_id', 'artist_term_id', 'artist_profile_id', 'artist_name', 'submitter_user_id', 'contact_name', 'contact_email', 'contact_phone', 'space_key', 'status', 'version', 'assignee_user_id', 'requested_start_at', 'requested_end_at', 'intake_payload', 'deal_payload', 'event_id', 'created_at', 'updated_at' ),
-				'types'   => array(
-					'id'             => 'bigint unsigned',
-					'public_id'      => 'char(36)',
-					'venue_term_id'  => 'bigint unsigned',
-					'status'         => 'varchar(32)',
-					'version'        => 'bigint unsigned',
-					'intake_payload' => 'longtext',
-					'event_id'       => 'bigint unsigned',
-				),
-				'indexes' => array(
-					'PRIMARY'                => array( true, array( 'id' ) ),
-					'public_id'              => array( true, array( 'public_id' ) ),
-					'event_id'               => array( true, array( 'event_id' ) ),
-					'venue_status_created'   => array( false, array( 'venue_term_id', 'status', 'created_at' ) ),
-					'venue_requested_start'  => array( false, array( 'venue_term_id', 'requested_start_at' ) ),
-					'artist_term_created'    => array( false, array( 'artist_term_id', 'created_at' ) ),
-					'artist_profile_created' => array( false, array( 'artist_profile_id', 'created_at' ) ),
-					'assignee_status'        => array( false, array( 'assignee_user_id', 'status' ) ),
-					'status_updated'         => array( false, array( 'status', 'updated_at' ) ),
-				),
-			),
-			self::activity_table() => array(
-				'columns' => array( 'id', 'booking_id', 'kind', 'actor_type', 'actor_id', 'direction', 'channel', 'payload', 'external_id', 'idempotency_key', 'occurred_at', 'created_at' ),
-				'types'   => array(
-					'id'              => 'bigint unsigned',
-					'booking_id'      => 'bigint unsigned',
-					'kind'            => 'varchar(64)',
-					'payload'         => 'longtext',
-					'idempotency_key' => 'varchar(191)',
-					'occurred_at'     => 'datetime',
-				),
-				'indexes' => array(
-					'PRIMARY'             => array( true, array( 'id' ) ),
-					'booking_idempotency' => array( true, array( 'booking_id', 'idempotency_key' ) ),
-					'booking_occurred'    => array( false, array( 'booking_id', 'occurred_at', 'id' ) ),
-					'kind_occurred'       => array( false, array( 'kind', 'occurred_at' ) ),
-					'channel_external'    => array( false, array( 'channel', 'external_id' ) ),
-				),
-			),
-		);
-
-		foreach ( $contracts as $table => $contract ) {
+		foreach ( self::contracts() as $table => $contract ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Installation health cannot be cached.
 			$found = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
 			if ( '' !== (string) $wpdb->last_error ) {
-				return new \WP_Error(
-					'booking_schema_db_error',
-					__( 'Could not inspect the booking tables.', 'extrachill-events' ),
-					array(
-						'table'          => $table,
-						'database_error' => $wpdb->last_error,
-					)
-				);
+				return self::database_error( __( 'Could not inspect the booking tables.', 'extrachill-events' ), $table );
 			}
 			if ( $found !== $table ) {
 				return new \WP_Error( 'booking_schema_table_missing', __( 'A required booking table is missing.', 'extrachill-events' ), array( 'table' => $table ) );
@@ -198,79 +154,54 @@ class BookingSchema {
 
 			$columns = $wpdb->get_results( "SHOW COLUMNS FROM `{$table}`", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted current-prefix table.
 			if ( '' !== (string) $wpdb->last_error ) {
-				return new \WP_Error(
-					'booking_schema_db_error',
-					__( 'Could not inspect booking columns.', 'extrachill-events' ),
-					array(
-						'table'          => $table,
-						'database_error' => $wpdb->last_error,
-					)
-				);
+				return self::database_error( __( 'Could not inspect booking columns.', 'extrachill-events' ), $table );
 			}
-			$column_names = array_column( (array) $columns, 'Field' );
-			$missing      = array_values( array_diff( $contract['columns'], $column_names ) );
-			if ( ! empty( $missing ) ) {
-				return new \WP_Error(
-					'booking_schema_columns_missing',
-					__( 'Required booking columns are missing.', 'extrachill-events' ),
-					array(
-						'table'   => $table,
-						'columns' => $missing,
-					)
-				);
-			}
-			$column_types = array();
+			$found_columns = array();
 			foreach ( (array) $columns as $column ) {
-				$column_types[ $column['Field'] ] = preg_replace( '/\(20\)/', '', strtolower( (string) $column['Type'] ) );
+				$found_columns[ $column['Field'] ] = self::normalize_column( $column );
 			}
-			foreach ( $contract['types'] as $column => $required_type ) {
-				if ( ! isset( $column_types[ $column ] ) || $required_type !== $column_types[ $column ] ) {
+			foreach ( $contract['columns'] as $name => $required_column ) {
+				if ( ! isset( $found_columns[ $name ] ) ) {
 					return new \WP_Error(
-						'booking_schema_column_invalid',
-						__( 'A critical booking column has an incompatible type.', 'extrachill-events' ),
+						'booking_schema_columns_missing',
+						__( 'A required booking column is missing.', 'extrachill-events' ),
 						array(
 							'table'  => $table,
-							'column' => $column,
-							'type'   => $required_type,
+							'column' => $name,
 						)
 					);
+				}
+				foreach ( $required_column as $attribute => $required_value ) {
+					if ( $required_value !== $found_columns[ $name ][ $attribute ] ) {
+						return new \WP_Error(
+							'booking_schema_column_invalid',
+							__( 'A required booking column has incompatible attributes.', 'extrachill-events' ),
+							array(
+								'table'     => $table,
+								'column'    => $name,
+								'attribute' => $attribute,
+								'expected'  => $required_value,
+								'actual'    => $found_columns[ $name ][ $attribute ],
+							)
+						);
+					}
 				}
 			}
 
 			$indexes = $wpdb->get_results( "SHOW INDEX FROM `{$table}`", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted current-prefix table.
 			if ( '' !== (string) $wpdb->last_error ) {
-				return new \WP_Error(
-					'booking_schema_db_error',
-					__( 'Could not inspect booking indexes.', 'extrachill-events' ),
-					array(
-						'table'          => $table,
-						'database_error' => $wpdb->last_error,
-					)
-				);
+				return self::database_error( __( 'Could not inspect booking indexes.', 'extrachill-events' ), $table );
 			}
-			$found_indexes = array();
-			foreach ( (array) $indexes as $index ) {
-				$name                             = $index['Key_name'];
-				$found_indexes[ $name ]['unique'] = 0 === (int) $index['Non_unique'];
-				$found_indexes[ $name ]['columns'][ (int) $index['Seq_in_index'] ] = $index['Column_name'];
-			}
-			foreach ( $found_indexes as &$found_index ) {
-				ksort( $found_index['columns'] );
-				$found_index['columns'] = array_values( $found_index['columns'] );
-			}
-			unset( $found_index );
+			$found_indexes = self::normalize_indexes( (array) $indexes );
 			foreach ( $contract['indexes'] as $name => $required_index ) {
-				$must_be_unique   = $required_index[0];
-				$required_columns = $required_index[1];
-				if ( ! isset( $found_indexes[ $name ] ) || $must_be_unique !== $found_indexes[ $name ]['unique'] || $required_columns !== $found_indexes[ $name ]['columns'] ) {
+				if ( ! isset( $found_indexes[ $name ] ) || $required_index !== $found_indexes[ $name ] ) {
 					return new \WP_Error(
 						'booking_schema_index_missing',
 						__( 'A required booking index is missing or invalid.', 'extrachill-events' ),
 						array(
-							'table'   => $table,
-							'index'   => $name,
-							'unique'  => $must_be_unique,
-							'columns' => $required_columns,
+							'table'      => $table,
+							'index'      => $name,
+							'definition' => $required_index,
 						)
 					);
 				}
@@ -282,5 +213,222 @@ class BookingSchema {
 	/** Backward-compatible table existence check backed by full schema health. */
 	public static function tables_exist(): bool {
 		return true === self::health();
+	}
+
+	/** Drop only required same-name indexes whose definitions block dbDelta repair. */
+	private static function drop_conflicting_indexes() {
+		global $wpdb;
+
+		foreach ( self::contracts() as $table => $contract ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Installation repair cannot be cached.
+			$found = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+			if ( '' !== (string) $wpdb->last_error ) {
+				return self::database_error( __( 'Could not inspect booking tables before repair.', 'extrachill-events' ), $table );
+			}
+			if ( $found !== $table ) {
+				continue;
+			}
+			$indexes = $wpdb->get_results( "SHOW INDEX FROM `{$table}`", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted current-prefix table.
+			if ( '' !== (string) $wpdb->last_error ) {
+				return self::database_error( __( 'Could not inspect booking indexes before repair.', 'extrachill-events' ), $table );
+			}
+			$found_indexes = self::normalize_indexes( (array) $indexes );
+			foreach ( $contract['indexes'] as $name => $required_index ) {
+				if ( ! isset( $found_indexes[ $name ] ) || $required_index === $found_indexes[ $name ] ) {
+					continue;
+				}
+				if ( 'PRIMARY' === $name ) {
+					$primary_columns = '`' . implode( '`, `', $required_index['columns'] ) . '`';
+					$drop            = "ALTER TABLE `{$table}` DROP PRIMARY KEY, ADD PRIMARY KEY ({$primary_columns})";
+				} else {
+					$drop = "ALTER TABLE `{$table}` DROP INDEX `{$name}`";
+				}
+				$result = $wpdb->query( $drop ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Internal table and index names from the schema contract.
+				if ( false === $result ) {
+					return new \WP_Error(
+						'booking_schema_index_repair_failed',
+						__( 'A malformed booking index could not be removed for repair.', 'extrachill-events' ),
+						array(
+							'table'          => $table,
+							'index'          => $name,
+							'database_error' => $wpdb->last_error,
+						)
+					);
+				}
+			}
+		}
+		return true;
+	}
+
+	/** Return the final initial schema contract shared by health and repair. */
+	private static function contracts(): array {
+		$required = static function ( string $type, bool $nullable, array $attributes = array() ): array {
+			return array_merge(
+				array(
+					'type'     => $type,
+					'nullable' => $nullable,
+				),
+				$attributes
+			);
+		};
+		return array(
+			self::bookings_table() => array(
+				'columns' => array(
+					'id'                 => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'public_id'          => $required( 'char(36)', false ),
+					'venue_term_id'      => $required( 'bigint unsigned', false ),
+					'artist_term_id'     => $required( 'bigint unsigned', true ),
+					'artist_profile_id'  => $required( 'bigint unsigned', true ),
+					'artist_name'        => $required( 'varchar(255)', false ),
+					'submitter_user_id'  => $required( 'bigint unsigned', true ),
+					'contact_name'       => $required( 'varchar(255)', true ),
+					'contact_email'      => $required( 'varchar(255)', true ),
+					'contact_phone'      => $required( 'varchar(64)', true ),
+					'space_key'          => $required( 'varchar(64)', true ),
+					'status'             => $required( 'varchar(32)', false, array( 'default' => 'inquiry' ) ),
+					'version'            => $required( 'bigint unsigned', false, array( 'default' => '1' ) ),
+					'assignee_user_id'   => $required( 'bigint unsigned', true ),
+					'requested_start_at' => $required( 'datetime', true ),
+					'requested_end_at'   => $required( 'datetime', true ),
+					'intake_payload'     => $required( 'longtext', false ),
+					'deal_payload'       => $required( 'longtext', true ),
+					'event_id'           => $required( 'bigint unsigned', true ),
+					'created_at'         => $required( 'datetime', false ),
+					'updated_at'         => $required( 'datetime', false ),
+				),
+				'indexes' => array(
+					'PRIMARY'                => array(
+						'unique'  => true,
+						'columns' => array( 'id' ),
+					),
+					'public_id'              => array(
+						'unique'  => true,
+						'columns' => array( 'public_id' ),
+					),
+					'event_id'               => array(
+						'unique'  => true,
+						'columns' => array( 'event_id' ),
+					),
+					'venue_status_created'   => array(
+						'unique'  => false,
+						'columns' => array( 'venue_term_id', 'status', 'created_at' ),
+					),
+					'venue_requested_start'  => array(
+						'unique'  => false,
+						'columns' => array( 'venue_term_id', 'requested_start_at' ),
+					),
+					'artist_term_created'    => array(
+						'unique'  => false,
+						'columns' => array( 'artist_term_id', 'created_at' ),
+					),
+					'artist_profile_created' => array(
+						'unique'  => false,
+						'columns' => array( 'artist_profile_id', 'created_at' ),
+					),
+					'assignee_status'        => array(
+						'unique'  => false,
+						'columns' => array( 'assignee_user_id', 'status' ),
+					),
+					'status_updated'         => array(
+						'unique'  => false,
+						'columns' => array( 'status', 'updated_at' ),
+					),
+				),
+			),
+			self::activity_table() => array(
+				'columns' => array(
+					'id'              => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'booking_id'      => $required( 'bigint unsigned', false ),
+					'kind'            => $required( 'varchar(64)', false ),
+					'actor_type'      => $required( 'varchar(32)', false, array( 'default' => 'system' ) ),
+					'actor_id'        => $required( 'bigint unsigned', true ),
+					'direction'       => $required( 'varchar(16)', true ),
+					'channel'         => $required( 'varchar(32)', true ),
+					'payload'         => $required( 'longtext', false ),
+					'external_id'     => $required( 'varchar(191)', true ),
+					'idempotency_key' => $required( 'varchar(191)', true ),
+					'occurred_at'     => $required( 'datetime', false ),
+					'created_at'      => $required( 'datetime', false ),
+				),
+				'indexes' => array(
+					'PRIMARY'             => array(
+						'unique'  => true,
+						'columns' => array( 'id' ),
+					),
+					'booking_idempotency' => array(
+						'unique'  => true,
+						'columns' => array( 'booking_id', 'idempotency_key' ),
+					),
+					'booking_occurred'    => array(
+						'unique'  => false,
+						'columns' => array( 'booking_id', 'occurred_at', 'id' ),
+					),
+					'kind_occurred'       => array(
+						'unique'  => false,
+						'columns' => array( 'kind', 'occurred_at' ),
+					),
+					'channel_external'    => array(
+						'unique'  => false,
+						'columns' => array( 'channel', 'external_id' ),
+					),
+				),
+			),
+		);
+	}
+
+	/** Normalize one SHOW COLUMNS row to the declared contract shape. */
+	private static function normalize_column( array $column ): array {
+		$type = preg_replace( '/\((?:8|11|20)\)(?=\s+unsigned)/', '', strtolower( trim( (string) ( $column['Type'] ?? '' ) ) ) );
+		return array(
+			'type'     => preg_replace( '/\s+/', ' ', $type ),
+			'nullable' => 'YES' === strtoupper( (string) ( $column['Null'] ?? '' ) ),
+			'default'  => null === ( $column['Default'] ?? null ) ? null : (string) $column['Default'],
+			'extra'    => strtolower( trim( (string) ( $column['Extra'] ?? '' ) ) ),
+		);
+	}
+
+	/** Normalize SHOW INDEX rows to exact uniqueness and ordered columns. */
+	private static function normalize_indexes( array $indexes ): array {
+		$normalized = array();
+		foreach ( $indexes as $index ) {
+			$name                          = $index['Key_name'];
+			$normalized[ $name ]['unique'] = 0 === (int) $index['Non_unique'];
+			$normalized[ $name ]['columns'][ (int) $index['Seq_in_index'] ] = $index['Column_name'];
+		}
+		foreach ( $normalized as &$definition ) {
+			ksort( $definition['columns'] );
+			$definition['columns'] = array_values( $definition['columns'] );
+		}
+		unset( $definition );
+		return $normalized;
+	}
+
+	/** Build a consistent database inspection error. */
+	private static function database_error( string $message, string $table ): \WP_Error {
+		global $wpdb;
+		return new \WP_Error(
+			'booking_schema_db_error',
+			$message,
+			array(
+				'table'          => $table,
+				'database_error' => $wpdb->last_error,
+			)
+		);
+	}
+
+	/** Record an actionable install failure without advancing the version. */
+	private static function record_failure( \WP_Error $error ): void {
+		global $wpdb;
+		update_option(
+			self::FAILURE_OPTION,
+			array(
+				'code'        => $error->get_error_code(),
+				'message'     => $error->get_error_message(),
+				'data'        => $error->get_error_data(),
+				'failed_at'   => gmdate( 'Y-m-d H:i:s' ),
+				'site_prefix' => $wpdb->prefix,
+			),
+			false
+		);
 	}
 }

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -2,6 +2,10 @@
 /**
  * Venue booking table installation.
  *
+ * Storage is intentionally scoped to the current Events-site route through
+ * `$wpdb->prefix`. Callers must execute on the Events site; repositories do
+ * not switch blogs around operational queries.
+ *
  * @package ExtraChillEvents\Core
  */
 
@@ -11,11 +15,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/** Owns the site-scoped private booking schema. */
+/** Owns and verifies the site-scoped private booking schema. */
 class BookingSchema {
 
 	public const SCHEMA_VERSION = '1';
 	public const VERSION_OPTION = 'extrachill_events_booking_schema_version';
+	public const FAILURE_OPTION = 'extrachill_events_booking_schema_error';
 
 	/** Get the bookings table for the current site. */
 	public static function bookings_table(): string {
@@ -29,8 +34,8 @@ class BookingSchema {
 		return $wpdb->prefix . 'ec_booking_activity';
 	}
 
-	/** Create or upgrade both tables with dbDelta(). */
-	public static function install(): void {
+	/** Create or repair both tables, stamping the version only after verification. */
+	public static function install() {
 		global $wpdb;
 
 		$bookings = self::bookings_table();
@@ -84,7 +89,7 @@ class BookingSchema {
 			occurred_at DATETIME NOT NULL,
 			created_at DATETIME NOT NULL,
 			PRIMARY KEY (id),
-			UNIQUE KEY idempotency_key (idempotency_key),
+			UNIQUE KEY booking_idempotency (booking_id, idempotency_key),
 			KEY booking_occurred (booking_id, occurred_at, id),
 			KEY kind_occurred (kind, occurred_at),
 			KEY channel_external (channel, external_id)
@@ -93,24 +98,189 @@ class BookingSchema {
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $bookings_sql );
 		dbDelta( $activity_sql );
-		update_option( self::VERSION_OPTION, self::SCHEMA_VERSION, false );
-	}
 
-	/** Install only when the site-scoped schema is stale or incomplete. */
-	public static function maybe_install(): void {
-		if ( self::SCHEMA_VERSION === (string) get_option( self::VERSION_OPTION, '' ) && self::tables_exist() ) {
-			return;
+		$health = self::health();
+		if ( is_wp_error( $health ) ) {
+			update_option(
+				self::FAILURE_OPTION,
+				array(
+					'code'        => $health->get_error_code(),
+					'message'     => $health->get_error_message(),
+					'data'        => $health->get_error_data(),
+					'failed_at'   => gmdate( 'Y-m-d H:i:s' ),
+					'site_prefix' => $wpdb->prefix,
+				),
+				false
+			);
+			return $health;
 		}
-		self::install();
+
+		update_option( self::VERSION_OPTION, self::SCHEMA_VERSION, false );
+		delete_option( self::FAILURE_OPTION );
+		return true;
 	}
 
-	/** Determine whether both current-site tables exist. */
-	public static function tables_exist(): bool {
+	/** Install when the version is stale or verified schema health is incomplete. */
+	public static function maybe_install() {
+		if ( self::SCHEMA_VERSION === (string) get_option( self::VERSION_OPTION, '' ) ) {
+			$health = self::health();
+			if ( true === $health ) {
+				return true;
+			}
+		}
+		return self::install();
+	}
+
+	/** Verify tables, critical columns, indexes, and uniqueness contracts. */
+	public static function health() {
 		global $wpdb;
-		$bookings = self::bookings_table();
-		$activity = self::activity_table();
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema health cannot be cached.
-		return $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $bookings ) ) === $bookings
-			&& $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $activity ) ) === $activity;
+
+		$contracts = array(
+			self::bookings_table() => array(
+				'columns' => array( 'id', 'public_id', 'venue_term_id', 'artist_term_id', 'artist_profile_id', 'artist_name', 'submitter_user_id', 'contact_name', 'contact_email', 'contact_phone', 'space_key', 'status', 'version', 'assignee_user_id', 'requested_start_at', 'requested_end_at', 'intake_payload', 'deal_payload', 'event_id', 'created_at', 'updated_at' ),
+				'types'   => array(
+					'id'             => 'bigint unsigned',
+					'public_id'      => 'char(36)',
+					'venue_term_id'  => 'bigint unsigned',
+					'status'         => 'varchar(32)',
+					'version'        => 'bigint unsigned',
+					'intake_payload' => 'longtext',
+					'event_id'       => 'bigint unsigned',
+				),
+				'indexes' => array(
+					'PRIMARY'                => array( true, array( 'id' ) ),
+					'public_id'              => array( true, array( 'public_id' ) ),
+					'event_id'               => array( true, array( 'event_id' ) ),
+					'venue_status_created'   => array( false, array( 'venue_term_id', 'status', 'created_at' ) ),
+					'venue_requested_start'  => array( false, array( 'venue_term_id', 'requested_start_at' ) ),
+					'artist_term_created'    => array( false, array( 'artist_term_id', 'created_at' ) ),
+					'artist_profile_created' => array( false, array( 'artist_profile_id', 'created_at' ) ),
+					'assignee_status'        => array( false, array( 'assignee_user_id', 'status' ) ),
+					'status_updated'         => array( false, array( 'status', 'updated_at' ) ),
+				),
+			),
+			self::activity_table() => array(
+				'columns' => array( 'id', 'booking_id', 'kind', 'actor_type', 'actor_id', 'direction', 'channel', 'payload', 'external_id', 'idempotency_key', 'occurred_at', 'created_at' ),
+				'types'   => array(
+					'id'              => 'bigint unsigned',
+					'booking_id'      => 'bigint unsigned',
+					'kind'            => 'varchar(64)',
+					'payload'         => 'longtext',
+					'idempotency_key' => 'varchar(191)',
+					'occurred_at'     => 'datetime',
+				),
+				'indexes' => array(
+					'PRIMARY'             => array( true, array( 'id' ) ),
+					'booking_idempotency' => array( true, array( 'booking_id', 'idempotency_key' ) ),
+					'booking_occurred'    => array( false, array( 'booking_id', 'occurred_at', 'id' ) ),
+					'kind_occurred'       => array( false, array( 'kind', 'occurred_at' ) ),
+					'channel_external'    => array( false, array( 'channel', 'external_id' ) ),
+				),
+			),
+		);
+
+		foreach ( $contracts as $table => $contract ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Installation health cannot be cached.
+			$found = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+			if ( '' !== (string) $wpdb->last_error ) {
+				return new \WP_Error(
+					'booking_schema_db_error',
+					__( 'Could not inspect the booking tables.', 'extrachill-events' ),
+					array(
+						'table'          => $table,
+						'database_error' => $wpdb->last_error,
+					)
+				);
+			}
+			if ( $found !== $table ) {
+				return new \WP_Error( 'booking_schema_table_missing', __( 'A required booking table is missing.', 'extrachill-events' ), array( 'table' => $table ) );
+			}
+
+			$columns = $wpdb->get_results( "SHOW COLUMNS FROM `{$table}`", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted current-prefix table.
+			if ( '' !== (string) $wpdb->last_error ) {
+				return new \WP_Error(
+					'booking_schema_db_error',
+					__( 'Could not inspect booking columns.', 'extrachill-events' ),
+					array(
+						'table'          => $table,
+						'database_error' => $wpdb->last_error,
+					)
+				);
+			}
+			$column_names = array_column( (array) $columns, 'Field' );
+			$missing      = array_values( array_diff( $contract['columns'], $column_names ) );
+			if ( ! empty( $missing ) ) {
+				return new \WP_Error(
+					'booking_schema_columns_missing',
+					__( 'Required booking columns are missing.', 'extrachill-events' ),
+					array(
+						'table'   => $table,
+						'columns' => $missing,
+					)
+				);
+			}
+			$column_types = array();
+			foreach ( (array) $columns as $column ) {
+				$column_types[ $column['Field'] ] = preg_replace( '/\(20\)/', '', strtolower( (string) $column['Type'] ) );
+			}
+			foreach ( $contract['types'] as $column => $required_type ) {
+				if ( ! isset( $column_types[ $column ] ) || $required_type !== $column_types[ $column ] ) {
+					return new \WP_Error(
+						'booking_schema_column_invalid',
+						__( 'A critical booking column has an incompatible type.', 'extrachill-events' ),
+						array(
+							'table'  => $table,
+							'column' => $column,
+							'type'   => $required_type,
+						)
+					);
+				}
+			}
+
+			$indexes = $wpdb->get_results( "SHOW INDEX FROM `{$table}`", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted current-prefix table.
+			if ( '' !== (string) $wpdb->last_error ) {
+				return new \WP_Error(
+					'booking_schema_db_error',
+					__( 'Could not inspect booking indexes.', 'extrachill-events' ),
+					array(
+						'table'          => $table,
+						'database_error' => $wpdb->last_error,
+					)
+				);
+			}
+			$found_indexes = array();
+			foreach ( (array) $indexes as $index ) {
+				$name                             = $index['Key_name'];
+				$found_indexes[ $name ]['unique'] = 0 === (int) $index['Non_unique'];
+				$found_indexes[ $name ]['columns'][ (int) $index['Seq_in_index'] ] = $index['Column_name'];
+			}
+			foreach ( $found_indexes as &$found_index ) {
+				ksort( $found_index['columns'] );
+				$found_index['columns'] = array_values( $found_index['columns'] );
+			}
+			unset( $found_index );
+			foreach ( $contract['indexes'] as $name => $required_index ) {
+				$must_be_unique   = $required_index[0];
+				$required_columns = $required_index[1];
+				if ( ! isset( $found_indexes[ $name ] ) || $must_be_unique !== $found_indexes[ $name ]['unique'] || $required_columns !== $found_indexes[ $name ]['columns'] ) {
+					return new \WP_Error(
+						'booking_schema_index_missing',
+						__( 'A required booking index is missing or invalid.', 'extrachill-events' ),
+						array(
+							'table'   => $table,
+							'index'   => $name,
+							'unique'  => $must_be_unique,
+							'columns' => $required_columns,
+						)
+					);
+				}
+			}
+		}
+		return true;
+	}
+
+	/** Backward-compatible table existence check backed by full schema health. */
+	public static function tables_exist(): bool {
+		return true === self::health();
 	}
 }

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Venue booking table installation.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Owns the site-scoped private booking schema. */
+class BookingSchema {
+
+	public const SCHEMA_VERSION = '1';
+	public const VERSION_OPTION = 'extrachill_events_booking_schema_version';
+
+	/** Get the bookings table for the current site. */
+	public static function bookings_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_bookings';
+	}
+
+	/** Get the booking activity table for the current site. */
+	public static function activity_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_booking_activity';
+	}
+
+	/** Create or upgrade both tables with dbDelta(). */
+	public static function install(): void {
+		global $wpdb;
+
+		$bookings = self::bookings_table();
+		$activity = self::activity_table();
+		$charset  = $wpdb->get_charset_collate();
+
+		$bookings_sql = "CREATE TABLE {$bookings} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			public_id CHAR(36) NOT NULL,
+			venue_term_id BIGINT UNSIGNED NOT NULL,
+			artist_term_id BIGINT UNSIGNED NULL,
+			artist_profile_id BIGINT UNSIGNED NULL,
+			artist_name VARCHAR(255) NOT NULL,
+			submitter_user_id BIGINT UNSIGNED NULL,
+			contact_name VARCHAR(255) NULL,
+			contact_email VARCHAR(255) NULL,
+			contact_phone VARCHAR(64) NULL,
+			space_key VARCHAR(64) NULL,
+			status VARCHAR(32) NOT NULL DEFAULT 'inquiry',
+			version BIGINT UNSIGNED NOT NULL DEFAULT 1,
+			assignee_user_id BIGINT UNSIGNED NULL,
+			requested_start_at DATETIME NULL,
+			requested_end_at DATETIME NULL,
+			intake_payload LONGTEXT NOT NULL,
+			deal_payload LONGTEXT NULL,
+			event_id BIGINT UNSIGNED NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY public_id (public_id),
+			UNIQUE KEY event_id (event_id),
+			KEY venue_status_created (venue_term_id, status, created_at),
+			KEY venue_requested_start (venue_term_id, requested_start_at),
+			KEY artist_term_created (artist_term_id, created_at),
+			KEY artist_profile_created (artist_profile_id, created_at),
+			KEY assignee_status (assignee_user_id, status),
+			KEY status_updated (status, updated_at)
+		) ENGINE=InnoDB {$charset};";
+
+		$activity_sql = "CREATE TABLE {$activity} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			booking_id BIGINT UNSIGNED NOT NULL,
+			kind VARCHAR(64) NOT NULL,
+			actor_type VARCHAR(32) NOT NULL DEFAULT 'system',
+			actor_id BIGINT UNSIGNED NULL,
+			direction VARCHAR(16) NULL,
+			channel VARCHAR(32) NULL,
+			payload LONGTEXT NOT NULL,
+			external_id VARCHAR(191) NULL,
+			idempotency_key VARCHAR(191) NULL,
+			occurred_at DATETIME NOT NULL,
+			created_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY idempotency_key (idempotency_key),
+			KEY booking_occurred (booking_id, occurred_at, id),
+			KEY kind_occurred (kind, occurred_at),
+			KEY channel_external (channel, external_id)
+		) ENGINE=InnoDB {$charset};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $bookings_sql );
+		dbDelta( $activity_sql );
+		update_option( self::VERSION_OPTION, self::SCHEMA_VERSION, false );
+	}
+
+	/** Install only when the site-scoped schema is stale or incomplete. */
+	public static function maybe_install(): void {
+		if ( self::SCHEMA_VERSION === (string) get_option( self::VERSION_OPTION, '' ) && self::tables_exist() ) {
+			return;
+		}
+		self::install();
+	}
+
+	/** Determine whether both current-site tables exist. */
+	public static function tables_exist(): bool {
+		global $wpdb;
+		$bookings = self::bookings_table();
+		$activity = self::activity_table();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema health cannot be cached.
+		return $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $bookings ) ) === $bookings
+			&& $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $activity ) ) === $activity;
+	}
+}

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -5,7 +5,6 @@
  * @package ExtraChillEvents\Core
  */
 
-// phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag,Squiz.Commenting.FunctionComment.Missing -- Concise internal helpers are typed and named by purpose.
 namespace ExtraChillEvents\Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -18,29 +17,58 @@ class VenueBookingConfig {
 	public const META_KEY = '_extrachill_booking_config';
 	public const VERSION  = 1;
 
-	/** Return normalized config for a venue. */
-	public function get( int $venue_term_id ): array {
+	/** Return validated config for a canonical venue term. */
+	public function get( int $venue_term_id ) {
+		$venue = $this->venue( $venue_term_id );
+		if ( is_wp_error( $venue ) ) {
+			return $venue;
+		}
 		$stored = get_term_meta( $venue_term_id, self::META_KEY, true );
-		$result = $this->normalize( is_array( $stored ) ? $stored : array() );
-		return is_wp_error( $result ) ? $this->defaults() : $result;
+		if ( '' === $stored || null === $stored ) {
+			return $this->defaults();
+		}
+		if ( ! is_array( $stored ) ) {
+			return new \WP_Error( 'invalid_booking_config_document', __( 'Stored venue booking configuration is malformed.', 'extrachill-events' ) );
+		}
+		return $this->normalize( $stored );
 	}
 
 	/** Validate and replace a venue's bounded booking config document. */
 	public function save( int $venue_term_id, array $config ) {
-		$venue = get_term( $venue_term_id, 'venue' );
-		if ( $venue_term_id < 1 || ! $venue || is_wp_error( $venue ) || 'venue' !== $venue->taxonomy ) {
-			return new \WP_Error( 'invalid_booking_config_venue', __( 'A valid Events venue term is required.', 'extrachill-events' ) );
+		$venue = $this->venue( $venue_term_id );
+		if ( is_wp_error( $venue ) ) {
+			return $venue;
 		}
 		$normalized = $this->normalize( $config );
 		if ( is_wp_error( $normalized ) ) {
 			return $normalized;
 		}
 		$result = update_term_meta( $venue_term_id, self::META_KEY, $normalized );
-		return false === $result ? new \WP_Error( 'booking_config_save_failed', __( 'The venue booking configuration could not be saved.', 'extrachill-events' ) ) : $normalized;
+		if ( false === $result && get_term_meta( $venue_term_id, self::META_KEY, true ) !== $normalized ) {
+			return new \WP_Error( 'booking_config_save_failed', __( 'The venue booking configuration could not be saved.', 'extrachill-events' ) );
+		}
+		return $normalized;
 	}
 
 	/** Normalize and validate the complete versioned contract. */
 	public function normalize( array $config ) {
+		$version = $config['version'] ?? self::VERSION;
+		if ( ! is_int( $version ) || self::VERSION !== $version ) {
+			return new \WP_Error( 'booking_config_version_unsupported', __( 'The venue booking configuration version is unsupported.', 'extrachill-events' ), array( 'version' => $version ) );
+		}
+		$intake_version = $config['intake']['version'] ?? 1;
+		$deal_version   = $config['default_deal']['version'] ?? 1;
+		if ( ! is_int( $intake_version ) || ! is_int( $deal_version ) || 1 !== $intake_version || 1 !== $deal_version ) {
+			return new \WP_Error(
+				'booking_config_section_version_unsupported',
+				__( 'A venue booking configuration section version is unsupported.', 'extrachill-events' ),
+				array(
+					'intake_version' => $intake_version,
+					'deal_version'   => $deal_version,
+				)
+			);
+		}
+
 		$basis_points = isset( $config['default_deal']['revenue_share_basis_points'] ) ? (int) $config['default_deal']['revenue_share_basis_points'] : 0;
 		if ( $basis_points < 0 || $basis_points > 10000 ) {
 			return new \WP_Error( 'invalid_booking_revenue_share', __( 'Revenue share basis points must be between 0 and 10000.', 'extrachill-events' ) );
@@ -50,6 +78,11 @@ class VenueBookingConfig {
 		if ( ! in_array( $basis, $allowed_basis, true ) ) {
 			return new \WP_Error( 'invalid_booking_revenue_basis', __( 'The revenue share basis is invalid.', 'extrachill-events' ) );
 		}
+		$currency = strtoupper( sanitize_text_field( (string) ( $config['default_deal']['currency'] ?? 'USD' ) ) );
+		if ( ! preg_match( '/^[A-Z]{3}$/', $currency ) ) {
+			return new \WP_Error( 'invalid_booking_currency', __( 'Deal currency must be a three-letter uppercase code.', 'extrachill-events' ) );
+		}
+
 		$spaces = $this->normalize_spaces( $config['spaces'] ?? array() );
 		if ( is_wp_error( $spaces ) ) {
 			return $spaces;
@@ -58,26 +91,30 @@ class VenueBookingConfig {
 		if ( is_wp_error( $fields ) ) {
 			return $fields;
 		}
-		$channels = array_values( array_unique( array_filter( array_map( 'sanitize_key', array_slice( (array) ( $config['marketing_channels'] ?? array() ), 0, 20 ) ) ) ) );
+		$channels = $this->normalize_channels( $config['marketing_channels'] ?? array() );
+		if ( is_wp_error( $channels ) ) {
+			return $channels;
+		}
 		$hold_ttl = isset( $config['hold_ttl_minutes'] ) ? (int) $config['hold_ttl_minutes'] : 1440;
 		if ( $hold_ttl < 5 || $hold_ttl > 10080 ) {
 			return new \WP_Error( 'invalid_booking_hold_ttl', __( 'Hold TTL must be between 5 minutes and 7 days.', 'extrachill-events' ) );
 		}
+
 		return array(
 			'version'                   => self::VERSION,
 			'enabled'                   => ! empty( $config['enabled'] ),
 			'intake'                    => array(
-				'version' => max( 1, (int) ( $config['intake']['version'] ?? 1 ) ),
+				'version' => 1,
 				'fields'  => $fields,
 			),
 			'spaces'                    => $spaces,
 			'default_deal'              => array(
-				'version'                    => max( 1, (int) ( $config['default_deal']['version'] ?? 1 ) ),
+				'version'                    => 1,
 				'type'                       => mb_substr( sanitize_key( (string) ( $config['default_deal']['type'] ?? 'custom' ) ), 0, 32 ),
 				'guarantee_cents'            => max( 0, (int) ( $config['default_deal']['guarantee_cents'] ?? 0 ) ),
 				'revenue_share_basis_points' => $basis_points,
 				'revenue_share_basis'        => $basis,
-				'currency'                   => strtoupper( mb_substr( sanitize_text_field( (string) ( $config['default_deal']['currency'] ?? 'USD' ) ), 0, 3 ) ),
+				'currency'                   => $currency,
 			),
 			'ticket_provider_reference' => $this->nullable_text( $config['ticket_provider_reference'] ?? null, 191 ),
 			'marketing_channels'        => $channels,
@@ -109,6 +146,13 @@ class VenueBookingConfig {
 		);
 	}
 
+	private function venue( int $venue_term_id ) {
+		$venue = $venue_term_id > 0 ? get_term( $venue_term_id, 'venue' ) : null;
+		return $venue && ! is_wp_error( $venue ) && 'venue' === $venue->taxonomy
+			? $venue
+			: new \WP_Error( 'invalid_booking_config_venue', __( 'A valid Events venue term is required.', 'extrachill-events' ) );
+	}
+
 	private function normalize_spaces( $spaces ) {
 		if ( ! is_array( $spaces ) || count( $spaces ) > 50 ) {
 			return new \WP_Error( 'invalid_booking_spaces', __( 'Venue spaces must be an array of at most 50 items.', 'extrachill-events' ) );
@@ -117,10 +161,10 @@ class VenueBookingConfig {
 		$seen       = array();
 		$default    = false;
 		foreach ( $spaces as $space ) {
-			$key  = sanitize_key( (string) ( $space['key'] ?? '' ) );
-			$name = sanitize_text_field( (string) ( $space['name'] ?? '' ) );
+			$key  = mb_substr( sanitize_key( (string) ( $space['key'] ?? '' ) ), 0, 64 );
+			$name = mb_substr( sanitize_text_field( (string) ( $space['name'] ?? '' ) ), 0, 191 );
 			if ( '' === $key || '' === $name || isset( $seen[ $key ] ) ) {
-				return new \WP_Error( 'invalid_booking_space', __( 'Each venue space needs a unique key and name.', 'extrachill-events' ) );
+				return new \WP_Error( 'invalid_booking_space', __( 'Each venue space needs a unique normalized key and name.', 'extrachill-events' ) );
 			}
 			$is_default = ! empty( $space['is_default'] );
 			if ( $is_default && $default ) {
@@ -129,8 +173,8 @@ class VenueBookingConfig {
 			$default      = $default || $is_default;
 			$seen[ $key ] = true;
 			$normalized[] = array(
-				'key'        => mb_substr( $key, 0, 64 ),
-				'name'       => mb_substr( $name, 0, 191 ),
+				'key'        => $key,
+				'name'       => $name,
 				'is_default' => $is_default,
 			);
 		}
@@ -148,19 +192,34 @@ class VenueBookingConfig {
 		$seen       = array();
 		$types      = array( 'text', 'textarea', 'email', 'phone', 'number', 'select', 'checkbox', 'url' );
 		foreach ( $fields as $field ) {
-			$key  = sanitize_key( (string) ( $field['key'] ?? '' ) );
+			$key  = mb_substr( sanitize_key( (string) ( $field['key'] ?? '' ) ), 0, 64 );
 			$type = sanitize_key( (string) ( $field['type'] ?? 'text' ) );
 			if ( '' === $key || isset( $seen[ $key ] ) || ! in_array( $type, $types, true ) ) {
-				return new \WP_Error( 'invalid_booking_intake_field', __( 'Each intake field needs a unique key and supported type.', 'extrachill-events' ) );
+				return new \WP_Error( 'invalid_booking_intake_field', __( 'Each intake field needs a unique normalized key and supported type.', 'extrachill-events' ) );
 			}
 			$seen[ $key ] = true;
 			$normalized[] = array(
-				'key'      => mb_substr( $key, 0, 64 ),
+				'key'      => $key,
 				'label'    => mb_substr( sanitize_text_field( (string) ( $field['label'] ?? $key ) ), 0, 191 ),
 				'type'     => $type,
 				'required' => ! empty( $field['required'] ),
 				'options'  => array_values( array_slice( array_map( 'sanitize_text_field', (array) ( $field['options'] ?? array() ) ), 0, 100 ) ),
 			);
+		}
+		return $normalized;
+	}
+
+	private function normalize_channels( $channels ) {
+		if ( ! is_array( $channels ) || count( $channels ) > 20 ) {
+			return new \WP_Error( 'invalid_booking_marketing_channels', __( 'Marketing channels must be an array of at most 20 keys.', 'extrachill-events' ) );
+		}
+		$normalized = array();
+		foreach ( $channels as $channel ) {
+			$key = mb_substr( sanitize_key( (string) $channel ), 0, 64 );
+			if ( '' === $key || in_array( $key, $normalized, true ) ) {
+				return new \WP_Error( 'invalid_booking_marketing_channel', __( 'Marketing channel keys must be unique after normalization.', 'extrachill-events' ) );
+			}
+			$normalized[] = $key;
 		}
 		return $normalized;
 	}

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Venue booking configuration service.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+// phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag,Squiz.Commenting.FunctionComment.Missing -- Concise internal helpers are typed and named by purpose.
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Validates one versioned termmeta document on canonical venue terms. */
+class VenueBookingConfig {
+
+	public const META_KEY = '_extrachill_booking_config';
+	public const VERSION  = 1;
+
+	/** Return normalized config for a venue. */
+	public function get( int $venue_term_id ): array {
+		$stored = get_term_meta( $venue_term_id, self::META_KEY, true );
+		$result = $this->normalize( is_array( $stored ) ? $stored : array() );
+		return is_wp_error( $result ) ? $this->defaults() : $result;
+	}
+
+	/** Validate and replace a venue's bounded booking config document. */
+	public function save( int $venue_term_id, array $config ) {
+		$venue = get_term( $venue_term_id, 'venue' );
+		if ( $venue_term_id < 1 || ! $venue || is_wp_error( $venue ) || 'venue' !== $venue->taxonomy ) {
+			return new \WP_Error( 'invalid_booking_config_venue', __( 'A valid Events venue term is required.', 'extrachill-events' ) );
+		}
+		$normalized = $this->normalize( $config );
+		if ( is_wp_error( $normalized ) ) {
+			return $normalized;
+		}
+		$result = update_term_meta( $venue_term_id, self::META_KEY, $normalized );
+		return false === $result ? new \WP_Error( 'booking_config_save_failed', __( 'The venue booking configuration could not be saved.', 'extrachill-events' ) ) : $normalized;
+	}
+
+	/** Normalize and validate the complete versioned contract. */
+	public function normalize( array $config ) {
+		$basis_points = isset( $config['default_deal']['revenue_share_basis_points'] ) ? (int) $config['default_deal']['revenue_share_basis_points'] : 0;
+		if ( $basis_points < 0 || $basis_points > 10000 ) {
+			return new \WP_Error( 'invalid_booking_revenue_share', __( 'Revenue share basis points must be between 0 and 10000.', 'extrachill-events' ) );
+		}
+		$basis         = sanitize_key( (string) ( $config['default_deal']['revenue_share_basis'] ?? 'gross_ticket_sales' ) );
+		$allowed_basis = array( 'gross_ticket_sales', 'net_ticket_sales', 'door_receipts' );
+		if ( ! in_array( $basis, $allowed_basis, true ) ) {
+			return new \WP_Error( 'invalid_booking_revenue_basis', __( 'The revenue share basis is invalid.', 'extrachill-events' ) );
+		}
+		$spaces = $this->normalize_spaces( $config['spaces'] ?? array() );
+		if ( is_wp_error( $spaces ) ) {
+			return $spaces;
+		}
+		$fields = $this->normalize_intake_fields( $config['intake']['fields'] ?? array() );
+		if ( is_wp_error( $fields ) ) {
+			return $fields;
+		}
+		$channels = array_values( array_unique( array_filter( array_map( 'sanitize_key', array_slice( (array) ( $config['marketing_channels'] ?? array() ), 0, 20 ) ) ) ) );
+		$hold_ttl = isset( $config['hold_ttl_minutes'] ) ? (int) $config['hold_ttl_minutes'] : 1440;
+		if ( $hold_ttl < 5 || $hold_ttl > 10080 ) {
+			return new \WP_Error( 'invalid_booking_hold_ttl', __( 'Hold TTL must be between 5 minutes and 7 days.', 'extrachill-events' ) );
+		}
+		return array(
+			'version'                   => self::VERSION,
+			'enabled'                   => ! empty( $config['enabled'] ),
+			'intake'                    => array(
+				'version' => max( 1, (int) ( $config['intake']['version'] ?? 1 ) ),
+				'fields'  => $fields,
+			),
+			'spaces'                    => $spaces,
+			'default_deal'              => array(
+				'version'                    => max( 1, (int) ( $config['default_deal']['version'] ?? 1 ) ),
+				'type'                       => mb_substr( sanitize_key( (string) ( $config['default_deal']['type'] ?? 'custom' ) ), 0, 32 ),
+				'guarantee_cents'            => max( 0, (int) ( $config['default_deal']['guarantee_cents'] ?? 0 ) ),
+				'revenue_share_basis_points' => $basis_points,
+				'revenue_share_basis'        => $basis,
+				'currency'                   => strtoupper( mb_substr( sanitize_text_field( (string) ( $config['default_deal']['currency'] ?? 'USD' ) ), 0, 3 ) ),
+			),
+			'ticket_provider_reference' => $this->nullable_text( $config['ticket_provider_reference'] ?? null, 191 ),
+			'marketing_channels'        => $channels,
+			'hold_ttl_minutes'          => $hold_ttl,
+		);
+	}
+
+	/** Default disabled venue contract. */
+	public function defaults(): array {
+		return array(
+			'version'                   => self::VERSION,
+			'enabled'                   => false,
+			'intake'                    => array(
+				'version' => 1,
+				'fields'  => array(),
+			),
+			'spaces'                    => array(),
+			'default_deal'              => array(
+				'version'                    => 1,
+				'type'                       => 'custom',
+				'guarantee_cents'            => 0,
+				'revenue_share_basis_points' => 0,
+				'revenue_share_basis'        => 'gross_ticket_sales',
+				'currency'                   => 'USD',
+			),
+			'ticket_provider_reference' => null,
+			'marketing_channels'        => array(),
+			'hold_ttl_minutes'          => 1440,
+		);
+	}
+
+	private function normalize_spaces( $spaces ) {
+		if ( ! is_array( $spaces ) || count( $spaces ) > 50 ) {
+			return new \WP_Error( 'invalid_booking_spaces', __( 'Venue spaces must be an array of at most 50 items.', 'extrachill-events' ) );
+		}
+		$normalized = array();
+		$seen       = array();
+		$default    = false;
+		foreach ( $spaces as $space ) {
+			$key  = sanitize_key( (string) ( $space['key'] ?? '' ) );
+			$name = sanitize_text_field( (string) ( $space['name'] ?? '' ) );
+			if ( '' === $key || '' === $name || isset( $seen[ $key ] ) ) {
+				return new \WP_Error( 'invalid_booking_space', __( 'Each venue space needs a unique key and name.', 'extrachill-events' ) );
+			}
+			$is_default = ! empty( $space['is_default'] );
+			if ( $is_default && $default ) {
+				return new \WP_Error( 'multiple_default_booking_spaces', __( 'Only one venue space may be the default.', 'extrachill-events' ) );
+			}
+			$default      = $default || $is_default;
+			$seen[ $key ] = true;
+			$normalized[] = array(
+				'key'        => mb_substr( $key, 0, 64 ),
+				'name'       => mb_substr( $name, 0, 191 ),
+				'is_default' => $is_default,
+			);
+		}
+		if ( ! empty( $normalized ) && ! $default ) {
+			$normalized[0]['is_default'] = true;
+		}
+		return $normalized;
+	}
+
+	private function normalize_intake_fields( $fields ) {
+		if ( ! is_array( $fields ) || count( $fields ) > 50 ) {
+			return new \WP_Error( 'invalid_booking_intake', __( 'Intake fields must be an array of at most 50 items.', 'extrachill-events' ) );
+		}
+		$normalized = array();
+		$seen       = array();
+		$types      = array( 'text', 'textarea', 'email', 'phone', 'number', 'select', 'checkbox', 'url' );
+		foreach ( $fields as $field ) {
+			$key  = sanitize_key( (string) ( $field['key'] ?? '' ) );
+			$type = sanitize_key( (string) ( $field['type'] ?? 'text' ) );
+			if ( '' === $key || isset( $seen[ $key ] ) || ! in_array( $type, $types, true ) ) {
+				return new \WP_Error( 'invalid_booking_intake_field', __( 'Each intake field needs a unique key and supported type.', 'extrachill-events' ) );
+			}
+			$seen[ $key ] = true;
+			$normalized[] = array(
+				'key'      => mb_substr( $key, 0, 64 ),
+				'label'    => mb_substr( sanitize_text_field( (string) ( $field['label'] ?? $key ) ), 0, 191 ),
+				'type'     => $type,
+				'required' => ! empty( $field['required'] ),
+				'options'  => array_values( array_slice( array_map( 'sanitize_text_field', (array) ( $field['options'] ?? array() ) ), 0, 100 ) ),
+			);
+		}
+		return $normalized;
+	}
+
+	private function nullable_text( $value, int $length ): ?string {
+		$value = sanitize_text_field( (string) $value );
+		return '' === $value ? null : mb_substr( $value, 0, $length );
+	}
+}

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+	beStrictAboutOutputDuringTests="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	failOnRisky="true"
+	failOnWarning="true">
+	<testsuites>
+		<testsuite name="booking-foundation">
+			<file>tests/BookingFoundationTest.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -11,46 +11,65 @@ use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\VenueBookingConfig;
 use PHPUnit\Framework\TestCase;
 
-// phpcs:disable -- Isolated WordPress and database test doubles.
 if ( ! defined( 'ARRAY_A' ) ) {
 	define( 'ARRAY_A', 'ARRAY_A' );
 }
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		private $code;
+		private $message;
 		private $data;
 		public function __construct( $code, $message = '', $data = array() ) {
-			unset( $message );
-			$this->code = $code;
-			$this->data = $data;
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
 		}
-		public function get_error_code() { return $this->code; }
-		public function get_error_data() { return $this->data; }
+		public function get_error_code() {
+			return $this->code; }
+		public function get_error_message() {
+			return $this->message; }
+		public function get_error_data() {
+			return $this->data; }
 	}
 }
 if ( ! function_exists( 'is_wp_error' ) ) {
-	function is_wp_error( $value ) { return $value instanceof WP_Error; }
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error; }
 }
 if ( ! function_exists( '__' ) ) {
-	function __( $text ) { return $text; }
+	function __( $text ) {
+		return $text; }
 }
 if ( ! function_exists( 'absint' ) ) {
-	function absint( $value ) { return abs( (int) $value ); }
+	function absint( $value ) {
+		return abs( (int) $value ); }
 }
 if ( ! function_exists( 'sanitize_key' ) ) {
-	function sanitize_key( $value ) { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) ); }
+	function sanitize_key( $value ) {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) ); }
 }
 if ( ! function_exists( 'sanitize_email' ) ) {
-	function sanitize_email( $value ) { return filter_var( trim( (string) $value ), FILTER_VALIDATE_EMAIL ) ?: ''; }
+	function sanitize_email( $value ) {
+		$sanitized = filter_var( trim( (string) $value ), FILTER_VALIDATE_EMAIL );
+		return false === $sanitized ? '' : $sanitized; }
 }
 if ( ! function_exists( 'wp_generate_uuid4' ) ) {
-	function wp_generate_uuid4() { return '123e4567-e89b-42d3-a456-426614174000'; }
+	function wp_generate_uuid4() {
+		++$GLOBALS['ec_artist_test']['uuid'];
+		return sprintf( '123e4567-e89b-42d3-a456-%012d', $GLOBALS['ec_artist_test']['uuid'] );
+	}
 }
 if ( ! function_exists( 'ec_get_blog_id' ) ) {
-	function ec_get_blog_id( $site ) { return array( 'main' => 1, 'artist' => 4, 'events' => 7 )[ $site ] ?? 0; }
+	function ec_get_blog_id( $site ) {
+		return array(
+			'main'   => 1,
+			'artist' => 4,
+			'events' => 7,
+		)[ $site ] ?? 0; }
 }
 if ( ! function_exists( 'get_current_blog_id' ) ) {
-	function get_current_blog_id() { return $GLOBALS['ec_artist_test']['blog_id']; }
+	function get_current_blog_id() {
+		return $GLOBALS['ec_artist_test']['blog_id']; }
 }
 if ( ! function_exists( 'switch_to_blog' ) ) {
 	function switch_to_blog( $blog_id ) {
@@ -59,11 +78,15 @@ if ( ! function_exists( 'switch_to_blog' ) ) {
 	}
 }
 if ( ! function_exists( 'restore_current_blog' ) ) {
-	function restore_current_blog() { $GLOBALS['ec_artist_test']['blog_id'] = array_pop( $GLOBALS['ec_artist_test']['stack'] ); }
+	function restore_current_blog() {
+		$GLOBALS['ec_artist_test']['blog_id'] = array_pop( $GLOBALS['ec_artist_test']['stack'] ); }
 }
 if ( ! function_exists( 'get_term' ) ) {
 	function get_term( $term_id, $taxonomy = '' ) {
-		$state = $GLOBALS['ec_artist_test'] ?? array();
+		if ( ! empty( $GLOBALS['ec_artist_test']['throw_get_term'] ) ) {
+			throw new RuntimeException( 'term read failed' );
+		}
+		$state = $GLOBALS['ec_artist_test'];
 		$term  = $state['terms'][ $state['blog_id'] ][ $term_id ] ?? null;
 		return $term && ( '' === $taxonomy || $taxonomy === $term->taxonomy ) ? $term : null;
 	}
@@ -71,24 +94,39 @@ if ( ! function_exists( 'get_term' ) ) {
 if ( ! function_exists( 'get_term_meta' ) ) {
 	function get_term_meta( $term_id, $key, $single = false ) {
 		unset( $single );
-		$state = $GLOBALS['ec_artist_test'] ?? array();
+		$state = $GLOBALS['ec_artist_test'];
 		return $state['meta'][ $state['blog_id'] ][ $term_id ][ $key ] ?? '';
 	}
 }
 if ( ! function_exists( 'update_term_meta' ) ) {
 	function update_term_meta( $term_id, $key, $value ) {
+		$current = get_term_meta( $term_id, $key, true );
+		if ( ! empty( $GLOBALS['ec_artist_test']['fail_term_meta'] ) || $current === $value ) {
+			return false;
+		}
 		$GLOBALS['ec_artist_test']['meta'][ get_current_blog_id() ][ $term_id ][ $key ] = $value;
 		return true;
 	}
 }
 if ( ! function_exists( 'get_post' ) ) {
 	function get_post( $post_id ) {
-		$state = $GLOBALS['ec_artist_test'] ?? array();
+		if ( ! empty( $GLOBALS['ec_artist_test']['throw_get_post'] ) ) {
+			throw new RuntimeException( 'post read failed' );
+		}
+		$state = $GLOBALS['ec_artist_test'];
 		return $state['posts'][ $state['blog_id'] ][ $post_id ] ?? null;
 	}
 }
+if ( ! function_exists( 'get_post_meta' ) ) {
+	function get_post_meta( $post_id, $key, $single = false ) {
+		unset( $single );
+		$state = $GLOBALS['ec_artist_test'];
+		return $state['post_meta'][ $state['blog_id'] ][ $post_id ][ $key ] ?? '';
+	}
+}
 if ( ! function_exists( 'get_option' ) ) {
-	function get_option( $key, $default = false ) { return $GLOBALS['ec_artist_test']['options'][ $key ] ?? $default; }
+	function get_option( $key, $default = false ) {
+		return $GLOBALS['ec_artist_test']['options'][ $key ] ?? $default; }
 }
 if ( ! function_exists( 'update_option' ) ) {
 	function update_option( $key, $value, $autoload = null ) {
@@ -97,20 +135,37 @@ if ( ! function_exists( 'update_option' ) ) {
 		return true;
 	}
 }
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( $key ) {
+		unset( $GLOBALS['ec_artist_test']['options'][ $key ] );
+		return true;
+	}
+}
 
-/** Minimal in-memory wpdb for repository and schema contracts. */
+/** Stateful wpdb fake that enforces the persistence contracts under test. */
 final class BookingWpdb {
-	public $prefix = 'wp_7_';
-	public $insert_id = 0;
-	public $rows = array();
-	public $last_query = '';
+	public $prefix                  = 'wp_7_';
+	public $insert_id               = 0;
+	public $last_error              = '';
+	public $rows                    = array();
+	public $schemas                 = array();
+	public $schema_omit             = array();
+	public $fail_reads              = false;
+	public $fail_activity_reads     = false;
+	public $fail_inserts            = false;
+	public $fail_updates            = false;
+	public $race_activity_insert    = false;
+	public $race_activity_read_fail = false;
+	public $race_event_read_fail    = false;
+	public $reads_before_failure    = null;
+	public $last_query              = '';
 
-	public function get_charset_collate() { return 'DEFAULT CHARACTER SET utf8mb4'; }
+	public function get_charset_collate() {
+		return 'DEFAULT CHARACTER SET utf8mb4'; }
 
 	public function prepare( $query, ...$args ) {
 		if ( 1 === count( $args ) && is_array( $args[0] ) ) {
-			$args = $args[0];
-		}
+			$args = $args[0]; }
 		$i = 0;
 		return preg_replace_callback(
 			'/%[ds]/',
@@ -122,23 +177,100 @@ final class BookingWpdb {
 		);
 	}
 
+	public function apply_schema( $sql ) {
+		if ( ! preg_match( '/CREATE TABLE ([^\s(]+)/', $sql, $match ) ) {
+			return; }
+		$table                   = $match[1];
+		$this->schemas[ $table ] = $this->schemas[ $table ] ?? array(
+			'columns' => array(),
+			'indexes' => array(),
+		);
+		foreach ( preg_split( '/\R/', $sql ) as $line ) {
+			$line = trim( rtrim( $line, ',' ) );
+			if ( preg_match( '/^(PRIMARY KEY|UNIQUE KEY|KEY)\s*(?:([a-zA-Z0-9_]+))?\s*\(([^)]+)\)/i', $line, $index ) ) {
+				$name    = 'PRIMARY KEY' === strtoupper( $index[1] ) ? 'PRIMARY' : $index[2];
+				$unique  = 'KEY' !== strtoupper( $index[1] );
+				$columns = array_map( 'trim', explode( ',', str_replace( '`', '', $index[3] ) ) );
+				if ( ! in_array( $name, $this->schema_omit[ $table ]['indexes'] ?? array(), true ) ) {
+					$this->schemas[ $table ]['indexes'][ $name ] = array(
+						'unique'  => $unique,
+						'columns' => $columns,
+					);
+				}
+			} elseif ( preg_match( '/^([a-z_]+)\s+(.+)$/', $line, $column ) && ! in_array( $column[1], $this->schema_omit[ $table ]['columns'] ?? array(), true ) ) {
+				preg_match( '/^(.+?)(?:\s+NOT NULL|\s+NULL|\s+DEFAULT|\s+AUTO_INCREMENT|$)/i', $column[2], $type );
+				$this->schemas[ $table ]['columns'][ $column[1] ] = strtolower( trim( $type[1] ) );
+			}
+		}
+	}
+
 	public function insert( $table, $row ) {
-		$this->insert_id = count( $this->rows[ $table ] ?? array() ) + 1;
-		$row['id'] = $this->insert_id;
+		$this->last_error = '';
+		if ( $this->fail_inserts ) {
+			$this->last_error = 'simulated insert failure';
+			return false;
+		}
+		if ( false !== strpos( $table, 'ec_booking_activity' ) && null !== $row['idempotency_key'] ) {
+			foreach ( $this->rows[ $table ] ?? array() as $existing ) {
+				if ( (int) $existing['booking_id'] === (int) $row['booking_id'] && $existing['idempotency_key'] === $row['idempotency_key'] ) {
+					$this->last_error = 'duplicate booking idempotency key';
+					return false;
+				}
+			}
+		}
+		$this->insert_id                          = count( $this->rows[ $table ] ?? array() ) + 1;
+		$row['id']                                = $this->insert_id;
 		$this->rows[ $table ][ $this->insert_id ] = $row;
+		if ( false !== strpos( $table, 'ec_booking_activity' ) && $this->race_activity_insert ) {
+			$this->race_activity_insert = false;
+			$this->last_error           = 'simulated concurrent duplicate';
+			if ( $this->race_activity_read_fail ) {
+				$this->fail_activity_reads = true;
+			}
+			return false;
+		}
 		return 1;
+	}
+
+	public function get_var( $query ) {
+		$this->last_error = '';
+		if ( $this->fail_reads ) {
+			$this->last_error = 'simulated schema read failure';
+			return null; }
+		if ( preg_match( "/LIKE '([^']+)'/", $query, $match ) && isset( $this->schemas[ stripslashes( $match[1] ) ] ) ) {
+			return stripslashes( $match[1] ); }
+		return null;
 	}
 
 	public function get_row( $query, $output = null ) {
 		unset( $output );
 		$this->last_query = $query;
-		$table = false !== strpos( $query, 'ec_booking_activity' ) ? $this->prefix . 'ec_booking_activity' : $this->prefix . 'ec_bookings';
-		if ( preg_match( '/WHERE id = (\d+)/', $query, $match ) ) {
-			return $this->rows[ $table ][ (int) $match[1] ] ?? null;
+		$this->last_error = '';
+		$is_activity      = false !== strpos( $query, 'ec_booking_activity' );
+		if ( null !== $this->reads_before_failure ) {
+			if ( 0 === $this->reads_before_failure ) {
+				$this->last_error = 'simulated delayed row read failure';
+				return null;
+			}
+			--$this->reads_before_failure;
 		}
+		if ( $this->fail_reads || ( $is_activity && $this->fail_activity_reads ) ) {
+			$this->last_error = 'simulated row read failure';
+			return null;
+		}
+		$table = $is_activity ? $this->prefix . 'ec_booking_activity' : $this->prefix . 'ec_bookings';
+		if ( preg_match( '/WHERE id = (\d+)/', $query, $match ) ) {
+			return $this->rows[ $table ][ (int) $match[1] ] ?? null; }
 		if ( preg_match( "/WHERE public_id = '([^']+)'/", $query, $match ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
-				if ( $row['public_id'] === $match[1] ) { return $row; }
+				if ( stripslashes( $match[1] ) === $row['public_id'] ) {
+					return $row; }
+			}
+		}
+		if ( preg_match( "/WHERE booking_id = (\d+) AND idempotency_key = '([^']+)'/", $query, $match ) ) {
+			foreach ( $this->rows[ $table ] ?? array() as $row ) {
+				if ( (int) $row['booking_id'] === (int) $match[1] && stripslashes( $match[2] ) === $row['idempotency_key'] ) {
+					return $row; }
 			}
 		}
 		return null;
@@ -147,27 +279,127 @@ final class BookingWpdb {
 	public function get_results( $query, $output = null ) {
 		unset( $output );
 		$this->last_query = $query;
-		$table = false !== strpos( $query, 'ec_booking_activity' ) ? $this->prefix . 'ec_booking_activity' : $this->prefix . 'ec_bookings';
-		return array_values( $this->rows[ $table ] ?? array() );
+		$this->last_error = '';
+		if ( $this->fail_reads ) {
+			$this->last_error = 'simulated result read failure';
+			return null; }
+		if ( preg_match( '/SHOW COLUMNS FROM `([^`]+)`/', $query, $match ) ) {
+			$rows = array();
+			foreach ( $this->schemas[ $match[1] ]['columns'] ?? array() as $name => $type ) {
+				$rows[] = array(
+					'Field' => $name,
+					'Type'  => $type,
+				);
+			}
+			return $rows;
+		}
+		if ( preg_match( '/SHOW INDEX FROM `([^`]+)`/', $query, $match ) ) {
+			$rows = array();
+			foreach ( $this->schemas[ $match[1] ]['indexes'] ?? array() as $name => $index ) {
+				foreach ( $index['columns'] as $position => $column ) {
+					$rows[] = array(
+						'Key_name'     => $name,
+						'Non_unique'   => $index['unique'] ? 0 : 1,
+						'Seq_in_index' => $position + 1,
+						'Column_name'  => $column,
+					);
+				}
+			}
+			return $rows;
+		}
+		$is_activity = false !== strpos( $query, 'ec_booking_activity' );
+		$table       = $is_activity ? $this->prefix . 'ec_booking_activity' : $this->prefix . 'ec_bookings';
+		$rows        = array_values( $this->rows[ $table ] ?? array() );
+		$filters     = array( 'venue_term_id', 'artist_term_id', 'artist_profile_id', 'assignee_user_id', 'booking_id' );
+		foreach ( $filters as $field ) {
+			if ( preg_match( "/{$field} = (\\d+)/", $query, $filter ) ) {
+				$rows = array_values(
+					array_filter(
+						$rows,
+						static function ( $row ) use ( $field, $filter ) {
+							return (int) ( $row[ $field ] ?? 0 ) === (int) $filter[1];
+						}
+					)
+				);
+			}
+		}
+		if ( preg_match( "/status = '([^']+)'/", $query, $filter ) ) {
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $filter ) {
+						return stripslashes( $filter[1] ) === $row['status'];
+					}
+				)
+			);
+		}
+		if ( preg_match( "/requested_start_at >= '([^']+)'/", $query, $filter ) ) {
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $filter ) {
+						return null !== $row['requested_start_at'] && $row['requested_start_at'] >= stripslashes( $filter[1] );
+					}
+				)
+			);
+		}
+		if ( preg_match( "/requested_end_at <= '([^']+)'/", $query, $filter ) ) {
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $filter ) {
+						return null !== $row['requested_end_at'] && $row['requested_end_at'] <= stripslashes( $filter[1] );
+					}
+				)
+			);
+		}
+		usort(
+			$rows,
+			static function ( $a, $b ) {
+				$date_order = $b['created_at'] <=> $a['created_at'];
+				return 0 !== $date_order ? $date_order : ( $b['id'] <=> $a['id'] );
+			}
+		);
+		if ( preg_match( '/LIMIT (\d+) OFFSET (\d+)/', $query, $page ) ) {
+			$rows = array_slice( $rows, (int) $page[2], (int) $page[1] );
+		}
+		return $rows;
 	}
 
 	public function query( $query ) {
 		$this->last_query = $query;
-		if ( ! preg_match( '/WHERE id = (\d+) AND version = (\d+)/', $query, $match ) ) { return false; }
-		$id = (int) $match[1];
+		$this->last_error = '';
+		if ( $this->fail_updates ) {
+			$this->last_error = 'simulated update failure';
+			return false; }
+		if ( ! preg_match( '/WHERE id = (\d+) AND version = (\d+)/', $query, $match ) ) {
+			return false; }
+		$id       = (int) $match[1];
 		$expected = (int) $match[2];
-		$table = $this->prefix . 'ec_bookings';
-		if ( ! isset( $this->rows[ $table ][ $id ] ) || (int) $this->rows[ $table ][ $id ]['version'] !== $expected ) { return 0; }
-		if ( preg_match( "/status = '([^']+)'/", $query, $status ) ) { $this->rows[ $table ][ $id ]['status'] = $status[1]; }
-		if ( preg_match( '/artist_term_id = (\d+)/', $query, $term ) ) { $this->rows[ $table ][ $id ]['artist_term_id'] = (int) $term[1]; }
-		if ( preg_match( '/artist_profile_id = (\d+)/', $query, $profile ) ) { $this->rows[ $table ][ $id ]['artist_profile_id'] = (int) $profile[1]; }
-		$this->rows[ $table ][ $id ]['version']++;
+		$table    = $this->prefix . 'ec_bookings';
+		if ( ! isset( $this->rows[ $table ][ $id ] ) || (int) $this->rows[ $table ][ $id ]['version'] !== $expected ) {
+			if ( $this->race_event_read_fail ) {
+				$this->reads_before_failure = 1;
+			}
+			return 0; }
+		if ( false !== strpos( $query, 'event_id IS NULL' ) && null !== $this->rows[ $table ][ $id ]['event_id'] ) {
+			return 0; }
+		$set = substr( $query, strpos( $query, ' SET ' ) + 5, strpos( $query, ' WHERE ' ) - strpos( $query, ' SET ' ) - 5 );
+		preg_match_all( "/([a-z_]+) = (version \\+ 1|NULL|\\d+|'(?:\\\\.|[^'])*')(?=, [a-z_]+ = |$)/", $set, $assignments, PREG_SET_ORDER );
+		foreach ( $assignments as $assignment ) {
+			$column = $assignment[1];
+			$value  = $assignment[2];
+			if ( 'version + 1' === $value ) {
+				++$this->rows[ $table ][ $id ]['version'];
+			} elseif ( 'NULL' === $value ) {
+				$this->rows[ $table ][ $id ][ $column ] = null;
+			} elseif ( "'" === substr( $value, 0, 1 ) ) {
+				$this->rows[ $table ][ $id ][ $column ] = stripslashes( substr( $value, 1, -1 ) );
+			} else {
+				$this->rows[ $table ][ $id ][ $column ] = (int) $value;
+			}
+		}
 		return 1;
-	}
-
-	public function get_var( $query ) {
-		if ( preg_match( "/LIKE '([^']+)'/", $query, $match ) ) { return stripslashes( $match[1] ); }
-		return null;
 	}
 }
 
@@ -179,87 +411,487 @@ require_once dirname( __DIR__ ) . '/inc/Core/VenueBookingConfig.php';
 final class BookingFoundationTest extends TestCase {
 	protected function setUp(): void {
 		$GLOBALS['ec_artist_test'] = array(
-			'blog_id' => 7,
-			'stack'   => array(),
-			'options' => array(),
-			'dbdelta' => array(),
-			'terms'   => array(
-				1 => array( 101 => (object) array( 'term_id' => 101, 'taxonomy' => 'artist', 'name' => 'Canonical Artist' ) ),
-				7 => array( 55 => (object) array( 'term_id' => 55, 'taxonomy' => 'venue', 'name' => 'The Room' ) ),
+			'blog_id'   => 7,
+			'stack'     => array(),
+			'uuid'      => 0,
+			'options'   => array(),
+			'dbdelta'   => array(),
+			'terms'     => array(
+				1 => array(
+					101 => (object) array(
+						'term_id'  => 101,
+						'taxonomy' => 'artist',
+						'name'     => 'Canonical Artist',
+					),
+				),
+				7 => array(
+					55 => (object) array(
+						'term_id'  => 55,
+						'taxonomy' => 'venue',
+						'name'     => 'The Room',
+					),
+					56 => (object) array(
+						'term_id'  => 56,
+						'taxonomy' => 'artist',
+						'name'     => 'Wrong Type',
+					),
+				),
 			),
-			'meta'    => array( 1 => array( 101 => array( '_artist_profile_id' => 501 ) ) ),
-			'posts'   => array( 4 => array( 501 => (object) array( 'ID' => 501, 'post_type' => 'artist_profile', 'post_title' => 'Canonical Artist' ) ) ),
+			'meta'      => array( 1 => array( 101 => array( '_artist_profile_id' => 501 ) ) ),
+			'posts'     => array(
+				4 => array(
+					501 => (object) array(
+						'ID'          => 501,
+						'post_type'   => 'artist_profile',
+						'post_status' => 'publish',
+						'post_title'  => 'Canonical Artist',
+					),
+					502 => (object) array(
+						'ID'          => 502,
+						'post_type'   => 'artist_profile',
+						'post_status' => 'publish',
+						'post_title'  => 'Unbound Artist',
+					),
+				),
+				7 => array(
+					900 => (object) array(
+						'ID'          => 900,
+						'post_type'   => 'data_machine_events',
+						'post_status' => 'publish',
+					),
+					901 => (object) array(
+						'ID'          => 901,
+						'post_type'   => 'post',
+						'post_status' => 'publish',
+					),
+				),
+			),
+			'post_meta' => array( 4 => array( 501 => array( '_artist_term_id' => 101 ) ) ),
 		);
-		unset( $GLOBALS['ec_booking_test'] );
-		$GLOBALS['wpdb'] = new BookingWpdb();
+		$GLOBALS['wpdb']           = new BookingWpdb();
 	}
 
-	public function test_schema_is_site_scoped_idempotent_and_indexed(): void {
-		$this->assertSame( 'wp_7_ec_bookings', BookingSchema::bookings_table() );
-		$this->assertSame( 'wp_7_ec_booking_activity', BookingSchema::activity_table() );
-		BookingSchema::install();
-		$this->assertCount( 2, $GLOBALS['ec_artist_test']['dbdelta'] );
-		$sql = implode( "\n", $GLOBALS['ec_artist_test']['dbdelta'] );
-		$this->assertStringContainsString( 'UNIQUE KEY event_id', $sql );
-		$this->assertStringContainsString( 'venue_status_created', $sql );
-		$this->assertStringContainsString( 'UNIQUE KEY idempotency_key', $sql );
-		$GLOBALS['ec_artist_test']['dbdelta'] = array();
-		BookingSchema::maybe_install();
-		$this->assertSame( array(), $GLOBALS['ec_artist_test']['dbdelta'] );
-		$GLOBALS['wpdb']->prefix = 'wp_12_';
-		$this->assertSame( 'wp_12_ec_bookings', BookingSchema::bookings_table() );
-	}
-
-	public function test_config_normalizes_integer_basis_points_and_default_space(): void {
-		$config = ( new VenueBookingConfig() )->normalize(
-			array(
-				'enabled' => true,
-				'spaces' => array( array( 'key' => 'Main Room', 'name' => 'Main Room' ) ),
-				'default_deal' => array( 'revenue_share_basis_points' => 1750, 'revenue_share_basis' => 'net_ticket_sales' ),
-				'marketing_channels' => array( 'Email', 'instagram' ),
+	private function create_booking( array $overrides = array() ) {
+		return ( new BookingRepository() )->create(
+			array_merge(
+				array(
+					'venue_term_id' => 55,
+					'artist_name'   => 'New Band',
+					'intake'        => array( 'draw' => 100 ),
+				),
+				$overrides
 			)
 		);
-		$this->assertSame( 1750, $config['default_deal']['revenue_share_basis_points'] );
-		$this->assertTrue( $config['spaces'][0]['is_default'] );
-		$this->assertSame( array( 'email', 'instagram' ), $config['marketing_channels'] );
-		$this->assertTrue( is_wp_error( ( new VenueBookingConfig() )->normalize( array( 'default_deal' => array( 'revenue_share_basis_points' => 10001 ) ) ) ) );
 	}
 
-	public function test_unresolved_canonical_and_profile_backed_identity_states(): void {
-		$repository = new BookingRepository();
-		$unresolved = $repository->create( array( 'venue_term_id' => 55, 'artist_name' => 'New Band', 'contact_email' => 'band@example.com', 'intake' => array( 'draw' => 100 ) ) );
+	public function test_schema_stamps_only_verified_site_scoped_contract(): void {
+		$this->assertTrue( BookingSchema::install() );
+		$this->assertSame( BookingSchema::SCHEMA_VERSION, get_option( BookingSchema::VERSION_OPTION ) );
+		$this->assertTrue( BookingSchema::health() );
+		$this->assertTrue( $GLOBALS['wpdb']->schemas['wp_7_ec_booking_activity']['indexes']['booking_idempotency']['unique'] );
+		$this->assertSame( array( 'booking_id', 'idempotency_key' ), $GLOBALS['wpdb']->schemas['wp_7_ec_booking_activity']['indexes']['booking_idempotency']['columns'] );
+		$GLOBALS['wpdb']->schemas['wp_7_ec_booking_activity']['indexes']['booking_idempotency']['columns'] = array( 'idempotency_key' );
+		$this->assertSame( 'booking_schema_index_missing', BookingSchema::health()->get_error_code() );
+		$GLOBALS['wpdb']->schemas['wp_7_ec_booking_activity']['indexes']['booking_idempotency']['columns'] = array( 'booking_id', 'idempotency_key' );
+		$GLOBALS['wpdb']->schemas['wp_7_ec_bookings']['columns']['status']                                 = 'text';
+		$this->assertSame( 'booking_schema_column_invalid', BookingSchema::health()->get_error_code() );
+		$GLOBALS['wpdb']->prefix = 'wp_12_';
+		$this->assertSame( 'wp_12_ec_bookings', BookingSchema::bookings_table() );
+		$this->assertSame( 'booking_schema_table_missing', BookingSchema::health()->get_error_code() );
+	}
+
+	public function test_partial_schema_is_not_stamped_and_repeat_install_repairs_it(): void {
+		$GLOBALS['wpdb']->schema_omit['wp_7_ec_bookings']['columns'] = array( 'event_id' );
+		$result = BookingSchema::install();
+		$this->assertSame( 'booking_schema_columns_missing', $result->get_error_code() );
+		$this->assertSame( '', get_option( BookingSchema::VERSION_OPTION, '' ) );
+		$this->assertSame( 'booking_schema_columns_missing', get_option( BookingSchema::FAILURE_OPTION )['code'] );
+		$GLOBALS['wpdb']->schema_omit = array();
+		$this->assertTrue( BookingSchema::maybe_install() );
+		$this->assertTrue( BookingSchema::health() );
+		$this->assertSame( BookingSchema::SCHEMA_VERSION, get_option( BookingSchema::VERSION_OPTION ) );
+	}
+
+	public function test_missing_unique_index_and_schema_read_errors_remain_retryable(): void {
+		$GLOBALS['wpdb']->schema_omit['wp_7_ec_booking_activity']['indexes'] = array( 'booking_idempotency' );
+		$this->assertSame( 'booking_schema_index_missing', BookingSchema::install()->get_error_code() );
+		$this->assertSame( '', get_option( BookingSchema::VERSION_OPTION, '' ) );
+		$GLOBALS['wpdb']->fail_reads = true;
+		$this->assertSame( 'booking_schema_db_error', BookingSchema::install()->get_error_code() );
+	}
+
+	public function test_json_encoding_failure_never_writes_or_increments(): void {
+		$recursive         = array();
+		$recursive['self'] =& $recursive;
+		$result            = $this->create_booking( array( 'intake' => $recursive ) );
+		$this->assertSame( 'booking_payload_encode_failed', $result->get_error_code() );
+		$this->assertSame( array(), $GLOBALS['wpdb']->rows );
+
+		$booking = $this->create_booking();
+		$result  = ( new BookingRepository() )->update( $booking['id'], array( 'deal' => $recursive ), 1 );
+		$this->assertSame( 'booking_payload_encode_failed', $result->get_error_code() );
+		$this->assertSame( 1, ( new BookingRepository() )->get( $booking['id'] )['version'] );
+		$result = ( new BookingActivityRepository() )->append(
+			array(
+				'booking_id' => $booking['id'],
+				'kind'       => 'note',
+				'payload'    => $recursive,
+			)
+		);
+		$this->assertSame( 'booking_activity_payload_encode_failed', $result->get_error_code() );
+	}
+
+	public function test_corrupt_and_unsupported_json_are_explicit_read_errors(): void {
+		$booking = $this->create_booking();
+		$table   = BookingSchema::bookings_table();
+		$GLOBALS['wpdb']->rows[ $table ][ $booking['id'] ]['intake_payload'] = '{bad';
+		$this->assertSame( 'booking_payload_invalid_json', ( new BookingRepository() )->get( $booking['id'] )->get_error_code() );
+		$GLOBALS['wpdb']->rows[ $table ][ $booking['id'] ]['intake_payload'] = '{"version":2,"data":{}}';
+		$this->assertSame( 'booking_payload_version_unsupported', ( new BookingRepository() )->get( $booking['id'] )->get_error_code() );
+		$GLOBALS['wpdb']->rows[ $table ][ $booking['id'] ]['intake_payload'] = '{"version":"1junk","data":{}}';
+		$this->assertSame( 'booking_payload_version_unsupported', ( new BookingRepository() )->get( $booking['id'] )->get_error_code() );
+
+		$activity = array(
+			'id'         => 1,
+			'booking_id' => 1,
+			'actor_id'   => null,
+			'payload'    => '{bad',
+		);
+		$this->assertSame( 'booking_activity_payload_invalid_json', ( new BookingActivityRepository() )->hydrate( $activity )->get_error_code() );
+		$activity['payload'] = '{"version":9,"data":{}}';
+		$this->assertSame( 'booking_activity_payload_version_unsupported', ( new BookingActivityRepository() )->hydrate( $activity )->get_error_code() );
+		$activity['payload'] = '{"version":"1junk","data":{}}';
+		$this->assertSame( 'booking_activity_payload_version_unsupported', ( new BookingActivityRepository() )->hydrate( $activity )->get_error_code() );
+	}
+
+	public function test_artist_identity_states_and_profile_only_resolution(): void {
+		$unresolved = $this->create_booking();
 		$this->assertNull( $unresolved['artist_term_id'] );
 		$this->assertNull( $unresolved['artist_profile_id'] );
-		$this->assertSame( 1, $unresolved['intake']['version'] );
-
-		$canonical = $repository->create( array( 'venue_term_id' => 55, 'artist_term_id' => 101 ) );
+		$canonical = $this->create_booking(
+			array(
+				'artist_term_id' => 101,
+				'artist_name'    => '',
+			)
+		);
 		$this->assertSame( 101, $canonical['artist_term_id'] );
-		$this->assertNull( $canonical['artist_profile_id'] );
-
-		$profile = $repository->create( array( 'venue_term_id' => 55, 'artist_term_id' => 101, 'artist_profile_id' => 501 ) );
+		$profile = $this->create_booking(
+			array(
+				'artist_profile_id' => 501,
+				'artist_name'       => '',
+			)
+		);
+		$this->assertSame( 101, $profile['artist_term_id'] );
 		$this->assertSame( 501, $profile['artist_profile_id'] );
-		$this->assertSame( 'Canonical Artist', $profile['artist_name'] );
+		$unbound = $this->create_booking(
+			array(
+				'artist_profile_id' => 502,
+				'artist_name'       => '',
+			)
+		);
+		$this->assertNull( $unbound['artist_term_id'] );
+		$this->assertSame( 502, $unbound['artist_profile_id'] );
 	}
 
-	public function test_later_binding_and_optimistic_version_conflict(): void {
-		$repository = new BookingRepository();
-		$booking = $repository->create( array( 'venue_term_id' => 55, 'artist_name' => 'New Band' ) );
-		$bound = $repository->update( $booking['id'], array( 'artist_term_id' => 101, 'artist_profile_id' => 501, 'status' => 'reviewing' ), 1 );
-		$this->assertSame( 2, $bound['version'] );
-		$this->assertSame( 101, $bound['artist_term_id'] );
-		$conflict = $repository->update( $booking['id'], array( 'status' => 'accepted' ), 1 );
-		$this->assertSame( 'booking_version_conflict', $conflict->get_error_code() );
+	public function test_profile_must_be_published_and_bindings_must_be_bidirectional(): void {
+		$GLOBALS['ec_artist_test']['posts'][4][501]->post_status = 'draft';
+		$this->assertSame( 'invalid_booking_artist_profile', $this->create_booking( array( 'artist_profile_id' => 501 ) )->get_error_code() );
+		$GLOBALS['ec_artist_test']['posts'][4][501]->post_status = 'trash';
+		$this->assertSame( 'invalid_booking_artist_profile', $this->create_booking( array( 'artist_profile_id' => 501 ) )->get_error_code() );
+		$GLOBALS['ec_artist_test']['posts'][4][501]->post_status = 'publish';
+		unset( $GLOBALS['ec_artist_test']['post_meta'][4][501]['_artist_term_id'] );
+		$this->assertSame(
+			'booking_artist_identity_mismatch',
+			$this->create_booking(
+				array(
+					'artist_term_id'    => 101,
+					'artist_profile_id' => 501,
+				)
+			)->get_error_code()
+		);
+		$GLOBALS['ec_artist_test']['post_meta'][4][501]['_artist_term_id'] = 999;
+		$this->assertSame(
+			'booking_artist_identity_mismatch',
+			$this->create_booking(
+				array(
+					'artist_term_id'    => 101,
+					'artist_profile_id' => 501,
+				)
+			)->get_error_code()
+		);
+		$GLOBALS['ec_artist_test']['post_meta'][4][501]['_artist_term_id'] = 101;
+		$GLOBALS['ec_artist_test']['meta'][1][101]['_artist_profile_id']   = 999;
+		$this->assertSame(
+			'booking_artist_identity_mismatch',
+			$this->create_booking(
+				array(
+					'artist_term_id'    => 101,
+					'artist_profile_id' => 501,
+				)
+			)->get_error_code()
+		);
 	}
 
-	public function test_lists_are_bounded_and_activity_payloads_are_versioned(): void {
+	public function test_artist_blog_switches_are_restored_on_success_and_exception(): void {
+		$this->create_booking( array( 'artist_profile_id' => 501 ) );
+		$this->assertSame( 7, get_current_blog_id() );
+		$GLOBALS['ec_artist_test']['throw_get_post'] = true;
+		try {
+			$this->create_booking( array( 'artist_profile_id' => 501 ) );
+			$this->fail( 'Expected profile read exception.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'post read failed', $exception->getMessage() );
+		}
+		$this->assertSame( 7, get_current_blog_id() );
+	}
+
+	public function test_event_handoff_is_null_only_validated_and_idempotent(): void {
 		$repository = new BookingRepository();
-		$repository->create( array( 'venue_term_id' => 55, 'artist_name' => 'New Band' ) );
-		$this->assertCount( 1, $repository->list( array( 'venue_term_id' => 55, 'limit' => 999 ) ) );
-		$this->assertStringContainsString( 'LIMIT 100', $GLOBALS['wpdb']->last_query );
-		$activity = ( new BookingActivityRepository() )->append( array( 'booking_id' => 1, 'kind' => 'inquiry_received', 'payload' => array( 'source' => 'form' ), 'idempotency_key' => 'inquiry-1' ) );
-		$this->assertSame( 1, $activity['payload']['version'] );
-		$this->assertSame( 'form', $activity['payload']['data']['source'] );
+		$booking    = $this->create_booking();
+		$claimed    = $repository->claim_event( $booking['id'], 900, 1 );
+		$this->assertSame( 900, $claimed['event_id'] );
+		$this->assertSame( 2, $claimed['version'] );
+		$this->assertSame( 900, $repository->claim_event( $booking['id'], 900, 1 )['event_id'] );
+		$this->assertSame( 'booking_event_already_linked', $repository->claim_event( $booking['id'], 902, 2 )->get_error_code() );
+		$unclaimed = $this->create_booking();
+		$this->assertSame( 'invalid_booking_event', $repository->claim_event( $unclaimed['id'], 999, 1 )->get_error_code() );
+		$this->assertSame( 'invalid_booking_event', $repository->claim_event( $unclaimed['id'], 901, 1 )->get_error_code() );
+		$this->assertSame( 'empty_booking_update', $repository->update( $booking['id'], array( 'event_id' => 900 ), 2 )->get_error_code() );
+	}
+
+	public function test_event_claim_distinguishes_stale_version_and_missing_booking(): void {
+		$repository = new BookingRepository();
+		$booking    = $this->create_booking();
+		$updated    = $repository->update( $booking['id'], array( 'status' => 'reviewing' ), 1 );
+		$this->assertSame( 2, $updated['version'] );
+		$this->assertSame( 'booking_version_conflict', $repository->claim_event( $booking['id'], 900, 1 )->get_error_code() );
+		$GLOBALS['wpdb']->race_event_read_fail = true;
+		$this->assertSame( 'booking_read_failed', $repository->claim_event( $booking['id'], 900, 1 )->get_error_code() );
+		$GLOBALS['wpdb']->fail_reads           = false;
+		$GLOBALS['wpdb']->reads_before_failure = null;
+		$this->assertSame( 'booking_not_found', $repository->claim_event( 999, 900, 1 )->get_error_code() );
+	}
+
+	public function test_activity_idempotency_is_booking_scoped_and_orphans_are_rejected(): void {
+		$activity = new BookingActivityRepository();
+		$one      = $this->create_booking();
+		$two      = $this->create_booking();
+		$input    = array(
+			'booking_id'      => $one['id'],
+			'kind'            => 'inquiry_received',
+			'idempotency_key' => 'intake:request-1',
+			'payload'         => array( 'source' => 'form' ),
+		);
+		$first    = $activity->append( $input );
+		$retry    = $activity->append( $input );
+		$this->assertSame( $first['id'], $retry['id'] );
+		$other = $activity->append( array_merge( $input, array( 'booking_id' => $two['id'] ) ) );
+		$this->assertNotSame( $first['id'], $other['id'] );
+		$this->assertSame( 'booking_activity_orphan', $activity->append( array_merge( $input, array( 'booking_id' => 999 ) ) )->get_error_code() );
+	}
+
+	public function test_activity_duplicate_insert_race_returns_winner_or_read_error(): void {
+		$booking                               = $this->create_booking();
+		$activity                              = new BookingActivityRepository();
+		$GLOBALS['wpdb']->race_activity_insert = true;
+		$result                                = $activity->append(
+			array(
+				'booking_id'      => $booking['id'],
+				'kind'            => 'note',
+				'idempotency_key' => 'note:race-1',
+			)
+		);
+		$this->assertIsArray( $result );
+		$this->assertSame( 'note:race-1', $result['idempotency_key'] );
+
+		$GLOBALS['wpdb']->race_activity_insert    = true;
+		$GLOBALS['wpdb']->race_activity_read_fail = true;
+		$result                                   = $activity->append(
+			array(
+				'booking_id'      => $booking['id'],
+				'kind'            => 'note',
+				'idempotency_key' => 'note:race-2',
+			)
+		);
+		$this->assertSame( 'booking_activity_read_failed', $result->get_error_code() );
+	}
+
+	public function test_activity_reports_read_and_write_failures_distinctly(): void {
+		$booking                              = $this->create_booking();
+		$activity                             = new BookingActivityRepository();
+		$GLOBALS['wpdb']->fail_activity_reads = true;
+		$result                               = $activity->append(
+			array(
+				'booking_id'      => $booking['id'],
+				'kind'            => 'note',
+				'idempotency_key' => 'note:1',
+			)
+		);
+		$this->assertSame( 'booking_activity_read_failed', $result->get_error_code() );
+		$GLOBALS['wpdb']->fail_activity_reads = false;
+		$GLOBALS['wpdb']->fail_inserts        = true;
+		$result                               = $activity->append(
+			array(
+				'booking_id' => $booking['id'],
+				'kind'       => 'note',
+			)
+		);
+		$this->assertSame( 'booking_activity_write_failed', $result->get_error_code() );
+		$GLOBALS['wpdb']->fail_inserts = false;
+		$GLOBALS['wpdb']->fail_reads   = true;
+		$result                        = $activity->append(
+			array(
+				'booking_id' => $booking['id'],
+				'kind'       => 'note',
+			)
+		);
+		$this->assertSame( 'booking_activity_booking_read_failed', $result->get_error_code() );
+	}
+
+	public function test_config_handles_unchanged_values_and_rejects_wrong_term_or_versions(): void {
+		$service = new VenueBookingConfig();
+		$config  = $service->save( 55, array( 'enabled' => true ) );
+		$this->assertIsArray( $config );
+		$this->assertSame( $config, $service->save( 55, $config ) );
+		$this->assertSame( 'invalid_booking_config_venue', $service->save( 56, array() )->get_error_code() );
+		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => 2 ) )->get_error_code() );
+		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => '1junk' ) )->get_error_code() );
+		$this->assertSame( 'booking_config_section_version_unsupported', $service->normalize( array( 'intake' => array( 'version' => 2 ) ) )->get_error_code() );
+		$GLOBALS['ec_artist_test']['meta'][7][55][ VenueBookingConfig::META_KEY ] = array( 'version' => 99 );
+		$this->assertSame( 'booking_config_version_unsupported', $service->get( 55 )->get_error_code() );
+	}
+
+	public function test_config_detects_truncated_collisions_and_validates_channels_currency(): void {
+		$service = new VenueBookingConfig();
+		$prefix  = str_repeat( 'a', 64 );
+		$result  = $service->normalize(
+			array(
+				'spaces' => array(
+					array(
+						'key'  => $prefix . 'x',
+						'name' => 'One',
+					),
+					array(
+						'key'  => $prefix . 'y',
+						'name' => 'Two',
+					),
+				),
+			)
+		);
+		$this->assertSame( 'invalid_booking_space', $result->get_error_code() );
+		$result = $service->normalize( array( 'intake' => array( 'fields' => array( array( 'key' => $prefix . 'x' ), array( 'key' => $prefix . 'y' ) ) ) ) );
+		$this->assertSame( 'invalid_booking_intake_field', $result->get_error_code() );
+		$this->assertSame( 'invalid_booking_marketing_channels', $service->normalize( array( 'marketing_channels' => array_fill( 0, 21, 'email' ) ) )->get_error_code() );
+		$this->assertSame( 'invalid_booking_marketing_channel', $service->normalize( array( 'marketing_channels' => array( $prefix . 'x', $prefix . 'y' ) ) )->get_error_code() );
+		$this->assertSame( 'invalid_booking_currency', $service->normalize( array( 'default_deal' => array( 'currency' => 'US1' ) ) )->get_error_code() );
+	}
+
+	public function test_repository_rejects_invalid_ids_dates_filters_and_normalizes_updates(): void {
+		$repository = new BookingRepository();
+		$this->assertSame( 'invalid_booking_id', $this->create_booking( array( 'venue_term_id' => -55 ) )->get_error_code() );
+		$this->assertSame( 'invalid_booking_id', $this->create_booking( array( 'assignee_user_id' => -2 ) )->get_error_code() );
+		$this->assertSame(
+			'invalid_booking_date_range',
+			$this->create_booking(
+				array(
+					'requested_start_at' => '2026-08-02 00:00:00',
+					'requested_end_at'   => '2026-08-01 00:00:00',
+				)
+			)->get_error_code()
+		);
+		$this->assertSame(
+			'invalid_booking_datetime',
+			$repository->list(
+				array(
+					'venue_term_id'      => 55,
+					'requested_start_at' => 'tomorrow',
+				)
+			)->get_error_code()
+		);
+		$booking = $this->create_booking();
+		$updated = $repository->update(
+			$booking['id'],
+			array(
+				'artist_name' => str_repeat( 'x', 300 ),
+				'space_key'   => str_repeat( 'y', 80 ),
+				'status'      => 'Needs Review!',
+				'intake'      => array(
+					'one' => 1,
+					'two' => 2,
+				),
+			),
+			1
+		);
+		$this->assertSame( 255, strlen( $updated['artist_name'] ) );
+		$this->assertSame( 64, strlen( $updated['space_key'] ) );
+		$this->assertSame( 'needsreview', $updated['status'] );
+		$this->assertSame(
+			array(
+				'one' => 1,
+				'two' => 2,
+			),
+			$updated['intake']['data']
+		);
+	}
+
+	public function test_repository_list_applies_filters_order_and_bounds(): void {
+		$repository = new BookingRepository();
+		$first      = $this->create_booking(
+			array(
+				'status'             => 'inquiry',
+				'requested_start_at' => '2026-08-01 00:00:00',
+				'requested_end_at'   => '2026-08-02 00:00:00',
+			)
+		);
+		$this->create_booking(
+			array(
+				'status'             => 'accepted',
+				'requested_start_at' => '2026-09-01 00:00:00',
+				'requested_end_at'   => '2026-09-02 00:00:00',
+			)
+		);
+		$latest = $this->create_booking(
+			array(
+				'status'             => 'inquiry',
+				'requested_start_at' => '2026-10-01 00:00:00',
+				'requested_end_at'   => '2026-10-02 00:00:00',
+				'artist_term_id'     => 101,
+			)
+		);
+		$rows   = $repository->list(
+			array(
+				'venue_term_id' => 55,
+				'status'        => 'inquiry',
+				'limit'         => 1,
+			)
+		);
+		$this->assertCount( 1, $rows );
+		$this->assertSame( $latest['id'], $rows[0]['id'] );
+		$rows = $repository->list(
+			array(
+				'venue_term_id'      => 55,
+				'artist_term_id'     => 101,
+				'requested_start_at' => '2026-09-30 00:00:00',
+			)
+		);
+		$this->assertSame( array( $latest['id'] ), array_column( $rows, 'id' ) );
+		$rows = $repository->list(
+			array(
+				'venue_term_id'    => 55,
+				'requested_end_at' => '2026-08-31 00:00:00',
+			)
+		);
+		$this->assertSame( array( $first['id'] ), array_column( $rows, 'id' ) );
+	}
+
+	public function test_repository_distinguishes_not_found_conflict_and_read_failure(): void {
+		$repository = new BookingRepository();
+		$this->assertSame( 'booking_not_found', $repository->update( 999, array( 'status' => 'reviewing' ), 1 )->get_error_code() );
+		$booking = $this->create_booking();
+		$repository->update( $booking['id'], array( 'status' => 'reviewing' ), 1 );
+		$this->assertSame( 'booking_version_conflict', $repository->update( $booking['id'], array( 'status' => 'accepted' ), 1 )->get_error_code() );
+		$GLOBALS['wpdb']->fail_reads = true;
+		$this->assertSame( 'booking_read_failed', $repository->get( $booking['id'] )->get_error_code() );
+		$this->assertSame( 'booking_list_failed', $repository->list( array( 'venue_term_id' => 55 ) )->get_error_code() );
 	}
 }
-// phpcs:enable
-

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Venue booking persistence foundation tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Core\BookingActivityRepository;
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\VenueBookingConfig;
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable -- Isolated WordPress and database test doubles.
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private $code;
+		private $data;
+		public function __construct( $code, $message = '', $data = array() ) {
+			unset( $message );
+			$this->code = $code;
+			$this->data = $data;
+		}
+		public function get_error_code() { return $this->code; }
+		public function get_error_data() { return $this->data; }
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) { return $value instanceof WP_Error; }
+}
+if ( ! function_exists( '__' ) ) {
+	function __( $text ) { return $text; }
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ) { return abs( (int) $value ); }
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $value ) { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) ); }
+}
+if ( ! function_exists( 'sanitize_email' ) ) {
+	function sanitize_email( $value ) { return filter_var( trim( (string) $value ), FILTER_VALIDATE_EMAIL ) ?: ''; }
+}
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4() { return '123e4567-e89b-42d3-a456-426614174000'; }
+}
+if ( ! function_exists( 'ec_get_blog_id' ) ) {
+	function ec_get_blog_id( $site ) { return array( 'main' => 1, 'artist' => 4, 'events' => 7 )[ $site ] ?? 0; }
+}
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id() { return $GLOBALS['ec_artist_test']['blog_id']; }
+}
+if ( ! function_exists( 'switch_to_blog' ) ) {
+	function switch_to_blog( $blog_id ) {
+		$GLOBALS['ec_artist_test']['stack'][] = $GLOBALS['ec_artist_test']['blog_id'];
+		$GLOBALS['ec_artist_test']['blog_id'] = (int) $blog_id;
+	}
+}
+if ( ! function_exists( 'restore_current_blog' ) ) {
+	function restore_current_blog() { $GLOBALS['ec_artist_test']['blog_id'] = array_pop( $GLOBALS['ec_artist_test']['stack'] ); }
+}
+if ( ! function_exists( 'get_term' ) ) {
+	function get_term( $term_id, $taxonomy = '' ) {
+		$state = $GLOBALS['ec_artist_test'] ?? array();
+		$term  = $state['terms'][ $state['blog_id'] ][ $term_id ] ?? null;
+		return $term && ( '' === $taxonomy || $taxonomy === $term->taxonomy ) ? $term : null;
+	}
+}
+if ( ! function_exists( 'get_term_meta' ) ) {
+	function get_term_meta( $term_id, $key, $single = false ) {
+		unset( $single );
+		$state = $GLOBALS['ec_artist_test'] ?? array();
+		return $state['meta'][ $state['blog_id'] ][ $term_id ][ $key ] ?? '';
+	}
+}
+if ( ! function_exists( 'update_term_meta' ) ) {
+	function update_term_meta( $term_id, $key, $value ) {
+		$GLOBALS['ec_artist_test']['meta'][ get_current_blog_id() ][ $term_id ][ $key ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'get_post' ) ) {
+	function get_post( $post_id ) {
+		$state = $GLOBALS['ec_artist_test'] ?? array();
+		return $state['posts'][ $state['blog_id'] ][ $post_id ] ?? null;
+	}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $key, $default = false ) { return $GLOBALS['ec_artist_test']['options'][ $key ] ?? $default; }
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $key, $value, $autoload = null ) {
+		unset( $autoload );
+		$GLOBALS['ec_artist_test']['options'][ $key ] = $value;
+		return true;
+	}
+}
+
+/** Minimal in-memory wpdb for repository and schema contracts. */
+final class BookingWpdb {
+	public $prefix = 'wp_7_';
+	public $insert_id = 0;
+	public $rows = array();
+	public $last_query = '';
+
+	public function get_charset_collate() { return 'DEFAULT CHARACTER SET utf8mb4'; }
+
+	public function prepare( $query, ...$args ) {
+		if ( 1 === count( $args ) && is_array( $args[0] ) ) {
+			$args = $args[0];
+		}
+		$i = 0;
+		return preg_replace_callback(
+			'/%[ds]/',
+			static function ( $match ) use ( &$args, &$i ) {
+				$value = $args[ $i++ ];
+				return '%d' === $match[0] ? (string) (int) $value : "'" . addslashes( (string) $value ) . "'";
+			},
+			$query
+		);
+	}
+
+	public function insert( $table, $row ) {
+		$this->insert_id = count( $this->rows[ $table ] ?? array() ) + 1;
+		$row['id'] = $this->insert_id;
+		$this->rows[ $table ][ $this->insert_id ] = $row;
+		return 1;
+	}
+
+	public function get_row( $query, $output = null ) {
+		unset( $output );
+		$this->last_query = $query;
+		$table = false !== strpos( $query, 'ec_booking_activity' ) ? $this->prefix . 'ec_booking_activity' : $this->prefix . 'ec_bookings';
+		if ( preg_match( '/WHERE id = (\d+)/', $query, $match ) ) {
+			return $this->rows[ $table ][ (int) $match[1] ] ?? null;
+		}
+		if ( preg_match( "/WHERE public_id = '([^']+)'/", $query, $match ) ) {
+			foreach ( $this->rows[ $table ] ?? array() as $row ) {
+				if ( $row['public_id'] === $match[1] ) { return $row; }
+			}
+		}
+		return null;
+	}
+
+	public function get_results( $query, $output = null ) {
+		unset( $output );
+		$this->last_query = $query;
+		$table = false !== strpos( $query, 'ec_booking_activity' ) ? $this->prefix . 'ec_booking_activity' : $this->prefix . 'ec_bookings';
+		return array_values( $this->rows[ $table ] ?? array() );
+	}
+
+	public function query( $query ) {
+		$this->last_query = $query;
+		if ( ! preg_match( '/WHERE id = (\d+) AND version = (\d+)/', $query, $match ) ) { return false; }
+		$id = (int) $match[1];
+		$expected = (int) $match[2];
+		$table = $this->prefix . 'ec_bookings';
+		if ( ! isset( $this->rows[ $table ][ $id ] ) || (int) $this->rows[ $table ][ $id ]['version'] !== $expected ) { return 0; }
+		if ( preg_match( "/status = '([^']+)'/", $query, $status ) ) { $this->rows[ $table ][ $id ]['status'] = $status[1]; }
+		if ( preg_match( '/artist_term_id = (\d+)/', $query, $term ) ) { $this->rows[ $table ][ $id ]['artist_term_id'] = (int) $term[1]; }
+		if ( preg_match( '/artist_profile_id = (\d+)/', $query, $profile ) ) { $this->rows[ $table ][ $id ]['artist_profile_id'] = (int) $profile[1]; }
+		$this->rows[ $table ][ $id ]['version']++;
+		return 1;
+	}
+
+	public function get_var( $query ) {
+		if ( preg_match( "/LIKE '([^']+)'/", $query, $match ) ) { return stripslashes( $match[1] ); }
+		return null;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/BookingSchema.php';
+require_once dirname( __DIR__ ) . '/inc/Core/BookingRepository.php';
+require_once dirname( __DIR__ ) . '/inc/Core/BookingActivityRepository.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VenueBookingConfig.php';
+
+final class BookingFoundationTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id' => 7,
+			'stack'   => array(),
+			'options' => array(),
+			'dbdelta' => array(),
+			'terms'   => array(
+				1 => array( 101 => (object) array( 'term_id' => 101, 'taxonomy' => 'artist', 'name' => 'Canonical Artist' ) ),
+				7 => array( 55 => (object) array( 'term_id' => 55, 'taxonomy' => 'venue', 'name' => 'The Room' ) ),
+			),
+			'meta'    => array( 1 => array( 101 => array( '_artist_profile_id' => 501 ) ) ),
+			'posts'   => array( 4 => array( 501 => (object) array( 'ID' => 501, 'post_type' => 'artist_profile', 'post_title' => 'Canonical Artist' ) ) ),
+		);
+		unset( $GLOBALS['ec_booking_test'] );
+		$GLOBALS['wpdb'] = new BookingWpdb();
+	}
+
+	public function test_schema_is_site_scoped_idempotent_and_indexed(): void {
+		$this->assertSame( 'wp_7_ec_bookings', BookingSchema::bookings_table() );
+		$this->assertSame( 'wp_7_ec_booking_activity', BookingSchema::activity_table() );
+		BookingSchema::install();
+		$this->assertCount( 2, $GLOBALS['ec_artist_test']['dbdelta'] );
+		$sql = implode( "\n", $GLOBALS['ec_artist_test']['dbdelta'] );
+		$this->assertStringContainsString( 'UNIQUE KEY event_id', $sql );
+		$this->assertStringContainsString( 'venue_status_created', $sql );
+		$this->assertStringContainsString( 'UNIQUE KEY idempotency_key', $sql );
+		$GLOBALS['ec_artist_test']['dbdelta'] = array();
+		BookingSchema::maybe_install();
+		$this->assertSame( array(), $GLOBALS['ec_artist_test']['dbdelta'] );
+		$GLOBALS['wpdb']->prefix = 'wp_12_';
+		$this->assertSame( 'wp_12_ec_bookings', BookingSchema::bookings_table() );
+	}
+
+	public function test_config_normalizes_integer_basis_points_and_default_space(): void {
+		$config = ( new VenueBookingConfig() )->normalize(
+			array(
+				'enabled' => true,
+				'spaces' => array( array( 'key' => 'Main Room', 'name' => 'Main Room' ) ),
+				'default_deal' => array( 'revenue_share_basis_points' => 1750, 'revenue_share_basis' => 'net_ticket_sales' ),
+				'marketing_channels' => array( 'Email', 'instagram' ),
+			)
+		);
+		$this->assertSame( 1750, $config['default_deal']['revenue_share_basis_points'] );
+		$this->assertTrue( $config['spaces'][0]['is_default'] );
+		$this->assertSame( array( 'email', 'instagram' ), $config['marketing_channels'] );
+		$this->assertTrue( is_wp_error( ( new VenueBookingConfig() )->normalize( array( 'default_deal' => array( 'revenue_share_basis_points' => 10001 ) ) ) ) );
+	}
+
+	public function test_unresolved_canonical_and_profile_backed_identity_states(): void {
+		$repository = new BookingRepository();
+		$unresolved = $repository->create( array( 'venue_term_id' => 55, 'artist_name' => 'New Band', 'contact_email' => 'band@example.com', 'intake' => array( 'draw' => 100 ) ) );
+		$this->assertNull( $unresolved['artist_term_id'] );
+		$this->assertNull( $unresolved['artist_profile_id'] );
+		$this->assertSame( 1, $unresolved['intake']['version'] );
+
+		$canonical = $repository->create( array( 'venue_term_id' => 55, 'artist_term_id' => 101 ) );
+		$this->assertSame( 101, $canonical['artist_term_id'] );
+		$this->assertNull( $canonical['artist_profile_id'] );
+
+		$profile = $repository->create( array( 'venue_term_id' => 55, 'artist_term_id' => 101, 'artist_profile_id' => 501 ) );
+		$this->assertSame( 501, $profile['artist_profile_id'] );
+		$this->assertSame( 'Canonical Artist', $profile['artist_name'] );
+	}
+
+	public function test_later_binding_and_optimistic_version_conflict(): void {
+		$repository = new BookingRepository();
+		$booking = $repository->create( array( 'venue_term_id' => 55, 'artist_name' => 'New Band' ) );
+		$bound = $repository->update( $booking['id'], array( 'artist_term_id' => 101, 'artist_profile_id' => 501, 'status' => 'reviewing' ), 1 );
+		$this->assertSame( 2, $bound['version'] );
+		$this->assertSame( 101, $bound['artist_term_id'] );
+		$conflict = $repository->update( $booking['id'], array( 'status' => 'accepted' ), 1 );
+		$this->assertSame( 'booking_version_conflict', $conflict->get_error_code() );
+	}
+
+	public function test_lists_are_bounded_and_activity_payloads_are_versioned(): void {
+		$repository = new BookingRepository();
+		$repository->create( array( 'venue_term_id' => 55, 'artist_name' => 'New Band' ) );
+		$this->assertCount( 1, $repository->list( array( 'venue_term_id' => 55, 'limit' => 999 ) ) );
+		$this->assertStringContainsString( 'LIMIT 100', $GLOBALS['wpdb']->last_query );
+		$activity = ( new BookingActivityRepository() )->append( array( 'booking_id' => 1, 'kind' => 'inquiry_received', 'payload' => array( 'source' => 'form' ), 'idempotency_key' => 'inquiry-1' ) );
+		$this->assertSame( 1, $activity['payload']['version'] );
+		$this->assertSame( 'form', $activity['payload']['data']['source'] );
+	}
+}
+// phpcs:enable
+

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -150,6 +150,8 @@ final class BookingWpdb {
 	public $rows                    = array();
 	public $schemas                 = array();
 	public $schema_omit             = array();
+	public $schema_queries          = 0;
+	public $dropped_indexes         = array();
 	public $fail_reads              = false;
 	public $fail_activity_reads     = false;
 	public $fail_inserts            = false;
@@ -191,15 +193,24 @@ final class BookingWpdb {
 				$name    = 'PRIMARY KEY' === strtoupper( $index[1] ) ? 'PRIMARY' : $index[2];
 				$unique  = 'KEY' !== strtoupper( $index[1] );
 				$columns = array_map( 'trim', explode( ',', str_replace( '`', '', $index[3] ) ) );
-				if ( ! in_array( $name, $this->schema_omit[ $table ]['indexes'] ?? array(), true ) ) {
+				if ( ! isset( $this->schemas[ $table ]['indexes'][ $name ] ) && ! in_array( $name, $this->schema_omit[ $table ]['indexes'] ?? array(), true ) ) {
 					$this->schemas[ $table ]['indexes'][ $name ] = array(
 						'unique'  => $unique,
 						'columns' => $columns,
 					);
 				}
 			} elseif ( preg_match( '/^([a-z_]+)\s+(.+)$/', $line, $column ) && ! in_array( $column[1], $this->schema_omit[ $table ]['columns'] ?? array(), true ) ) {
-				preg_match( '/^(.+?)(?:\s+NOT NULL|\s+NULL|\s+DEFAULT|\s+AUTO_INCREMENT|$)/i', $column[2], $type );
-				$this->schemas[ $table ]['columns'][ $column[1] ] = strtolower( trim( $type[1] ) );
+				$definition = $column[2];
+				preg_match( '/^(.+?)(?:\s+NOT NULL|\s+NULL|\s+DEFAULT|\s+AUTO_INCREMENT|$)/i', $definition, $type );
+				preg_match( "/\sDEFAULT\s+(?:'([^']*)'|([^\s]+))/i", $definition, $default );
+				if ( ! isset( $this->schemas[ $table ]['columns'][ $column[1] ] ) ) {
+					$this->schemas[ $table ]['columns'][ $column[1] ] = array(
+						'Type'    => strtolower( trim( $type[1] ) ),
+						'Null'    => false !== stripos( $definition, 'NOT NULL' ) ? 'NO' : 'YES',
+						'Default' => isset( $default[1] ) && '' !== $default[1] ? $default[1] : ( $default[2] ?? null ),
+						'Extra'   => false !== stripos( $definition, 'AUTO_INCREMENT' ) ? 'auto_increment' : '',
+					);
+				}
 			}
 		}
 	}
@@ -234,6 +245,7 @@ final class BookingWpdb {
 
 	public function get_var( $query ) {
 		$this->last_error = '';
+		++$this->schema_queries;
 		if ( $this->fail_reads ) {
 			$this->last_error = 'simulated schema read failure';
 			return null; }
@@ -284,16 +296,15 @@ final class BookingWpdb {
 			$this->last_error = 'simulated result read failure';
 			return null; }
 		if ( preg_match( '/SHOW COLUMNS FROM `([^`]+)`/', $query, $match ) ) {
+			++$this->schema_queries;
 			$rows = array();
-			foreach ( $this->schemas[ $match[1] ]['columns'] ?? array() as $name => $type ) {
-				$rows[] = array(
-					'Field' => $name,
-					'Type'  => $type,
-				);
+			foreach ( $this->schemas[ $match[1] ]['columns'] ?? array() as $name => $metadata ) {
+				$rows[] = array_merge( array( 'Field' => $name ), $metadata );
 			}
 			return $rows;
 		}
 		if ( preg_match( '/SHOW INDEX FROM `([^`]+)`/', $query, $match ) ) {
+			++$this->schema_queries;
 			$rows = array();
 			foreach ( $this->schemas[ $match[1] ]['indexes'] ?? array() as $name => $index ) {
 				foreach ( $index['columns'] as $position => $column ) {
@@ -369,6 +380,21 @@ final class BookingWpdb {
 	public function query( $query ) {
 		$this->last_query = $query;
 		$this->last_error = '';
+		if ( preg_match( '/ALTER TABLE `([^`]+)` DROP (?:INDEX `([^`]+)`|PRIMARY KEY)/', $query, $drop ) ) {
+			$name = ! empty( $drop[2] ) ? $drop[2] : 'PRIMARY';
+			unset( $this->schemas[ $drop[1] ]['indexes'][ $name ] );
+			if ( 'PRIMARY' === $name && preg_match( '/ADD PRIMARY KEY \(([^)]+)\)/', $query, $primary ) ) {
+				$this->schemas[ $drop[1] ]['indexes']['PRIMARY'] = array(
+					'unique'  => true,
+					'columns' => array_map( 'trim', explode( ',', str_replace( '`', '', $primary[1] ) ) ),
+				);
+			}
+			$this->dropped_indexes[] = array(
+				'table' => $drop[1],
+				'index' => $name,
+			);
+			return 1;
+		}
 		if ( $this->fail_updates ) {
 			$this->last_error = 'simulated update failure';
 			return false; }
@@ -484,20 +510,42 @@ final class BookingFoundationTest extends TestCase {
 		);
 	}
 
-	public function test_schema_stamps_only_verified_site_scoped_contract(): void {
+	public function test_schema_health_validates_attributes_and_site_scope(): void {
 		$this->assertTrue( BookingSchema::install() );
 		$this->assertSame( BookingSchema::SCHEMA_VERSION, get_option( BookingSchema::VERSION_OPTION ) );
 		$this->assertTrue( BookingSchema::health() );
-		$this->assertTrue( $GLOBALS['wpdb']->schemas['wp_7_ec_booking_activity']['indexes']['booking_idempotency']['unique'] );
-		$this->assertSame( array( 'booking_id', 'idempotency_key' ), $GLOBALS['wpdb']->schemas['wp_7_ec_booking_activity']['indexes']['booking_idempotency']['columns'] );
-		$GLOBALS['wpdb']->schemas['wp_7_ec_booking_activity']['indexes']['booking_idempotency']['columns'] = array( 'idempotency_key' );
-		$this->assertSame( 'booking_schema_index_missing', BookingSchema::health()->get_error_code() );
-		$GLOBALS['wpdb']->schemas['wp_7_ec_booking_activity']['indexes']['booking_idempotency']['columns'] = array( 'booking_id', 'idempotency_key' );
-		$GLOBALS['wpdb']->schemas['wp_7_ec_bookings']['columns']['status']                                 = 'text';
-		$this->assertSame( 'booking_schema_column_invalid', BookingSchema::health()->get_error_code() );
+
+		$columns                   =& $GLOBALS['wpdb']->schemas['wp_7_ec_bookings']['columns'];
+		$columns['status']['Type'] = 'text';
+		$this->assertSame( 'type', BookingSchema::health()->get_error_data()['attribute'] );
+		$columns['status']['Type'] = 'varchar(32)';
+		$columns['status']['Null'] = 'YES';
+		$this->assertSame( 'nullable', BookingSchema::health()->get_error_data()['attribute'] );
+		$columns['status']['Null']    = 'NO';
+		$columns['status']['Default'] = 'pending';
+		$this->assertSame( 'default', BookingSchema::health()->get_error_data()['attribute'] );
+		$columns['status']['Default']  = 'inquiry';
+		$columns['version']['Default'] = '2';
+		$this->assertSame( 'default', BookingSchema::health()->get_error_data()['attribute'] );
+		$columns['version']['Default'] = '1';
+		$columns['id']['Extra']        = '';
+		$this->assertSame( 'extra', BookingSchema::health()->get_error_data()['attribute'] );
+		$columns['id']['Extra'] = 'auto_increment';
+		$this->assertTrue( BookingSchema::health() );
+
 		$GLOBALS['wpdb']->prefix = 'wp_12_';
 		$this->assertSame( 'wp_12_ec_bookings', BookingSchema::bookings_table() );
 		$this->assertSame( 'booking_schema_table_missing', BookingSchema::health()->get_error_code() );
+	}
+
+	public function test_unrepairable_column_attributes_are_not_stamped(): void {
+		$this->assertTrue( BookingSchema::install() );
+		$GLOBALS['wpdb']->schemas['wp_7_ec_bookings']['columns']['status']['Null'] = 'YES';
+		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ]     = '';
+		$result = BookingSchema::maybe_install();
+		$this->assertSame( 'booking_schema_column_invalid', $result->get_error_code() );
+		$this->assertSame( 'nullable', $result->get_error_data()['attribute'] );
+		$this->assertSame( '', get_option( BookingSchema::VERSION_OPTION, '' ) );
 	}
 
 	public function test_partial_schema_is_not_stamped_and_repeat_install_repairs_it(): void {
@@ -510,6 +558,54 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertTrue( BookingSchema::maybe_install() );
 		$this->assertTrue( BookingSchema::health() );
 		$this->assertSame( BookingSchema::SCHEMA_VERSION, get_option( BookingSchema::VERSION_OPTION ) );
+	}
+
+	public function test_malformed_required_indexes_are_dropped_and_repaired(): void {
+		$this->assertTrue( BookingSchema::install() );
+		$bookings = 'wp_7_ec_bookings';
+		$activity = 'wp_7_ec_booking_activity';
+		$GLOBALS['wpdb']->schemas[ $bookings ]['indexes']['PRIMARY']['columns']             = array( 'id', 'public_id' );
+		$GLOBALS['wpdb']->schemas[ $bookings ]['indexes']['public_id']['unique']            = false;
+		$GLOBALS['wpdb']->schemas[ $activity ]['indexes']['booking_idempotency']['columns'] = array( 'idempotency_key' );
+		$GLOBALS['wpdb']->schemas[ $activity ]['indexes']['operator_extra']                 = array(
+			'unique'  => false,
+			'columns' => array( 'created_at' ),
+		);
+		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ]              = '';
+		$GLOBALS['wpdb']->dropped_indexes = array();
+
+		$this->assertTrue( BookingSchema::maybe_install() );
+		$this->assertTrue( BookingSchema::health() );
+		$this->assertSame( array( 'id' ), $GLOBALS['wpdb']->schemas[ $bookings ]['indexes']['PRIMARY']['columns'] );
+		$this->assertTrue( $GLOBALS['wpdb']->schemas[ $bookings ]['indexes']['public_id']['unique'] );
+		$this->assertSame( array( 'booking_id', 'idempotency_key' ), $GLOBALS['wpdb']->schemas[ $activity ]['indexes']['booking_idempotency']['columns'] );
+		$this->assertArrayHasKey( 'operator_extra', $GLOBALS['wpdb']->schemas[ $activity ]['indexes'] );
+		$this->assertSame(
+			array(
+				array(
+					'table' => $bookings,
+					'index' => 'PRIMARY',
+				),
+				array(
+					'table' => $bookings,
+					'index' => 'public_id',
+				),
+				array(
+					'table' => $activity,
+					'index' => 'booking_idempotency',
+				),
+			),
+			$GLOBALS['wpdb']->dropped_indexes
+		);
+	}
+
+	public function test_current_version_maybe_install_performs_no_schema_queries(): void {
+		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = BookingSchema::SCHEMA_VERSION;
+		$GLOBALS['wpdb']->schema_queries                                       = 0;
+		$GLOBALS['ec_artist_test']['dbdelta']                                  = array();
+		$this->assertTrue( BookingSchema::maybe_install() );
+		$this->assertSame( 0, $GLOBALS['wpdb']->schema_queries );
+		$this->assertSame( array(), $GLOBALS['ec_artist_test']['dbdelta'] );
 	}
 
 	public function test_missing_unique_index_and_schema_read_errors_remain_retryable(): void {

--- a/tests/fixtures/wp-admin/includes/upgrade.php
+++ b/tests/fixtures/wp-admin/includes/upgrade.php
@@ -1,8 +1,23 @@
 <?php
-/** Test dbDelta capture. */
+/**
+ * Test dbDelta simulation backed by BookingWpdb schema metadata.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
 if ( ! function_exists( 'dbDelta' ) ) {
+	/**
+	 * Simulate WordPress core's schema reconciler.
+	 *
+	 * @param string $sql CREATE TABLE statement.
+	 * @return array Empty change list.
+	 */
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid -- Matches the WordPress core API under test.
 	function dbDelta( $sql ) {
 		$GLOBALS['ec_artist_test']['dbdelta'][] = $sql;
+		if ( isset( $GLOBALS['wpdb'] ) && method_exists( $GLOBALS['wpdb'], 'apply_schema' ) ) {
+			$GLOBALS['wpdb']->apply_schema( $sql );
+		}
 		return array();
 	}
 }

--- a/tests/fixtures/wp-admin/includes/upgrade.php
+++ b/tests/fixtures/wp-admin/includes/upgrade.php
@@ -1,0 +1,8 @@
+<?php
+/** Test dbDelta capture. */
+if ( ! function_exists( 'dbDelta' ) ) {
+	function dbDelta( $sql ) {
+		$GLOBALS['ec_artist_test']['dbdelta'][] = $sql;
+		return array();
+	}
+}


### PR DESCRIPTION
## Summary

- Add site-scoped private booking and append-only activity tables, installed through the existing versioned `dbDelta()` lifecycle.
- Add bounded booking/activity repositories with versioned JSON serialization, tenant-scoped listing, canonical identity validation, and optimistic conditional updates.
- Add one validated, versioned venue booking configuration document on the existing canonical `venue` term.

Closes #292.

## Why operational tables

Bookings contain private contact PII, mutable workflow state, concurrency versions, idempotency keys, and event-handoff bookkeeping. Custom operational tables keep that data outside public post queries, post archives, generic CPT REST behavior, and editorial revision semantics. Public events remain the existing Data Machine Events CPT; a booking only stores an optional unique handoff `event_id`.

## Schema

Schema version `1` is stored per Events site in `extrachill_events_booking_schema_version`. Activation calls `BookingSchema::install()` and runtime `plugins_loaded` calls `maybe_install()`. Both tables use the active Events site's `$wpdb->prefix`, not `base_prefix`.

### `<prefix>ec_bookings`

Columns:

- `id`, UUID `public_id`
- canonical `venue_term_id`
- optional canonical main-site `artist_term_id`
- optional Artist Platform `artist_profile_id`
- unresolved-safe `artist_name`
- `submitter_user_id`, `contact_name`, `contact_email`, `contact_phone`
- optional `space_key`
- lifecycle placeholders `status`, optimistic `version`, `assignee_user_id`
- UTC `requested_start_at`, `requested_end_at`
- versioned JSON `intake_payload`, optional versioned JSON `deal_payload`
- optional event handoff `event_id`
- UTC `created_at`, `updated_at`

Indexes:

- primary `id`
- unique `public_id`
- unique `event_id`
- `venue_status_created (venue_term_id, status, created_at)`
- `venue_requested_start (venue_term_id, requested_start_at)`
- `artist_term_created (artist_term_id, created_at)`
- `artist_profile_created (artist_profile_id, created_at)`
- `assignee_status (assignee_user_id, status)`
- `status_updated (status, updated_at)`

### `<prefix>ec_booking_activity`

Columns:

- `id`, `booking_id`, `kind`
- `actor_type`, optional `actor_id`
- optional `direction`, `channel`
- versioned JSON `payload`
- optional `external_id`, `idempotency_key`
- UTC `occurred_at`, `created_at`

Indexes:

- primary `id`
- unique nullable `booking_idempotency (booking_id, idempotency_key)`
- `booking_occurred (booking_id, occurred_at, id)`
- `kind_occurred (kind, occurred_at)`
- `channel_external (channel, external_id)`

## Venue configuration

`VenueBookingConfig` owns `_extrachill_booking_config` on existing Events-site `venue` terms. The bounded version `1` document contains:

- `enabled`
- versioned intake fields
- up to 50 uniquely keyed spaces with one default
- versioned default deal type, integer `guarantee_cents`, integer `revenue_share_basis_points`, revenue basis, and currency
- non-secret `ticket_provider_reference`
- up to 20 normalized marketing channel keys
- bounded `hold_ttl_minutes`

The service normalizes and validates the whole document. It stores no credentials and uses no floating-point revenue values.

## Identity reuse

- Existing Events-site `venue` terms remain canonical booking tenants; no venue model was added.
- Existing main-site `artist` terms remain canonical editorial/discovery artist identity.
- Existing Artist Platform `artist_profile` posts remain optional claimed/manageable identity.
- Name/contact-only unresolved inquiries remain valid.
- Canonical-term-only and profile-backed inquiries are validated on their owning sites.
- Artist profiles must be published. Profile-only input resolves its existing canonical `_artist_term_id` when present; supplied term/profile pairs must agree through both `term._artist_profile_id` and `profile._artist_term_id`.
- No Events-local artist term is persisted as canonical identity and no cross-site mapping logic is duplicated. Future event conversion can continue using `extrachill_events_resolve_artist_term()`.

## Repository contracts

- `BookingRepository::create()`, `get()`, venue-required bounded `list()`, normalized `update( ..., $expected_version )`, and dedicated NULL-only `claim_event()`
- Conditional updates increment `version` atomically and return `booking_version_conflict` with HTTP-style status `409` when stale.
- `BookingActivityRepository::append()`, `get()`, and bounded `list_for_booking()`; activity is append-only.
- Flexible intake, deal, and activity values use strictly validated `{ version, data }` JSON envelopes; encoding, corruption, and unsupported versions return explicit errors without lossy fallback writes.
- No REST route or generic ability is registered.

## Out of scope

- #291 membership and authorization
- #298 lifecycle abilities
- #295 holds
- public REST routes or Roadie tools
- marketing execution
- ticket settlement
- UI or other user-facing features
- duplicated Data Machine workflow, scheduling, email, approvals, files, or retry systems

## Persistence hardening

Follow-up commit `3155629` resolves the independent persistence review blockers:

- Schema versions are stamped only after declarative type, NULL/NOT NULL, relevant default, AUTO_INCREMENT, exact index-column, and exact uniqueness verification; failures are recorded without stamping. Required same-name malformed indexes are repaired selectively, unknown indexes remain untouched, and current-version requests take a zero-introspection fast path.
- JSON encoding and hydration are lossless and strict, including non-coercive envelope versions.
- Artist profiles must be published; profile-only canonical binding, bidirectional split-brain checks, and `try/finally` blog restoration are covered.
- Event handoff moved out of generic updates into an idempotent, validated, optimistic NULL-only claim.
- Activity idempotency is booking-scoped and duplicate-insert race recovery returns the winning row or the precise reread error.
- Venue config handles unchanged termmeta writes, validates venue/version/currency/channel contracts, and detects normalized key collisions.
- Create/update/list semantics reject negative IDs, malformed dates and reversed ranges, preserve JSON with comma-separated values, and propagate read/write errors distinctly.
- Storage remains explicitly current-site scoped through the Events route-affinity boundary.
- Independent final re-review reported no findings.

Residual integration risk: real WordPress/MySQL `dbDelta()` repair metadata and true concurrent writes remain unverified because Codebox fails before runtime startup on the shared WordPress archive lock.

## Verification

Passed:

- `vendor/bin/phpunit -c phpunit-booking.xml.dist` (`21 tests`, `109 assertions`)
- direct PHPCS on production and focused-test PHP using WordPress standards, with narrow invocation exclusions for CamelCase filenames, exhaustive helper docblocks, and isolated mixed test-double topology; no broad in-file suppression
- PHP syntax checks on all new PHP files
- `homeboy review build extrachill-events --path <worktree>` including frontend compilation, production packaging, and full build PHP syntax validation
- clean-checkout `homeboy review ... --changed-since origin/main`: audit passed with zero findings; lint passed with zero findings

Infrastructure/pre-existing blockers:

- Homeboy.s Codebox test stage consistently timed out before test execution while waiting for the shared WordPress `7.0.2.zip.lock` (`wp-codebox-playground-startup-asset-unavailable`). The selected booking suite was therefore run directly and passed.
- The repository default pure-PHP suite remains red in unrelated existing location, qualify recheck, festival notification, canonical contract fixture, and concert stats tests; the isolated booking suite avoids adding more global-stub collisions.
- An initial Homeboy PHPCS invocation encountered a corrupted extension autoloader; the clean-checkout Homeboy lint subsequently completed with zero findings, and direct repository PHPCS also passed.

## Confirmation

No Lo-Fi-specific logic, credentials, duplicate venue/artist model, public PII contract, user-facing feature, changelog edit, or version bump was added.