### PR TITLE
feat: add venue-scoped booking authorization

### DIFF
--- a/docs/venue-booking-authorization.md
+++ b/docs/venue-booking-authorization.md
@@ -1,0 +1,55 @@
+# Venue Booking Authorization
+
+Venue booking authority belongs to Extra Chill Events. Network user identity
+continues to belong to Extra Chill Users, while venue identity remains the
+Events-site `venue` taxonomy term.
+
+Memberships are stored in the site-scoped `ec_venue_members` table. A network
+user may belong to multiple venues, but authority never crosses venue IDs.
+
+## Roles
+
+| Action | owner | booking_manager | marketing | finance | viewer |
+|---|---:|---:|---:|---:|---:|
+| `view_bookings` | Yes | Yes | Yes | Yes | Yes |
+| `manage_inquiries` | Yes | Yes | No | No | No |
+| `manage_holds` | Yes | Yes | No | No | No |
+| `send_communication` | Yes | Yes | No | No | No |
+| `manage_marketing` | Yes | No | Yes | No | No |
+| `view_sales` | Yes | No | No | Yes | No |
+| `finalize_settlements` | Yes | No | No | Yes | No |
+| `manage_members` | Yes | No | No | No | No |
+
+Only `active` memberships authorize actions. `invited` and `revoked` rows
+authorize nothing. Invitation acceptance and first-owner claim verification
+are separate work; issue #291 permits only an administrator to bootstrap an
+unowned venue.
+
+Administrators receive an explicit capability-based override without a
+synthetic membership row. Global Extra Chill team status and artist membership
+do not imply venue authority.
+
+The final active owner cannot be demoted or revoked. Owner-removing mutations
+lock all memberships for the venue before checking this invariant.
+Every membership write also rechecks the actor's owner or administrator
+authority while those rows are locked, preventing a revoked owner from
+finishing an operation authorized before revocation.
+
+Membership abilities are not registered until schema version 2 has been fully
+verified. Internal authorization also fails closed with a service-unavailable
+error if invoked before readiness. Installation verifies the membership table
+uses InnoDB because row locks and transactions are part of the authorization
+contract.
+
+## Abilities
+
+- `extrachill/create-venue-membership`
+- `extrachill/update-venue-membership`
+- `extrachill/revoke-venue-membership`
+- `extrachill/list-venue-memberships`
+
+Every ability uses the same `manage_members` authorization service in its
+permission callback and rechecks authorization during execution. Create adds
+an existing network user as active. Update changes only the bounded role.
+Revoke preserves the row and records its revoked timestamp. Update and revoke
+require the caller's `expected_version`.

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -236,6 +236,9 @@ class ExtraChillEvents {
 		// init_abilities(); the admin screen instantiates in init_admin().
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ArtistUrlSubmissionsTable.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingSchema.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueAuthorization.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingConfig.php';
@@ -319,6 +322,11 @@ class ExtraChillEvents {
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/LocationEventAbilities.php';
 		new \ExtraChillEvents\Abilities\LocationEventAbilities();
+
+		if ( \ExtraChillEvents\Core\BookingSchema::is_ready() ) {
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueMembershipAbilities.php';
+			new \ExtraChillEvents\Abilities\VenueMembershipAbilities();
+		}
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/PriorityVenueAbilities.php';
 		new \ExtraChillEvents\Abilities\PriorityVenueAbilities();

--- a/inc/Abilities/VenueMembershipAbilities.php
+++ b/inc/Abilities/VenueMembershipAbilities.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Venue membership abilities.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+use ExtraChillEvents\Core\VenueAuthorization;
+use ExtraChillEvents\Core\VenueMembershipService;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Registers owner/admin-managed venue membership operations. */
+class VenueMembershipAbilities {
+
+	private static bool $registered = false;
+
+	/** @var VenueAuthorization */
+	private $authorization;
+
+	/** @var VenueMembershipService */
+	private $service;
+
+	public function __construct( ?VenueMembershipService $service = null, ?VenueAuthorization $authorization = null ) {
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+		$this->service       = $service ? $service : new VenueMembershipService( null, $this->authorization );
+		if ( ! self::$registered ) {
+			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+			self::$registered = true;
+		}
+	}
+
+	/** Register the four venue membership contracts. */
+	public function register(): void {
+		$base_properties = array(
+			'venue_term_id' => array(
+				'type'        => 'integer',
+				'minimum'     => 1,
+				'description' => __( 'Events-site venue term ID.', 'extrachill-events' ),
+			),
+			'user_id'       => array(
+				'type'        => 'integer',
+				'minimum'     => 1,
+				'description' => __( 'Network user ID.', 'extrachill-events' ),
+			),
+		);
+		$role_schema     = array(
+			'type' => 'string',
+			'enum' => VenueAuthorization::roles(),
+		);
+		$version_schema  = array(
+			'type'    => 'integer',
+			'minimum' => 1,
+		);
+
+		$this->register_ability(
+			'extrachill/create-venue-membership',
+			__( 'Create Venue Membership', 'extrachill-events' ),
+			__( 'Add an existing network user to a venue.', 'extrachill-events' ),
+			array_merge( $base_properties, array( 'role' => $role_schema ) ),
+			array( 'venue_term_id', 'user_id', 'role' ),
+			array( $this, 'create_membership' ),
+			false,
+			false,
+			false
+		);
+
+		$this->register_ability(
+			'extrachill/update-venue-membership',
+			__( 'Update Venue Membership', 'extrachill-events' ),
+			__( 'Change a venue member role at an expected version.', 'extrachill-events' ),
+			array_merge(
+				$base_properties,
+				array(
+					'role'             => $role_schema,
+					'expected_version' => $version_schema,
+				)
+			),
+			array( 'venue_term_id', 'user_id', 'role', 'expected_version' ),
+			array( $this, 'update_membership' ),
+			false,
+			false,
+			true
+		);
+
+		$this->register_ability(
+			'extrachill/revoke-venue-membership',
+			__( 'Revoke Venue Membership', 'extrachill-events' ),
+			__( 'Revoke a venue membership at an expected version.', 'extrachill-events' ),
+			array_merge( $base_properties, array( 'expected_version' => $version_schema ) ),
+			array( 'venue_term_id', 'user_id', 'expected_version' ),
+			array( $this, 'revoke_membership' ),
+			false,
+			false,
+			true
+		);
+
+		$this->register_ability(
+			'extrachill/list-venue-memberships',
+			__( 'List Venue Memberships', 'extrachill-events' ),
+			__( 'List members for one authorized venue.', 'extrachill-events' ),
+			array(
+				'venue_term_id' => $base_properties['venue_term_id'],
+				'role'          => array(
+					'type' => 'string',
+					'enum' => VenueAuthorization::roles(),
+				),
+				'status'        => array(
+					'type' => 'string',
+					'enum' => VenueAuthorization::statuses(),
+				),
+				'limit'         => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+					'maximum' => 100,
+					'default' => 50,
+				),
+				'offset'        => array(
+					'type'    => 'integer',
+					'minimum' => 0,
+					'default' => 0,
+				),
+			),
+			array( 'venue_term_id' ),
+			array( $this, 'list_memberships' ),
+			true,
+			true,
+			false,
+			array(
+				'type'  => 'array',
+				'items' => $this->membership_schema(),
+			)
+		);
+	}
+
+	/** Canonical permission callback shared by every operation. */
+	public function can_manage_members( array $input ) {
+		return $this->authorization->authorize(
+			get_current_user_id(),
+			absint( $input['venue_term_id'] ?? 0 ),
+			VenueAuthorization::ACTION_MANAGE_MEMBERS
+		);
+	}
+
+	public function create_membership( array $input ) {
+		return $this->service->create( get_current_user_id(), absint( $input['venue_term_id'] ?? 0 ), absint( $input['user_id'] ?? 0 ), (string) ( $input['role'] ?? '' ) );
+	}
+
+	public function update_membership( array $input ) {
+		return $this->service->update_role(
+			get_current_user_id(),
+			absint( $input['venue_term_id'] ?? 0 ),
+			absint( $input['user_id'] ?? 0 ),
+			(string) ( $input['role'] ?? '' ),
+			absint( $input['expected_version'] ?? 0 )
+		);
+	}
+
+	public function revoke_membership( array $input ) {
+		return $this->service->revoke(
+			get_current_user_id(),
+			absint( $input['venue_term_id'] ?? 0 ),
+			absint( $input['user_id'] ?? 0 ),
+			absint( $input['expected_version'] ?? 0 )
+		);
+	}
+
+	public function list_memberships( array $input ) {
+		return $this->service->list( get_current_user_id(), absint( $input['venue_term_id'] ?? 0 ), $input );
+	}
+
+	/** Register one operation with shared authorization and metadata. */
+	private function register_ability( string $name, string $label, string $description, array $properties, array $required, callable $execute, bool $is_readonly, bool $idempotent, bool $destructive, ?array $output_schema = null ): void {
+		wp_register_ability(
+			$name,
+			array(
+				'label'               => $label,
+				'description'         => $description,
+				'category'            => 'extrachill-events',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => $properties,
+					'required'             => $required,
+					'additionalProperties' => false,
+				),
+				'output_schema'       => $output_schema ? $output_schema : $this->membership_schema(),
+				'execute_callback'    => $execute,
+				'permission_callback' => array( $this, 'can_manage_members' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => $is_readonly,
+						'idempotent'  => $idempotent,
+						'destructive' => $destructive,
+					),
+				),
+			)
+		);
+	}
+
+	/** Shared public membership result shape. */
+	private function membership_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'                 => array( 'type' => 'integer' ),
+				'venue_term_id'      => array( 'type' => 'integer' ),
+				'user_id'            => array( 'type' => 'integer' ),
+				'role'               => array(
+					'type' => 'string',
+					'enum' => VenueAuthorization::roles(),
+				),
+				'status'             => array(
+					'type' => 'string',
+					'enum' => VenueAuthorization::statuses(),
+				),
+				'version'            => array( 'type' => 'integer' ),
+				'created_by_user_id' => array( 'type' => 'integer' ),
+				'created_at'         => array( 'type' => 'string' ),
+				'updated_at'         => array( 'type' => 'string' ),
+				'revoked_at'         => array(
+					'type' => array( 'string', 'null' ),
+				),
+			),
+		);
+	}
+}

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -333,7 +333,7 @@ class BookingSchema {
 			if ( ! is_array( $status ) ) {
 				continue;
 			}
-			if ( $contract['engine'] === strtolower( (string) ( $status['Engine'] ?? '' ) ) ) {
+			if ( strtolower( (string) ( $status['Engine'] ?? '' ) ) === $contract['engine'] ) {
 				continue;
 			}
 			$engine = strtoupper( $contract['engine'] );

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Owns and verifies the site-scoped private booking schema. */
 class BookingSchema {
 
-	public const SCHEMA_VERSION = '1';
+	public const SCHEMA_VERSION = '2';
 	public const VERSION_OPTION = 'extrachill_events_booking_schema_version';
 	public const FAILURE_OPTION = 'extrachill_events_booking_schema_error';
 
@@ -34,12 +34,19 @@ class BookingSchema {
 		return $wpdb->prefix . 'ec_booking_activity';
 	}
 
-	/** Create or repair both tables, stamping the version only after verification. */
+	/** Get the venue membership table for the current site. */
+	public static function memberships_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_venue_members';
+	}
+
+	/** Create or repair all tables, stamping the version only after verification. */
 	public static function install() {
 		global $wpdb;
 
 		$bookings = self::bookings_table();
 		$activity = self::activity_table();
+		$members  = self::memberships_table();
 		$charset  = $wpdb->get_charset_collate();
 
 		$bookings_sql = "CREATE TABLE {$bookings} (
@@ -95,6 +102,23 @@ class BookingSchema {
 			KEY channel_external (channel, external_id)
 		) ENGINE=InnoDB {$charset};";
 
+		$members_sql = "CREATE TABLE {$members} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			venue_term_id BIGINT UNSIGNED NOT NULL,
+			user_id BIGINT UNSIGNED NOT NULL,
+			role VARCHAR(32) NOT NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'active',
+			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
+			created_by_user_id BIGINT UNSIGNED NOT NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			revoked_at DATETIME NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY venue_user (venue_term_id, user_id),
+			KEY user_status_venue (user_id, status, venue_term_id),
+			KEY venue_status_role (venue_term_id, status, role)
+		) ENGINE=InnoDB {$charset};";
+
 		$repair = self::drop_conflicting_indexes();
 		if ( is_wp_error( $repair ) ) {
 			self::record_failure( $repair );
@@ -106,17 +130,26 @@ class BookingSchema {
 		$bookings_error = (string) $wpdb->last_error;
 		dbDelta( $activity_sql );
 		$activity_error = (string) $wpdb->last_error;
-		if ( '' !== $bookings_error || '' !== $activity_error ) {
+		dbDelta( $members_sql );
+		$members_error = (string) $wpdb->last_error;
+		if ( '' !== $bookings_error || '' !== $activity_error || '' !== $members_error ) {
 			$error = new \WP_Error(
 				'booking_schema_dbdelta_failed',
 				__( 'The booking schema could not be reconciled.', 'extrachill-events' ),
 				array(
 					'bookings_error' => $bookings_error,
 					'activity_error' => $activity_error,
+					'members_error'  => $members_error,
 				)
 			);
 			self::record_failure( $error );
 			return $error;
+		}
+
+		$engine_repair = self::repair_storage_engines();
+		if ( is_wp_error( $engine_repair ) ) {
+			self::record_failure( $engine_repair );
+			return $engine_repair;
 		}
 
 		$health = self::health();
@@ -138,6 +171,11 @@ class BookingSchema {
 		return self::install();
 	}
 
+	/** Check the cheap request-time readiness signal established by install. */
+	public static function is_ready(): bool {
+		return self::SCHEMA_VERSION === (string) get_option( self::VERSION_OPTION, '' );
+	}
+
 	/** Verify tables, column attributes, indexes, and uniqueness contracts. */
 	public static function health() {
 		global $wpdb;
@@ -150,6 +188,25 @@ class BookingSchema {
 			}
 			if ( $found !== $table ) {
 				return new \WP_Error( 'booking_schema_table_missing', __( 'A required booking table is missing.', 'extrachill-events' ), array( 'table' => $table ) );
+			}
+			if ( isset( $contract['engine'] ) ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Installation health cannot be cached.
+				$status = $wpdb->get_row( $wpdb->prepare( 'SHOW TABLE STATUS WHERE Name = %s', $table ), ARRAY_A );
+				if ( '' !== (string) $wpdb->last_error ) {
+					return self::database_error( __( 'Could not inspect the booking table engine.', 'extrachill-events' ), $table );
+				}
+				$engine = strtolower( (string) ( $status['Engine'] ?? '' ) );
+				if ( $contract['engine'] !== $engine ) {
+					return new \WP_Error(
+						'booking_schema_engine_invalid',
+						__( 'A booking table does not use the required transactional engine.', 'extrachill-events' ),
+						array(
+							'table'    => $table,
+							'expected' => $contract['engine'],
+							'actual'   => $engine,
+						)
+					);
+				}
 			}
 
 			$columns = $wpdb->get_results( "SHOW COLUMNS FROM `{$table}`", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted current-prefix table.
@@ -260,6 +317,42 @@ class BookingSchema {
 		return true;
 	}
 
+	/** Convert required tables to their declared transactional engine. */
+	private static function repair_storage_engines() {
+		global $wpdb;
+
+		foreach ( self::contracts() as $table => $contract ) {
+			if ( ! isset( $contract['engine'] ) ) {
+				continue;
+			}
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Installation repair cannot be cached.
+			$status = $wpdb->get_row( $wpdb->prepare( 'SHOW TABLE STATUS WHERE Name = %s', $table ), ARRAY_A );
+			if ( '' !== (string) $wpdb->last_error ) {
+				return self::database_error( __( 'Could not inspect the booking table engine for repair.', 'extrachill-events' ), $table );
+			}
+			if ( ! is_array( $status ) ) {
+				continue;
+			}
+			if ( $contract['engine'] === strtolower( (string) ( $status['Engine'] ?? '' ) ) ) {
+				continue;
+			}
+			$engine = strtoupper( $contract['engine'] );
+			$result = $wpdb->query( "ALTER TABLE `{$table}` ENGINE={$engine}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Table and engine come from the private schema contract.
+			if ( false === $result ) {
+				return new \WP_Error(
+					'booking_schema_engine_repair_failed',
+					__( 'A booking table could not be converted to its required transactional engine.', 'extrachill-events' ),
+					array(
+						'table'          => $table,
+						'engine'         => $contract['engine'],
+						'database_error' => $wpdb->last_error,
+					)
+				);
+			}
+		}
+		return true;
+	}
+
 	/** Return the final initial schema contract shared by health and repair. */
 	private static function contracts(): array {
 		$required = static function ( string $type, bool $nullable, array $attributes = array() ): array {
@@ -272,7 +365,7 @@ class BookingSchema {
 			);
 		};
 		return array(
-			self::bookings_table() => array(
+			self::bookings_table()    => array(
 				'columns' => array(
 					'id'                 => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
 					'public_id'          => $required( 'char(36)', false ),
@@ -335,7 +428,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::activity_table() => array(
+			self::activity_table()    => array(
 				'columns' => array(
 					'id'              => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
 					'booking_id'      => $required( 'bigint unsigned', false ),
@@ -370,6 +463,39 @@ class BookingSchema {
 					'channel_external'    => array(
 						'unique'  => false,
 						'columns' => array( 'channel', 'external_id' ),
+					),
+				),
+			),
+			self::memberships_table() => array(
+				'engine'  => 'innodb',
+				'columns' => array(
+					'id'                 => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'venue_term_id'      => $required( 'bigint unsigned', false ),
+					'user_id'            => $required( 'bigint unsigned', false ),
+					'role'               => $required( 'varchar(32)', false ),
+					'status'             => $required( 'varchar(20)', false, array( 'default' => 'active' ) ),
+					'version'            => $required( 'bigint unsigned', false, array( 'default' => '1' ) ),
+					'created_by_user_id' => $required( 'bigint unsigned', false ),
+					'created_at'         => $required( 'datetime', false ),
+					'updated_at'         => $required( 'datetime', false ),
+					'revoked_at'         => $required( 'datetime', true ),
+				),
+				'indexes' => array(
+					'PRIMARY'           => array(
+						'unique'  => true,
+						'columns' => array( 'id' ),
+					),
+					'venue_user'        => array(
+						'unique'  => true,
+						'columns' => array( 'venue_term_id', 'user_id' ),
+					),
+					'user_status_venue' => array(
+						'unique'  => false,
+						'columns' => array( 'user_id', 'status', 'venue_term_id' ),
+					),
+					'venue_status_role' => array(
+						'unique'  => false,
+						'columns' => array( 'venue_term_id', 'status', 'role' ),
 					),
 				),
 			),

--- a/inc/Core/VenueAuthorization.php
+++ b/inc/Core/VenueAuthorization.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Venue-scoped booking authorization.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Applies the bounded venue booking role matrix. */
+class VenueAuthorization {
+
+	public const ROLE_OWNER           = 'owner';
+	public const ROLE_BOOKING_MANAGER = 'booking_manager';
+	public const ROLE_MARKETING       = 'marketing';
+	public const ROLE_FINANCE         = 'finance';
+	public const ROLE_VIEWER          = 'viewer';
+
+	public const STATUS_ACTIVE  = 'active';
+	public const STATUS_INVITED = 'invited';
+	public const STATUS_REVOKED = 'revoked';
+
+	public const ACTION_VIEW_BOOKINGS        = 'view_bookings';
+	public const ACTION_MANAGE_INQUIRIES     = 'manage_inquiries';
+	public const ACTION_MANAGE_HOLDS         = 'manage_holds';
+	public const ACTION_SEND_COMMUNICATION   = 'send_communication';
+	public const ACTION_MANAGE_MARKETING     = 'manage_marketing';
+	public const ACTION_VIEW_SALES           = 'view_sales';
+	public const ACTION_FINALIZE_SETTLEMENTS = 'finalize_settlements';
+	public const ACTION_MANAGE_MEMBERS       = 'manage_members';
+
+	/** @var VenueMembershipRepository */
+	private $memberships;
+
+	public function __construct( ?VenueMembershipRepository $memberships = null ) {
+		$this->memberships = $memberships ? $memberships : new VenueMembershipRepository();
+	}
+
+	/** Return every supported venue role. */
+	public static function roles(): array {
+		return array_keys( self::matrix() );
+	}
+
+	/** Return every supported membership status. */
+	public static function statuses(): array {
+		return array( self::STATUS_ACTIVE, self::STATUS_INVITED, self::STATUS_REVOKED );
+	}
+
+	/** Return every supported booking-domain action. */
+	public static function actions(): array {
+		$actions = array();
+		foreach ( self::matrix() as $allowed ) {
+			$actions = array_merge( $actions, $allowed );
+		}
+		return array_values( array_unique( $actions ) );
+	}
+
+	/** Authorize one network user for one action at one Events-site venue. */
+	public function authorize( int $user_id, int $venue_term_id, string $action ) {
+		if ( ! in_array( $action, self::actions(), true ) ) {
+			return new \WP_Error(
+				'invalid_venue_action',
+				__( 'The requested venue action is not supported.', 'extrachill-events' ),
+				array( 'status' => 400 )
+			);
+		}
+		if ( ! BookingSchema::is_ready() ) {
+			return new \WP_Error(
+				'venue_membership_schema_unavailable',
+				__( 'Venue membership storage is not ready.', 'extrachill-events' ),
+				array( 'status' => 503 )
+			);
+		}
+
+		$venue = get_term( $venue_term_id, 'venue' );
+		if ( $venue_term_id < 1 || ! $venue || is_wp_error( $venue ) || 'venue' !== $venue->taxonomy ) {
+			return new \WP_Error(
+				'invalid_venue_membership_venue',
+				__( 'A valid Events venue term is required.', 'extrachill-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( $user_id < 1 || ! get_userdata( $user_id ) ) {
+			return $this->denied();
+		}
+
+		if ( $this->is_administrator( $user_id ) ) {
+			return true;
+		}
+
+		$membership = $this->active_membership( $user_id, $venue_term_id );
+		if ( is_wp_error( $membership ) ) {
+			return $membership;
+		}
+		if ( ! is_array( $membership ) || ! $this->role_allows( $membership['role'], $action ) ) {
+			return $this->denied();
+		}
+
+		return true;
+	}
+
+	/** Boolean convenience wrapper for template and UI checks. */
+	public function can( int $user_id, int $venue_term_id, string $action ): bool {
+		return true === $this->authorize( $user_id, $venue_term_id, $action );
+	}
+
+	/** Resolve only an active relationship for this exact venue and user. */
+	public function active_membership( int $user_id, int $venue_term_id ) {
+		return $this->memberships->get_active( $venue_term_id, $user_id );
+	}
+
+	/** Check one role/action pair against the explicit domain matrix. */
+	public function role_allows( string $role, string $action ): bool {
+		$matrix = self::matrix();
+		return isset( $matrix[ $role ] ) && in_array( $action, $matrix[ $role ], true );
+	}
+
+	/** Administrators override venue membership without receiving synthetic rows. */
+	public function is_administrator( int $user_id ): bool {
+		return $user_id > 0 && user_can( $user_id, 'manage_options' );
+	}
+
+	/** Return the explicit role/action policy. */
+	private static function matrix(): array {
+		return array(
+			self::ROLE_OWNER           => array(
+				self::ACTION_VIEW_BOOKINGS,
+				self::ACTION_MANAGE_INQUIRIES,
+				self::ACTION_MANAGE_HOLDS,
+				self::ACTION_SEND_COMMUNICATION,
+				self::ACTION_MANAGE_MARKETING,
+				self::ACTION_VIEW_SALES,
+				self::ACTION_FINALIZE_SETTLEMENTS,
+				self::ACTION_MANAGE_MEMBERS,
+			),
+			self::ROLE_BOOKING_MANAGER => array(
+				self::ACTION_VIEW_BOOKINGS,
+				self::ACTION_MANAGE_INQUIRIES,
+				self::ACTION_MANAGE_HOLDS,
+				self::ACTION_SEND_COMMUNICATION,
+			),
+			self::ROLE_MARKETING       => array(
+				self::ACTION_VIEW_BOOKINGS,
+				self::ACTION_MANAGE_MARKETING,
+			),
+			self::ROLE_FINANCE         => array(
+				self::ACTION_VIEW_BOOKINGS,
+				self::ACTION_VIEW_SALES,
+				self::ACTION_FINALIZE_SETTLEMENTS,
+			),
+			self::ROLE_VIEWER          => array( self::ACTION_VIEW_BOOKINGS ),
+		);
+	}
+
+	/** Build a non-enumerating authorization denial. */
+	private function denied(): \WP_Error {
+		return new \WP_Error(
+			'venue_action_forbidden',
+			__( 'You are not authorized to perform this venue action.', 'extrachill-events' ),
+			array( 'status' => 403 )
+		);
+	}
+}

--- a/inc/Core/VenueMembershipRepository.php
+++ b/inc/Core/VenueMembershipRepository.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * Site-scoped venue membership persistence.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Provides bounded persistence for venue/user relationships. */
+class VenueMembershipRepository {
+
+	/** Create one unique venue/user relationship. */
+	public function create( array $data ) {
+		global $wpdb;
+
+		$venue_term_id = $this->positive_id( $data['venue_term_id'] ?? null, 'venue_term_id' );
+		$user_id       = $this->positive_id( $data['user_id'] ?? null, 'user_id' );
+		$creator_id    = $this->positive_id( $data['created_by_user_id'] ?? null, 'created_by_user_id' );
+		foreach ( array( $venue_term_id, $user_id, $creator_id ) as $validated ) {
+			if ( is_wp_error( $validated ) ) {
+				return $validated;
+			}
+		}
+
+		$venue = get_term( $venue_term_id, 'venue' );
+		if ( ! $venue || is_wp_error( $venue ) || 'venue' !== $venue->taxonomy ) {
+			return new \WP_Error( 'invalid_venue_membership_venue', __( 'A valid Events venue term is required.', 'extrachill-events' ) );
+		}
+		if ( ! get_userdata( $user_id ) || ! get_userdata( $creator_id ) ) {
+			return new \WP_Error( 'invalid_venue_membership_user', __( 'Venue memberships require existing network users.', 'extrachill-events' ) );
+		}
+
+		$role   = sanitize_key( (string) ( $data['role'] ?? '' ) );
+		$status = sanitize_key( (string) ( $data['status'] ?? VenueAuthorization::STATUS_ACTIVE ) );
+		if ( ! in_array( $role, VenueAuthorization::roles(), true ) ) {
+			return new \WP_Error( 'invalid_venue_membership_role', __( 'The venue membership role is not supported.', 'extrachill-events' ) );
+		}
+		if ( ! in_array( $status, VenueAuthorization::statuses(), true ) ) {
+			return new \WP_Error( 'invalid_venue_membership_status', __( 'The venue membership status is not supported.', 'extrachill-events' ) );
+		}
+
+		$now = gmdate( 'Y-m-d H:i:s' );
+		$row = array(
+			'venue_term_id'      => $venue_term_id,
+			'user_id'            => $user_id,
+			'role'               => $role,
+			'status'             => $status,
+			'version'            => 1,
+			'created_by_user_id' => $creator_id,
+			'created_at'         => $now,
+			'updated_at'         => $now,
+			'revoked_at'         => VenueAuthorization::STATUS_REVOKED === $status ? $now : null,
+		);
+		$table = BookingSchema::memberships_table();
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serializes authorization and membership creation.
+			return new \WP_Error( 'venue_membership_transaction_failed', __( 'The venue membership transaction could not start.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		$locked = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $venue_term_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks the venue authority range through the venue-prefixed unique index.
+		if ( '' !== (string) $wpdb->last_error ) {
+			$database_error = $wpdb->last_error;
+			$this->rollback();
+			return new \WP_Error( 'venue_membership_read_failed', __( 'Venue memberships could not be locked.', 'extrachill-events' ), array( 'database_error' => $database_error ) );
+		}
+		$memberships = $this->hydrate_locked( (array) $locked );
+		if ( is_wp_error( $memberships ) ) {
+			$this->rollback();
+			return $memberships;
+		}
+		if ( ! $this->actor_can_manage_members( $creator_id, $memberships ) ) {
+			$this->rollback();
+			return $this->forbidden();
+		}
+		foreach ( $memberships as $existing ) {
+			if ( $existing['user_id'] === $user_id ) {
+				$this->rollback();
+				return $this->conflict( $existing );
+			}
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private operational table write.
+		if ( false === $wpdb->insert( $table, $row ) ) {
+			$database_error = $wpdb->last_error;
+			$winner = $this->get( $venue_term_id, $user_id );
+			if ( is_array( $winner ) ) {
+				$this->rollback();
+				return $this->conflict( $winner );
+			}
+			if ( is_wp_error( $winner ) ) {
+				$this->rollback();
+				return $winner;
+			}
+			$this->rollback();
+			return new \WP_Error(
+				'venue_membership_create_failed',
+				__( 'The venue membership could not be created.', 'extrachill-events' ),
+				array( 'database_error' => $database_error )
+			);
+		}
+		if ( false === $wpdb->query( 'COMMIT' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Completes serialized creation.
+			$database_error = $wpdb->last_error;
+			return new \WP_Error( 'venue_membership_commit_uncertain', __( 'The venue membership transaction outcome could not be confirmed.', 'extrachill-events' ), array( 'database_error' => $database_error ) );
+		}
+
+		return $this->get( $venue_term_id, $user_id );
+	}
+
+	/** Get one relationship by its venue/user natural key. */
+	public function get( int $venue_term_id, int $user_id ) {
+		global $wpdb;
+		$table = BookingSchema::memberships_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d AND user_id = %d LIMIT 1", $venue_term_id, $user_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted current-prefix table.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'venue_membership_read_failed', __( 'The venue membership could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return is_array( $row ) ? $this->hydrate( $row ) : null;
+	}
+
+	/** Get an active relationship, returning null for invited or revoked rows. */
+	public function get_active( int $venue_term_id, int $user_id ) {
+		$membership = $this->get( $venue_term_id, $user_id );
+		if ( is_wp_error( $membership ) || ! is_array( $membership ) ) {
+			return $membership;
+		}
+		return VenueAuthorization::STATUS_ACTIVE === $membership['status'] ? $membership : null;
+	}
+
+	/** List memberships for one venue with bounded filters. */
+	public function list_for_venue( int $venue_term_id, array $filters = array(), int $actor_user_id = 0 ) {
+		global $wpdb;
+
+		$table      = BookingSchema::memberships_table();
+		$table_from = "{$table} AS member";
+		$where      = array( 'member.venue_term_id = %d' );
+		$values     = array( $venue_term_id );
+		if ( $actor_user_id > 0 && ! user_can( $actor_user_id, 'manage_options' ) ) {
+			$table_from .= " INNER JOIN {$table} AS actor ON actor.venue_term_id = member.venue_term_id AND actor.user_id = %d AND actor.role = 'owner' AND actor.status = 'active'";
+			array_unshift( $values, $actor_user_id );
+		}
+		foreach ( array( 'role', 'status' ) as $field ) {
+			if ( empty( $filters[ $field ] ) ) {
+				continue;
+			}
+			$allowed = 'role' === $field ? VenueAuthorization::roles() : VenueAuthorization::statuses();
+			$value   = sanitize_key( (string) $filters[ $field ] );
+			if ( ! in_array( $value, $allowed, true ) ) {
+				return new \WP_Error( "invalid_venue_membership_{$field}", __( 'The venue membership filter is not supported.', 'extrachill-events' ) );
+			}
+			$where[]  = "member.{$field} = %s";
+			$values[] = $value;
+		}
+
+		$limit    = max( 1, min( 100, absint( $filters['limit'] ?? 50 ) ) );
+		$offset   = max( 0, absint( $filters['offset'] ?? 0 ) );
+		$values[] = $limit;
+		$values[] = $offset;
+		$query    = "SELECT member.* FROM {$table_from} WHERE " . implode( ' AND ', $where ) . ' ORDER BY member.created_at ASC, member.id ASC LIMIT %d OFFSET %d'; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Trusted table and fixed clauses.
+		$rows     = $wpdb->get_results( $wpdb->prepare( $query, $values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Dynamic values are prepared.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'venue_membership_list_failed', __( 'Venue memberships could not be listed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+
+		$memberships = array();
+		foreach ( (array) $rows as $row ) {
+			$membership = $this->hydrate( $row );
+			if ( is_wp_error( $membership ) ) {
+				return $membership;
+			}
+			$memberships[] = $membership;
+		}
+		return $memberships;
+	}
+
+	/** Change one role at an expected version while preserving an active owner. */
+	public function update_role( int $venue_term_id, int $user_id, string $role, int $expected_version, int $actor_user_id ) {
+		$role = sanitize_key( $role );
+		if ( ! in_array( $role, VenueAuthorization::roles(), true ) ) {
+			return new \WP_Error( 'invalid_venue_membership_role', __( 'The venue membership role is not supported.', 'extrachill-events' ) );
+		}
+		return $this->mutate( $venue_term_id, $user_id, $expected_version, $role, null, $actor_user_id );
+	}
+
+	/** Revoke one relationship at an expected version while preserving an active owner. */
+	public function revoke( int $venue_term_id, int $user_id, int $expected_version, int $actor_user_id ) {
+		return $this->mutate( $venue_term_id, $user_id, $expected_version, null, VenueAuthorization::STATUS_REVOKED, $actor_user_id );
+	}
+
+	/** Hydrate scalar fields and fail closed on corrupt role/status values. */
+	public function hydrate( array $row ) {
+		if ( ! in_array( $row['role'] ?? '', VenueAuthorization::roles(), true ) ) {
+			return new \WP_Error( 'venue_membership_corrupt_role', __( 'The stored venue membership role is invalid.', 'extrachill-events' ) );
+		}
+		if ( ! in_array( $row['status'] ?? '', VenueAuthorization::statuses(), true ) ) {
+			return new \WP_Error( 'venue_membership_corrupt_status', __( 'The stored venue membership status is invalid.', 'extrachill-events' ) );
+		}
+		foreach ( array( 'id', 'venue_term_id', 'user_id', 'version', 'created_by_user_id' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		$row['revoked_at'] = empty( $row['revoked_at'] ) ? null : (string) $row['revoked_at'];
+		return $row;
+	}
+
+	/** Execute one serialized membership mutation. */
+	private function mutate( int $venue_term_id, int $user_id, int $expected_version, ?string $role, ?string $status, int $actor_user_id ) {
+		global $wpdb;
+
+		if ( $venue_term_id < 1 || $user_id < 1 || $expected_version < 1 || $actor_user_id < 1 ) {
+			return new \WP_Error( 'invalid_venue_membership_id', __( 'Positive venue, user, and version identifiers are required.', 'extrachill-events' ) );
+		}
+
+		$table = BookingSchema::memberships_table();
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Required for last-owner serialization.
+			return new \WP_Error( 'venue_membership_transaction_failed', __( 'The venue membership transaction could not start.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+
+		$locked = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $venue_term_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serializes membership mutations for one venue.
+		if ( '' !== (string) $wpdb->last_error ) {
+			$database_error = $wpdb->last_error;
+			$this->rollback();
+			return new \WP_Error( 'venue_membership_read_failed', __( 'Venue memberships could not be locked.', 'extrachill-events' ), array( 'database_error' => $database_error ) );
+		}
+
+		$current      = null;
+		$active_owner = 0;
+		$memberships  = $this->hydrate_locked( (array) $locked );
+		if ( is_wp_error( $memberships ) ) {
+			$this->rollback();
+			return $memberships;
+		}
+		foreach ( $memberships as $membership ) {
+			if ( $membership['user_id'] === $user_id ) {
+				$current = $membership;
+			}
+			if ( VenueAuthorization::ROLE_OWNER === $membership['role'] && VenueAuthorization::STATUS_ACTIVE === $membership['status'] ) {
+				++$active_owner;
+			}
+		}
+		if ( ! $this->actor_can_manage_members( $actor_user_id, $memberships ) ) {
+			$this->rollback();
+			return $this->forbidden();
+		}
+
+		if ( null === $current ) {
+			$this->rollback();
+			return new \WP_Error( 'venue_membership_not_found', __( 'The venue membership was not found.', 'extrachill-events' ), array( 'status' => 404 ) );
+		}
+		if ( $current['version'] !== $expected_version ) {
+			$this->rollback();
+			return $this->version_conflict( $current );
+		}
+
+		$removes_owner = VenueAuthorization::ROLE_OWNER === $current['role']
+			&& VenueAuthorization::STATUS_ACTIVE === $current['status']
+			&& ( ( null !== $role && VenueAuthorization::ROLE_OWNER !== $role ) || VenueAuthorization::STATUS_REVOKED === $status );
+		if ( $removes_owner && $active_owner < 2 ) {
+			$this->rollback();
+			return new \WP_Error( 'venue_membership_last_owner', __( 'The final active venue owner cannot be removed.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+
+		$set    = array( 'version = version + 1', 'updated_at = %s' );
+		$values = array( gmdate( 'Y-m-d H:i:s' ) );
+		if ( null !== $role ) {
+			$set[]    = 'role = %s';
+			$values[] = $role;
+		}
+		if ( null !== $status ) {
+			$set[]    = 'status = %s';
+			$values[] = $status;
+			$set[]    = 'revoked_at = %s';
+			$values[] = gmdate( 'Y-m-d H:i:s' );
+		}
+		$values[] = $venue_term_id;
+		$values[] = $user_id;
+		$values[] = $expected_version;
+		$query    = "UPDATE {$table} SET " . implode( ', ', $set ) . ' WHERE venue_term_id = %d AND user_id = %d AND version = %d'; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Fixed columns and trusted table.
+		$result   = $wpdb->query( $wpdb->prepare( $query, $values ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Dynamic values are prepared.
+		if ( false === $result ) {
+			$database_error = $wpdb->last_error;
+			$this->rollback();
+			return new \WP_Error( 'venue_membership_update_failed', __( 'The venue membership could not be updated.', 'extrachill-events' ), array( 'database_error' => $database_error ) );
+		}
+		if ( 0 === $result ) {
+			$this->rollback();
+			$latest = $this->get( $venue_term_id, $user_id );
+			return is_array( $latest ) ? $this->version_conflict( $latest ) : new \WP_Error( 'venue_membership_not_found', __( 'The venue membership was not found.', 'extrachill-events' ), array( 'status' => 404 ) );
+		}
+
+		if ( false === $wpdb->query( 'COMMIT' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Completes serialized mutation.
+			$database_error = $wpdb->last_error;
+			return new \WP_Error( 'venue_membership_commit_uncertain', __( 'The venue membership transaction outcome could not be confirmed.', 'extrachill-events' ), array( 'database_error' => $database_error ) );
+		}
+		return $this->get( $venue_term_id, $user_id );
+	}
+
+	/** Hydrate rows held under the venue transaction lock. */
+	private function hydrate_locked( array $rows ) {
+		$memberships = array();
+		foreach ( $rows as $row ) {
+			$membership = $this->hydrate( $row );
+			if ( is_wp_error( $membership ) ) {
+				return $membership;
+			}
+			$memberships[] = $membership;
+		}
+		return $memberships;
+	}
+
+	/** Recheck owner/admin authority after venue rows are locked. */
+	private function actor_can_manage_members( int $actor_user_id, array $memberships ): bool {
+		if ( user_can( $actor_user_id, 'manage_options' ) ) {
+			return true;
+		}
+		foreach ( $memberships as $membership ) {
+			if ( $membership['user_id'] === $actor_user_id && VenueAuthorization::ROLE_OWNER === $membership['role'] && VenueAuthorization::STATUS_ACTIVE === $membership['status'] ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function rollback(): void {
+		global $wpdb;
+		$wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Rolls back failed membership mutation.
+	}
+
+	private function positive_id( $value, string $field ) {
+		if ( ( ! is_int( $value ) && ! ( is_string( $value ) && ctype_digit( $value ) ) ) || (int) $value < 1 ) {
+			return new \WP_Error( 'invalid_venue_membership_id', __( 'Venue membership identifiers must be positive integers.', 'extrachill-events' ), array( 'field' => $field ) );
+		}
+		return (int) $value;
+	}
+
+	private function conflict( array $membership ): \WP_Error {
+		return new \WP_Error(
+			'venue_membership_exists',
+			__( 'A venue membership already exists for this user.', 'extrachill-events' ),
+			array(
+				'status'          => 409,
+				'current_version' => $membership['version'],
+			)
+		);
+	}
+
+	private function version_conflict( array $membership ): \WP_Error {
+		return new \WP_Error(
+			'venue_membership_version_conflict',
+			__( 'The venue membership changed since it was read.', 'extrachill-events' ),
+			array(
+				'status'          => 409,
+				'current_version' => $membership['version'],
+			)
+		);
+	}
+
+	private function forbidden(): \WP_Error {
+		return new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to manage members for this venue.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+}

--- a/inc/Core/VenueMembershipRepository.php
+++ b/inc/Core/VenueMembershipRepository.php
@@ -44,8 +44,8 @@ class VenueMembershipRepository {
 			return new \WP_Error( 'invalid_venue_membership_status', __( 'The venue membership status is not supported.', 'extrachill-events' ) );
 		}
 
-		$now = gmdate( 'Y-m-d H:i:s' );
-		$row = array(
+		$now   = gmdate( 'Y-m-d H:i:s' );
+		$row   = array(
 			'venue_term_id'      => $venue_term_id,
 			'user_id'            => $user_id,
 			'role'               => $role,
@@ -85,7 +85,7 @@ class VenueMembershipRepository {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private operational table write.
 		if ( false === $wpdb->insert( $table, $row ) ) {
 			$database_error = $wpdb->last_error;
-			$winner = $this->get( $venue_term_id, $user_id );
+			$winner         = $this->get( $venue_term_id, $user_id );
 			if ( is_array( $winner ) ) {
 				$this->rollback();
 				return $this->conflict( $winner );

--- a/inc/Core/VenueMembershipService.php
+++ b/inc/Core/VenueMembershipService.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Venue membership management policy.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Reauthorizes and executes venue membership operations. */
+class VenueMembershipService {
+
+	/** @var VenueMembershipRepository */
+	private $memberships;
+
+	/** @var VenueAuthorization */
+	private $authorization;
+
+	public function __construct( ?VenueMembershipRepository $memberships = null, ?VenueAuthorization $authorization = null ) {
+		$this->memberships   = $memberships ? $memberships : new VenueMembershipRepository();
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization( $this->memberships );
+	}
+
+	/** Add an active membership for an existing network user. */
+	public function create( int $actor_user_id, int $venue_term_id, int $target_user_id, string $role ) {
+		$allowed = $this->authorization->authorize( $actor_user_id, $venue_term_id, VenueAuthorization::ACTION_MANAGE_MEMBERS );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		return $this->memberships->create(
+			array(
+				'venue_term_id'      => $venue_term_id,
+				'user_id'            => $target_user_id,
+				'role'               => $role,
+				'status'             => VenueAuthorization::STATUS_ACTIVE,
+				'created_by_user_id' => $actor_user_id,
+			)
+		);
+	}
+
+	/** Change one membership role. */
+	public function update_role( int $actor_user_id, int $venue_term_id, int $target_user_id, string $role, int $expected_version ) {
+		$allowed = $this->authorization->authorize( $actor_user_id, $venue_term_id, VenueAuthorization::ACTION_MANAGE_MEMBERS );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		return $this->memberships->update_role( $venue_term_id, $target_user_id, $role, $expected_version, $actor_user_id );
+	}
+
+	/** Revoke one membership without deleting its audit identity. */
+	public function revoke( int $actor_user_id, int $venue_term_id, int $target_user_id, int $expected_version ) {
+		$allowed = $this->authorization->authorize( $actor_user_id, $venue_term_id, VenueAuthorization::ACTION_MANAGE_MEMBERS );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		return $this->memberships->revoke( $venue_term_id, $target_user_id, $expected_version, $actor_user_id );
+	}
+
+	/** List memberships for one authorized venue. */
+	public function list( int $actor_user_id, int $venue_term_id, array $filters = array() ) {
+		$allowed = $this->authorization->authorize( $actor_user_id, $venue_term_id, VenueAuthorization::ACTION_MANAGE_MEMBERS );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		return $this->memberships->list_for_venue( $venue_term_id, $filters, $actor_user_id );
+	}
+}

--- a/phpunit-membership.xml.dist
+++ b/phpunit-membership.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+	beStrictAboutOutputDuringTests="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	failOnRisky="true"
+	failOnWarning="true">
+	<testsuites>
+		<testsuite name="venue-membership-authorization">
+			<file>tests/VenueMembershipAuthorizationTest.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -149,6 +149,7 @@ final class BookingWpdb {
 	public $last_error              = '';
 	public $rows                    = array();
 	public $schemas                 = array();
+	public $engines                 = array();
 	public $schema_omit             = array();
 	public $schema_queries          = 0;
 	public $dropped_indexes         = array();
@@ -156,6 +157,7 @@ final class BookingWpdb {
 	public $fail_activity_reads     = false;
 	public $fail_inserts            = false;
 	public $fail_updates            = false;
+	public $fail_engine_repair      = false;
 	public $race_activity_insert    = false;
 	public $race_activity_read_fail = false;
 	public $race_event_read_fail    = false;
@@ -183,6 +185,7 @@ final class BookingWpdb {
 		if ( ! preg_match( '/CREATE TABLE ([^\s(]+)/', $sql, $match ) ) {
 			return; }
 		$table                   = $match[1];
+		$this->engines[ $table ] = $this->engines[ $table ] ?? ( preg_match( '/ENGINE=([a-zA-Z0-9_]+)/', $sql, $engine ) ? $engine[1] : '' );
 		$this->schemas[ $table ] = $this->schemas[ $table ] ?? array(
 			'columns' => array(),
 			'indexes' => array(),
@@ -258,6 +261,10 @@ final class BookingWpdb {
 		unset( $output );
 		$this->last_query = $query;
 		$this->last_error = '';
+		if ( preg_match( "/SHOW TABLE STATUS WHERE Name = '([^']+)'/", $query, $match ) ) {
+			$table = stripslashes( $match[1] );
+			return isset( $this->engines[ $table ] ) ? array( 'Engine' => $this->engines[ $table ] ) : null;
+		}
 		$is_activity      = false !== strpos( $query, 'ec_booking_activity' );
 		if ( null !== $this->reads_before_failure ) {
 			if ( 0 === $this->reads_before_failure ) {
@@ -380,6 +387,14 @@ final class BookingWpdb {
 	public function query( $query ) {
 		$this->last_query = $query;
 		$this->last_error = '';
+		if ( preg_match( '/ALTER TABLE `([^`]+)` ENGINE=([a-zA-Z0-9_]+)/', $query, $engine ) ) {
+			if ( $this->fail_engine_repair ) {
+				$this->last_error = 'simulated engine conversion failure';
+				return false;
+			}
+			$this->engines[ $engine[1] ] = $engine[2];
+			return 1;
+		}
 		if ( preg_match( '/ALTER TABLE `([^`]+)` DROP (?:INDEX `([^`]+)`|PRIMARY KEY)/', $query, $drop ) ) {
 			$name = ! empty( $drop[2] ) ? $drop[2] : 'PRIMARY';
 			unset( $this->schemas[ $drop[1] ]['indexes'][ $name ] );
@@ -535,6 +550,7 @@ final class BookingFoundationTest extends TestCase {
 
 		$GLOBALS['wpdb']->prefix = 'wp_12_';
 		$this->assertSame( 'wp_12_ec_bookings', BookingSchema::bookings_table() );
+		$this->assertSame( 'wp_12_ec_venue_members', BookingSchema::memberships_table() );
 		$this->assertSame( 'booking_schema_table_missing', BookingSchema::health()->get_error_code() );
 	}
 
@@ -564,9 +580,11 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertTrue( BookingSchema::install() );
 		$bookings = 'wp_7_ec_bookings';
 		$activity = 'wp_7_ec_booking_activity';
+		$members  = 'wp_7_ec_venue_members';
 		$GLOBALS['wpdb']->schemas[ $bookings ]['indexes']['PRIMARY']['columns']             = array( 'id', 'public_id' );
 		$GLOBALS['wpdb']->schemas[ $bookings ]['indexes']['public_id']['unique']            = false;
 		$GLOBALS['wpdb']->schemas[ $activity ]['indexes']['booking_idempotency']['columns'] = array( 'idempotency_key' );
+		$GLOBALS['wpdb']->schemas[ $members ]['indexes']['venue_user']['unique']            = false;
 		$GLOBALS['wpdb']->schemas[ $activity ]['indexes']['operator_extra']                 = array(
 			'unique'  => false,
 			'columns' => array( 'created_at' ),
@@ -579,6 +597,7 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertSame( array( 'id' ), $GLOBALS['wpdb']->schemas[ $bookings ]['indexes']['PRIMARY']['columns'] );
 		$this->assertTrue( $GLOBALS['wpdb']->schemas[ $bookings ]['indexes']['public_id']['unique'] );
 		$this->assertSame( array( 'booking_id', 'idempotency_key' ), $GLOBALS['wpdb']->schemas[ $activity ]['indexes']['booking_idempotency']['columns'] );
+		$this->assertTrue( $GLOBALS['wpdb']->schemas[ $members ]['indexes']['venue_user']['unique'] );
 		$this->assertArrayHasKey( 'operator_extra', $GLOBALS['wpdb']->schemas[ $activity ]['indexes'] );
 		$this->assertSame(
 			array(
@@ -594,6 +613,10 @@ final class BookingFoundationTest extends TestCase {
 					'table' => $activity,
 					'index' => 'booking_idempotency',
 				),
+				array(
+					'table' => $members,
+					'index' => 'venue_user',
+				),
 			),
 			$GLOBALS['wpdb']->dropped_indexes
 		);
@@ -606,6 +629,22 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertTrue( BookingSchema::maybe_install() );
 		$this->assertSame( 0, $GLOBALS['wpdb']->schema_queries );
 		$this->assertSame( array(), $GLOBALS['ec_artist_test']['dbdelta'] );
+	}
+
+	public function test_membership_table_engine_is_repaired_before_version_stamp(): void {
+		$this->assertTrue( BookingSchema::install() );
+		$table = BookingSchema::memberships_table();
+		$GLOBALS['wpdb']->engines[ $table ] = 'MyISAM';
+		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '';
+		$this->assertTrue( BookingSchema::maybe_install() );
+		$this->assertSame( 'INNODB', strtoupper( $GLOBALS['wpdb']->engines[ $table ] ) );
+
+		$GLOBALS['wpdb']->engines[ $table ]                                  = 'MyISAM';
+		$GLOBALS['wpdb']->fail_engine_repair                                  = true;
+		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '';
+		$result = BookingSchema::maybe_install();
+		$this->assertSame( 'booking_schema_engine_repair_failed', $result->get_error_code() );
+		$this->assertSame( '', get_option( BookingSchema::VERSION_OPTION, '' ) );
 	}
 
 	public function test_missing_unique_index_and_schema_read_errors_remain_retryable(): void {

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -1,0 +1,504 @@
+<?php
+/**
+ * Venue membership and authorization tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Abilities\VenueMembershipAbilities;
+use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\VenueAuthorization;
+use ExtraChillEvents\Core\VenueMembershipRepository;
+use ExtraChillEvents\Core\VenueMembershipService;
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private $code;
+		private $message;
+		private $data;
+		public function __construct( $code, $message = '', $data = array() ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+		public function get_error_code() {
+			return $this->code; }
+		public function get_error_message() {
+			return $this->message; }
+		public function get_error_data() {
+			return $this->data; }
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error; }
+}
+if ( ! function_exists( '__' ) ) {
+	function __( $text ) {
+		return $text; }
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ) {
+		return abs( (int) $value ); }
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $value ) {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) ); }
+}
+if ( ! function_exists( 'get_term' ) ) {
+	function get_term( $term_id, $taxonomy = '' ) {
+		$term = $GLOBALS['venue_membership_test']['terms'][ $term_id ] ?? null;
+		return $term && ( '' === $taxonomy || $taxonomy === $term->taxonomy ) ? $term : null;
+	}
+}
+if ( ! function_exists( 'get_userdata' ) ) {
+	function get_userdata( $user_id ) {
+		return $GLOBALS['venue_membership_test']['users'][ $user_id ] ?? false;
+	}
+}
+if ( ! function_exists( 'user_can' ) ) {
+	function user_can( $user_id, $capability ) {
+		return 'manage_options' === $capability && ! empty( $GLOBALS['venue_membership_test']['administrators'][ $user_id ] );
+	}
+}
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id() {
+		return $GLOBALS['venue_membership_test']['current_user_id']; }
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback ) {
+		$GLOBALS['venue_membership_test']['actions'][ $hook ][] = $callback; }
+}
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( $name, $definition ) {
+		$GLOBALS['venue_membership_test']['abilities'][ $name ] = $definition; }
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $key, $default = false ) {
+		return $GLOBALS['venue_membership_test']['options'][ $key ] ?? $default; }
+}
+
+/** Minimal membership wpdb fake with transaction and optimistic update support. */
+final class VenueMembershipWpdb {
+	public $prefix      = 'wp_7_';
+	public $insert_id   = 0;
+	public $last_error  = '';
+	public $rows        = array();
+	public $race_insert = false;
+	public $after_start = null;
+	public $before_list = null;
+	private $snapshot   = null;
+
+	public function prepare( $query, ...$args ) {
+		if ( 1 === count( $args ) && is_array( $args[0] ) ) {
+			$args = $args[0];
+		}
+		$i = 0;
+		return preg_replace_callback(
+			'/%[ds]/',
+			static function ( $match ) use ( &$args, &$i ) {
+				$value = $args[ $i++ ];
+				return '%d' === $match[0] ? (string) (int) $value : "'" . addslashes( (string) $value ) . "'";
+			},
+			$query
+		);
+	}
+
+	public function insert( $table, $row ) {
+		$this->last_error = '';
+		foreach ( $this->rows[ $table ] ?? array() as $existing ) {
+			if ( (int) $existing['venue_term_id'] === (int) $row['venue_term_id'] && (int) $existing['user_id'] === (int) $row['user_id'] ) {
+				$this->last_error = 'duplicate venue user';
+				return false;
+			}
+		}
+		if ( $this->race_insert ) {
+			$this->race_insert = false;
+			$this->store( $table, array_merge( $row, array( 'role' => VenueAuthorization::ROLE_VIEWER ) ) );
+			$this->snapshot   = $this->rows;
+			$this->last_error = 'simulated concurrent duplicate';
+			return false;
+		}
+		$this->store( $table, $row );
+		return 1;
+	}
+
+	public function get_row( $query, $output = null ) {
+		unset( $output );
+		$this->last_error = '';
+		if ( ! preg_match( '/venue_term_id = (\d+) AND user_id = (\d+)/', $query, $match ) ) {
+			return null;
+		}
+		foreach ( $this->rows[ $this->prefix . 'ec_venue_members' ] ?? array() as $row ) {
+			if ( (int) $row['venue_term_id'] === (int) $match[1] && (int) $row['user_id'] === (int) $match[2] ) {
+				return $row;
+			}
+		}
+		return null;
+	}
+
+	public function get_results( $query, $output = null ) {
+		unset( $output );
+		$this->last_error = '';
+		if ( false !== strpos( $query, 'SELECT member.*' ) && is_callable( $this->before_list ) ) {
+			$callback          = $this->before_list;
+			$this->before_list = null;
+			$callback( $this );
+		}
+		$rows             = array_values( $this->rows[ $this->prefix . 'ec_venue_members' ] ?? array() );
+		if ( preg_match( '/AS actor .*actor.user_id = (\d+)/', $query, $actor ) ) {
+			$authorized = false;
+			preg_match( '/member\.venue_term_id = (\d+)/', $query, $requested_venue );
+			foreach ( $rows as $row ) {
+				if ( (int) $row['user_id'] === (int) $actor[1] && (int) $row['venue_term_id'] === (int) ( $requested_venue[1] ?? 0 ) && VenueAuthorization::ROLE_OWNER === $row['role'] && VenueAuthorization::STATUS_ACTIVE === $row['status'] ) {
+					$authorized = true;
+					break;
+				}
+			}
+			if ( ! $authorized ) {
+				return array();
+			}
+		}
+		if ( preg_match( '/venue_term_id = (\d+)/', $query, $match ) ) {
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $match ) {
+						return (int) $row['venue_term_id'] === (int) $match[1];
+					}
+				)
+			);
+		}
+		foreach ( array( 'role', 'status' ) as $field ) {
+			if ( preg_match( "/member\.{$field} = '([^']+)'/", $query, $match ) ) {
+				$rows = array_values(
+					array_filter(
+						$rows,
+						static function ( $row ) use ( $field, $match ) {
+							return $row[ $field ] === stripslashes( $match[1] );
+						}
+					)
+				);
+			}
+		}
+		usort(
+			$rows,
+			static function ( $a, $b ) {
+				return $a['id'] <=> $b['id'];
+			}
+		);
+		if ( preg_match( '/LIMIT (\d+) OFFSET (\d+)/', $query, $page ) ) {
+			$rows = array_slice( $rows, (int) $page[2], (int) $page[1] );
+		}
+		return $rows;
+	}
+
+	public function query( $query ) {
+		$this->last_error = '';
+		if ( 'START TRANSACTION' === $query ) {
+			$this->snapshot = $this->rows;
+			if ( is_callable( $this->after_start ) ) {
+				$callback          = $this->after_start;
+				$this->after_start = null;
+				$callback( $this );
+				$this->snapshot = $this->rows;
+			}
+			return 1;
+		}
+		if ( 'ROLLBACK' === $query ) {
+			$this->rows     = $this->snapshot;
+			$this->snapshot = null;
+			return 1;
+		}
+		if ( 'COMMIT' === $query ) {
+			$this->snapshot = null;
+			return 1;
+		}
+		if ( ! preg_match( '/WHERE venue_term_id = (\d+) AND user_id = (\d+) AND version = (\d+)/', $query, $match ) ) {
+			return false;
+		}
+		$table = $this->prefix . 'ec_venue_members';
+		foreach ( $this->rows[ $table ] ?? array() as $id => $row ) {
+			if ( (int) $row['venue_term_id'] !== (int) $match[1] || (int) $row['user_id'] !== (int) $match[2] || (int) $row['version'] !== (int) $match[3] ) {
+				continue;
+			}
+			$set = substr( $query, strpos( $query, ' SET ' ) + 5, strpos( $query, ' WHERE ' ) - strpos( $query, ' SET ' ) - 5 );
+			preg_match_all( "/([a-z_]+) = (version \\+ 1|'(?:\\\\.|[^'])*')(?=, [a-z_]+ = |$)/", $set, $assignments, PREG_SET_ORDER );
+			foreach ( $assignments as $assignment ) {
+				if ( 'version + 1' === $assignment[2] ) {
+					++$this->rows[ $table ][ $id ]['version'];
+				} else {
+					$this->rows[ $table ][ $id ][ $assignment[1] ] = stripslashes( substr( $assignment[2], 1, -1 ) );
+				}
+			}
+			return 1;
+		}
+		return 0;
+	}
+
+	private function store( $table, $row ): void {
+		$this->insert_id                          = count( $this->rows[ $table ] ?? array() ) + 1;
+		$row['id']                                = $this->insert_id;
+		$this->rows[ $table ][ $this->insert_id ] = $row;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/BookingSchema.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VenueAuthorization.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VenueMembershipRepository.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VenueMembershipService.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/VenueMembershipAbilities.php';
+
+final class VenueMembershipAuthorizationTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['venue_membership_test'] = array(
+			'terms'           => array(
+				55 => (object) array(
+					'term_id'  => 55,
+					'taxonomy' => 'venue',
+				),
+				56 => (object) array(
+					'term_id'  => 56,
+					'taxonomy' => 'venue',
+				),
+				57 => (object) array(
+					'term_id'  => 57,
+					'taxonomy' => 'artist',
+				),
+			),
+			'users'           => array(
+				1 => (object) array( 'ID' => 1 ),
+				2 => (object) array( 'ID' => 2 ),
+				3 => (object) array( 'ID' => 3 ),
+				4 => (object) array( 'ID' => 4 ),
+				5 => (object) array( 'ID' => 5 ),
+				6 => (object) array( 'ID' => 6 ),
+				7 => (object) array( 'ID' => 7 ),
+			),
+			'administrators'  => array( 1 => true ),
+			'current_user_id' => 1,
+			'actions'         => array(),
+			'abilities'       => array(),
+			'options'         => array( BookingSchema::VERSION_OPTION => BookingSchema::SCHEMA_VERSION ),
+		);
+		$GLOBALS['wpdb']                  = new VenueMembershipWpdb();
+	}
+
+	private function create_member( int $venue, int $user, string $role, string $status = VenueAuthorization::STATUS_ACTIVE, int $creator = 1 ) {
+		return ( new VenueMembershipRepository() )->create(
+			array(
+				'venue_term_id'      => $venue,
+				'user_id'            => $user,
+				'role'               => $role,
+				'status'             => $status,
+				'created_by_user_id' => $creator,
+			)
+		);
+	}
+
+	public function test_role_matrix_and_inactive_statuses_fail_closed(): void {
+		$authorization = new VenueAuthorization();
+		$expected      = array(
+			VenueAuthorization::ROLE_OWNER           => VenueAuthorization::actions(),
+			VenueAuthorization::ROLE_BOOKING_MANAGER => array( 'view_bookings', 'manage_inquiries', 'manage_holds', 'send_communication' ),
+			VenueAuthorization::ROLE_MARKETING       => array( 'view_bookings', 'manage_marketing' ),
+			VenueAuthorization::ROLE_FINANCE         => array( 'view_bookings', 'view_sales', 'finalize_settlements' ),
+			VenueAuthorization::ROLE_VIEWER          => array( 'view_bookings' ),
+		);
+
+		$user = 2;
+		foreach ( $expected as $role => $allowed ) {
+			$this->create_member( 55, $user, $role );
+			foreach ( VenueAuthorization::actions() as $action ) {
+				$this->assertSame( in_array( $action, $allowed, true ), $authorization->can( $user, 55, $action ), "{$role}:{$action}" );
+			}
+			++$user;
+		}
+
+		foreach ( array( VenueAuthorization::STATUS_INVITED, VenueAuthorization::STATUS_REVOKED ) as $status ) {
+			$this->create_member( 56, $user, VenueAuthorization::ROLE_OWNER, $status );
+			foreach ( VenueAuthorization::actions() as $action ) {
+				$this->assertFalse( $authorization->can( $user, 56, $action ), "{$status}:{$action}" );
+			}
+			++$user;
+		}
+	}
+
+	public function test_administrator_override_validates_venue_and_cross_venue_access_is_denied(): void {
+		$authorization = new VenueAuthorization();
+		$this->assertTrue( $authorization->can( 1, 55, VenueAuthorization::ACTION_MANAGE_MEMBERS ) );
+		$this->assertSame( 'invalid_venue_membership_venue', $authorization->authorize( 1, 999, VenueAuthorization::ACTION_MANAGE_MEMBERS )->get_error_code() );
+		$this->assertSame( 'invalid_venue_membership_venue', $authorization->authorize( 1, 57, VenueAuthorization::ACTION_MANAGE_MEMBERS )->get_error_code() );
+
+		$this->create_member( 55, 2, VenueAuthorization::ROLE_OWNER );
+		$this->assertTrue( $authorization->can( 2, 55, VenueAuthorization::ACTION_MANAGE_MEMBERS ) );
+		$this->assertFalse( $authorization->can( 2, 56, VenueAuthorization::ACTION_MANAGE_MEMBERS ) );
+	}
+
+	public function test_admin_bootstraps_owner_and_only_owner_can_manage_exact_venue(): void {
+		$service = new VenueMembershipService();
+		$owner   = $service->create( 1, 55, 2, VenueAuthorization::ROLE_OWNER );
+		$this->assertSame( VenueAuthorization::ROLE_OWNER, $owner['role'] );
+		$this->assertSame( 1, $owner['created_by_user_id'] );
+
+		$manager = $service->create( 2, 55, 3, VenueAuthorization::ROLE_BOOKING_MANAGER );
+		$this->assertSame( VenueAuthorization::ROLE_BOOKING_MANAGER, $manager['role'] );
+		$this->assertSame( 'venue_action_forbidden', $service->create( 3, 55, 4, VenueAuthorization::ROLE_VIEWER )->get_error_code() );
+		$this->assertSame( 'venue_action_forbidden', $service->create( 2, 56, 4, VenueAuthorization::ROLE_VIEWER )->get_error_code() );
+		$this->assertSame( 'venue_action_forbidden', $service->create( 4, 56, 4, VenueAuthorization::ROLE_OWNER )->get_error_code() );
+	}
+
+	public function test_unique_relationship_and_concurrent_create_conflicts_are_explicit(): void {
+		$repository = new VenueMembershipRepository();
+		$first      = $this->create_member( 55, 2, VenueAuthorization::ROLE_OWNER );
+		$duplicate  = $this->create_member( 55, 2, VenueAuthorization::ROLE_VIEWER );
+		$this->assertSame( 'venue_membership_exists', $duplicate->get_error_code() );
+		$this->assertSame( $first['version'], $duplicate->get_error_data()['current_version'] );
+
+		$same_user_other_venue = $this->create_member( 56, 2, VenueAuthorization::ROLE_VIEWER );
+		$this->assertSame( 56, $same_user_other_venue['venue_term_id'] );
+
+		$GLOBALS['wpdb']->race_insert = true;
+		$race                         = $repository->create(
+			array(
+				'venue_term_id'      => 55,
+				'user_id'            => 3,
+				'role'               => VenueAuthorization::ROLE_MARKETING,
+				'created_by_user_id' => 1,
+			)
+		);
+		$this->assertSame( 'venue_membership_exists', $race->get_error_code() );
+		$this->assertSame( VenueAuthorization::ROLE_VIEWER, $repository->get( 55, 3 )['role'] );
+	}
+
+	public function test_optimistic_updates_and_last_owner_invariant(): void {
+		$repository = new VenueMembershipRepository();
+		$owner      = $this->create_member( 55, 2, VenueAuthorization::ROLE_OWNER );
+		$this->assertSame( 'venue_membership_last_owner', $repository->update_role( 55, 2, VenueAuthorization::ROLE_VIEWER, $owner['version'], 1 )->get_error_code() );
+		$this->assertSame( 'venue_membership_last_owner', $repository->revoke( 55, 2, $owner['version'], 1 )->get_error_code() );
+
+		$second = $this->create_member( 55, 3, VenueAuthorization::ROLE_OWNER );
+		$viewer = $repository->update_role( 55, 2, VenueAuthorization::ROLE_VIEWER, $owner['version'], 1 );
+		$this->assertSame( VenueAuthorization::ROLE_VIEWER, $viewer['role'] );
+		$this->assertSame( 2, $viewer['version'] );
+		$this->assertSame( 'venue_membership_version_conflict', $repository->update_role( 55, 2, VenueAuthorization::ROLE_FINANCE, 1, 1 )->get_error_code() );
+
+		$this->create_member( 55, 4, VenueAuthorization::ROLE_OWNER );
+		$revoked = $repository->revoke( 55, 3, $second['version'], 1 );
+		$this->assertSame( VenueAuthorization::STATUS_REVOKED, $revoked['status'] );
+		$this->assertNotNull( $revoked['revoked_at'] );
+		$this->assertFalse( ( new VenueAuthorization( $repository ) )->can( 3, 55, VenueAuthorization::ACTION_VIEW_BOOKINGS ) );
+	}
+
+	public function test_actor_authority_is_rechecked_under_the_venue_lock(): void {
+		$service = new VenueMembershipService();
+		$owner   = $service->create( 1, 55, 2, VenueAuthorization::ROLE_OWNER );
+		$this->assertSame( VenueAuthorization::STATUS_ACTIVE, $owner['status'] );
+
+		$GLOBALS['wpdb']->after_start = static function ( VenueMembershipWpdb $wpdb ): void {
+			foreach ( $wpdb->rows['wp_7_ec_venue_members'] as &$row ) {
+				if ( 2 === (int) $row['user_id'] ) {
+					$row['status'] = VenueAuthorization::STATUS_REVOKED;
+				}
+			}
+			unset( $row );
+		};
+
+		$result = $service->create( 2, 55, 3, VenueAuthorization::ROLE_VIEWER );
+		$this->assertSame( 'venue_action_forbidden', $result->get_error_code() );
+		$this->assertSame( VenueAuthorization::STATUS_REVOKED, ( new VenueMembershipRepository() )->get( 55, 2 )['status'] );
+		$this->assertNull( ( new VenueMembershipRepository() )->get( 55, 3 ) );
+	}
+
+	public function test_authorization_fails_closed_until_schema_is_ready(): void {
+		unset( $GLOBALS['venue_membership_test']['options'][ BookingSchema::VERSION_OPTION ] );
+		$result = ( new VenueAuthorization() )->authorize( 1, 55, VenueAuthorization::ACTION_MANAGE_MEMBERS );
+		$this->assertSame( 'venue_membership_schema_unavailable', $result->get_error_code() );
+		$this->assertSame( 503, $result->get_error_data()['status'] );
+	}
+
+	public function test_member_listing_rechecks_actor_in_the_same_query(): void {
+		$service = new VenueMembershipService();
+		$service->create( 1, 55, 2, VenueAuthorization::ROLE_OWNER );
+		$service->create( 2, 55, 3, VenueAuthorization::ROLE_VIEWER );
+
+		$GLOBALS['wpdb']->before_list = static function ( VenueMembershipWpdb $wpdb ): void {
+			foreach ( $wpdb->rows['wp_7_ec_venue_members'] as &$row ) {
+				if ( 2 === (int) $row['user_id'] ) {
+					$row['status'] = VenueAuthorization::STATUS_REVOKED;
+				}
+			}
+			unset( $row );
+		};
+
+		$this->assertSame( array(), $service->list( 2, 55 ) );
+	}
+
+	public function test_list_filters_and_corrupt_rows_fail_closed(): void {
+		$repository = new VenueMembershipRepository();
+		$this->create_member( 55, 2, VenueAuthorization::ROLE_OWNER );
+		$this->create_member( 55, 3, VenueAuthorization::ROLE_MARKETING );
+		$this->create_member( 55, 4, VenueAuthorization::ROLE_VIEWER, VenueAuthorization::STATUS_INVITED );
+		$this->create_member( 56, 5, VenueAuthorization::ROLE_OWNER );
+
+		$this->assertCount( 3, $repository->list_for_venue( 55 ) );
+		$this->assertCount( 2, $repository->list_for_venue( 55, array( 'status' => VenueAuthorization::STATUS_ACTIVE ) ) );
+		$this->assertSame( 3, $repository->list_for_venue( 55, array( 'role' => VenueAuthorization::ROLE_MARKETING ) )[0]['user_id'] );
+
+		$row         = $repository->get( 55, 2 );
+		$row['role'] = 'super_owner';
+		$this->assertSame( 'venue_membership_corrupt_role', $repository->hydrate( $row )->get_error_code() );
+		$row['role']   = VenueAuthorization::ROLE_OWNER;
+		$row['status'] = 'paused';
+		$this->assertSame( 'venue_membership_corrupt_status', $repository->hydrate( $row )->get_error_code() );
+	}
+
+	public function test_abilities_share_authorization_and_execution_rechecks_it(): void {
+		$this->create_member( 55, 2, VenueAuthorization::ROLE_OWNER );
+		$GLOBALS['venue_membership_test']['current_user_id'] = 2;
+		$abilities = new VenueMembershipAbilities();
+		$abilities->register();
+
+		$this->assertSame(
+			array(
+				'extrachill/create-venue-membership',
+				'extrachill/update-venue-membership',
+				'extrachill/revoke-venue-membership',
+				'extrachill/list-venue-memberships',
+			),
+			array_keys( $GLOBALS['venue_membership_test']['abilities'] )
+		);
+		foreach ( $GLOBALS['venue_membership_test']['abilities'] as $definition ) {
+			$this->assertSame( 'extrachill-events', $definition['category'] );
+			$this->assertTrue( $definition['meta']['show_in_rest'] );
+			$this->assertTrue( call_user_func( $definition['permission_callback'], array( 'venue_term_id' => 55 ) ) );
+			$this->assertSame( 'venue_action_forbidden', call_user_func( $definition['permission_callback'], array( 'venue_term_id' => 56 ) )->get_error_code() );
+		}
+		$this->assertTrue( $GLOBALS['venue_membership_test']['abilities']['extrachill/update-venue-membership']['meta']['annotations']['destructive'] );
+
+		$created = call_user_func(
+			$GLOBALS['venue_membership_test']['abilities']['extrachill/create-venue-membership']['execute_callback'],
+			array(
+				'venue_term_id' => 55,
+				'user_id'       => 3,
+				'role'          => VenueAuthorization::ROLE_VIEWER,
+			)
+		);
+		$this->assertSame( 3, $created['user_id'] );
+
+		$GLOBALS['venue_membership_test']['current_user_id'] = 3;
+		$denied = call_user_func(
+			$GLOBALS['venue_membership_test']['abilities']['extrachill/create-venue-membership']['execute_callback'],
+			array(
+				'venue_term_id' => 55,
+				'user_id'       => 4,
+				'role'          => VenueAuthorization::ROLE_VIEWER,
+			)
+		);
+		$this->assertSame( 'venue_action_forbidden', $denied->get_error_code() );
+	}
+}


### PR DESCRIPTION
## Summary

- add the site-scoped `ec_venue_members` relationship with verified InnoDB storage, unique venue/user identity, optimistic versions, and fail-closed schema readiness
- add an explicit Events-owned role/action matrix with active-only membership, administrator bootstrap, cross-venue isolation, atomic actor reauthorization, and final-owner protection
- expose create, update, revoke, and list abilities backed by the same canonical service and document the authorization contract

## Verification

- `vendor/bin/phpunit -c phpunit-membership.xml.dist` (10 tests, 112 assertions)
- `vendor/bin/phpunit -c phpunit-booking.xml.dist` (22 tests, 116 assertions)
- `npm run build`
- WordPress runtime registration of all four ability schemas
- Homeboy PR audit: 0 introduced findings
- Homeboy scoped lint: PHPCS, ESLint, and PHPStan passed
- independent final code review: no blocking findings

## Known test infrastructure

- Homeboy's Codebox test stage could not start because the shared WordPress 7.0.2 Playground archive lock timed out twice; no tests executed in that stage.
- The repository's broader local default suite retains unrelated existing shared-state/dependency-fixture failures. The isolated booking and membership suites above pass.

Closes #291