### PR TITLE
fix: use scoped capabilities for venue access

### DIFF
--- a/docs/venue-booking-authorization.md
+++ b/docs/venue-booking-authorization.md
@@ -1,45 +1,44 @@
 # Venue Booking Authorization
 
 Venue booking authority belongs to Extra Chill Events. Network user identity
-continues to belong to Extra Chill Users, while venue identity remains the
-Events-site `venue` taxonomy term.
+and WordPress capabilities continue to belong to Extra Chill Users, while venue
+identity remains the Events-site `venue` taxonomy term.
 
-Memberships are stored in the site-scoped `ec_venue_members` table. A network
-user may belong to multiple venues, but authority never crosses venue IDs.
+## Authorization
 
-## Roles
+Venue authorization composes two existing platform concepts:
 
-| Action | owner | booking_manager | marketing | finance | viewer |
-|---|---:|---:|---:|---:|---:|
-| `view_bookings` | Yes | Yes | Yes | Yes | Yes |
-| `manage_inquiries` | Yes | Yes | No | No | No |
-| `manage_holds` | Yes | Yes | No | No | No |
-| `send_communication` | Yes | Yes | No | No | No |
-| `manage_marketing` | Yes | No | Yes | No | No |
-| `view_sales` | Yes | No | No | Yes | No |
-| `finalize_settlements` | Yes | No | No | Yes | No |
-| `manage_members` | Yes | No | No | No | No |
+1. WordPress answers whether the user may operate the feature. The
+   `extra_chill_team` role grants `access_events_admin`, and
+   `ec_feature_available( 'venue_booking' )` keeps the initial rollout on the
+   `team` rung.
+2. Extra Chill Events answers which venue the user may operate through an
+   active row in the site-scoped `ec_venue_members` table.
 
-Only `active` memberships authorize actions. `invited` and `revoked` rows
+Both checks must pass. A team member without a venue relationship cannot access
+that venue, and a venue relationship does not grant the WordPress capability.
+Administrators retain an explicit `manage_options` bootstrap override without
+receiving synthetic membership rows.
+
+Membership has no operational role taxonomy. An active member may access the
+venue booking feature. The structural `is_owner` flag only determines whether
+that member may administer venue membership. Product permissions must not be
+predicted before real workflow demonstrates a need.
+
+Only `active` memberships authorize access. `invited` and `revoked` rows
 authorize nothing. Invitation acceptance and first-owner claim verification
-are separate work; issue #291 permits only an administrator to bootstrap an
-unowned venue.
-
-Administrators receive an explicit capability-based override without a
-synthetic membership row. Global Extra Chill team status and artist membership
-do not imply venue authority.
+remain separate work; an administrator may bootstrap an unowned venue.
 
 The final active owner cannot be demoted or revoked. Owner-removing mutations
-lock all memberships for the venue before checking this invariant.
-Every membership write also rechecks the actor's owner or administrator
-authority while those rows are locked, preventing a revoked owner from
-finishing an operation authorized before revocation.
+lock all memberships for the venue before checking this invariant. Every
+membership write also rechecks the actor's WordPress capability, rollout access,
+and active owner relationship while those rows are locked.
 
-Membership abilities are not registered until schema version 2 has been fully
-verified. Internal authorization also fails closed with a service-unavailable
-error if invoked before readiness. Installation verifies the membership table
-uses InnoDB because row locks and transactions are part of the authorization
-contract.
+Membership abilities are not registered until schema version 3 has been fully
+verified. Installation migrates the unreleased role column to `is_owner`,
+preserving only rows that were previously marked `owner`, and then removes the
+obsolete column. Installation also verifies InnoDB because row locks and
+transactions are part of the authorization contract.
 
 ## Abilities
 
@@ -48,8 +47,8 @@ contract.
 - `extrachill/revoke-venue-membership`
 - `extrachill/list-venue-memberships`
 
-Every ability uses the same `manage_members` authorization service in its
-permission callback and rechecks authorization during execution. Create adds
-an existing network user as active. Update changes only the bounded role.
+Every ability uses the same owner/administrator authorization service in its
+permission callback and rechecks authorization during execution. Create adds an
+existing network user as active. Update changes only structural ownership.
 Revoke preserves the row and records its revoked timestamp. Update and revoke
 require the caller's `expected_version`.

--- a/docs/venue-booking-authorization.md
+++ b/docs/venue-booking-authorization.md
@@ -17,8 +17,10 @@ Venue authorization composes two existing platform concepts:
 
 Both checks must pass. A team member without a venue relationship cannot access
 that venue, and a venue relationship does not grant the WordPress capability.
-Administrators retain an explicit `manage_options` bootstrap override without
-receiving synthetic membership rows.
+Administrators retain an explicit `manage_options` override only for membership
+administration so they can bootstrap an owner without receiving a synthetic
+row. Ordinary venue operations still require the feature gate and an active
+membership for the exact venue.
 
 Membership has no operational role taxonomy. An active member may access the
 venue booking feature. The structural `is_owner` flag only determines whether

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -190,6 +190,7 @@ class ExtraChillEvents {
 	}
 
 	private function init_hooks() {
+		add_filter( 'ec_feature_ceilings', array( $this, 'register_feature_ceilings' ) );
 		add_action( 'init', array( $this, 'load_textdomain' ) );
 		add_action( 'init', array( $this, 'init_data_machine_handlers' ), 20 );
 		add_action( 'init', array( $this, 'init_abilities' ), 25 );
@@ -203,6 +204,12 @@ class ExtraChillEvents {
 		}
 		register_activation_hook( __FILE__, array( $this, 'activate' ) );
 		register_deactivation_hook( __FILE__, array( $this, 'deactivate' ) );
+	}
+
+	/** Keep venue booking tools on the established internal-team rollout rung. */
+	public function register_feature_ceilings( array $ceilings ): array {
+		$ceilings[ \ExtraChillEvents\Core\VenueAuthorization::FEATURE ] = 'team';
+		return $ceilings;
 	}
 
 	public function load_textdomain() {

--- a/inc/Abilities/VenueMembershipAbilities.php
+++ b/inc/Abilities/VenueMembershipAbilities.php
@@ -48,9 +48,9 @@ class VenueMembershipAbilities {
 				'description' => __( 'Network user ID.', 'extrachill-events' ),
 			),
 		);
-		$role_schema     = array(
-			'type' => 'string',
-			'enum' => VenueAuthorization::roles(),
+		$owner_schema    = array(
+			'type'        => 'boolean',
+			'description' => __( 'Whether the member may administer venue membership.', 'extrachill-events' ),
 		);
 		$version_schema  = array(
 			'type'    => 'integer',
@@ -61,8 +61,8 @@ class VenueMembershipAbilities {
 			'extrachill/create-venue-membership',
 			__( 'Create Venue Membership', 'extrachill-events' ),
 			__( 'Add an existing network user to a venue.', 'extrachill-events' ),
-			array_merge( $base_properties, array( 'role' => $role_schema ) ),
-			array( 'venue_term_id', 'user_id', 'role' ),
+			array_merge( $base_properties, array( 'is_owner' => $owner_schema ) ),
+			array( 'venue_term_id', 'user_id', 'is_owner' ),
 			array( $this, 'create_membership' ),
 			false,
 			false,
@@ -72,15 +72,15 @@ class VenueMembershipAbilities {
 		$this->register_ability(
 			'extrachill/update-venue-membership',
 			__( 'Update Venue Membership', 'extrachill-events' ),
-			__( 'Change a venue member role at an expected version.', 'extrachill-events' ),
+			__( 'Change structural venue ownership at an expected version.', 'extrachill-events' ),
 			array_merge(
 				$base_properties,
 				array(
-					'role'             => $role_schema,
+					'is_owner'         => $owner_schema,
 					'expected_version' => $version_schema,
 				)
 			),
-			array( 'venue_term_id', 'user_id', 'role', 'expected_version' ),
+			array( 'venue_term_id', 'user_id', 'is_owner', 'expected_version' ),
 			array( $this, 'update_membership' ),
 			false,
 			false,
@@ -105,10 +105,7 @@ class VenueMembershipAbilities {
 			__( 'List members for one authorized venue.', 'extrachill-events' ),
 			array(
 				'venue_term_id' => $base_properties['venue_term_id'],
-				'role'          => array(
-					'type' => 'string',
-					'enum' => VenueAuthorization::roles(),
-				),
+				'is_owner'      => $owner_schema,
 				'status'        => array(
 					'type' => 'string',
 					'enum' => VenueAuthorization::statuses(),
@@ -147,15 +144,15 @@ class VenueMembershipAbilities {
 	}
 
 	public function create_membership( array $input ) {
-		return $this->service->create( get_current_user_id(), absint( $input['venue_term_id'] ?? 0 ), absint( $input['user_id'] ?? 0 ), (string) ( $input['role'] ?? '' ) );
+		return $this->service->create( get_current_user_id(), absint( $input['venue_term_id'] ?? 0 ), absint( $input['user_id'] ?? 0 ), (bool) ( $input['is_owner'] ?? false ) );
 	}
 
 	public function update_membership( array $input ) {
-		return $this->service->update_role(
+		return $this->service->update_owner(
 			get_current_user_id(),
 			absint( $input['venue_term_id'] ?? 0 ),
 			absint( $input['user_id'] ?? 0 ),
-			(string) ( $input['role'] ?? '' ),
+			(bool) ( $input['is_owner'] ?? false ),
 			absint( $input['expected_version'] ?? 0 )
 		);
 	}
@@ -210,10 +207,7 @@ class VenueMembershipAbilities {
 				'id'                 => array( 'type' => 'integer' ),
 				'venue_term_id'      => array( 'type' => 'integer' ),
 				'user_id'            => array( 'type' => 'integer' ),
-				'role'               => array(
-					'type' => 'string',
-					'enum' => VenueAuthorization::roles(),
-				),
+				'is_owner'           => array( 'type' => 'boolean' ),
 				'status'             => array(
 					'type' => 'string',
 					'enum' => VenueAuthorization::statuses(),

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Owns and verifies the site-scoped private booking schema. */
 class BookingSchema {
 
-	public const SCHEMA_VERSION = '2';
+	public const SCHEMA_VERSION = '3';
 	public const VERSION_OPTION = 'extrachill_events_booking_schema_version';
 	public const FAILURE_OPTION = 'extrachill_events_booking_schema_error';
 
@@ -106,7 +106,7 @@ class BookingSchema {
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 			venue_term_id BIGINT UNSIGNED NOT NULL,
 			user_id BIGINT UNSIGNED NOT NULL,
-			role VARCHAR(32) NOT NULL,
+			is_owner TINYINT UNSIGNED NOT NULL DEFAULT '0',
 			status VARCHAR(20) NOT NULL DEFAULT 'active',
 			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
 			created_by_user_id BIGINT UNSIGNED NOT NULL,
@@ -116,7 +116,7 @@ class BookingSchema {
 			PRIMARY KEY (id),
 			UNIQUE KEY venue_user (venue_term_id, user_id),
 			KEY user_status_venue (user_id, status, venue_term_id),
-			KEY venue_status_role (venue_term_id, status, role)
+			KEY venue_status_owner (venue_term_id, status, is_owner)
 		) ENGINE=InnoDB {$charset};";
 
 		$repair = self::drop_conflicting_indexes();
@@ -144,6 +144,12 @@ class BookingSchema {
 			);
 			self::record_failure( $error );
 			return $error;
+		}
+
+		$membership_migration = self::migrate_membership_authority();
+		if ( is_wp_error( $membership_migration ) ) {
+			self::record_failure( $membership_migration );
+			return $membership_migration;
 		}
 
 		$engine_repair = self::repair_storage_engines();
@@ -353,6 +359,49 @@ class BookingSchema {
 		return true;
 	}
 
+	/** Collapse the unreleased speculative role matrix into structural ownership. */
+	private static function migrate_membership_authority() {
+		global $wpdb;
+
+		$table   = self::memberships_table();
+		$columns = $wpdb->get_results( "SHOW COLUMNS FROM `{$table}`", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private schema migration.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return self::database_error( __( 'Could not inspect venue membership authority.', 'extrachill-events' ), $table );
+		}
+		$column_names = array_column( (array) $columns, 'Field' );
+		if ( ! in_array( 'role', $column_names, true ) ) {
+			return true;
+		}
+
+		$result = $wpdb->query( "UPDATE `{$table}` SET is_owner = IF(role = 'owner', 1, 0)" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- One-time migration from the unreleased role matrix.
+		if ( false === $result ) {
+			$remaining_columns = $wpdb->get_results( "SHOW COLUMNS FROM `{$table}`", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Distinguishes a concurrent completed migration from a real failure.
+			if ( '' !== (string) $wpdb->last_error || in_array( 'role', array_column( (array) $remaining_columns, 'Field' ), true ) ) {
+				return self::database_error( __( 'Could not migrate venue membership ownership.', 'extrachill-events' ), $table );
+			}
+			return true;
+		}
+
+		$indexes = self::normalize_indexes( (array) $wpdb->get_results( "SHOW INDEX FROM `{$table}`", ARRAY_A ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private schema migration.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return self::database_error( __( 'Could not inspect venue membership indexes.', 'extrachill-events' ), $table );
+		}
+		if ( isset( $indexes['venue_status_role'] ) && false === $wpdb->query( "ALTER TABLE `{$table}` DROP INDEX `venue_status_role`" ) ) { // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Removes the obsolete private index.
+			$current_indexes = self::normalize_indexes( (array) $wpdb->get_results( "SHOW INDEX FROM `{$table}`", ARRAY_A ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Distinguishes concurrent removal from a real failure.
+			if ( '' !== (string) $wpdb->last_error || isset( $current_indexes['venue_status_role'] ) ) {
+				return self::database_error( __( 'Could not remove the obsolete venue membership index.', 'extrachill-events' ), $table );
+			}
+		}
+		if ( false === $wpdb->query( "ALTER TABLE `{$table}` DROP COLUMN `role`" ) ) { // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Removes an unreleased speculative field after preserving structural ownership.
+			$current_columns = $wpdb->get_results( "SHOW COLUMNS FROM `{$table}`", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Distinguishes concurrent removal from a real failure.
+			if ( '' !== (string) $wpdb->last_error || in_array( 'role', array_column( (array) $current_columns, 'Field' ), true ) ) {
+				return self::database_error( __( 'Could not remove obsolete venue membership roles.', 'extrachill-events' ), $table );
+			}
+		}
+
+		return true;
+	}
+
 	/** Return the final initial schema contract shared by health and repair. */
 	private static function contracts(): array {
 		$required = static function ( string $type, bool $nullable, array $attributes = array() ): array {
@@ -472,7 +521,7 @@ class BookingSchema {
 					'id'                 => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
 					'venue_term_id'      => $required( 'bigint unsigned', false ),
 					'user_id'            => $required( 'bigint unsigned', false ),
-					'role'               => $required( 'varchar(32)', false ),
+					'is_owner'           => $required( 'tinyint unsigned', false, array( 'default' => '0' ) ),
 					'status'             => $required( 'varchar(20)', false, array( 'default' => 'active' ) ),
 					'version'            => $required( 'bigint unsigned', false, array( 'default' => '1' ) ),
 					'created_by_user_id' => $required( 'bigint unsigned', false ),
@@ -481,21 +530,21 @@ class BookingSchema {
 					'revoked_at'         => $required( 'datetime', true ),
 				),
 				'indexes' => array(
-					'PRIMARY'           => array(
+					'PRIMARY'            => array(
 						'unique'  => true,
 						'columns' => array( 'id' ),
 					),
-					'venue_user'        => array(
+					'venue_user'         => array(
 						'unique'  => true,
 						'columns' => array( 'venue_term_id', 'user_id' ),
 					),
-					'user_status_venue' => array(
+					'user_status_venue'  => array(
 						'unique'  => false,
 						'columns' => array( 'user_id', 'status', 'venue_term_id' ),
 					),
-					'venue_status_role' => array(
+					'venue_status_owner' => array(
 						'unique'  => false,
-						'columns' => array( 'venue_term_id', 'status', 'role' ),
+						'columns' => array( 'venue_term_id', 'status', 'is_owner' ),
 					),
 				),
 			),
@@ -504,7 +553,7 @@ class BookingSchema {
 
 	/** Normalize one SHOW COLUMNS row to the declared contract shape. */
 	private static function normalize_column( array $column ): array {
-		$type = preg_replace( '/\((?:8|11|20)\)(?=\s+unsigned)/', '', strtolower( trim( (string) ( $column['Type'] ?? '' ) ) ) );
+		$type = preg_replace( '/\(\d+\)(?=\s+unsigned)/', '', strtolower( trim( (string) ( $column['Type'] ?? '' ) ) ) );
 		return array(
 			'type'     => preg_replace( '/\s+/', ' ', $type ),
 			'nullable' => 'YES' === strtoupper( (string) ( $column['Null'] ?? '' ) ),

--- a/inc/Core/VenueAuthorization.php
+++ b/inc/Core/VenueAuthorization.php
@@ -71,7 +71,7 @@ class VenueAuthorization {
 			return $this->denied();
 		}
 
-		if ( $this->is_administrator( $user_id ) ) {
+		if ( self::ACTION_MANAGE_MEMBERS === $action && $this->is_administrator( $user_id ) ) {
 			return true;
 		}
 		if ( ! $this->has_feature_access( $user_id ) ) {

--- a/inc/Core/VenueAuthorization.php
+++ b/inc/Core/VenueAuthorization.php
@@ -11,27 +11,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/** Applies the bounded venue booking role matrix. */
+/** Composes WordPress feature access with an exact venue relationship. */
 class VenueAuthorization {
-
-	public const ROLE_OWNER           = 'owner';
-	public const ROLE_BOOKING_MANAGER = 'booking_manager';
-	public const ROLE_MARKETING       = 'marketing';
-	public const ROLE_FINANCE         = 'finance';
-	public const ROLE_VIEWER          = 'viewer';
 
 	public const STATUS_ACTIVE  = 'active';
 	public const STATUS_INVITED = 'invited';
 	public const STATUS_REVOKED = 'revoked';
 
-	public const ACTION_VIEW_BOOKINGS        = 'view_bookings';
-	public const ACTION_MANAGE_INQUIRIES     = 'manage_inquiries';
-	public const ACTION_MANAGE_HOLDS         = 'manage_holds';
-	public const ACTION_SEND_COMMUNICATION   = 'send_communication';
-	public const ACTION_MANAGE_MARKETING     = 'manage_marketing';
-	public const ACTION_VIEW_SALES           = 'view_sales';
-	public const ACTION_FINALIZE_SETTLEMENTS = 'finalize_settlements';
-	public const ACTION_MANAGE_MEMBERS       = 'manage_members';
+	public const ACTION_ACCESS_VENUE   = 'access_venue';
+	public const ACTION_MANAGE_MEMBERS = 'manage_members';
+
+	public const ACCESS_CAPABILITY = 'access_events_admin';
+	public const FEATURE           = 'venue_booking';
 
 	/** @var VenueMembershipRepository */
 	private $memberships;
@@ -40,23 +31,14 @@ class VenueAuthorization {
 		$this->memberships = $memberships ? $memberships : new VenueMembershipRepository();
 	}
 
-	/** Return every supported venue role. */
-	public static function roles(): array {
-		return array_keys( self::matrix() );
-	}
-
 	/** Return every supported membership status. */
 	public static function statuses(): array {
 		return array( self::STATUS_ACTIVE, self::STATUS_INVITED, self::STATUS_REVOKED );
 	}
 
-	/** Return every supported booking-domain action. */
+	/** Return only the concrete authorization checks currently implemented. */
 	public static function actions(): array {
-		$actions = array();
-		foreach ( self::matrix() as $allowed ) {
-			$actions = array_merge( $actions, $allowed );
-		}
-		return array_values( array_unique( $actions ) );
+		return array( self::ACTION_ACCESS_VENUE, self::ACTION_MANAGE_MEMBERS );
 	}
 
 	/** Authorize one network user for one action at one Events-site venue. */
@@ -92,12 +74,18 @@ class VenueAuthorization {
 		if ( $this->is_administrator( $user_id ) ) {
 			return true;
 		}
+		if ( ! $this->has_feature_access( $user_id ) ) {
+			return $this->denied();
+		}
 
 		$membership = $this->active_membership( $user_id, $venue_term_id );
 		if ( is_wp_error( $membership ) ) {
 			return $membership;
 		}
-		if ( ! is_array( $membership ) || ! $this->role_allows( $membership['role'], $action ) ) {
+		if ( ! is_array( $membership ) ) {
+			return $this->denied();
+		}
+		if ( self::ACTION_MANAGE_MEMBERS === $action && ! $membership['is_owner'] ) {
 			return $this->denied();
 		}
 
@@ -114,47 +102,17 @@ class VenueAuthorization {
 		return $this->memberships->get_active( $venue_term_id, $user_id );
 	}
 
-	/** Check one role/action pair against the explicit domain matrix. */
-	public function role_allows( string $role, string $action ): bool {
-		$matrix = self::matrix();
-		return isset( $matrix[ $role ] ) && in_array( $action, $matrix[ $role ], true );
-	}
-
 	/** Administrators override venue membership without receiving synthetic rows. */
 	public function is_administrator( int $user_id ): bool {
 		return $user_id > 0 && user_can( $user_id, 'manage_options' );
 	}
 
-	/** Return the explicit role/action policy. */
-	private static function matrix(): array {
-		return array(
-			self::ROLE_OWNER           => array(
-				self::ACTION_VIEW_BOOKINGS,
-				self::ACTION_MANAGE_INQUIRIES,
-				self::ACTION_MANAGE_HOLDS,
-				self::ACTION_SEND_COMMUNICATION,
-				self::ACTION_MANAGE_MARKETING,
-				self::ACTION_VIEW_SALES,
-				self::ACTION_FINALIZE_SETTLEMENTS,
-				self::ACTION_MANAGE_MEMBERS,
-			),
-			self::ROLE_BOOKING_MANAGER => array(
-				self::ACTION_VIEW_BOOKINGS,
-				self::ACTION_MANAGE_INQUIRIES,
-				self::ACTION_MANAGE_HOLDS,
-				self::ACTION_SEND_COMMUNICATION,
-			),
-			self::ROLE_MARKETING       => array(
-				self::ACTION_VIEW_BOOKINGS,
-				self::ACTION_MANAGE_MARKETING,
-			),
-			self::ROLE_FINANCE         => array(
-				self::ACTION_VIEW_BOOKINGS,
-				self::ACTION_VIEW_SALES,
-				self::ACTION_FINALIZE_SETTLEMENTS,
-			),
-			self::ROLE_VIEWER          => array( self::ACTION_VIEW_BOOKINGS ),
-		);
+	/** Check the established WordPress capability and rollout primitives. */
+	public function has_feature_access( int $user_id ): bool {
+		if ( $user_id < 1 || ! user_can( $user_id, self::ACCESS_CAPABILITY ) ) {
+			return false;
+		}
+		return function_exists( 'ec_feature_available' ) && ec_feature_available( self::FEATURE, $user_id );
 	}
 
 	/** Build a non-enumerating authorization denial. */

--- a/inc/Core/VenueMembershipRepository.php
+++ b/inc/Core/VenueMembershipRepository.php
@@ -35,11 +35,8 @@ class VenueMembershipRepository {
 			return new \WP_Error( 'invalid_venue_membership_user', __( 'Venue memberships require existing network users.', 'extrachill-events' ) );
 		}
 
-		$role   = sanitize_key( (string) ( $data['role'] ?? '' ) );
-		$status = sanitize_key( (string) ( $data['status'] ?? VenueAuthorization::STATUS_ACTIVE ) );
-		if ( ! in_array( $role, VenueAuthorization::roles(), true ) ) {
-			return new \WP_Error( 'invalid_venue_membership_role', __( 'The venue membership role is not supported.', 'extrachill-events' ) );
-		}
+		$is_owner = ! empty( $data['is_owner'] );
+		$status   = sanitize_key( (string) ( $data['status'] ?? VenueAuthorization::STATUS_ACTIVE ) );
 		if ( ! in_array( $status, VenueAuthorization::statuses(), true ) ) {
 			return new \WP_Error( 'invalid_venue_membership_status', __( 'The venue membership status is not supported.', 'extrachill-events' ) );
 		}
@@ -48,7 +45,7 @@ class VenueMembershipRepository {
 		$row   = array(
 			'venue_term_id'      => $venue_term_id,
 			'user_id'            => $user_id,
-			'role'               => $role,
+			'is_owner'           => $is_owner ? 1 : 0,
 			'status'             => $status,
 			'version'            => 1,
 			'created_by_user_id' => $creator_id,
@@ -75,11 +72,19 @@ class VenueMembershipRepository {
 			$this->rollback();
 			return $this->forbidden();
 		}
+		$has_active_owner = false;
 		foreach ( $memberships as $existing ) {
 			if ( $existing['user_id'] === $user_id ) {
 				$this->rollback();
 				return $this->conflict( $existing );
 			}
+			if ( $existing['is_owner'] && VenueAuthorization::STATUS_ACTIVE === $existing['status'] ) {
+				$has_active_owner = true;
+			}
+		}
+		if ( VenueAuthorization::STATUS_ACTIVE === $status && ! $is_owner && ! $has_active_owner ) {
+			$this->rollback();
+			return new \WP_Error( 'venue_membership_owner_required', __( 'The first active venue member must be an owner.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private operational table write.
@@ -138,20 +143,20 @@ class VenueMembershipRepository {
 		$where      = array( 'member.venue_term_id = %d' );
 		$values     = array( $venue_term_id );
 		if ( $actor_user_id > 0 && ! user_can( $actor_user_id, 'manage_options' ) ) {
-			$table_from .= " INNER JOIN {$table} AS actor ON actor.venue_term_id = member.venue_term_id AND actor.user_id = %d AND actor.role = 'owner' AND actor.status = 'active'";
+			$table_from .= " INNER JOIN {$table} AS actor ON actor.venue_term_id = member.venue_term_id AND actor.user_id = %d AND actor.is_owner = 1 AND actor.status = 'active'";
 			array_unshift( $values, $actor_user_id );
 		}
-		foreach ( array( 'role', 'status' ) as $field ) {
-			if ( empty( $filters[ $field ] ) ) {
-				continue;
+		if ( array_key_exists( 'is_owner', $filters ) ) {
+			$where[]  = 'member.is_owner = %d';
+			$values[] = $filters['is_owner'] ? 1 : 0;
+		}
+		if ( ! empty( $filters['status'] ) ) {
+			$status = sanitize_key( (string) $filters['status'] );
+			if ( ! in_array( $status, VenueAuthorization::statuses(), true ) ) {
+				return new \WP_Error( 'invalid_venue_membership_status', __( 'The venue membership filter is not supported.', 'extrachill-events' ) );
 			}
-			$allowed = 'role' === $field ? VenueAuthorization::roles() : VenueAuthorization::statuses();
-			$value   = sanitize_key( (string) $filters[ $field ] );
-			if ( ! in_array( $value, $allowed, true ) ) {
-				return new \WP_Error( "invalid_venue_membership_{$field}", __( 'The venue membership filter is not supported.', 'extrachill-events' ) );
-			}
-			$where[]  = "member.{$field} = %s";
-			$values[] = $value;
+			$where[]  = 'member.status = %s';
+			$values[] = $status;
 		}
 
 		$limit    = max( 1, min( 100, absint( $filters['limit'] ?? 50 ) ) );
@@ -175,13 +180,9 @@ class VenueMembershipRepository {
 		return $memberships;
 	}
 
-	/** Change one role at an expected version while preserving an active owner. */
-	public function update_role( int $venue_term_id, int $user_id, string $role, int $expected_version, int $actor_user_id ) {
-		$role = sanitize_key( $role );
-		if ( ! in_array( $role, VenueAuthorization::roles(), true ) ) {
-			return new \WP_Error( 'invalid_venue_membership_role', __( 'The venue membership role is not supported.', 'extrachill-events' ) );
-		}
-		return $this->mutate( $venue_term_id, $user_id, $expected_version, $role, null, $actor_user_id );
+	/** Change structural ownership at an expected version. */
+	public function update_owner( int $venue_term_id, int $user_id, bool $is_owner, int $expected_version, int $actor_user_id ) {
+		return $this->mutate( $venue_term_id, $user_id, $expected_version, $is_owner, null, $actor_user_id );
 	}
 
 	/** Revoke one relationship at an expected version while preserving an active owner. */
@@ -189,23 +190,24 @@ class VenueMembershipRepository {
 		return $this->mutate( $venue_term_id, $user_id, $expected_version, null, VenueAuthorization::STATUS_REVOKED, $actor_user_id );
 	}
 
-	/** Hydrate scalar fields and fail closed on corrupt role/status values. */
+	/** Hydrate scalar fields and fail closed on corrupt status values. */
 	public function hydrate( array $row ) {
-		if ( ! in_array( $row['role'] ?? '', VenueAuthorization::roles(), true ) ) {
-			return new \WP_Error( 'venue_membership_corrupt_role', __( 'The stored venue membership role is invalid.', 'extrachill-events' ) );
-		}
 		if ( ! in_array( $row['status'] ?? '', VenueAuthorization::statuses(), true ) ) {
 			return new \WP_Error( 'venue_membership_corrupt_status', __( 'The stored venue membership status is invalid.', 'extrachill-events' ) );
+		}
+		if ( ! in_array( $row['is_owner'] ?? null, array( 0, 1, '0', '1' ), true ) ) {
+			return new \WP_Error( 'venue_membership_corrupt_owner', __( 'The stored venue membership ownership value is invalid.', 'extrachill-events' ) );
 		}
 		foreach ( array( 'id', 'venue_term_id', 'user_id', 'version', 'created_by_user_id' ) as $field ) {
 			$row[ $field ] = (int) $row[ $field ];
 		}
+		$row['is_owner']   = (bool) (int) ( $row['is_owner'] ?? 0 );
 		$row['revoked_at'] = empty( $row['revoked_at'] ) ? null : (string) $row['revoked_at'];
 		return $row;
 	}
 
 	/** Execute one serialized membership mutation. */
-	private function mutate( int $venue_term_id, int $user_id, int $expected_version, ?string $role, ?string $status, int $actor_user_id ) {
+	private function mutate( int $venue_term_id, int $user_id, int $expected_version, ?bool $is_owner, ?string $status, int $actor_user_id ) {
 		global $wpdb;
 
 		if ( $venue_term_id < 1 || $user_id < 1 || $expected_version < 1 || $actor_user_id < 1 ) {
@@ -235,7 +237,7 @@ class VenueMembershipRepository {
 			if ( $membership['user_id'] === $user_id ) {
 				$current = $membership;
 			}
-			if ( VenueAuthorization::ROLE_OWNER === $membership['role'] && VenueAuthorization::STATUS_ACTIVE === $membership['status'] ) {
+			if ( $membership['is_owner'] && VenueAuthorization::STATUS_ACTIVE === $membership['status'] ) {
 				++$active_owner;
 			}
 		}
@@ -253,9 +255,9 @@ class VenueMembershipRepository {
 			return $this->version_conflict( $current );
 		}
 
-		$removes_owner = VenueAuthorization::ROLE_OWNER === $current['role']
+		$removes_owner = $current['is_owner']
 			&& VenueAuthorization::STATUS_ACTIVE === $current['status']
-			&& ( ( null !== $role && VenueAuthorization::ROLE_OWNER !== $role ) || VenueAuthorization::STATUS_REVOKED === $status );
+			&& ( false === $is_owner || VenueAuthorization::STATUS_REVOKED === $status );
 		if ( $removes_owner && $active_owner < 2 ) {
 			$this->rollback();
 			return new \WP_Error( 'venue_membership_last_owner', __( 'The final active venue owner cannot be removed.', 'extrachill-events' ), array( 'status' => 409 ) );
@@ -263,9 +265,9 @@ class VenueMembershipRepository {
 
 		$set    = array( 'version = version + 1', 'updated_at = %s' );
 		$values = array( gmdate( 'Y-m-d H:i:s' ) );
-		if ( null !== $role ) {
-			$set[]    = 'role = %s';
-			$values[] = $role;
+		if ( null !== $is_owner ) {
+			$set[]    = 'is_owner = %d';
+			$values[] = $is_owner ? 1 : 0;
 		}
 		if ( null !== $status ) {
 			$set[]    = 'status = %s';
@@ -314,8 +316,14 @@ class VenueMembershipRepository {
 		if ( user_can( $actor_user_id, 'manage_options' ) ) {
 			return true;
 		}
+		if ( ! user_can( $actor_user_id, VenueAuthorization::ACCESS_CAPABILITY ) ) {
+			return false;
+		}
+		if ( ! function_exists( 'ec_feature_available' ) || ! ec_feature_available( VenueAuthorization::FEATURE, $actor_user_id ) ) {
+			return false;
+		}
 		foreach ( $memberships as $membership ) {
-			if ( $membership['user_id'] === $actor_user_id && VenueAuthorization::ROLE_OWNER === $membership['role'] && VenueAuthorization::STATUS_ACTIVE === $membership['status'] ) {
+			if ( $membership['user_id'] === $actor_user_id && $membership['is_owner'] && VenueAuthorization::STATUS_ACTIVE === $membership['status'] ) {
 				return true;
 			}
 		}

--- a/inc/Core/VenueMembershipService.php
+++ b/inc/Core/VenueMembershipService.php
@@ -26,7 +26,7 @@ class VenueMembershipService {
 	}
 
 	/** Add an active membership for an existing network user. */
-	public function create( int $actor_user_id, int $venue_term_id, int $target_user_id, string $role ) {
+	public function create( int $actor_user_id, int $venue_term_id, int $target_user_id, bool $is_owner ) {
 		$allowed = $this->authorization->authorize( $actor_user_id, $venue_term_id, VenueAuthorization::ACTION_MANAGE_MEMBERS );
 		if ( is_wp_error( $allowed ) ) {
 			return $allowed;
@@ -35,20 +35,20 @@ class VenueMembershipService {
 			array(
 				'venue_term_id'      => $venue_term_id,
 				'user_id'            => $target_user_id,
-				'role'               => $role,
+				'is_owner'           => $is_owner,
 				'status'             => VenueAuthorization::STATUS_ACTIVE,
 				'created_by_user_id' => $actor_user_id,
 			)
 		);
 	}
 
-	/** Change one membership role. */
-	public function update_role( int $actor_user_id, int $venue_term_id, int $target_user_id, string $role, int $expected_version ) {
+	/** Change structural membership ownership. */
+	public function update_owner( int $actor_user_id, int $venue_term_id, int $target_user_id, bool $is_owner, int $expected_version ) {
 		$allowed = $this->authorization->authorize( $actor_user_id, $venue_term_id, VenueAuthorization::ACTION_MANAGE_MEMBERS );
 		if ( is_wp_error( $allowed ) ) {
 			return $allowed;
 		}
-		return $this->memberships->update_role( $venue_term_id, $target_user_id, $role, $expected_version, $actor_user_id );
+		return $this->memberships->update_owner( $venue_term_id, $target_user_id, $is_owner, $expected_version, $actor_user_id );
 	}
 
 	/** Revoke one membership without deleting its audit identity. */

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -144,25 +144,26 @@ if ( ! function_exists( 'delete_option' ) ) {
 
 /** Stateful wpdb fake that enforces the persistence contracts under test. */
 final class BookingWpdb {
-	public $prefix                  = 'wp_7_';
-	public $insert_id               = 0;
-	public $last_error              = '';
-	public $rows                    = array();
-	public $schemas                 = array();
-	public $engines                 = array();
-	public $schema_omit             = array();
-	public $schema_queries          = 0;
-	public $dropped_indexes         = array();
-	public $fail_reads              = false;
-	public $fail_activity_reads     = false;
-	public $fail_inserts            = false;
-	public $fail_updates            = false;
-	public $fail_engine_repair      = false;
-	public $race_activity_insert    = false;
-	public $race_activity_read_fail = false;
-	public $race_event_read_fail    = false;
-	public $reads_before_failure    = null;
-	public $last_query              = '';
+	public $prefix                    = 'wp_7_';
+	public $insert_id                 = 0;
+	public $last_error                = '';
+	public $rows                      = array();
+	public $schemas                   = array();
+	public $engines                   = array();
+	public $schema_omit               = array();
+	public $schema_queries            = 0;
+	public $dropped_indexes           = array();
+	public $fail_reads                = false;
+	public $fail_activity_reads       = false;
+	public $fail_inserts              = false;
+	public $fail_updates              = false;
+	public $fail_engine_repair        = false;
+	public $race_activity_insert      = false;
+	public $race_activity_read_fail   = false;
+	public $race_event_read_fail      = false;
+	public $concurrent_role_migration = false;
+	public $reads_before_failure      = null;
+	public $last_query                = '';
 
 	public function get_charset_collate() {
 		return 'DEFAULT CHARACTER SET utf8mb4'; }
@@ -265,7 +266,7 @@ final class BookingWpdb {
 			$table = stripslashes( $match[1] );
 			return isset( $this->engines[ $table ] ) ? array( 'Engine' => $this->engines[ $table ] ) : null;
 		}
-		$is_activity      = false !== strpos( $query, 'ec_booking_activity' );
+		$is_activity = false !== strpos( $query, 'ec_booking_activity' );
 		if ( null !== $this->reads_before_failure ) {
 			if ( 0 === $this->reads_before_failure ) {
 				$this->last_error = 'simulated delayed row read failure';
@@ -387,12 +388,38 @@ final class BookingWpdb {
 	public function query( $query ) {
 		$this->last_query = $query;
 		$this->last_error = '';
+		if ( preg_match( "/UPDATE `([^`]+)` SET is_owner = IF\(role = 'owner', 1, 0\)/", $query, $migration ) ) {
+			$this->rows[ $migration[1] ] = $this->rows[ $migration[1] ] ?? array();
+			foreach ( $this->rows[ $migration[1] ] as &$row ) {
+				$row['is_owner'] = 'owner' === ( $row['role'] ?? '' ) ? 1 : 0;
+				if ( $this->concurrent_role_migration ) {
+					unset( $row['role'] );
+				}
+			}
+			unset( $row );
+			if ( $this->concurrent_role_migration ) {
+				$this->concurrent_role_migration = false;
+				unset( $this->schemas[ $migration[1] ]['columns']['role'], $this->schemas[ $migration[1] ]['indexes']['venue_status_role'] );
+				$this->last_error = 'simulated concurrent migration';
+				return false;
+			}
+			return 1;
+		}
 		if ( preg_match( '/ALTER TABLE `([^`]+)` ENGINE=([a-zA-Z0-9_]+)/', $query, $engine ) ) {
 			if ( $this->fail_engine_repair ) {
 				$this->last_error = 'simulated engine conversion failure';
 				return false;
 			}
 			$this->engines[ $engine[1] ] = $engine[2];
+			return 1;
+		}
+		if ( preg_match( '/ALTER TABLE `([^`]+)` DROP COLUMN `([^`]+)`/', $query, $drop_column ) ) {
+			unset( $this->schemas[ $drop_column[1] ]['columns'][ $drop_column[2] ] );
+			$this->rows[ $drop_column[1] ] = $this->rows[ $drop_column[1] ] ?? array();
+			foreach ( $this->rows[ $drop_column[1] ] as &$row ) {
+				unset( $row[ $drop_column[2] ] );
+			}
+			unset( $row );
 			return 1;
 		}
 		if ( preg_match( '/ALTER TABLE `([^`]+)` DROP (?:INDEX `([^`]+)`|PRIMARY KEY)/', $query, $drop ) ) {
@@ -529,6 +556,8 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertTrue( BookingSchema::install() );
 		$this->assertSame( BookingSchema::SCHEMA_VERSION, get_option( BookingSchema::VERSION_OPTION ) );
 		$this->assertTrue( BookingSchema::health() );
+		$this->assertArrayHasKey( 'is_owner', $GLOBALS['wpdb']->schemas['wp_7_ec_venue_members']['columns'] );
+		$this->assertArrayNotHasKey( 'role', $GLOBALS['wpdb']->schemas['wp_7_ec_venue_members']['columns'] );
 
 		$columns                   =& $GLOBALS['wpdb']->schemas['wp_7_ec_bookings']['columns'];
 		$columns['status']['Type'] = 'text';
@@ -552,6 +581,68 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertSame( 'wp_12_ec_bookings', BookingSchema::bookings_table() );
 		$this->assertSame( 'wp_12_ec_venue_members', BookingSchema::memberships_table() );
 		$this->assertSame( 'booking_schema_table_missing', BookingSchema::health()->get_error_code() );
+	}
+
+	public function test_role_schema_migrates_only_structural_ownership(): void {
+		$this->assertTrue( BookingSchema::install() );
+		$table = BookingSchema::memberships_table();
+		$GLOBALS['wpdb']->schemas[ $table ]['columns']['role']                 = array(
+			'Type'    => 'varchar(32)',
+			'Null'    => 'NO',
+			'Default' => null,
+			'Extra'   => '',
+		);
+		$GLOBALS['wpdb']->schemas[ $table ]['indexes']['venue_status_role']    = array(
+			'unique'  => false,
+			'columns' => array( 'venue_term_id', 'status', 'role' ),
+		);
+		$GLOBALS['wpdb']->rows[ $table ]                                       = array(
+			1 => array(
+				'role'     => 'owner',
+				'is_owner' => 0,
+			),
+			2 => array(
+				'role'     => 'marketing',
+				'is_owner' => 1,
+			),
+		);
+		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '2';
+
+		$this->assertTrue( BookingSchema::maybe_install() );
+		$this->assertSame( 1, $GLOBALS['wpdb']->rows[ $table ][1]['is_owner'] );
+		$this->assertSame( 0, $GLOBALS['wpdb']->rows[ $table ][2]['is_owner'] );
+		$this->assertArrayNotHasKey( 'role', $GLOBALS['wpdb']->rows[ $table ][1] );
+		$this->assertArrayNotHasKey( 'role', $GLOBALS['wpdb']->schemas[ $table ]['columns'] );
+		$this->assertArrayNotHasKey( 'venue_status_role', $GLOBALS['wpdb']->schemas[ $table ]['indexes'] );
+		$this->assertSame( BookingSchema::SCHEMA_VERSION, get_option( BookingSchema::VERSION_OPTION ) );
+	}
+
+	public function test_concurrent_completed_role_migration_is_treated_as_success(): void {
+		$this->assertTrue( BookingSchema::install() );
+		$table = BookingSchema::memberships_table();
+		$GLOBALS['wpdb']->schemas[ $table ]['columns']['role']                 = array(
+			'Type'    => 'varchar(32)',
+			'Null'    => 'NO',
+			'Default' => null,
+			'Extra'   => '',
+		);
+		$GLOBALS['wpdb']->schemas[ $table ]['indexes']['venue_status_role']    = array(
+			'unique'  => false,
+			'columns' => array( 'venue_term_id', 'status', 'role' ),
+		);
+		$GLOBALS['wpdb']->rows[ $table ]                                       = array(
+			1 => array(
+				'role'     => 'owner',
+				'is_owner' => 0,
+			),
+		);
+		$GLOBALS['wpdb']->concurrent_role_migration                            = true;
+		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '2';
+
+		$this->assertTrue( BookingSchema::maybe_install() );
+		$this->assertSame( 1, $GLOBALS['wpdb']->rows[ $table ][1]['is_owner'] );
+		$this->assertSame( BookingSchema::SCHEMA_VERSION, get_option( BookingSchema::VERSION_OPTION ) );
+		$this->assertFalse( get_option( BookingSchema::FAILURE_OPTION, false ) );
 	}
 
 	public function test_unrepairable_column_attributes_are_not_stamped(): void {
@@ -633,14 +724,14 @@ final class BookingFoundationTest extends TestCase {
 
 	public function test_membership_table_engine_is_repaired_before_version_stamp(): void {
 		$this->assertTrue( BookingSchema::install() );
-		$table = BookingSchema::memberships_table();
+		$table                              = BookingSchema::memberships_table();
 		$GLOBALS['wpdb']->engines[ $table ] = 'MyISAM';
 		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '';
 		$this->assertTrue( BookingSchema::maybe_install() );
 		$this->assertSame( 'INNODB', strtoupper( $GLOBALS['wpdb']->engines[ $table ] ) );
 
-		$GLOBALS['wpdb']->engines[ $table ]                                  = 'MyISAM';
-		$GLOBALS['wpdb']->fail_engine_repair                                  = true;
+		$GLOBALS['wpdb']->engines[ $table ]                                    = 'MyISAM';
+		$GLOBALS['wpdb']->fail_engine_repair                                   = true;
 		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '';
 		$result = BookingSchema::maybe_install();
 		$this->assertSame( 'booking_schema_engine_repair_failed', $result->get_error_code() );

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -353,6 +353,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 	public function test_administrator_override_validates_venue_and_cross_venue_access_is_denied(): void {
 		$authorization = new VenueAuthorization();
 		$this->assertTrue( $authorization->can( 1, 55, VenueAuthorization::ACTION_MANAGE_MEMBERS ) );
+		$this->assertFalse( $authorization->can( 1, 55, VenueAuthorization::ACTION_ACCESS_VENUE ) );
 		$this->assertSame( 'invalid_venue_membership_venue', $authorization->authorize( 1, 999, VenueAuthorization::ACTION_MANAGE_MEMBERS )->get_error_code() );
 		$this->assertSame( 'invalid_venue_membership_venue', $authorization->authorize( 1, 57, VenueAuthorization::ACTION_MANAGE_MEMBERS )->get_error_code() );
 

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -62,7 +62,16 @@ if ( ! function_exists( 'get_userdata' ) ) {
 }
 if ( ! function_exists( 'user_can' ) ) {
 	function user_can( $user_id, $capability ) {
-		return 'manage_options' === $capability && ! empty( $GLOBALS['venue_membership_test']['administrators'][ $user_id ] );
+		if ( 'manage_options' === $capability ) {
+			return ! empty( $GLOBALS['venue_membership_test']['administrators'][ $user_id ] );
+		}
+		return VenueAuthorization::ACCESS_CAPABILITY === $capability && ! empty( $GLOBALS['venue_membership_test']['team_access'][ $user_id ] );
+	}
+}
+if ( ! function_exists( 'ec_feature_available' ) ) {
+	function ec_feature_available( $feature, $user_id = null ) {
+		unset( $user_id );
+		return VenueAuthorization::FEATURE === $feature && ! empty( $GLOBALS['venue_membership_test']['feature_available'] );
 	}
 }
 if ( ! function_exists( 'get_current_user_id' ) ) {
@@ -118,7 +127,7 @@ final class VenueMembershipWpdb {
 		}
 		if ( $this->race_insert ) {
 			$this->race_insert = false;
-			$this->store( $table, array_merge( $row, array( 'role' => VenueAuthorization::ROLE_VIEWER ) ) );
+			$this->store( $table, array_merge( $row, array( 'is_owner' => 0 ) ) );
 			$this->snapshot   = $this->rows;
 			$this->last_error = 'simulated concurrent duplicate';
 			return false;
@@ -149,12 +158,12 @@ final class VenueMembershipWpdb {
 			$this->before_list = null;
 			$callback( $this );
 		}
-		$rows             = array_values( $this->rows[ $this->prefix . 'ec_venue_members' ] ?? array() );
+		$rows = array_values( $this->rows[ $this->prefix . 'ec_venue_members' ] ?? array() );
 		if ( preg_match( '/AS actor .*actor.user_id = (\d+)/', $query, $actor ) ) {
 			$authorized = false;
 			preg_match( '/member\.venue_term_id = (\d+)/', $query, $requested_venue );
 			foreach ( $rows as $row ) {
-				if ( (int) $row['user_id'] === (int) $actor[1] && (int) $row['venue_term_id'] === (int) ( $requested_venue[1] ?? 0 ) && VenueAuthorization::ROLE_OWNER === $row['role'] && VenueAuthorization::STATUS_ACTIVE === $row['status'] ) {
+				if ( (int) $row['user_id'] === (int) $actor[1] && (int) $row['venue_term_id'] === (int) ( $requested_venue[1] ?? 0 ) && ! empty( $row['is_owner'] ) && VenueAuthorization::STATUS_ACTIVE === $row['status'] ) {
 					$authorized = true;
 					break;
 				}
@@ -173,7 +182,7 @@ final class VenueMembershipWpdb {
 				)
 			);
 		}
-		foreach ( array( 'role', 'status' ) as $field ) {
+		foreach ( array( 'status' ) as $field ) {
 			if ( preg_match( "/member\.{$field} = '([^']+)'/", $query, $match ) ) {
 				$rows = array_values(
 					array_filter(
@@ -184,6 +193,16 @@ final class VenueMembershipWpdb {
 					)
 				);
 			}
+		}
+		if ( preg_match( '/member\.is_owner = ([01])/', $query, $owner_match ) ) {
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $owner_match ) {
+						return (int) $row['is_owner'] === (int) $owner_match[1];
+					}
+				)
+			);
 		}
 		usort(
 			$rows,
@@ -227,12 +246,14 @@ final class VenueMembershipWpdb {
 				continue;
 			}
 			$set = substr( $query, strpos( $query, ' SET ' ) + 5, strpos( $query, ' WHERE ' ) - strpos( $query, ' SET ' ) - 5 );
-			preg_match_all( "/([a-z_]+) = (version \\+ 1|'(?:\\\\.|[^'])*')(?=, [a-z_]+ = |$)/", $set, $assignments, PREG_SET_ORDER );
+			preg_match_all( "/([a-z_]+) = (version \\+ 1|[01]|'(?:\\\\.|[^'])*')(?=, [a-z_]+ = |$)/", $set, $assignments, PREG_SET_ORDER );
 			foreach ( $assignments as $assignment ) {
 				if ( 'version + 1' === $assignment[2] ) {
 					++$this->rows[ $table ][ $id ]['version'];
-				} else {
+				} elseif ( "'" === $assignment[2][0] ) {
 					$this->rows[ $table ][ $id ][ $assignment[1] ] = stripslashes( substr( $assignment[2], 1, -1 ) );
+				} else {
+					$this->rows[ $table ][ $id ][ $assignment[1] ] = (int) $assignment[2];
 				}
 			}
 			return 1;
@@ -256,7 +277,7 @@ require_once dirname( __DIR__ ) . '/inc/Abilities/VenueMembershipAbilities.php';
 final class VenueMembershipAuthorizationTest extends TestCase {
 	protected function setUp(): void {
 		$GLOBALS['venue_membership_test'] = array(
-			'terms'           => array(
+			'terms'             => array(
 				55 => (object) array(
 					'term_id'  => 55,
 					'taxonomy' => 'venue',
@@ -270,7 +291,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 					'taxonomy' => 'artist',
 				),
 			),
-			'users'           => array(
+			'users'             => array(
 				1 => (object) array( 'ID' => 1 ),
 				2 => (object) array( 'ID' => 2 ),
 				3 => (object) array( 'ID' => 3 ),
@@ -279,53 +300,54 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 				6 => (object) array( 'ID' => 6 ),
 				7 => (object) array( 'ID' => 7 ),
 			),
-			'administrators'  => array( 1 => true ),
-			'current_user_id' => 1,
-			'actions'         => array(),
-			'abilities'       => array(),
-			'options'         => array( BookingSchema::VERSION_OPTION => BookingSchema::SCHEMA_VERSION ),
+			'administrators'    => array( 1 => true ),
+			'team_access'       => array(
+				2 => true,
+				3 => true,
+				4 => true,
+				5 => true,
+				6 => true,
+				7 => true,
+			),
+			'feature_available' => true,
+			'current_user_id'   => 1,
+			'actions'           => array(),
+			'abilities'         => array(),
+			'options'           => array( BookingSchema::VERSION_OPTION => BookingSchema::SCHEMA_VERSION ),
 		);
 		$GLOBALS['wpdb']                  = new VenueMembershipWpdb();
 	}
 
-	private function create_member( int $venue, int $user, string $role, string $status = VenueAuthorization::STATUS_ACTIVE, int $creator = 1 ) {
+	private function create_member( int $venue, int $user, bool $is_owner, string $status = VenueAuthorization::STATUS_ACTIVE, int $creator = 1 ) {
 		return ( new VenueMembershipRepository() )->create(
 			array(
 				'venue_term_id'      => $venue,
 				'user_id'            => $user,
-				'role'               => $role,
+				'is_owner'           => $is_owner,
 				'status'             => $status,
 				'created_by_user_id' => $creator,
 			)
 		);
 	}
 
-	public function test_role_matrix_and_inactive_statuses_fail_closed(): void {
+	public function test_capability_scope_and_inactive_statuses_fail_closed(): void {
 		$authorization = new VenueAuthorization();
-		$expected      = array(
-			VenueAuthorization::ROLE_OWNER           => VenueAuthorization::actions(),
-			VenueAuthorization::ROLE_BOOKING_MANAGER => array( 'view_bookings', 'manage_inquiries', 'manage_holds', 'send_communication' ),
-			VenueAuthorization::ROLE_MARKETING       => array( 'view_bookings', 'manage_marketing' ),
-			VenueAuthorization::ROLE_FINANCE         => array( 'view_bookings', 'view_sales', 'finalize_settlements' ),
-			VenueAuthorization::ROLE_VIEWER          => array( 'view_bookings' ),
-		);
+		$this->create_member( 55, 3, true );
+		$this->create_member( 55, 2, false );
+		$this->create_member( 56, 4, true, VenueAuthorization::STATUS_INVITED );
+		$this->create_member( 56, 5, true, VenueAuthorization::STATUS_REVOKED );
+		$this->create_member( 56, 6, true );
 
-		$user = 2;
-		foreach ( $expected as $role => $allowed ) {
-			$this->create_member( 55, $user, $role );
-			foreach ( VenueAuthorization::actions() as $action ) {
-				$this->assertSame( in_array( $action, $allowed, true ), $authorization->can( $user, 55, $action ), "{$role}:{$action}" );
-			}
-			++$user;
-		}
+		$this->assertTrue( $authorization->can( 2, 55, VenueAuthorization::ACTION_ACCESS_VENUE ) );
+		$this->assertFalse( $authorization->can( 2, 55, VenueAuthorization::ACTION_MANAGE_MEMBERS ) );
+		$this->assertTrue( $authorization->can( 3, 55, VenueAuthorization::ACTION_MANAGE_MEMBERS ) );
+		$this->assertFalse( $authorization->can( 4, 56, VenueAuthorization::ACTION_ACCESS_VENUE ) );
+		$this->assertFalse( $authorization->can( 5, 56, VenueAuthorization::ACTION_ACCESS_VENUE ) );
 
-		foreach ( array( VenueAuthorization::STATUS_INVITED, VenueAuthorization::STATUS_REVOKED ) as $status ) {
-			$this->create_member( 56, $user, VenueAuthorization::ROLE_OWNER, $status );
-			foreach ( VenueAuthorization::actions() as $action ) {
-				$this->assertFalse( $authorization->can( $user, 56, $action ), "{$status}:{$action}" );
-			}
-			++$user;
-		}
+		unset( $GLOBALS['venue_membership_test']['team_access'][6] );
+		$this->assertFalse( $authorization->can( 6, 56, VenueAuthorization::ACTION_ACCESS_VENUE ) );
+		$GLOBALS['venue_membership_test']['feature_available'] = false;
+		$this->assertFalse( $authorization->can( 3, 55, VenueAuthorization::ACTION_ACCESS_VENUE ) );
 	}
 
 	public function test_administrator_override_validates_venue_and_cross_venue_access_is_denied(): void {
@@ -334,32 +356,33 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->assertSame( 'invalid_venue_membership_venue', $authorization->authorize( 1, 999, VenueAuthorization::ACTION_MANAGE_MEMBERS )->get_error_code() );
 		$this->assertSame( 'invalid_venue_membership_venue', $authorization->authorize( 1, 57, VenueAuthorization::ACTION_MANAGE_MEMBERS )->get_error_code() );
 
-		$this->create_member( 55, 2, VenueAuthorization::ROLE_OWNER );
+		$this->create_member( 55, 2, true );
 		$this->assertTrue( $authorization->can( 2, 55, VenueAuthorization::ACTION_MANAGE_MEMBERS ) );
 		$this->assertFalse( $authorization->can( 2, 56, VenueAuthorization::ACTION_MANAGE_MEMBERS ) );
 	}
 
 	public function test_admin_bootstraps_owner_and_only_owner_can_manage_exact_venue(): void {
 		$service = new VenueMembershipService();
-		$owner   = $service->create( 1, 55, 2, VenueAuthorization::ROLE_OWNER );
-		$this->assertSame( VenueAuthorization::ROLE_OWNER, $owner['role'] );
+		$this->assertSame( 'venue_membership_owner_required', $service->create( 1, 55, 3, false )->get_error_code() );
+		$owner = $service->create( 1, 55, 2, true );
+		$this->assertTrue( $owner['is_owner'] );
 		$this->assertSame( 1, $owner['created_by_user_id'] );
 
-		$manager = $service->create( 2, 55, 3, VenueAuthorization::ROLE_BOOKING_MANAGER );
-		$this->assertSame( VenueAuthorization::ROLE_BOOKING_MANAGER, $manager['role'] );
-		$this->assertSame( 'venue_action_forbidden', $service->create( 3, 55, 4, VenueAuthorization::ROLE_VIEWER )->get_error_code() );
-		$this->assertSame( 'venue_action_forbidden', $service->create( 2, 56, 4, VenueAuthorization::ROLE_VIEWER )->get_error_code() );
-		$this->assertSame( 'venue_action_forbidden', $service->create( 4, 56, 4, VenueAuthorization::ROLE_OWNER )->get_error_code() );
+		$member = $service->create( 2, 55, 3, false );
+		$this->assertFalse( $member['is_owner'] );
+		$this->assertSame( 'venue_action_forbidden', $service->create( 3, 55, 4, false )->get_error_code() );
+		$this->assertSame( 'venue_action_forbidden', $service->create( 2, 56, 4, false )->get_error_code() );
+		$this->assertSame( 'venue_action_forbidden', $service->create( 4, 56, 4, true )->get_error_code() );
 	}
 
 	public function test_unique_relationship_and_concurrent_create_conflicts_are_explicit(): void {
 		$repository = new VenueMembershipRepository();
-		$first      = $this->create_member( 55, 2, VenueAuthorization::ROLE_OWNER );
-		$duplicate  = $this->create_member( 55, 2, VenueAuthorization::ROLE_VIEWER );
+		$first      = $this->create_member( 55, 2, true );
+		$duplicate  = $this->create_member( 55, 2, false );
 		$this->assertSame( 'venue_membership_exists', $duplicate->get_error_code() );
 		$this->assertSame( $first['version'], $duplicate->get_error_data()['current_version'] );
 
-		$same_user_other_venue = $this->create_member( 56, 2, VenueAuthorization::ROLE_VIEWER );
+		$same_user_other_venue = $this->create_member( 56, 2, true );
 		$this->assertSame( 56, $same_user_other_venue['venue_term_id'] );
 
 		$GLOBALS['wpdb']->race_insert = true;
@@ -367,36 +390,36 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			array(
 				'venue_term_id'      => 55,
 				'user_id'            => 3,
-				'role'               => VenueAuthorization::ROLE_MARKETING,
+				'is_owner'           => false,
 				'created_by_user_id' => 1,
 			)
 		);
 		$this->assertSame( 'venue_membership_exists', $race->get_error_code() );
-		$this->assertSame( VenueAuthorization::ROLE_VIEWER, $repository->get( 55, 3 )['role'] );
+		$this->assertFalse( $repository->get( 55, 3 )['is_owner'] );
 	}
 
 	public function test_optimistic_updates_and_last_owner_invariant(): void {
 		$repository = new VenueMembershipRepository();
-		$owner      = $this->create_member( 55, 2, VenueAuthorization::ROLE_OWNER );
-		$this->assertSame( 'venue_membership_last_owner', $repository->update_role( 55, 2, VenueAuthorization::ROLE_VIEWER, $owner['version'], 1 )->get_error_code() );
+		$owner      = $this->create_member( 55, 2, true );
+		$this->assertSame( 'venue_membership_last_owner', $repository->update_owner( 55, 2, false, $owner['version'], 1 )->get_error_code() );
 		$this->assertSame( 'venue_membership_last_owner', $repository->revoke( 55, 2, $owner['version'], 1 )->get_error_code() );
 
-		$second = $this->create_member( 55, 3, VenueAuthorization::ROLE_OWNER );
-		$viewer = $repository->update_role( 55, 2, VenueAuthorization::ROLE_VIEWER, $owner['version'], 1 );
-		$this->assertSame( VenueAuthorization::ROLE_VIEWER, $viewer['role'] );
-		$this->assertSame( 2, $viewer['version'] );
-		$this->assertSame( 'venue_membership_version_conflict', $repository->update_role( 55, 2, VenueAuthorization::ROLE_FINANCE, 1, 1 )->get_error_code() );
+		$second = $this->create_member( 55, 3, true );
+		$member = $repository->update_owner( 55, 2, false, $owner['version'], 1 );
+		$this->assertFalse( $member['is_owner'] );
+		$this->assertSame( 2, $member['version'] );
+		$this->assertSame( 'venue_membership_version_conflict', $repository->update_owner( 55, 2, true, 1, 1 )->get_error_code() );
 
-		$this->create_member( 55, 4, VenueAuthorization::ROLE_OWNER );
+		$this->create_member( 55, 4, true );
 		$revoked = $repository->revoke( 55, 3, $second['version'], 1 );
 		$this->assertSame( VenueAuthorization::STATUS_REVOKED, $revoked['status'] );
 		$this->assertNotNull( $revoked['revoked_at'] );
-		$this->assertFalse( ( new VenueAuthorization( $repository ) )->can( 3, 55, VenueAuthorization::ACTION_VIEW_BOOKINGS ) );
+		$this->assertFalse( ( new VenueAuthorization( $repository ) )->can( 3, 55, VenueAuthorization::ACTION_ACCESS_VENUE ) );
 	}
 
 	public function test_actor_authority_is_rechecked_under_the_venue_lock(): void {
 		$service = new VenueMembershipService();
-		$owner   = $service->create( 1, 55, 2, VenueAuthorization::ROLE_OWNER );
+		$owner   = $service->create( 1, 55, 2, true );
 		$this->assertSame( VenueAuthorization::STATUS_ACTIVE, $owner['status'] );
 
 		$GLOBALS['wpdb']->after_start = static function ( VenueMembershipWpdb $wpdb ): void {
@@ -408,7 +431,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			unset( $row );
 		};
 
-		$result = $service->create( 2, 55, 3, VenueAuthorization::ROLE_VIEWER );
+		$result = $service->create( 2, 55, 3, false );
 		$this->assertSame( 'venue_action_forbidden', $result->get_error_code() );
 		$this->assertSame( VenueAuthorization::STATUS_REVOKED, ( new VenueMembershipRepository() )->get( 55, 2 )['status'] );
 		$this->assertNull( ( new VenueMembershipRepository() )->get( 55, 3 ) );
@@ -423,8 +446,8 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 
 	public function test_member_listing_rechecks_actor_in_the_same_query(): void {
 		$service = new VenueMembershipService();
-		$service->create( 1, 55, 2, VenueAuthorization::ROLE_OWNER );
-		$service->create( 2, 55, 3, VenueAuthorization::ROLE_VIEWER );
+		$service->create( 1, 55, 2, true );
+		$service->create( 2, 55, 3, false );
 
 		$GLOBALS['wpdb']->before_list = static function ( VenueMembershipWpdb $wpdb ): void {
 			foreach ( $wpdb->rows['wp_7_ec_venue_members'] as &$row ) {
@@ -440,25 +463,26 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 
 	public function test_list_filters_and_corrupt_rows_fail_closed(): void {
 		$repository = new VenueMembershipRepository();
-		$this->create_member( 55, 2, VenueAuthorization::ROLE_OWNER );
-		$this->create_member( 55, 3, VenueAuthorization::ROLE_MARKETING );
-		$this->create_member( 55, 4, VenueAuthorization::ROLE_VIEWER, VenueAuthorization::STATUS_INVITED );
-		$this->create_member( 56, 5, VenueAuthorization::ROLE_OWNER );
+		$this->create_member( 55, 2, true );
+		$this->create_member( 55, 3, false );
+		$this->create_member( 55, 4, false, VenueAuthorization::STATUS_INVITED );
+		$this->create_member( 56, 5, true );
 
 		$this->assertCount( 3, $repository->list_for_venue( 55 ) );
 		$this->assertCount( 2, $repository->list_for_venue( 55, array( 'status' => VenueAuthorization::STATUS_ACTIVE ) ) );
-		$this->assertSame( 3, $repository->list_for_venue( 55, array( 'role' => VenueAuthorization::ROLE_MARKETING ) )[0]['user_id'] );
+		$this->assertSame( 2, $repository->list_for_venue( 55, array( 'is_owner' => true ) )[0]['user_id'] );
+		$this->assertCount( 2, $repository->list_for_venue( 55, array( 'is_owner' => false ) ) );
 
-		$row         = $repository->get( 55, 2 );
-		$row['role'] = 'super_owner';
-		$this->assertSame( 'venue_membership_corrupt_role', $repository->hydrate( $row )->get_error_code() );
-		$row['role']   = VenueAuthorization::ROLE_OWNER;
-		$row['status'] = 'paused';
+		$row             = $repository->get( 55, 2 );
+		$row['is_owner'] = 2;
+		$this->assertSame( 'venue_membership_corrupt_owner', $repository->hydrate( $row )->get_error_code() );
+		$row['is_owner'] = 1;
+		$row['status']   = 'paused';
 		$this->assertSame( 'venue_membership_corrupt_status', $repository->hydrate( $row )->get_error_code() );
 	}
 
 	public function test_abilities_share_authorization_and_execution_rechecks_it(): void {
-		$this->create_member( 55, 2, VenueAuthorization::ROLE_OWNER );
+		$this->create_member( 55, 2, true );
 		$GLOBALS['venue_membership_test']['current_user_id'] = 2;
 		$abilities = new VenueMembershipAbilities();
 		$abilities->register();
@@ -478,6 +502,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			$this->assertTrue( call_user_func( $definition['permission_callback'], array( 'venue_term_id' => 55 ) ) );
 			$this->assertSame( 'venue_action_forbidden', call_user_func( $definition['permission_callback'], array( 'venue_term_id' => 56 ) )->get_error_code() );
 		}
+		$this->assertStringNotContainsString( '"role"', json_encode( $GLOBALS['venue_membership_test']['abilities'] ) );
 		$this->assertTrue( $GLOBALS['venue_membership_test']['abilities']['extrachill/update-venue-membership']['meta']['annotations']['destructive'] );
 
 		$created = call_user_func(
@@ -485,7 +510,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			array(
 				'venue_term_id' => 55,
 				'user_id'       => 3,
-				'role'          => VenueAuthorization::ROLE_VIEWER,
+				'is_owner'      => false,
 			)
 		);
 		$this->assertSame( 3, $created['user_id'] );
@@ -496,7 +521,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			array(
 				'venue_term_id' => 55,
 				'user_id'       => 4,
-				'role'          => VenueAuthorization::ROLE_VIEWER,
+				'is_owner'      => false,
 			)
 		);
 		$this->assertSame( 'venue_action_forbidden', $denied->get_error_code() );


### PR DESCRIPTION
## Summary
- remove the speculative booking manager, marketing, finance, and viewer role/action matrix
- compose the existing `access_events_admin` capability and `venue_booking` team rollout gate with exact active venue membership scope
- retain only structural `is_owner` authority for membership administration and migrate the unreleased role schema safely
- preserve optimistic concurrency, cross-venue isolation, atomic actor reauthorization, and final-owner protection

## Verification
- `vendor/bin/phpunit tests/VenueMembershipAuthorizationTest.php` (10 tests, 66 assertions)
- `vendor/bin/phpunit tests/BookingFoundationTest.php` (24 tests, 131 assertions)
- `npm run lint:js`
- Homeboy audit: passed, 0 introduced findings
- Homeboy lint: PHPCS, ESLint, and PHPStan passed with 0 findings
- Homeboy sandbox test could not start because the shared WordPress Playground archive cache lock timed out; focused local suites above passed
- full local PHPUnit failures exactly match the pre-change baseline (19 failures, 2 errors in unrelated environment-sensitive suites)

Closes #330