### PR TITLE
fix: qualify persisted flows with production context

### DIFF
--- a/inc/Abilities/VenueQualificationAbilities.php
+++ b/inc/Abilities/VenueQualificationAbilities.php
@@ -314,6 +314,7 @@ class VenueQualificationAbilities {
 					$attempt                          = QualifyFingerprinter::add_production_eligibility( $attempt, $flow_context );
 					$fingerprint['production_context'] = $attempt['production_context'];
 				}
+				unset( $attempt['_diagnostic_identifiers'] );
 				if ( ! empty( $attempt['ran'] ) ) {
 					$ran_any = true;
 				}

--- a/inc/Abilities/VenueQualificationAbilities.php
+++ b/inc/Abilities/VenueQualificationAbilities.php
@@ -127,7 +127,6 @@ class VenueQualificationAbilities {
 					'category'            => 'extrachill-events',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'required'   => array( 'url' ),
 						'properties' => array(
 							'url'  => array(
 								'type'        => 'string',
@@ -136,6 +135,15 @@ class VenueQualificationAbilities {
 							'name' => array(
 								'type'        => 'string',
 								'description' => 'Venue name (optional, for display).',
+							),
+							'flow_id' => array(
+								'type'        => 'integer',
+								'description' => 'Existing flow whose persisted scraper config and lifecycle scope must be diagnosed.',
+							),
+							'persist_verdict' => array(
+								'type'        => 'boolean',
+								'description' => 'Whether to persist the qualification verdict. Defaults to true; dry-run callers pass false.',
+								'default'     => true,
 							),
 						),
 					),
@@ -151,6 +159,8 @@ class VenueQualificationAbilities {
 							'improvement_hint' => array( 'type' => 'string' ),
 							'agent_guidance'   => array( 'type' => 'string' ),
 							'warnings'         => array( 'type' => 'array' ),
+							'production_context' => array( 'type' => 'object' ),
+							'repair_proposal'    => array( 'type' => array( 'object', 'null' ) ),
 						),
 					),
 					'execute_callback'    => array( $this, 'executeQualifyVenue' ),
@@ -177,8 +187,18 @@ class VenueQualificationAbilities {
 	 * @return array Results.
 	 */
 	public function executeQualifyVenue( array $input ): array|\WP_Error {
-		$url  = esc_url_raw( $input['url'] ?? '' );
-		$name = sanitize_text_field( $input['name'] ?? '' );
+		$url             = esc_url_raw( $input['url'] ?? '' );
+		$name            = sanitize_text_field( $input['name'] ?? '' );
+		$flow_context    = null;
+		$persist_verdict = ! array_key_exists( 'persist_verdict', $input ) || ! empty( $input['persist_verdict'] );
+
+		if ( ! empty( $input['flow_id'] ) ) {
+			$flow_context = $this->loadPersistedFlowContext( (int) $input['flow_id'] );
+			if ( is_wp_error( $flow_context ) ) {
+				return $flow_context;
+			}
+			$url = esc_url_raw( $flow_context['handler_config']['source_url'] ?? '' );
+		}
 
 		if ( empty( $url ) ) {
 			return new \WP_Error( 'missing_url', 'URL is required.', array( 'status' => 400 ) );
@@ -211,6 +231,17 @@ class VenueQualificationAbilities {
 			),
 			'urls_tested'           => array(),
 			'elapsed_ms'            => 0,
+			'production_context'    => null === $flow_context
+				? array(
+					'context_supplied' => false,
+					'reason'           => 'Ad-hoc URL mode has no persisted production flow context.',
+				)
+				: array(
+					'context_supplied' => true,
+					'flow_id'          => (int) $flow_context['flow_id'],
+					'flow_step_id'     => (string) $flow_context['flow_step_id'],
+					'job_id'           => (string) $flow_context['job_id'],
+				),
 		);
 
 		// ---- Ticketmaster precheck (short-circuits everything else). ----
@@ -221,7 +252,7 @@ class VenueQualificationAbilities {
 				'matched'      => (string) ( $tm_check['matched'] ?? '' ),
 			);
 			$fingerprint['elapsed_ms']            = (int) round( ( microtime( true ) - $started_at ) * 1000 );
-			return $this->finalize_and_persist( $url, $name, 'ticketmaster_precheck', $fingerprint );
+			return $this->finalize_and_persist( $url, $name, 'ticketmaster_precheck', $fingerprint, $persist_verdict );
 		}
 
 		// ---- Fetch the homepage once and capture status/redirects/HTML. ----
@@ -275,7 +306,14 @@ class VenueQualificationAbilities {
 				}
 				$urls_tested[] = $candidate['url'];
 
-				$attempt = QualifyFingerprinter::run_extractor_attempt( $candidate['url'] );
+				$attempt = QualifyFingerprinter::run_extractor_attempt(
+					$candidate['url'],
+					null !== $flow_context ? $flow_context['handler_config'] : null
+				);
+				if ( null !== $flow_context && $candidate['url'] === $url ) {
+					$attempt                          = QualifyFingerprinter::add_production_eligibility( $attempt, $flow_context );
+					$fingerprint['production_context'] = $attempt['production_context'];
+				}
 				if ( ! empty( $attempt['ran'] ) ) {
 					$ran_any = true;
 				}
@@ -306,7 +344,61 @@ class VenueQualificationAbilities {
 		$fingerprint['elapsed_ms'] = (int) round( ( microtime( true ) - $started_at ) * 1000 );
 
 		$method = '' !== $short_circuit_method ? $short_circuit_method : $this->resolve_method_from_attempts( $fingerprint['extractor_attempts'] );
-		return $this->finalize_and_persist( $url, $name, $method, $fingerprint );
+		return $this->finalize_and_persist( $url, $name, $method, $fingerprint, $persist_verdict );
+	}
+
+	/**
+	 * Load the persisted universal web scraper step and its lifecycle scope.
+	 *
+	 * @param int $flow_id Flow ID.
+	 * @return array|\WP_Error Flow context or an error.
+	 */
+	protected function loadPersistedFlowContext( int $flow_id ): array|\WP_Error {
+		if ( ! class_exists( '\\DataMachine\\Core\\Database\\Flows\\Flows' ) ) {
+			return new \WP_Error( 'flow_context_unavailable', 'Data Machine flow storage is unavailable.' );
+		}
+
+		$flow = ( new \DataMachine\Core\Database\Flows\Flows() )->get_flow( $flow_id );
+		if ( ! is_array( $flow ) ) {
+			return new \WP_Error( 'flow_not_found', sprintf( 'Flow %d was not found.', $flow_id ) );
+		}
+
+		foreach ( (array) ( $flow['flow_config'] ?? array() ) as $step ) {
+			if ( ! is_array( $step ) || 'event_import' !== ( $step['step_type'] ?? '' ) ) {
+				continue;
+			}
+
+			$handler_config = null;
+			if ( 'universal_web_scraper' === ( $step['handler_slug'] ?? '' ) ) {
+				$handler_config = $step['handler_config'] ?? null;
+			} elseif ( isset( $step['handler_configs']['universal_web_scraper'] ) ) {
+				$handler_config = $step['handler_configs']['universal_web_scraper'];
+			}
+			if ( ! is_array( $handler_config ) || empty( $handler_config['source_url'] ) ) {
+				continue;
+			}
+
+			global $wpdb;
+			$jobs_table = $wpdb->prefix . 'datamachine_jobs';
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$job_id = $wpdb->get_var(
+				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Trusted internal table name.
+					"SELECT job_id FROM {$jobs_table} WHERE flow_id = %s ORDER BY created_at DESC LIMIT 1",
+					(string) $flow_id
+				)
+			);
+
+			return array(
+				'flow_id'        => $flow_id,
+				'pipeline_id'    => (int) ( $step['pipeline_id'] ?? 0 ),
+				'flow_step_id'   => (string) ( $step['flow_step_id'] ?? '' ),
+				'job_id'         => (string) $job_id,
+				'handler_config' => $handler_config,
+			);
+		}
+
+		return new \WP_Error( 'flow_context_missing', sprintf( 'Flow %d has no configured universal web scraper step.', $flow_id ) );
 	}
 
 	/**
@@ -387,14 +479,14 @@ class VenueQualificationAbilities {
 	/**
 	 * Resolve the verdict, persist the row, and return the ability payload.
 	 */
-	private function finalize_and_persist( string $url, string $name, string $method, array $fingerprint ): array {
+	private function finalize_and_persist( string $url, string $name, string $method, array $fingerprint, bool $persist_verdict = true ): array {
 		$resolved = QualifyVerdictResolver::resolve( $fingerprint );
 
 		$qualifier_version = defined( 'EXTRACHILL_EVENTS_VERSION' ) ? (string) EXTRACHILL_EVENTS_VERSION : '';
 
 		// Persist — fire-and-forget. The verdict log is best-effort; a missing
 		// table should not break qualify for callers.
-		if ( class_exists( '\\ExtraChillEvents\\Core\\QualifyVerdictsTable' ) && QualifyVerdictsTable::table_exists() ) {
+		if ( $persist_verdict && class_exists( '\\ExtraChillEvents\\Core\\QualifyVerdictsTable' ) && QualifyVerdictsTable::table_exists() ) {
 			QualifyVerdictsTable::insert(
 				array(
 					'url'               => $url,
@@ -418,6 +510,21 @@ class VenueQualificationAbilities {
 			$warnings[] = $resolved['improvement_hint'];
 		}
 
+		$repair_proposal = null;
+		$events_url      = (string) ( $resolved['events_url'] ?? '' );
+		if ( ! empty( $fingerprint['production_context']['context_supplied'] )
+			&& '' !== $events_url
+			&& untrailingslashit( $events_url ) !== untrailingslashit( $url ) ) {
+			$repair_proposal = array(
+				'type'            => 'source_url',
+				'current'         => $url,
+				'proposed'        => $events_url,
+				'same_host'       => strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) ) === strtolower( (string) wp_parse_url( $events_url, PHP_URL_HOST ) ),
+				'applied'         => false,
+				'confirmation'    => 'A separate explicit apply with confirmation is required.',
+			);
+		}
+
 		return array(
 			'qualified'        => QualifyVerdict::is_qualified( $resolved['verdict'] ),
 			'verdict'          => $resolved['verdict'],
@@ -430,6 +537,8 @@ class VenueQualificationAbilities {
 			'agent_guidance'   => $resolved['agent_guidance'],
 			'warnings'         => $warnings,
 			'urls_tested'      => isset( $fingerprint['urls_tested'] ) ? $fingerprint['urls_tested'] : array(),
+			'production_context' => $fingerprint['production_context'] ?? array(),
+			'repair_proposal'    => $repair_proposal,
 		);
 	}
 

--- a/inc/Cli/FlowOps.php
+++ b/inc/Cli/FlowOps.php
@@ -417,6 +417,57 @@ class FlowOps {
 	}
 
 	/**
+	 * Apply an explicitly confirmed, same-host source URL repair only.
+	 *
+	 * Unlike resume_flow_from_qualified(), this does not alter scheduling or
+	 * enqueue a run. The caller must separately obtain operator confirmation.
+	 *
+	 * @param int    $flow_id      Flow ID.
+	 * @param string $current_url  Source URL observed during diagnosis.
+	 * @param string $proposed_url Same-host replacement URL.
+	 * @return bool True when at least one matching scraper step was updated.
+	 */
+	public static function repair_flow_source_url( int $flow_id, string $current_url, string $proposed_url ): bool {
+		if ( '' === $current_url || '' === $proposed_url || ! self::same_host( $current_url, $proposed_url ) ) {
+			return false;
+		}
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_flows';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$encoded = $wpdb->get_var(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Trusted internal table name.
+				"SELECT flow_config FROM {$table} WHERE flow_id = %d",
+				$flow_id
+			)
+		);
+		$flow_config = json_decode( (string) $encoded, true );
+		if ( ! is_array( $flow_config ) || self::extract_source_url_from_flow_config( $flow_config ) !== $current_url ) {
+			return false;
+		}
+
+		$patched = self::patch_source_url_in_flow_config( $flow_config, $current_url, $proposed_url );
+		if ( 0 === $patched['changed'] ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $wpdb->update(
+			$table,
+			array( 'flow_config' => wp_json_encode( $patched['config'] ) ),
+			array(
+				'flow_id'    => $flow_id,
+				'flow_config' => (string) $encoded,
+			),
+			array( '%s' ),
+			array( '%d', '%s' )
+		);
+
+		return is_int( $updated ) && $updated > 0;
+	}
+
+	/**
 	 * Extract the universal_web_scraper source_url from a decoded
 	 * flow_config array. Mirrors the parsing in FlowHelpers::extract_web_scraper_meta
 	 * but kept local here so FlowOps does not depend on the trait.

--- a/inc/Cli/RequalifyFlowCommand.php
+++ b/inc/Cli/RequalifyFlowCommand.php
@@ -125,7 +125,12 @@ class RequalifyFlowCommand {
 				continue;
 			}
 
-			$result = $ability->execute( array( 'url' => $flow['source_url'] ) );
+			$result = $ability->execute(
+				array(
+					'url'     => $flow['source_url'],
+					'flow_id' => (int) $flow['flow_id'],
+				)
+			);
 			if ( is_wp_error( $result ) ) {
 				$row['new_verdict'] = 'error';
 				$row['action']      = 'error: ' . $result->get_error_message();

--- a/inc/Cli/UnqualifiableFlowsCommand.php
+++ b/inc/Cli/UnqualifiableFlowsCommand.php
@@ -208,6 +208,9 @@ class UnqualifiableFlowsCommand {
 				'selected_by_max_items' => null,
 				'production_eligible' => null,
 				'context_supplied' => false,
+				'complete'         => false,
+				'identifier_source' => '',
+				'diagnostic_error' => '',
 				'repair_proposal' => null,
 				'action'      => 'none',
 			);
@@ -230,6 +233,9 @@ class UnqualifiableFlowsCommand {
 			$row['selected_by_max_items'] = $production['selected_by_max_items'] ?? null;
 			$row['production_eligible']  = $production['production_eligible'] ?? null;
 			$row['context_supplied']     = ! empty( $production['context_supplied'] );
+			$row['complete']             = true === ( $production['complete'] ?? false );
+			$row['identifier_source']    = (string) ( $production['identifier_source'] ?? '' );
+			$row['diagnostic_error']     = (string) ( $production['error'] ?? '' );
 			$row['repair_proposal']      = $result['repair_proposal'] ?? null;
 
 			if ( QualifyVerdict::QUALIFIED_STRUCTURED === $row['new_verdict'] ) {
@@ -276,7 +282,7 @@ class UnqualifiableFlowsCommand {
 		\WP_CLI\Utils\format_items(
 			$format,
 			$results,
-			array( 'flow_id', 'flow_name', 'new_verdict', 'raw_extracted', 'unique_source', 'processed', 'active_claim', 'reprocess_eligible', 'selected_by_max_items', 'production_eligible', 'action' )
+			array( 'flow_id', 'flow_name', 'new_verdict', 'raw_extracted', 'unique_source', 'processed', 'active_claim', 'reprocess_eligible', 'selected_by_max_items', 'production_eligible', 'complete', 'identifier_source', 'diagnostic_error', 'action' )
 		);
 
 		$paused      = array_filter( $results, fn( $r ) => 'paused' === $r['action'] );
@@ -314,12 +320,12 @@ class UnqualifiableFlowsCommand {
 	 * @return string CLI action.
 	 */
 	protected function classify_qualified_action( array $production, ?array $repair_proposal ): string {
+		if ( ! empty( $repair_proposal ) ) {
+			return 'repair_proposed';
+		}
 		if ( true === ( $production['complete'] ?? false )
 			&& 0 === ( $production['production_eligible'] ?? null ) ) {
 			return 'expected_zero';
-		}
-		if ( ! empty( $repair_proposal ) ) {
-			return 'repair_proposed';
 		}
 		return 'unexpected_pass';
 	}

--- a/inc/Cli/UnqualifiableFlowsCommand.php
+++ b/inc/Cli/UnqualifiableFlowsCommand.php
@@ -59,7 +59,15 @@ class UnqualifiableFlowsCommand {
 	 * venue is dead. Requires --auto-pause.
 	 *
 	 * [--dry-run]
-	 * : List candidate flows but do not run qualify or pause anything.
+	 * : Run bounded qualification diagnostics without persisting verdicts,
+	 * pausing flows, or applying repair proposals.
+	 *
+	 * [--apply-repair]
+	 * : Apply same-host source_url repair proposals. Requires --yes and cannot
+	 * be combined with --dry-run.
+	 *
+	 * [--yes]
+	 * : Confirm source_url repairs requested with --apply-repair.
 	 *
 	 * [--limit=<n>]
 	 * : Maximum flows to audit.
@@ -96,8 +104,15 @@ class UnqualifiableFlowsCommand {
 		$auto            = ! empty( $assoc_args['auto-pause'] );
 		$force           = ! empty( $assoc_args['force'] );
 		$dry_run         = ! empty( $assoc_args['dry-run'] );
+		$apply_repair    = ! empty( $assoc_args['apply-repair'] );
+		$confirmed       = ! empty( $assoc_args['yes'] );
 		$limit           = max( 1, (int) ( $assoc_args['limit'] ?? 200 ) );
 		$format          = $assoc_args['format'] ?? 'table';
+
+		if ( $apply_repair && ( $dry_run || ! $confirmed ) ) {
+			\WP_CLI::error( '--apply-repair requires --yes and cannot be combined with --dry-run.' );
+			return;
+		}
 
 		// Network option lets operators disable confirmation globally
 		// (restores pre-v0.21 "pause on first failing verdict" behavior).
@@ -160,17 +175,6 @@ class UnqualifiableFlowsCommand {
 
 		\WP_CLI::log( sprintf( 'Auditing %d zero-yield flow(s)%s.', count( $candidates ), $dry_run ? ' (dry run)' : '' ) );
 
-		if ( $dry_run ) {
-			\WP_CLI\Utils\format_items(
-				$format,
-				$candidates,
-				array( 'flow_id', 'flow_name', 'source_url', 'recent_runs', 'zero_yield' )
-			);
-			\WP_CLI::log( '' );
-			\WP_CLI::log( 'Run without --dry-run to qualify and (optionally) pause.' );
-			return;
-		}
-
 		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/qualify-venue' ) : null;
 		if ( ! $ability ) {
 			\WP_CLI::error( 'extrachill/qualify-venue ability not available.' );
@@ -181,7 +185,13 @@ class UnqualifiableFlowsCommand {
 		$results        = array();
 		$progress       = \WP_CLI\Utils\make_progress_bar( 'Auditing', count( $candidates ) );
 		foreach ( $candidates as $c ) {
-			$result = $ability->execute( array( 'url' => $c['source_url'] ) );
+			$result = $ability->execute(
+				array(
+					'url'             => $c['source_url'],
+					'flow_id'         => (int) $c['flow_id'],
+					'persist_verdict' => ! $dry_run,
+				)
+			);
 			$progress->tick();
 
 			$row = array(
@@ -190,6 +200,15 @@ class UnqualifiableFlowsCommand {
 				'source_url'  => $c['source_url'],
 				'new_verdict' => '',
 				'event_count' => 0,
+				'raw_extracted' => 0,
+				'unique_source' => 0,
+				'processed'     => null,
+				'active_claim'  => null,
+				'reprocess_eligible' => null,
+				'selected_by_max_items' => null,
+				'production_eligible' => null,
+				'context_supplied' => false,
+				'repair_proposal' => null,
 				'action'      => 'none',
 			);
 
@@ -202,10 +221,32 @@ class UnqualifiableFlowsCommand {
 
 			$row['new_verdict'] = (string) ( $result['verdict'] ?? '' );
 			$row['event_count'] = (int) ( $result['event_count'] ?? 0 );
+			$production = is_array( $result['production_context'] ?? null ) ? $result['production_context'] : array();
+			$row['raw_extracted']         = (int) ( $production['raw_extracted'] ?? 0 );
+			$row['unique_source']        = (int) ( $production['unique_source'] ?? 0 );
+			$row['processed']            = $production['processed'] ?? null;
+			$row['active_claim']         = $production['active_claim'] ?? null;
+			$row['reprocess_eligible']    = $production['reprocess_eligible'] ?? null;
+			$row['selected_by_max_items'] = $production['selected_by_max_items'] ?? null;
+			$row['production_eligible']  = $production['production_eligible'] ?? null;
+			$row['context_supplied']     = ! empty( $production['context_supplied'] );
+			$row['repair_proposal']      = $result['repair_proposal'] ?? null;
 
 			if ( QualifyVerdict::QUALIFIED_STRUCTURED === $row['new_verdict'] ) {
-				$row['action'] = 'unexpected_pass';
-			} elseif ( $auto ) {
+				$row['action'] = $this->classify_qualified_action( $production, $row['repair_proposal'] );
+				if ( 'repair_proposed' === $row['action'] ) {
+					if ( $apply_repair && ! empty( $row['repair_proposal']['same_host'] ) ) {
+						$repaired      = FlowOps::repair_flow_source_url(
+							(int) $c['flow_id'],
+							(string) $row['repair_proposal']['current'],
+							(string) $row['repair_proposal']['proposed']
+						);
+						$row['action'] = $repaired ? 'repaired' : 'repair_failed';
+					} else {
+						$row['action'] = 'repair_proposed';
+					}
+				}
+			} elseif ( $auto && ! $dry_run ) {
 				// Confirmation gate — unless --force or the network option
 				// has disabled it, the candidate verdict must clear the
 				// per-verdict CONFIRMATION_RULES threshold before we pause.
@@ -235,7 +276,7 @@ class UnqualifiableFlowsCommand {
 		\WP_CLI\Utils\format_items(
 			$format,
 			$results,
-			array( 'flow_id', 'flow_name', 'new_verdict', 'event_count', 'action' )
+			array( 'flow_id', 'flow_name', 'new_verdict', 'raw_extracted', 'unique_source', 'processed', 'active_claim', 'reprocess_eligible', 'selected_by_max_items', 'production_eligible', 'action' )
 		);
 
 		$paused      = array_filter( $results, fn( $r ) => 'paused' === $r['action'] );
@@ -263,5 +304,23 @@ class UnqualifiableFlowsCommand {
 			\WP_CLI::log( '' );
 			\WP_CLI::warning( sprintf( '%d zero-yield flow(s) now qualify as STRUCTURED — investigate why they were yielding zero.', count( $unexpected ) ) );
 		}
+	}
+
+	/**
+	 * Interpret a structured extraction using production lifecycle evidence.
+	 *
+	 * @param array      $production     Production diagnostics.
+	 * @param array|null $repair_proposal Optional source URL repair proposal.
+	 * @return string CLI action.
+	 */
+	protected function classify_qualified_action( array $production, ?array $repair_proposal ): string {
+		if ( true === ( $production['complete'] ?? false )
+			&& 0 === ( $production['production_eligible'] ?? null ) ) {
+			return 'expected_zero';
+		}
+		if ( ! empty( $repair_proposal ) ) {
+			return 'repair_proposed';
+		}
+		return 'unexpected_pass';
 	}
 }

--- a/inc/Core/QualifyFingerprinter.php
+++ b/inc/Core/QualifyFingerprinter.php
@@ -27,6 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class QualifyFingerprinter {
+	private const MAX_LIFECYCLE_IDENTIFIERS = 500;
 
 	/**
 	 * Extractor classes that ship with data-machine-events. Used to mark
@@ -232,6 +233,7 @@ class QualifyFingerprinter {
 			'unique_source_events'      => 0,
 			'production_max_items'      => null,
 			'production_context'        => null,
+			'_diagnostic_identifiers'   => array(),
 			'ran'                       => false,
 			'name'                      => '',
 			'exists'                    => true,
@@ -251,7 +253,13 @@ class QualifyFingerprinter {
 
 		$ability_input = array( 'target_url' => $url );
 		if ( null !== $handler_config ) {
-			$ability_input['handler_config'] = $handler_config;
+			$ability_config = $handler_config;
+			if ( method_exists( $ability, 'get_input_schema' ) ) {
+				$input_schema       = (array) $ability->get_input_schema();
+				$config_properties  = (array) ( $input_schema['properties']['handler_config']['properties'] ?? array() );
+				$ability_config     = array_intersect_key( $handler_config, $config_properties );
+			}
+			$ability_input['handler_config'] = $ability_config;
 		}
 
 		$result = $ability->execute( $ability_input );
@@ -281,6 +289,13 @@ class QualifyFingerprinter {
 		if ( ! empty( $result['success'] ) ) {
 			$event_data        = is_array( $result['event_data'] ?? null ) ? $result['event_data'] : array();
 			$attempt['events'] = self::count_events( $event_data, $payload_type );
+			if ( null !== $handler_config ) {
+				$attempt['_diagnostic_identifiers'] = self::diagnostic_identifiers(
+					$event_data,
+					$handler_config,
+					$attempt['unique_source_events']
+				);
+			}
 		}
 
 		return $attempt;
@@ -309,6 +324,8 @@ class QualifyFingerprinter {
 			'production_eligible'  => null,
 			'complete'             => false,
 			'bounded'              => true,
+			'identifier_limit'     => self::MAX_LIFECYCLE_IDENTIFIERS,
+			'identifier_source'    => '',
 			'error'                => '',
 		);
 
@@ -340,12 +357,58 @@ class QualifyFingerprinter {
 			return $attempt;
 		}
 
-		$identifiers = array();
+		$raw_identifiers = array();
 		foreach ( (array) ( $raw_result['packets'] ?? array() ) as $packet ) {
+			$payload = json_decode( (string) ( $packet['data']['body'] ?? '' ), true );
+			if ( ! is_array( $payload ) || ! is_array( $payload['event'] ?? null ) ) {
+				continue;
+			}
 			$identifier = (string) ( $packet['metadata']['item_identifier'] ?? '' );
 			if ( '' !== $identifier ) {
-				$identifiers[] = $identifier;
+				$raw_identifiers[] = $identifier;
 			}
+		}
+
+		$expected_identifiers   = (int) $diagnostics['unique_source'];
+		$derived_identifiers    = (array) ( $attempt['_diagnostic_identifiers'] ?? array() );
+		$identifiers            = $raw_identifiers;
+		$identifier_source      = 'bounded_raw';
+		$derived_inventory_used = $expected_identifiers > count( array_unique( $raw_identifiers ) )
+			&& $expected_identifiers <= self::MAX_LIFECYCLE_IDENTIFIERS
+			&& count( array_unique( $derived_identifiers ) ) === $expected_identifiers
+			&& empty( array_diff( $raw_identifiers, $derived_identifiers ) );
+		if ( $derived_inventory_used ) {
+			$identifiers       = $derived_identifiers;
+			$identifier_source = 'verified_event_inventory';
+		}
+
+		$unique_identifiers = array_values( array_unique( $identifiers ) );
+		$complete           = count( $unique_identifiers ) === $expected_identifiers
+			&& $expected_identifiers <= self::MAX_LIFECYCLE_IDENTIFIERS;
+		$diagnostics['complete']             = $complete;
+		$diagnostics['identifier_source']    = $identifier_source;
+		$diagnostics['returned_identifiers'] = count( $unique_identifiers );
+		$diagnostics['truncation']           = (array) ( $raw_result['truncation'] ?? array() );
+
+		if ( ! $complete ) {
+			$diagnostics['error'] = sprintf(
+				'Lifecycle coverage is incomplete: observed %d of %d unique identifiers within the %d-item safety ceiling.',
+				count( $unique_identifiers ),
+				$expected_identifiers,
+				self::MAX_LIFECYCLE_IDENTIFIERS
+			);
+			$attempt['production_context'] = $diagnostics;
+			return $attempt;
+		}
+
+		if ( 0 === $expected_identifiers ) {
+			$diagnostics['processed']             = 0;
+			$diagnostics['active_claim']          = 0;
+			$diagnostics['reprocess_eligible']    = 0;
+			$diagnostics['selected_by_max_items'] = 0;
+			$diagnostics['production_eligible']   = 0;
+			$attempt['production_context']         = $diagnostics;
+			return $attempt;
 		}
 
 		$context = \DataMachine\Core\ExecutionContext::fromFlow(
@@ -356,7 +419,7 @@ class QualifyFingerprinter {
 			'universal_web_scraper'
 		);
 		$classification = $context->classifySourceItems(
-			$identifiers,
+			$unique_identifiers,
 			max( 0, (int) ( $flow_context['handler_config']['max_items'] ?? 0 ) )
 		);
 		$counts = (array) ( $classification['diagnostics'] ?? array() );
@@ -367,21 +430,63 @@ class QualifyFingerprinter {
 			}
 		}
 
-		$truncated = ! empty( $raw_result['truncation']['truncated'] );
-		$complete  = ! $truncated
-			&& count( array_unique( $identifiers ) ) >= (int) $diagnostics['unique_source'];
-
 		$diagnostics['processed']             = $processed;
 		$diagnostics['active_claim']          = (int) ( $counts['actively_claimed'] ?? 0 );
 		$diagnostics['reprocess_eligible']     = (int) ( $counts['processed_reprocess_eligible'] ?? 0 );
 		$diagnostics['selected_by_max_items'] = (int) ( $counts['selected'] ?? 0 );
-		$diagnostics['production_eligible']   = $complete ? (int) ( $counts['selected'] ?? 0 ) : null;
-		$diagnostics['complete']              = $complete;
-		$diagnostics['returned_identifiers']  = count( $identifiers );
-		$diagnostics['truncation']            = (array) ( $raw_result['truncation'] ?? array() );
+		$diagnostics['production_eligible']   = (int) ( $counts['selected'] ?? 0 );
 
 		$attempt['production_context'] = $diagnostics;
 		return $attempt;
+	}
+
+	/**
+	 * Derive canonical identifiers from the bounded structured inventory.
+	 *
+	 * Raw output validates the generated identities before callers may use the
+	 * generated tail beyond the generic raw ability's 100-packet ceiling.
+	 *
+	 * @param array $event_data     Scraper diagnostic event summaries.
+	 * @param array $handler_config Persisted scraper configuration.
+	 * @param int   $expected_count Reported unique structured event count.
+	 * @return string[] Canonical identifiers, or an empty array when unprovable.
+	 */
+	private static function diagnostic_identifiers( array $event_data, array $handler_config, int $expected_count ): array {
+		if ( $expected_count <= 0 || $expected_count > self::MAX_LIFECYCLE_IDENTIFIERS ) {
+			return array();
+		}
+		$items = is_array( $event_data['items'] ?? null ) ? $event_data['items'] : array();
+		if ( count( $items ) !== $expected_count
+			|| ! class_exists( '\\DataMachineEvents\\Utilities\\EventIdentifierGenerator' ) ) {
+			return array();
+		}
+
+		$venue_name = (string) ( $handler_config['venue_name'] ?? '' );
+		if ( ! empty( $handler_config['venue'] ) && is_numeric( $handler_config['venue'] ) && function_exists( 'get_term' ) ) {
+			$term = get_term( (int) $handler_config['venue'], 'venue' );
+			if ( is_object( $term ) && isset( $term->name ) ) {
+				$venue_name = (string) $term->name;
+			}
+		}
+		if ( '' === trim( $venue_name ) ) {
+			return array();
+		}
+
+		$identifiers = array();
+		foreach ( $items as $item ) {
+			$title      = (string) ( $item['title'] ?? '' );
+			$start_date = (string) ( $item['startDate'] ?? '' );
+			if ( '' === $title || '' === $start_date ) {
+				return array();
+			}
+			$identifiers[] = \DataMachineEvents\Utilities\EventIdentifierGenerator::generate(
+				$title,
+				$start_date,
+				$venue_name
+			);
+		}
+
+		return count( array_unique( $identifiers ) ) === $expected_count ? $identifiers : array();
 	}
 
 	/**

--- a/inc/Core/QualifyFingerprinter.php
+++ b/inc/Core/QualifyFingerprinter.php
@@ -219,19 +219,24 @@ class QualifyFingerprinter {
 	 * data-machine-events/test-event-scraper ability and inspecting the
 	 * result.
 	 *
-	 * @param string $url URL to test.
+	 * @param string     $url            URL to test.
+	 * @param array|null $handler_config Persisted handler configuration, when available.
 	 * @return array Attempt record.
 	 */
-	public static function run_extractor_attempt( string $url ): array {
+	public static function run_extractor_attempt( string $url, ?array $handler_config = null ): array {
 		$attempt = array(
-			'url'         => $url,
-			'events_url'  => $url,
-			'events'      => 0,
-			'ran'         => false,
-			'name'        => '',
-			'exists'      => true,
-			'matched'     => false,
-			'source_type' => '',
+			'url'                       => $url,
+			'events_url'                => $url,
+			'events'                    => 0,
+			'raw_extracted'             => 0,
+			'unique_source_events'      => 0,
+			'production_max_items'      => null,
+			'production_context'        => null,
+			'ran'                       => false,
+			'name'                      => '',
+			'exists'                    => true,
+			'matched'                   => false,
+			'source_type'               => '',
 		);
 
 		$ability = function_exists( 'wp_get_ability' )
@@ -244,7 +249,12 @@ class QualifyFingerprinter {
 			return $attempt;
 		}
 
-		$result = $ability->execute( array( 'target_url' => $url ) );
+		$ability_input = array( 'target_url' => $url );
+		if ( null !== $handler_config ) {
+			$ability_input['handler_config'] = $handler_config;
+		}
+
+		$result = $ability->execute( $ability_input );
 
 		if ( is_wp_error( $result ) ) {
 			$attempt['ran']  = true;
@@ -261,6 +271,11 @@ class QualifyFingerprinter {
 		$attempt['matched']     = ! empty( $result['success'] );
 		$attempt['source_type'] = $source_type ? $source_type : $payload_type;
 		$attempt['name']        = self::extractor_class_from_method( $extraction_method, $payload_type, $source_type );
+		$attempt['raw_extracted']        = (int) ( $extraction['extracted_packet_count'] ?? 0 );
+		$attempt['unique_source_events'] = (int) ( $extraction['unique_source_event_count'] ?? 0 );
+		$attempt['production_max_items'] = isset( $extraction['production_max_items'] )
+			? (int) $extraction['production_max_items']
+			: null;
 
 		// Count events for the extractor_attempts entry.
 		if ( ! empty( $result['success'] ) ) {
@@ -268,6 +283,104 @@ class QualifyFingerprinter {
 			$attempt['events'] = self::count_events( $event_data, $payload_type );
 		}
 
+		return $attempt;
+	}
+
+	/**
+	 * Classify source identifiers against a persisted flow without claiming or
+	 * marking any item. Raw handler output and the lifecycle query are bounded.
+	 *
+	 * @param array $attempt      Scraper attempt to enrich.
+	 * @param array $flow_context Persisted flow, step, config, and job scope.
+	 * @return array Enriched attempt.
+	 */
+	public static function add_production_eligibility( array $attempt, array $flow_context ): array {
+		$diagnostics = array(
+			'context_supplied'     => true,
+			'flow_id'              => (int) ( $flow_context['flow_id'] ?? 0 ),
+			'flow_step_id'         => (string) ( $flow_context['flow_step_id'] ?? '' ),
+			'job_id'               => (string) ( $flow_context['job_id'] ?? '' ),
+			'raw_extracted'         => (int) ( $attempt['raw_extracted'] ?? 0 ),
+			'unique_source'        => (int) ( $attempt['unique_source_events'] ?? 0 ),
+			'processed'            => null,
+			'active_claim'         => null,
+			'reprocess_eligible'    => null,
+			'selected_by_max_items' => null,
+			'production_eligible'  => null,
+			'complete'             => false,
+			'bounded'              => true,
+			'error'                => '',
+		);
+
+		$test_handler = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/test-handler' ) : null;
+		if ( ! $test_handler || ! class_exists( '\\DataMachine\\Core\\ExecutionContext' ) ) {
+			$diagnostics['error']             = 'Production lifecycle diagnostics are unavailable.';
+			$attempt['production_context'] = $diagnostics;
+			return $attempt;
+		}
+
+		$raw_result = $test_handler->execute(
+			array(
+				'flow_id'     => (int) $flow_context['flow_id'],
+				'config'      => array(
+					'source_url' => (string) $attempt['url'],
+					'max_items'  => 100,
+				),
+				'limit'       => 100,
+				'output_mode' => 'raw',
+				'byte_limit'  => 5242880,
+			)
+		);
+
+		if ( is_wp_error( $raw_result ) || empty( $raw_result['success'] ) ) {
+			$diagnostics['error'] = is_wp_error( $raw_result )
+				? $raw_result->get_error_message()
+				: (string) ( $raw_result['error'] ?? 'Handler diagnostics failed.' );
+			$attempt['production_context'] = $diagnostics;
+			return $attempt;
+		}
+
+		$identifiers = array();
+		foreach ( (array) ( $raw_result['packets'] ?? array() ) as $packet ) {
+			$identifier = (string) ( $packet['metadata']['item_identifier'] ?? '' );
+			if ( '' !== $identifier ) {
+				$identifiers[] = $identifier;
+			}
+		}
+
+		$context = \DataMachine\Core\ExecutionContext::fromFlow(
+			(int) ( $flow_context['pipeline_id'] ?? 0 ),
+			(int) $flow_context['flow_id'],
+			(string) $flow_context['flow_step_id'],
+			(string) ( $flow_context['job_id'] ?? '' ),
+			'universal_web_scraper'
+		);
+		$classification = $context->classifySourceItems(
+			$identifiers,
+			max( 0, (int) ( $flow_context['handler_config']['max_items'] ?? 0 ) )
+		);
+		$counts = (array) ( $classification['diagnostics'] ?? array() );
+		$processed = 0;
+		foreach ( (array) ( $classification['classifications'] ?? array() ) as $item ) {
+			if ( ! empty( $item['processed'] ) ) {
+				++$processed;
+			}
+		}
+
+		$truncated = ! empty( $raw_result['truncation']['truncated'] );
+		$complete  = ! $truncated
+			&& count( array_unique( $identifiers ) ) >= (int) $diagnostics['unique_source'];
+
+		$diagnostics['processed']             = $processed;
+		$diagnostics['active_claim']          = (int) ( $counts['actively_claimed'] ?? 0 );
+		$diagnostics['reprocess_eligible']     = (int) ( $counts['processed_reprocess_eligible'] ?? 0 );
+		$diagnostics['selected_by_max_items'] = (int) ( $counts['selected'] ?? 0 );
+		$diagnostics['production_eligible']   = $complete ? (int) ( $counts['selected'] ?? 0 ) : null;
+		$diagnostics['complete']              = $complete;
+		$diagnostics['returned_identifiers']  = count( $identifiers );
+		$diagnostics['truncation']            = (array) ( $raw_result['truncation'] ?? array() );
+
+		$attempt['production_context'] = $diagnostics;
 		return $attempt;
 	}
 

--- a/tests/Integration/PersistedQualificationContextTest.php
+++ b/tests/Integration/PersistedQualificationContextTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Persisted-flow qualification integration coverage.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+	require_once __DIR__ . '/Stubs/persisted-qualification-global-stubs.php';
+	require_once __DIR__ . '/Stubs/persisted-qualification-stubs.php';
+
+	use DataMachine\Core\ExecutionContext;
+	use ExtraChillEvents\Abilities\VenueQualificationAbilities;
+	use ExtraChillEvents\Cli\UnqualifiableFlowsCommand;
+	use ExtraChillEvents\Core\QualifyVerdict;
+	use PHPUnit\Framework\TestCase;
+
+	class PersistedQualificationContextTest extends TestCase {
+		protected function setUp(): void {
+			parent::setUp();
+			$GLOBALS['ec_persisted_qualification_abilities'] = array();
+			ExecutionContext::$scope                           = array();
+		}
+
+		public function test_real_ability_caller_passes_persisted_config_and_classifies_all_processed(): void {
+			$scraper = new class() {
+				public array $input = array();
+
+				public function execute( array $input ): array {
+					$this->input = $input;
+					return array(
+						'success'         => true,
+						'extraction_info' => array(
+							'extraction_method'         => 'squarespace',
+							'source_type'               => 'universal_web_scraper',
+							'payload_type'              => 'event',
+							'extracted_packet_count'    => 2,
+							'unique_source_event_count' => 2,
+							'production_max_items'      => 1,
+						),
+						'event_data'      => array(
+							'items' => array(
+								array( 'title' => 'One' ),
+								array( 'title' => 'Two' ),
+							),
+						),
+					);
+				}
+			};
+
+			$GLOBALS['ec_persisted_qualification_abilities']['data-machine-events/test-event-scraper'] = $scraper;
+			$GLOBALS['ec_persisted_qualification_abilities']['datamachine/test-handler']                = new class() {
+				public function execute(): array {
+					return array(
+						'success'    => true,
+						'packets'    => array(
+							array( 'metadata' => array( 'item_identifier' => 'event-one' ) ),
+							array( 'metadata' => array( 'item_identifier' => 'event-two' ) ),
+						),
+						'truncation' => array( 'truncated' => false ),
+					);
+				}
+			};
+
+			$ability = new class() extends VenueQualificationAbilities {
+				protected function loadPersistedFlowContext( int $flow_id ): array {
+					return array(
+						'flow_id'        => $flow_id,
+						'pipeline_id'    => 3,
+						'flow_step_id'   => 'step-42',
+						'job_id'         => '9001',
+						'handler_config' => array(
+							'source_url'       => 'https://venue.example/events',
+							'exclude_keywords' => 'comedy',
+							'venue'            => 1491,
+							'max_items'        => 1,
+						),
+					);
+				}
+			};
+
+			$result = $ability->executeQualifyVenue(
+				array(
+					'flow_id'         => 42,
+					'persist_verdict' => false,
+				)
+			);
+
+			$this->assertSame( QualifyVerdict::QUALIFIED_STRUCTURED, $result['verdict'] );
+			$this->assertSame( 2, $result['production_context']['raw_extracted'] );
+			$this->assertSame( 2, $result['production_context']['processed'] );
+			$this->assertSame( 0, $result['production_context']['production_eligible'] );
+			$this->assertTrue( $result['production_context']['complete'] );
+			$this->assertSame( 'comedy', $scraper->input['handler_config']['exclude_keywords'] );
+			$this->assertSame( 1491, $scraper->input['handler_config']['venue'] );
+			$this->assertSame( 'step-42', ExecutionContext::$scope['flow_step_id'] );
+			$this->assertSame( '9001', ExecutionContext::$scope['job_id'] );
+		}
+
+		public function test_ad_hoc_mode_reports_missing_production_context(): void {
+			$GLOBALS['ec_persisted_qualification_abilities']['data-machine-events/test-event-scraper'] = new class() {
+				public function execute(): array {
+					return array(
+						'success'         => true,
+						'extraction_info' => array(
+							'extraction_method'         => 'jsonld',
+							'source_type'               => 'universal_web_scraper',
+							'payload_type'              => 'event',
+							'extracted_packet_count'    => 2,
+							'unique_source_event_count' => 2,
+						),
+						'event_data'      => array( 'items' => array( array(), array() ) ),
+					);
+				}
+			};
+
+			$result = ( new VenueQualificationAbilities() )->executeQualifyVenue(
+				array(
+					'url'             => 'https://venue.example/events',
+					'persist_verdict' => false,
+				)
+			);
+
+			$this->assertFalse( $result['production_context']['context_supplied'] );
+			$this->assertStringContainsString( 'no persisted production flow context', $result['production_context']['reason'] );
+		}
+
+		public function test_all_processed_stable_zero_is_expected_zero(): void {
+			require_once dirname( __DIR__, 2 ) . '/inc/Cli/FlowHelpers.php';
+			require_once dirname( __DIR__, 2 ) . '/inc/Cli/UnqualifiableFlowsCommand.php';
+
+			$command = new class() extends UnqualifiableFlowsCommand {
+				public function classify( array $production ): string {
+					return $this->classify_qualified_action( $production, null );
+				}
+			};
+
+			$this->assertSame(
+				'expected_zero',
+				$command->classify(
+					array(
+						'complete'             => true,
+						'production_eligible' => 0,
+					)
+				)
+			);
+		}
+	}

--- a/tests/Integration/PersistedQualificationContextTest.php
+++ b/tests/Integration/PersistedQualificationContextTest.php
@@ -9,10 +9,12 @@ namespace ExtraChillEvents\Tests\Unit\Core;
 
 	require_once __DIR__ . '/Stubs/persisted-qualification-global-stubs.php';
 	require_once __DIR__ . '/Stubs/persisted-qualification-stubs.php';
+	require_once __DIR__ . '/Stubs/wp-cli-stubs.php';
 
 	use DataMachine\Core\ExecutionContext;
 	use ExtraChillEvents\Abilities\VenueQualificationAbilities;
 	use ExtraChillEvents\Cli\UnqualifiableFlowsCommand;
+	use ExtraChillEvents\Cli\FlowOps;
 	use ExtraChillEvents\Core\QualifyVerdict;
 	use PHPUnit\Framework\TestCase;
 
@@ -21,11 +23,32 @@ namespace ExtraChillEvents\Tests\Unit\Core;
 			parent::setUp();
 			$GLOBALS['ec_persisted_qualification_abilities'] = array();
 			ExecutionContext::$scope                           = array();
+			ExecutionContext::$classify_calls                  = 0;
+			ExecutionContext::$lifecycle_writes                = 0;
+			ExecutionContext::$classified_identifiers         = array();
+			FlowOps::$repairs                                  = array();
+			\WP_CLI::$logs                                    = array();
+			\WP_CLI::$formatted                               = array();
 		}
 
 		public function test_real_ability_caller_passes_persisted_config_and_classifies_all_processed(): void {
 			$scraper = new class() {
 				public array $input = array();
+
+				public function get_input_schema(): array {
+					return array(
+						'properties' => array(
+							'handler_config' => array(
+								'properties' => array(
+									'source_url'       => array(),
+									'exclude_keywords' => array(),
+									'venue'            => array(),
+									'max_items'        => array(),
+								),
+							),
+						),
+					);
+				}
 
 				public function execute( array $input ): array {
 					$this->input = $input;
@@ -55,8 +78,8 @@ namespace ExtraChillEvents\Tests\Unit\Core;
 					return array(
 						'success'    => true,
 						'packets'    => array(
-							array( 'metadata' => array( 'item_identifier' => 'event-one' ) ),
-							array( 'metadata' => array( 'item_identifier' => 'event-two' ) ),
+							array( 'data' => array( 'body' => '{"event":{}}' ), 'metadata' => array( 'item_identifier' => 'event-one' ) ),
+							array( 'data' => array( 'body' => '{"event":{}}' ), 'metadata' => array( 'item_identifier' => 'event-two' ) ),
 						),
 						'truncation' => array( 'truncated' => false ),
 					);
@@ -75,6 +98,7 @@ namespace ExtraChillEvents\Tests\Unit\Core;
 							'exclude_keywords' => 'comedy',
 							'venue'            => 1491,
 							'max_items'        => 1,
+							'venue_coordinates' => '32,-79',
 						),
 					);
 				}
@@ -94,6 +118,7 @@ namespace ExtraChillEvents\Tests\Unit\Core;
 			$this->assertTrue( $result['production_context']['complete'] );
 			$this->assertSame( 'comedy', $scraper->input['handler_config']['exclude_keywords'] );
 			$this->assertSame( 1491, $scraper->input['handler_config']['venue'] );
+			$this->assertArrayNotHasKey( 'venue_coordinates', $scraper->input['handler_config'] );
 			$this->assertSame( 'step-42', ExecutionContext::$scope['flow_step_id'] );
 			$this->assertSame( '9001', ExecutionContext::$scope['job_id'] );
 		}
@@ -145,5 +170,275 @@ namespace ExtraChillEvents\Tests\Unit\Core;
 					)
 				)
 			);
+		}
+
+		/**
+		 * @dataProvider large_inventory_provider
+		 */
+		public function test_large_all_processed_inventory_is_complete_with_one_bulk_classification( int $count ): void {
+			$this->install_inventory_abilities( $count );
+			$result = $this->new_qualification_ability()->executeQualifyVenue(
+				array(
+					'flow_id'         => 42,
+					'persist_verdict' => false,
+				)
+			);
+
+			$this->assertTrue( $result['production_context']['complete'] );
+			$this->assertSame( $count, $result['production_context']['processed'] );
+			$this->assertSame( 0, $result['production_context']['production_eligible'] );
+			$this->assertSame( 'verified_event_inventory', $result['production_context']['identifier_source'] );
+			$this->assertSame( 1, ExecutionContext::$classify_calls );
+			$this->assertCount( $count, ExecutionContext::$classified_identifiers );
+			$this->assertSame( 0, ExecutionContext::$lifecycle_writes );
+		}
+
+		public function large_inventory_provider(): array {
+			return array(
+				'dinghy-sized'     => array( 115 ),
+				'knuckleheads-sized' => array( 206 ),
+			);
+		}
+
+		public function test_inventory_above_safety_ceiling_is_explicitly_incomplete(): void {
+			$this->install_inventory_abilities( 501 );
+			$result = $this->new_qualification_ability()->executeQualifyVenue(
+				array(
+					'flow_id'         => 42,
+					'persist_verdict' => false,
+				)
+			);
+
+			$this->assertFalse( $result['production_context']['complete'] );
+			$this->assertNull( $result['production_context']['processed'] );
+			$this->assertNull( $result['production_context']['production_eligible'] );
+			$this->assertStringContainsString( 'observed 100 of 501', $result['production_context']['error'] );
+			$this->assertSame( 0, ExecutionContext::$classify_calls );
+		}
+
+		public function test_command_invocation_forwards_persisted_context_and_renders_truthful_counts(): void {
+			$this->install_inventory_abilities( 115 );
+			$qualification = $this->new_qualification_ability();
+			$calls         = array();
+			$GLOBALS['ec_persisted_qualification_abilities']['extrachill/qualify-venue'] = new class( $qualification, $calls ) {
+				private VenueQualificationAbilities $qualification;
+				public array $calls;
+
+				public function __construct( VenueQualificationAbilities $qualification, array &$calls ) {
+					$this->qualification = $qualification;
+					$this->calls         = &$calls;
+				}
+
+				public function execute( array $input ): array {
+					$this->calls[] = $input;
+					return $this->qualification->executeQualifyVenue( $input );
+				}
+			};
+
+			$this->new_command()->__invoke( array(), array( 'dry-run' => true, 'min-runs' => 1 ) );
+			$row = \WP_CLI::$formatted[0]['items'][0];
+
+			$this->assertSame( 42, $calls[0]['flow_id'] );
+			$this->assertFalse( $calls[0]['persist_verdict'] );
+			$this->assertSame( 115, $row['raw_extracted'] );
+			$this->assertSame( 115, $row['unique_source'] );
+			$this->assertSame( 115, $row['processed'] );
+			$this->assertSame( 0, $row['production_eligible'] );
+			$this->assertTrue( $row['complete'] );
+			$this->assertSame( 'verified_event_inventory', $row['identifier_source'] );
+			$this->assertSame( 'expected_zero', $row['action'] );
+		}
+
+		public function test_command_renders_incomplete_lifecycle_counts_as_non_authoritative(): void {
+			$this->install_inventory_abilities( 501 );
+			$qualification = $this->new_qualification_ability();
+			$GLOBALS['ec_persisted_qualification_abilities']['extrachill/qualify-venue'] = new class( $qualification ) {
+				private VenueQualificationAbilities $qualification;
+				public function __construct( VenueQualificationAbilities $qualification ) {
+					$this->qualification = $qualification;
+				}
+				public function execute( array $input ): array {
+					return $this->qualification->executeQualifyVenue( $input );
+				}
+			};
+
+			$this->new_command()->__invoke( array(), array( 'dry-run' => true, 'min-runs' => 1 ) );
+			$row = \WP_CLI::$formatted[0]['items'][0];
+
+			$this->assertFalse( $row['complete'] );
+			$this->assertNull( $row['processed'] );
+			$this->assertNull( $row['production_eligible'] );
+			$this->assertStringContainsString( 'observed 100 of 501', $row['diagnostic_error'] );
+			$this->assertSame( 'unexpected_pass', $row['action'] );
+		}
+
+		public function test_stale_zero_command_proposes_in_dry_run_then_applies_only_when_confirmed(): void {
+			$GLOBALS['ec_persisted_qualification_abilities']['data-machine-events/test-event-scraper'] = new class() {
+				public function execute( array $input ): array {
+					$qualified = 'https://venue.example/events' === $input['target_url'];
+					$items     = $qualified
+						? array(
+							array( 'title' => 'One', 'startDate' => '2026-08-01' ),
+							array( 'title' => 'Two', 'startDate' => '2026-08-02' ),
+						)
+						: array();
+					return array(
+						'success'         => true,
+						'extraction_info' => array(
+							'extraction_method'         => 'jsonld',
+							'source_type'               => 'universal_web_scraper',
+							'payload_type'              => 'event',
+							'extracted_packet_count'    => count( $items ),
+							'unique_source_event_count' => count( $items ),
+						),
+						'event_data'      => array( 'items' => $items ),
+					);
+				}
+			};
+			$GLOBALS['ec_persisted_qualification_abilities']['datamachine/test-handler'] = new class() {
+				public function execute(): array {
+					return array(
+						'success'    => true,
+						'packets'    => array(),
+						'truncation' => array( 'truncated' => false ),
+					);
+				}
+			};
+			$qualification = $this->new_qualification_ability( 'https://venue.example/stale' );
+			$result        = $qualification->executeQualifyVenue( array( 'flow_id' => 42, 'persist_verdict' => false ) );
+			$this->assertSame( 0, $result['production_context']['production_eligible'] );
+			$this->assertSame( 'https://venue.example/events', $result['repair_proposal']['proposed'] );
+
+			$GLOBALS['ec_persisted_qualification_abilities']['extrachill/qualify-venue'] = new class( $result ) {
+				private array $result;
+				public function __construct( array $result ) {
+					$this->result = $result;
+				}
+				public function execute(): array {
+					return $this->result;
+				}
+			};
+
+			$this->new_command()->__invoke( array(), array( 'dry-run' => true, 'min-runs' => 1 ) );
+			$this->assertSame( 'repair_proposed', \WP_CLI::$formatted[0]['items'][0]['action'] );
+			$this->assertSame( array(), FlowOps::$repairs );
+
+			\WP_CLI::$formatted = array();
+			$this->new_command()->__invoke(
+				array(),
+				array( 'apply-repair' => true, 'yes' => true, 'min-runs' => 1 )
+			);
+			$this->assertSame( 'repaired', \WP_CLI::$formatted[0]['items'][0]['action'] );
+			$this->assertCount( 1, FlowOps::$repairs );
+			$this->assertSame( 'https://venue.example/events', FlowOps::$repairs[0]['proposed_url'] );
+		}
+
+		public function test_apply_repair_requires_explicit_confirmation(): void {
+			$this->expectException( \RuntimeException::class );
+			$this->expectExceptionMessage( '--apply-repair requires --yes' );
+			$this->new_command()->__invoke( array(), array( 'apply-repair' => true, 'min-runs' => 1 ) );
+		}
+
+		private function install_inventory_abilities( int $count ): void {
+			$items = array();
+			foreach ( range( 1, $count ) as $index ) {
+				$items[] = array(
+					'title'     => 'Event ' . $index,
+					'startDate' => sprintf( '2026-08-%02d', ( ( $index - 1 ) % 28 ) + 1 ),
+				);
+			}
+			$GLOBALS['ec_persisted_qualification_abilities']['data-machine-events/test-event-scraper'] = new class( $items ) {
+				private array $items;
+				public function __construct( array $items ) {
+					$this->items = $items;
+				}
+				public function execute(): array {
+					$count = count( $this->items );
+					return array(
+						'success'         => true,
+						'extraction_info' => array(
+							'extraction_method'         => 'jsonld',
+							'source_type'               => 'universal_web_scraper',
+							'payload_type'              => 'event',
+							'extracted_packet_count'    => $count,
+							'unique_source_event_count' => $count,
+						),
+						'event_data'      => array( 'items' => $this->items ),
+					);
+				}
+			};
+			$GLOBALS['ec_persisted_qualification_abilities']['datamachine/test-handler'] = new class( $items ) {
+				private array $items;
+				public int $calls = 0;
+				public function __construct( array $items ) {
+					$this->items = $items;
+				}
+				public function execute(): array {
+					++$this->calls;
+					$packets = array();
+					foreach ( array_slice( $this->items, 0, 100 ) as $item ) {
+						$packets[] = array(
+							'data'     => array( 'body' => '{"event":{}}' ),
+							'metadata' => array(
+								'item_identifier' => \DataMachineEvents\Utilities\EventIdentifierGenerator::generate(
+									$item['title'],
+									$item['startDate'],
+									'Test Venue'
+								),
+							),
+						);
+					}
+					return array(
+						'success'    => true,
+						'packets'    => $packets,
+						'truncation' => array( 'truncated' => count( $this->items ) > 100 ),
+					);
+				}
+			};
+		}
+
+		private function new_qualification_ability( string $source_url = 'https://venue.example/events' ): VenueQualificationAbilities {
+			return new class( $source_url ) extends VenueQualificationAbilities {
+				private string $source_url;
+				public function __construct( string $source_url ) {
+					$this->source_url = $source_url;
+					parent::__construct();
+				}
+				protected function loadPersistedFlowContext( int $flow_id ): array {
+					return array(
+						'flow_id'        => $flow_id,
+						'pipeline_id'    => 3,
+						'flow_step_id'   => 'step-42',
+						'job_id'         => '9001',
+						'handler_config' => array(
+							'source_url' => $this->source_url,
+							'venue_name' => 'Test Venue',
+							'venue_coordinates' => '32,-79',
+						),
+					);
+				}
+			};
+		}
+
+		private function new_command(): UnqualifiableFlowsCommand {
+			require_once dirname( __DIR__, 2 ) . '/inc/Cli/FlowHelpers.php';
+			require_once dirname( __DIR__, 2 ) . '/inc/Cli/UnqualifiableFlowsCommand.php';
+
+			return new class() extends UnqualifiableFlowsCommand {
+				protected function load_all_web_scraper_flows(): array {
+					return array(
+						array(
+							'flow_id'           => 42,
+							'flow_name'         => 'Test Venue',
+							'source_url'        => 'https://venue.example/events',
+							'handler_slug'      => 'universal_web_scraper',
+							'scheduling_config' => array( 'interval' => 'daily' ),
+						),
+					);
+				}
+				protected function count_recent_runs( int $flow_id, int $lookback = 25 ): array {
+					return array( 'recent' => 25, 'zero_yield' => 25, 'any_completed' => 25 );
+				}
+			};
 		}
 	}

--- a/tests/Integration/Stubs/persisted-qualification-global-stubs.php
+++ b/tests/Integration/Stubs/persisted-qualification-global-stubs.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Global ability lookup stub for persisted qualification integration tests.
+ *
+ * @package ExtraChillEvents\Tests\Integration
+ */
+
+function wp_get_ability( string $name ) {
+	return $GLOBALS['ec_persisted_qualification_abilities'][ $name ] ?? null;
+}

--- a/tests/Integration/Stubs/persisted-qualification-stubs.php
+++ b/tests/Integration/Stubs/persisted-qualification-stubs.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Isolated stubs for persisted qualification tests.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+function wp_get_ability( string $name ) {
+	return $GLOBALS['ec_persisted_qualification_abilities'][ $name ] ?? null;
+}
+
+function is_wp_error(): bool {
+	return false;
+}
+
+function wp_remote_get(): array {
+	return array(
+		'response' => array( 'code' => 200 ),
+		'body'     => '<html><body>Events</body></html>',
+	);
+}
+
+function wp_remote_retrieve_response_code( array $response ): int {
+	return (int) ( $response['response']['code'] ?? 0 );
+}
+
+function wp_remote_retrieve_body( array $response ): string {
+	return (string) ( $response['body'] ?? '' );
+}
+
+function wp_remote_retrieve_header(): string {
+	return '';
+}
+
+namespace ExtraChillEvents\Abilities;
+
+function add_action(): void {}
+
+function is_wp_error(): bool {
+	return false;
+}
+
+function wp_remote_get(): array {
+	return \ExtraChillEvents\Core\wp_remote_get();
+}
+
+function wp_remote_retrieve_body( array $response ): string {
+	return \ExtraChillEvents\Core\wp_remote_retrieve_body( $response );
+}
+
+function untrailingslashit( string $value ): string {
+	return rtrim( $value, '/\\' );
+}
+
+namespace DataMachine\Core;
+
+class ExecutionContext {
+	public static array $scope = array();
+
+	public static function fromFlow( int $pipeline_id, int $flow_id, string $flow_step_id, ?string $job_id, string $handler_type ): self {
+		self::$scope = compact( 'pipeline_id', 'flow_id', 'flow_step_id', 'job_id', 'handler_type' );
+		return new self();
+	}
+
+	public function classifySourceItems( array $identifiers, int $max_items = 0 ): array {
+		return array(
+			'classifications' => array_map(
+				static fn( string $identifier ): array => array(
+					'item_identifier'    => $identifier,
+					'processed'          => true,
+					'reprocess_eligible' => false,
+					'actively_claimed'   => false,
+					'selected'           => false,
+				),
+				$identifiers
+			),
+			'diagnostics'     => array(
+				'actively_claimed'             => 0,
+				'processed_reprocess_eligible' => 0,
+				'selected'                     => 0,
+				'max_items'                    => $max_items,
+			),
+		);
+	}
+}

--- a/tests/Integration/Stubs/persisted-qualification-stubs.php
+++ b/tests/Integration/Stubs/persisted-qualification-stubs.php
@@ -34,6 +34,12 @@ function wp_remote_retrieve_header(): string {
 	return '';
 }
 
+class QualifyVerdictsTable {
+	public function meets_pause_confirmation(): bool {
+		return false;
+	}
+}
+
 namespace ExtraChillEvents\Abilities;
 
 function add_action(): void {}
@@ -58,6 +64,9 @@ namespace DataMachine\Core;
 
 class ExecutionContext {
 	public static array $scope = array();
+	public static int $classify_calls = 0;
+	public static int $lifecycle_writes = 0;
+	public static array $classified_identifiers = array();
 
 	public static function fromFlow( int $pipeline_id, int $flow_id, string $flow_step_id, ?string $job_id, string $handler_type ): self {
 		self::$scope = compact( 'pipeline_id', 'flow_id', 'flow_step_id', 'job_id', 'handler_type' );
@@ -65,6 +74,8 @@ class ExecutionContext {
 	}
 
 	public function classifySourceItems( array $identifiers, int $max_items = 0 ): array {
+		++self::$classify_calls;
+		self::$classified_identifiers = $identifiers;
 		return array(
 			'classifications' => array_map(
 				static fn( string $identifier ): array => array(
@@ -83,5 +94,28 @@ class ExecutionContext {
 				'max_items'                    => $max_items,
 			),
 		);
+	}
+}
+
+namespace DataMachineEvents\Utilities;
+
+class EventIdentifierGenerator {
+	public static function generate( string $title, string $start_date, string $venue ): string {
+		return md5( strtolower( trim( $title ) ) . $start_date . strtolower( trim( $venue ) ) );
+	}
+}
+
+namespace ExtraChillEvents\Cli;
+
+function is_wp_error(): bool {
+	return false;
+}
+
+class FlowOps {
+	public static array $repairs = array();
+
+	public static function repair_flow_source_url( int $flow_id, string $current_url, string $proposed_url ): bool {
+		self::$repairs[] = compact( 'flow_id', 'current_url', 'proposed_url' );
+		return true;
 	}
 }

--- a/tests/Integration/Stubs/wp-cli-stubs.php
+++ b/tests/Integration/Stubs/wp-cli-stubs.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * WP-CLI capture stubs for command-level integration tests.
+ *
+ * @package ExtraChillEvents\Tests\Integration
+ */
+
+namespace {
+	if ( ! defined( 'WP_CLI' ) ) {
+		define( 'WP_CLI', true );
+	}
+
+	class WP_CLI {
+		public static array $logs = array();
+		public static array $formatted = array();
+
+		public static function log( string $message ): void {
+			self::$logs[] = $message;
+		}
+
+		public static function warning( string $message ): void {
+			self::$logs[] = $message;
+		}
+
+		public static function success( string $message ): void {
+			self::$logs[] = $message;
+		}
+
+		public static function error( string $message ): void {
+			throw new \RuntimeException( $message );
+		}
+	}
+
+	function get_site_option( string $name, $default = false ) {
+		return $default;
+	}
+}
+
+namespace WP_CLI\Utils {
+	function format_items( string $format, array $items, array $fields ): void {
+		\WP_CLI::$formatted[] = compact( 'format', 'items', 'fields' );
+	}
+
+	function make_progress_bar(): object {
+		return new class() {
+			public function tick(): void {}
+			public function finish(): void {}
+		};
+	}
+}

--- a/tests/Unit/Core/FlowOpsResumeTest.php
+++ b/tests/Unit/Core/FlowOpsResumeTest.php
@@ -316,4 +316,23 @@ class FlowOpsResumeTest extends TestCase {
 			$patched[0]['handler_configs']['universal_web_scraper']['source_url']
 		);
 	}
+
+	public function test_confirmed_repair_only_updates_same_host_source_url(): void {
+		$this->seed_paused_flow( 107, 'https://venue.com/calendar' );
+
+		$this->assertTrue(
+			FlowOps::repair_flow_source_url( 107, 'https://venue.com/calendar', 'https://venue.com/events' )
+		);
+		$patched = $this->captured_flow_config( 107 );
+		$this->assertSame( 'https://venue.com/events', $patched[0]['handler_config']['source_url'] );
+	}
+
+	public function test_confirmed_repair_rejects_cross_host_source_url(): void {
+		$this->seed_paused_flow( 108, 'https://venue.com/calendar' );
+
+		$this->assertFalse(
+			FlowOps::repair_flow_source_url( 108, 'https://venue.com/calendar', 'https://other.example/events' )
+		);
+		$this->assertNull( $this->captured_flow_config( 108 ) );
+	}
 }

--- a/tests/Unit/Core/Stubs/flowops-resume-stubs.php
+++ b/tests/Unit/Core/Stubs/flowops-resume-stubs.php
@@ -73,6 +73,11 @@ namespace ExtraChillEvents\Tests\Unit\Core {
 				return $row;
 			}
 
+			public function get_var( string $sql ) {
+				$row = $this->get_row( $sql );
+				return is_array( $row ) ? ( $row['flow_config'] ?? null ) : null;
+			}
+
 			public function update( string $table, array $data, array $where, $format = null, $where_format = null ) {
 				$this->updates[] = array(
 					'table'        => $table,


### PR DESCRIPTION
## Summary
- load persisted universal web scraper config and flow/step/job scope when qualification receives `flow_id`
- combine config-aware scraper diagnostics with bounded raw handler output and Data Machine's bulk lifecycle classifier
- report raw, unique, processed, active-claim, reprocess, max-items selection, and production-eligible counts without lifecycle writes
- classify complete all-processed stable-zero flows as `expected_zero` instead of `unexpected_pass`
- keep ad-hoc URL mode explicit about missing production context and make same-host source repairs require `--apply-repair --yes`

## Reproduction
Installed dependencies used for the live-safe reproduction:
- Data Machine `0.167.0` (`datamachine/test-handler` raw bounded output and `ExecutionContext::classifySourceItems()`)
- Data Machine Events `0.51.0` (`data-machine-events/test-event-scraper` config-aware extraction diagnostics)
- Extra Chill Events `0.48.2` before this change

Representative stable-zero flow `7` (`The Bounty Bar`) has persisted source `https://www.thebountybar.com/schedule`, venue `1491`, pipeline `3`, and flow step `3_b27b1934-40c7-478f-9586-e474bd7d84ad_7`.

Read-only handler execution and one bulk lifecycle classification produced:

```json
{
  "raw_packet_count": 62,
  "returned_identifiers": 62,
  "unique": 62,
  "processed_skipped": 62,
  "processed_reprocess_eligible": 0,
  "actively_claimed": 0,
  "selected": 0
}
```

Before this PR, `unqualifiable-flows` passed only `url`, so the synthetic scraper saw the 62 events and labeled the stable-zero flow `unexpected_pass`. It had no persisted venue/exclusion/max-items config or lifecycle scope.

## After
Existing-flow qualification now:
- resolves the persisted `event_import` scraper step from `flow_id`
- passes the persisted handler config to `data-machine-events/test-event-scraper`
- requests raw `datamachine/test-handler` output with hard bounds of 100 packets and 5 MiB
- sends all returned stable identifiers to one `classifySourceItems()` call with the actual pipeline, flow step, latest job, handler type, and persisted `max_items`
- returns `production_eligible: null` when bounded output is incomplete rather than presenting a partial count as authoritative
- returns `expected_zero` when a complete structured extraction has zero production-eligible items
- returns `context_supplied: false` plus an explicit reason for ad-hoc URL mode

## Query and mutation evidence
The read-only reproduction captured the scoped lifecycle state, flow config hash, and job count immediately before and after handler testing plus classification:

```json
{
  "before": {
    "rows_total": "62",
    "processed": "62",
    "claimed": "0",
    "max_id": "639599",
    "flow_hash": "c55c679cd7e90d63f3e3979370716db8",
    "job_count": 64
  },
  "after": {
    "rows_total": "62",
    "processed": "62",
    "claimed": "0",
    "max_id": "639599",
    "flow_hash": "c55c679cd7e90d63f3e3979370716db8",
    "job_count": 64
  },
  "unchanged": true
}
```

No processed rows were cleared or inserted, no claims were acquired, no jobs were created, and no flow/content state was changed.

## Live-safe repair behavior
Qualification may return a bounded `source_url` repair proposal when a same-host candidate qualifies. Diagnosis never applies it. `unqualifiable-flows` requires both `--apply-repair` and `--yes`; `--dry-run` rejects apply. The write path:
- rejects cross-host URLs
- re-reads and matches the diagnosed current URL
- patches only matching universal web scraper steps
- includes the original serialized flow config in the update predicate to avoid overwriting concurrent edits
- does not alter scheduling, enqueue a run, activate a flow, release claims, or touch content

## Tests
- `./vendor/bin/phpunit tests/Integration/PersistedQualificationContextTest.php` - 3 tests, 12 assertions
- `./vendor/bin/phpunit tests/Unit/Core/FlowOpsResumeTest.php` - 9 tests, 32 assertions
- `homeboy review audit extrachill-events --profile pr --changed-since origin/main` - no introduced findings
- `homeboy review lint extrachill-events --changed-only --errors-only` - PHPCS passed; PHPStan level 7 passed
- targeted lint for the integration test and stubs passed
- PHP syntax and `git diff --check` passed

The aggregate `qualify-v2-unit` suite remains red at its existing cross-test/global-stub baseline (230 tests: 19 unrelated failures and 2 unrelated errors in recheck, canonical location, notification, adapter-contract, and profile-render tests). The focused changed paths pass.

## Dependencies and issues
- Closes Extra-Chill/extrachill-events#305
- Related: Extra-Chill/data-machine-events#511
- Config-aware diagnostics: Extra-Chill/data-machine-events#517
- Bulk eligibility: Extra-Chill/data-machine#2951
- Bounded raw handler output: Extra-Chill/data-machine#2948
- Related generic lifecycle work: Extra-Chill/data-machine#2945 and Extra-Chill/data-machine#2946