### PR TITLE
feat: add conflict-safe booking holds

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -248,8 +248,10 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingHoldRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingLifecycle.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingConfig.php';
+		\ExtraChillEvents\Core\BookingHoldRepository::register();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/ArtistUrlImport.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/ArtistUrlImportRoutes.php';
 
@@ -340,6 +342,9 @@ class ExtraChillEvents {
 
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueBookingAbilities.php';
 			new \ExtraChillEvents\Abilities\VenueBookingAbilities();
+
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueBookingHoldAbilities.php';
+			new \ExtraChillEvents\Abilities\VenueBookingHoldAbilities();
 		}
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/PriorityVenueAbilities.php';

--- a/inc/Abilities/VenueBookingAbilities.php
+++ b/inc/Abilities/VenueBookingAbilities.php
@@ -8,6 +8,7 @@
 namespace ExtraChillEvents\Abilities;
 
 use ExtraChillEvents\Core\BookingLifecycle;
+use ExtraChillEvents\Core\BookingHoldRepository;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\VenueAuthorization;
 
@@ -42,6 +43,8 @@ class VenueBookingAbilities {
 	 * @var VenueAuthorization
 	 */
 	private $authorization;
+	/** @var BookingHoldRepository */
+	private $holds;
 
 	/**
 	 * Build and hook the booking ability surface.
@@ -49,11 +52,13 @@ class VenueBookingAbilities {
 	 * @param BookingRepository|null  $bookings      Booking reads.
 	 * @param BookingLifecycle|null   $lifecycle     Booking mutations.
 	 * @param VenueAuthorization|null $authorization Venue authorization.
+	 * @param BookingHoldRepository|null $holds     Hold reconciliation.
 	 */
-	public function __construct( ?BookingRepository $bookings = null, ?BookingLifecycle $lifecycle = null, ?VenueAuthorization $authorization = null ) {
+	public function __construct( ?BookingRepository $bookings = null, ?BookingLifecycle $lifecycle = null, ?VenueAuthorization $authorization = null, ?BookingHoldRepository $holds = null ) {
 		$this->bookings      = $bookings ? $bookings : new BookingRepository();
 		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
-		$this->lifecycle     = $lifecycle ? $lifecycle : new BookingLifecycle( $this->bookings, null, $this->authorization );
+		$this->holds         = $holds ? $holds : new BookingHoldRepository( $this->bookings, null, $this->authorization );
+		$this->lifecycle     = $lifecycle ? $lifecycle : new BookingLifecycle( $this->bookings, null, $this->authorization, null, $this->holds );
 		if ( ! self::$registered ) {
 			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
 			self::$registered = true;
@@ -100,7 +105,7 @@ class VenueBookingAbilities {
 				'meta'                => array(
 					'show_in_rest' => true,
 					'annotations'  => array(
-						'readonly'    => true,
+						'readonly'    => false,
 						'idempotent'  => true,
 						'destructive' => false,
 					),
@@ -132,7 +137,7 @@ class VenueBookingAbilities {
 				'meta'                => array(
 					'show_in_rest' => true,
 					'annotations'  => array(
-						'readonly'    => true,
+						'readonly'    => false,
 						'idempotent'  => true,
 						'destructive' => false,
 					),
@@ -292,8 +297,11 @@ class VenueBookingAbilities {
 			'limit'              => $input['limit'] ?? 50,
 			'offset'             => $input['offset'] ?? 0,
 		);
-		$result  = $this->bookings->list( $filters );
-		return is_array( $result ) ? array_map( array( $this, 'present' ), $result ) : $result;
+		$result  = $this->holds->list_bookings_authorized( $filters, get_current_user_id() );
+		if ( ! is_array( $result ) ) {
+			return $result;
+		}
+		return array_map( array( $this, 'present' ), $result );
 	}
 
 	/**
@@ -302,7 +310,7 @@ class VenueBookingAbilities {
 	 * @param array $input Ability input.
 	 */
 	public function get_booking( array $input ) {
-		$result = $this->bookings->get( absint( $input['booking_id'] ?? 0 ) );
+		$result = $this->holds->get_booking_authorized( absint( $input['booking_id'] ?? 0 ), get_current_user_id() );
 		return is_array( $result ) ? $this->present( $result ) : $result;
 	}
 

--- a/inc/Abilities/VenueBookingHoldAbilities.php
+++ b/inc/Abilities/VenueBookingHoldAbilities.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Authorized venue booking hold abilities.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+use ExtraChillEvents\Core\BookingHoldRepository;
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\VenueAuthorization;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Registers create, release, and bounded venue hold operations. */
+class VenueBookingHoldAbilities {
+
+	private static bool $registered = false;
+	/** @var BookingHoldRepository */
+	private $holds;
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var VenueAuthorization */
+	private $authorization;
+
+	public function __construct( ?BookingHoldRepository $holds = null, ?BookingRepository $bookings = null, ?VenueAuthorization $authorization = null ) {
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+		$this->bookings      = $bookings ? $bookings : new BookingRepository();
+		$this->holds         = $holds ? $holds : new BookingHoldRepository( $this->bookings, null, $this->authorization );
+		if ( ! self::$registered ) {
+			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+			self::$registered = true;
+		}
+	}
+
+	public function register(): void {
+		wp_register_ability(
+			'extrachill/create-booking-hold',
+			array(
+				'label'               => __( 'Create Booking Hold', 'extrachill-events' ),
+				'description'         => __( 'Create a venue-space hold from a booking persisted selection.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => $this->create_schema(),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'hold'            => $this->hold_schema(),
+						'booking_version' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+					),
+					'required'             => array( 'hold', 'booking_version' ),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => array( $this, 'create' ),
+				'permission_callback' => array( $this, 'can_access_booking' ),
+				'meta'                => $this->meta( false ),
+			)
+		);
+		wp_register_ability(
+			'extrachill/release-booking-hold',
+			array(
+				'label'               => __( 'Release Booking Hold', 'extrachill-events' ),
+				'description'         => __( 'Release an active booking hold at an expected hold version.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => $this->release_schema(),
+				'output_schema'       => $this->hold_schema(),
+				'execute_callback'    => array( $this, 'release' ),
+				'permission_callback' => array( $this, 'can_access_hold' ),
+				'meta'                => $this->meta( false ),
+			)
+		);
+		wp_register_ability(
+			'extrachill/list-booking-holds',
+			array(
+				'label'               => __( 'List Booking Holds', 'extrachill-events' ),
+				'description'         => __( 'List bounded booking holds for one authorized venue.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => $this->list_schema(),
+				'output_schema'       => array(
+					'type'     => 'array',
+					'maxItems' => 100,
+					'items'    => $this->hold_schema(),
+				),
+				'execute_callback'    => array( $this, 'list_holds' ),
+				'permission_callback' => array( $this, 'can_access_venue' ),
+				'meta'                => $this->meta( true ),
+			)
+		);
+	}
+
+	public function create( array $input ) {
+		return $this->holds->create( (int) $input['booking_id'], (int) $input['expected_booking_version'], get_current_user_id() );
+	}
+
+	public function release( array $input ) {
+		return $this->holds->release( (int) $input['hold_id'], (int) $input['expected_version'], get_current_user_id(), (string) $input['reason'] );
+	}
+
+	public function list_holds( array $input ) {
+		return $this->holds->list( $input, get_current_user_id() );
+	}
+
+	public function can_access_booking( array $input ) {
+		$booking = $this->bookings->get( absint( $input['booking_id'] ?? 0 ) );
+		return is_array( $booking )
+			? $this->authorization->authorize( get_current_user_id(), $booking['venue_term_id'], VenueAuthorization::ACTION_ACCESS_VENUE )
+			: new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+
+	public function can_access_hold( array $input ) {
+		$hold = $this->holds->get( absint( $input['hold_id'] ?? 0 ) );
+		return is_array( $hold )
+			? $this->authorization->authorize( get_current_user_id(), $hold['venue_term_id'], VenueAuthorization::ACTION_ACCESS_VENUE )
+			: new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+
+	public function can_access_venue( array $input ) {
+		return $this->authorization->authorize( get_current_user_id(), absint( $input['venue_term_id'] ?? 0 ), VenueAuthorization::ACTION_ACCESS_VENUE );
+	}
+
+	private function create_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'booking_id'               => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'expected_booking_version' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+			),
+			'required'             => array( 'booking_id', 'expected_booking_version' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function release_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'hold_id'          => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'expected_version' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'reason'           => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 255,
+				),
+			),
+			'required'             => array( 'hold_id', 'expected_version', 'reason' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function list_schema(): array {
+		$datetime = array(
+			'type'    => array( 'string', 'null' ),
+			'pattern' => '^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$',
+		);
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'venue_term_id' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'booking_id'    => array(
+					'type'    => array( 'integer', 'null' ),
+					'minimum' => 1,
+				),
+				'status'        => array(
+					'type' => array( 'string', 'null' ),
+					'enum' => array_merge( BookingHoldRepository::STATUSES, array( null ) ),
+				),
+				'range_start'   => $datetime,
+				'range_end'     => $datetime,
+				'limit'         => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+					'maximum' => 100,
+				),
+				'offset'        => array(
+					'type'    => 'integer',
+					'minimum' => 0,
+					'maximum' => 10000,
+				),
+			),
+			'required'             => array( 'venue_term_id' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function hold_schema(): array {
+		$nullable_id     = array(
+			'type'    => array( 'integer', 'null' ),
+			'minimum' => 1,
+		);
+		$nullable_string = array( 'type' => array( 'string', 'null' ) );
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'id'                   => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'booking_id'           => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'venue_term_id'        => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'space_key'            => array( 'type' => 'string' ),
+				'start_at'             => array( 'type' => 'string' ),
+				'end_at'               => array( 'type' => 'string' ),
+				'expires_at'           => array( 'type' => 'string' ),
+				'status'               => array(
+					'type' => 'string',
+					'enum' => BookingHoldRepository::STATUSES,
+				),
+				'version'              => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'created_by_user_id'   => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'created_at'           => array( 'type' => 'string' ),
+				'updated_at'           => array( 'type' => 'string' ),
+				'released_at'          => $nullable_string,
+				'released_by_user_id'  => $nullable_id,
+				'release_reason'       => $nullable_string,
+				'expired_at'           => $nullable_string,
+				'converted_at'         => $nullable_string,
+				'converted_by_user_id' => $nullable_id,
+			),
+			'required'             => array( 'id', 'booking_id', 'venue_term_id', 'space_key', 'start_at', 'end_at', 'expires_at', 'status', 'version', 'created_by_user_id', 'created_at', 'updated_at', 'released_at', 'released_by_user_id', 'release_reason', 'expired_at', 'converted_at', 'converted_by_user_id' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function meta( bool $is_readonly ): array {
+		return array(
+			'show_in_rest' => true,
+			'annotations'  => array(
+				'readonly'    => $is_readonly,
+				'idempotent'  => $is_readonly,
+				'destructive' => ! $is_readonly,
+			),
+		);
+	}
+}

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -70,8 +70,7 @@ class BookingHoldRepository {
 		}
 		global $wpdb;
 		$table = BookingSchema::holds_table();
-		$now   = gmdate( 'Y-m-d H:i:s' );
-		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at <= %s ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'], $now ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Detects only the elapsed exact selected hold before entering the expiry lock.
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at <= UTC_TIMESTAMP() ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Detects only the elapsed exact selected hold by database time.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_hold_reconciliation_failed', __( 'The held booking could not be reconciled.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
@@ -97,8 +96,7 @@ class BookingHoldRepository {
 		$holds     = BookingSchema::holds_table();
 		$processed = 0;
 		do {
-			$now  = gmdate( 'Y-m-d H:i:s' );
-			$rows = $wpdb->get_results( $wpdb->prepare( "SELECT b.* FROM {$bookings} b INNER JOIN {$holds} h ON h.booking_id = b.id AND h.venue_term_id = b.venue_term_id AND h.space_key = b.space_key AND h.start_at = b.requested_start_at AND h.end_at = b.requested_end_at WHERE b.venue_term_id = %d AND b.status = 'held' AND h.status = 'active' AND h.expires_at <= %s ORDER BY b.id ASC LIMIT 100", $venue_id, $now ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Selects only stale exact held aggregates in a bounded batch.
+			$rows = $wpdb->get_results( $wpdb->prepare( "SELECT b.* FROM {$bookings} b INNER JOIN {$holds} h ON h.booking_id = b.id AND h.venue_term_id = b.venue_term_id AND h.space_key = b.space_key AND h.start_at = b.requested_start_at AND h.end_at = b.requested_end_at WHERE b.venue_term_id = %d AND b.status = 'held' AND h.status = 'active' AND h.expires_at <= UTC_TIMESTAMP() ORDER BY b.id ASC LIMIT 100", $venue_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Selects only stale exact held aggregates by database time.
 			if ( '' !== (string) $wpdb->last_error ) {
 				return new \WP_Error( 'booking_hold_venue_reconciliation_failed', __( 'Held bookings for this venue could not be reconciled.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 			}
@@ -115,7 +113,7 @@ class BookingHoldRepository {
 				++$processed;
 			}
 			if ( $processed >= 1000 && 100 === $batch_count ) {
-				$remaining = $this->venue_has_stale_booking( $venue_id, $now );
+				$remaining = $this->venue_has_stale_booking( $venue_id );
 				if ( is_wp_error( $remaining ) ) {
 					return $remaining;
 				}
@@ -187,11 +185,11 @@ class BookingHoldRepository {
 	}
 
 	/** Check whether stale exact held state remains after the operational cap. */
-	private function venue_has_stale_booking( int $venue_id, string $now ) {
+	private function venue_has_stale_booking( int $venue_id ) {
 		global $wpdb;
 		$bookings = BookingSchema::bookings_table();
 		$holds    = BookingSchema::holds_table();
-		$row      = $wpdb->get_var( $wpdb->prepare( "SELECT b.id FROM {$bookings} b INNER JOIN {$holds} h ON h.booking_id = b.id AND h.venue_term_id = b.venue_term_id AND h.space_key = b.space_key AND h.start_at = b.requested_start_at AND h.end_at = b.requested_end_at WHERE b.venue_term_id = %d AND b.status = 'held' AND h.status = 'active' AND h.expires_at <= %s LIMIT 1", $venue_id, $now ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Cheap post-cap existence check.
+		$row      = $wpdb->get_var( $wpdb->prepare( "SELECT b.id FROM {$bookings} b INNER JOIN {$holds} h ON h.booking_id = b.id AND h.venue_term_id = b.venue_term_id AND h.space_key = b.space_key AND h.start_at = b.requested_start_at AND h.end_at = b.requested_end_at WHERE b.venue_term_id = %d AND b.status = 'held' AND h.status = 'active' AND h.expires_at <= UTC_TIMESTAMP() LIMIT 1", $venue_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Cheap database-time post-cap existence check.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_hold_venue_reconciliation_failed', __( 'Remaining stale held bookings could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
@@ -221,11 +219,12 @@ class BookingHoldRepository {
 		if ( is_wp_error( $selection ) ) {
 			return $selection;
 		}
-		$lock   = $this->lock_name( $booking['venue_term_id'], $booking['space_key'] );
-		$result = $this->with_lock(
+		$lock     = $this->lock_name( $booking['venue_term_id'], $booking['space_key'] );
+		$venue_id = (int) $booking['venue_term_id'];
+		$result   = $this->with_lock(
 			$lock,
-			function () use ( $booking_id, $expected_booking_version, $actor_id ) {
-				$started = $this->begin_authorized( $booking_id, $actor_id );
+			function () use ( $booking_id, $expected_booking_version, $actor_id, $venue_id ) {
+				$started = $this->begin_authorized( $venue_id, $actor_id );
 				if ( is_wp_error( $started ) ) {
 					return $started;
 				}
@@ -259,7 +258,7 @@ class BookingHoldRepository {
 				if ( ! $this->configured_space( $config, $booking['space_key'] ) ) {
 					return $this->rollback( new \WP_Error( 'booking_hold_space_invalid', __( 'The selected booking space is not configured for this venue.', 'extrachill-events' ), array( 'status' => 409 ) ) );
 				}
-				$existing = $this->has_other_matching_active_hold( $booking, 0, gmdate( 'Y-m-d H:i:s' ) );
+				$existing = $this->has_other_matching_active_hold( $booking, 0 );
 				if ( is_wp_error( $existing ) ) {
 					return $this->rollback( $existing );
 				}
@@ -353,18 +352,19 @@ class BookingHoldRepository {
 		if ( is_wp_error( $hold ) || ! is_array( $hold ) ) {
 			return is_wp_error( $hold ) ? $hold : new \WP_Error( 'booking_hold_not_found', __( 'The booking hold was not found.', 'extrachill-events' ) );
 		}
-		if ( 'active' === $hold['status'] && $hold['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) ) {
+		$elapsed = $this->hold_is_elapsed( $hold_id );
+		if ( is_wp_error( $elapsed ) ) {
+			return $elapsed;
+		}
+		if ( 'active' === $hold['status'] && $elapsed ) {
 			$reconciled = $this->reconcile_hold_booking( $hold );
 			return is_wp_error( $reconciled ) ? $reconciled : $this->hold_not_active_error();
 		}
-		$result = $this->with_lock(
+		$venue_id = (int) $hold['venue_term_id'];
+		$result   = $this->with_lock(
 			$this->lock_name( $hold['venue_term_id'], $hold['space_key'] ),
-			function () use ( $hold_id, $expected_version, $actor_id, $reason ) {
-				$hold = $this->raw_get( $hold_id );
-				if ( is_wp_error( $hold ) || ! is_array( $hold ) ) {
-					return is_wp_error( $hold ) ? $hold : new \WP_Error( 'booking_hold_not_found', __( 'The booking hold was not found.', 'extrachill-events' ) );
-				}
-				$started = $this->begin_authorized( $hold['booking_id'], $actor_id );
+			function () use ( $hold_id, $expected_version, $actor_id, $reason, $venue_id ) {
+				$started = $this->begin_authorized( $venue_id, $actor_id );
 				if ( is_wp_error( $started ) ) {
 					return $started;
 				}
@@ -416,7 +416,11 @@ class BookingHoldRepository {
 							)
 						);
 					}
-					if ( 'active' !== $latest['status'] || $latest['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) ) {
+					$elapsed = $this->hold_is_elapsed( $hold_id );
+					if ( is_wp_error( $elapsed ) ) {
+						return $this->rollback( $elapsed );
+					}
+					if ( 'active' !== $latest['status'] || $elapsed ) {
 						return $this->rollback( new \WP_Error( 'booking_hold_reconcile_after_release_lock', 'internal' ) );
 					}
 					return $this->rollback( new \WP_Error( 'booking_hold_update_failed', __( 'The booking hold could not be released.', 'extrachill-events' ) ) );
@@ -514,13 +518,10 @@ class BookingHoldRepository {
 		if ( is_wp_error( $started ) ) {
 			return $started;
 		}
-		$now = gmdate( 'Y-m-d H:i:s' );
 		if ( 'active' === $status ) {
-			$where[]  = "status = 'active' AND expires_at > %s";
-			$values[] = $now;
+			$where[] = "status = 'active' AND expires_at > UTC_TIMESTAMP()";
 		} elseif ( 'expired' === $status ) {
-			$where[]  = "(status = 'expired' OR (status = 'active' AND expires_at <= %s))";
-			$values[] = $now;
+			$where[] = "(status = 'expired' OR (status = 'active' AND expires_at <= UTC_TIMESTAMP()))";
 		} elseif ( ! empty( $status ) ) {
 			$where[]  = 'status = %s';
 			$values[] = $status;
@@ -541,15 +542,23 @@ class BookingHoldRepository {
 	/** Expire an elapsed active hold idempotently under its venue-space lock. */
 	public function expire( int $hold_id ) {
 		$hold = $this->raw_get( $hold_id );
-		if ( ! is_array( $hold ) || 'active' !== $hold['status'] || $hold['expires_at'] > gmdate( 'Y-m-d H:i:s' ) ) {
+		if ( ! is_array( $hold ) || 'active' !== $hold['status'] ) {
 			return is_array( $hold ) ? $this->hydrate( $hold ) : $hold;
+		}
+		$elapsed = $this->hold_is_elapsed( $hold_id );
+		if ( is_wp_error( $elapsed ) || ! $elapsed ) {
+			return is_wp_error( $elapsed ) ? $elapsed : $this->hydrate( $hold );
 		}
 		return $this->with_lock(
 			$this->lock_name( $hold['venue_term_id'], $hold['space_key'] ),
 			function () use ( $hold_id ) {
 				$hold = $this->raw_get( $hold_id );
-				if ( ! is_array( $hold ) || 'active' !== $hold['status'] || $hold['expires_at'] > gmdate( 'Y-m-d H:i:s' ) ) {
+				if ( ! is_array( $hold ) || 'active' !== $hold['status'] ) {
 					return is_array( $hold ) ? $this->hydrate( $hold ) : $hold;
+				}
+				$elapsed = $this->hold_is_elapsed( $hold_id );
+				if ( is_wp_error( $elapsed ) || ! $elapsed ) {
+					return is_wp_error( $elapsed ) ? $elapsed : $this->hydrate( $hold );
 				}
 				global $wpdb;
 				$started = $this->begin();
@@ -557,9 +566,17 @@ class BookingHoldRepository {
 					return $started;
 				}
 				$hold = $this->raw_get( $hold_id );
-				if ( ! is_array( $hold ) || 'active' !== $hold['status'] || $hold['expires_at'] > gmdate( 'Y-m-d H:i:s' ) ) {
+				if ( ! is_array( $hold ) || 'active' !== $hold['status'] ) {
 					$committed = $this->commit();
 					return is_wp_error( $committed ) ? $committed : ( is_array( $hold ) ? $this->hydrate( $hold ) : $hold );
+				}
+				$elapsed = $this->hold_is_elapsed( $hold_id );
+				if ( is_wp_error( $elapsed ) ) {
+					return $this->rollback( $elapsed );
+				}
+				if ( ! $elapsed ) {
+					$committed = $this->commit();
+					return is_wp_error( $committed ) ? $committed : $this->hydrate( $hold );
 				}
 				$booking = $this->bookings->get( $hold['booking_id'] );
 				if ( ! is_array( $booking ) ) {
@@ -582,7 +599,7 @@ class BookingHoldRepository {
 				}
 				$other_hold = false;
 				if ( 'held' === $booking['status'] && $this->hold_matches_booking( $hold, $booking ) ) {
-					$other_hold = $this->has_other_matching_active_hold( $booking, $hold_id, $now );
+					$other_hold = $this->has_other_matching_active_hold( $booking, $hold_id );
 					if ( is_wp_error( $other_hold ) ) {
 						return $this->rollback( $other_hold );
 					}
@@ -644,7 +661,7 @@ class BookingHoldRepository {
 		return $this->with_lock(
 			$lock,
 			function () use ( $booking, $to_status, $expected_version, $actor_id, $note ) {
-				$started = $this->begin_authorized( $booking['id'], $actor_id );
+				$started = $this->begin_authorized( $booking['venue_term_id'], $actor_id );
 				if ( is_wp_error( $started ) ) {
 					return $started;
 				}
@@ -676,7 +693,7 @@ class BookingHoldRepository {
 					return $this->rollback( false === $result ? new \WP_Error( 'booking_update_failed', __( 'The booking could not be updated.', 'extrachill-events' ) ) : $this->booking_version_conflict( $this->bookings->get( $current['id'] ) ) );
 				}
 				if ( 'confirmed' === $to_status ) {
-					$converted = $this->update_hold(
+					$converted = $this->convert_hold(
 						$hold['id'],
 						$hold['version'],
 						'converted',
@@ -733,8 +750,7 @@ class BookingHoldRepository {
 	private function matching_active_hold( array $booking ) {
 		global $wpdb;
 		$table = BookingSchema::holds_table();
-		$now   = gmdate( 'Y-m-d H:i:s' );
-		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at > %s ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'], $now ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact persisted selection.
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact persisted selection by database time.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_hold_read_failed', __( 'The booking hold could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
@@ -745,8 +761,7 @@ class BookingHoldRepository {
 	private function find_conflict( array $booking, int $excluded_hold_id ) {
 		global $wpdb;
 		$holds = BookingSchema::holds_table();
-		$now   = gmdate( 'Y-m-d H:i:s' );
-		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT id, booking_id, 'hold' AS conflict_type FROM {$holds} WHERE venue_term_id = %d AND space_key = %s AND status = 'active' AND expires_at > %s AND start_at < %s AND end_at > %s AND booking_id <> %d AND id <> %d LIMIT 1", $booking['venue_term_id'], $booking['space_key'], $now, $booking['requested_end_at'], $booking['requested_start_at'], $booking['id'], $excluded_hold_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serialized overlap check.
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT id, booking_id, 'hold' AS conflict_type FROM {$holds} WHERE venue_term_id = %d AND space_key = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND start_at < %s AND end_at > %s AND booking_id <> %d AND id <> %d LIMIT 1", $booking['venue_term_id'], $booking['space_key'], $booking['requested_end_at'], $booking['requested_start_at'], $booking['id'], $excluded_hold_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serialized database-time overlap check.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_conflict_check_failed', __( 'Booking conflicts could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
@@ -797,11 +812,11 @@ class BookingHoldRepository {
 		global $wpdb;
 		$table   = BookingSchema::holds_table();
 		$now     = gmdate( 'Y-m-d H:i:s' );
-		$expired = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = 'expired', version = version + 1, updated_at = %s, expired_at = %s WHERE booking_id = %d AND status = 'active' AND expires_at <= %s AND id <> %d", $now, $now, $booking_id, $now, $except_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Preserve elapsed alternatives as expired.
+		$expired = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = 'expired', version = version + 1, updated_at = %s, expired_at = %s WHERE booking_id = %d AND status = 'active' AND expires_at <= UTC_TIMESTAMP() AND id <> %d", $now, $now, $booking_id, $except_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Preserve database-time elapsed alternatives as expired.
 		if ( false === $expired ) {
 			return new \WP_Error( 'booking_hold_expiry_failed', __( 'Elapsed alternative holds could not be expired.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
-		$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = 'released', version = version + 1, updated_at = %s, released_at = %s, released_by_user_id = %d, release_reason = %s WHERE booking_id = %d AND status = 'active' AND expires_at > %s AND id <> %d", $now, $now, $actor_id, $reason, $booking_id, $now, $except_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate live alternative release.
+		$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = 'released', version = version + 1, updated_at = %s, released_at = %s, released_by_user_id = %d, release_reason = %s WHERE booking_id = %d AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND id <> %d", $now, $now, $actor_id, $reason, $booking_id, $except_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate database-time live alternative release.
 		return false === $result ? new \WP_Error( 'booking_hold_release_failed', __( 'Alternative booking holds could not be released.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) : true;
 	}
 
@@ -825,6 +840,32 @@ class BookingHoldRepository {
 		return 1 === $result ? true : new \WP_Error( 'booking_hold_version_conflict', __( 'The booking hold changed since it was read.', 'extrachill-events' ), array( 'status' => 409 ) );
 	}
 
+	/** Convert only a lock-current active hold that remains unexpired at database time. */
+	private function convert_hold( int $hold_id, int $expected_version, string $status, array $fields ) {
+		global $wpdb;
+		$set    = array( 'status = %s', 'version = version + 1', 'updated_at = %s' );
+		$values = array( $status, gmdate( 'Y-m-d H:i:s' ) );
+		foreach ( $fields as $field => $value ) {
+			$set[]    = is_int( $value ) ? "{$field} = %d" : "{$field} = %s";
+			$values[] = $value;
+		}
+		$values[] = $hold_id;
+		$values[] = $expected_version;
+		$table    = BookingSchema::holds_table();
+		$result   = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET " . implode( ', ', $set ) . " WHERE id = %d AND version = %d AND status = 'active' AND expires_at > UTC_TIMESTAMP()", $values ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- The conversion boundary is enforced by database time.
+		if ( false === $result ) {
+			return new \WP_Error( 'booking_hold_update_failed', __( 'The booking hold could not be converted.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		if ( 1 === $result ) {
+			return true;
+		}
+		$latest = $this->raw_get( $hold_id );
+		if ( is_array( $latest ) && (int) $latest['version'] === $expected_version && 'active' === $latest['status'] ) {
+			return new \WP_Error( 'booking_hold_expired_during_confirmation', __( 'The booking hold expired before confirmation completed.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return new \WP_Error( 'booking_hold_version_conflict', __( 'The booking hold changed since it was read.', 'extrachill-events' ), array( 'status' => 409 ) );
+	}
+
 	/** Conditionally release only a still-active, still-unexpired hold. */
 	private function release_hold( int $hold_id, int $expected_version, int $actor_id, string $reason ) {
 		global $wpdb;
@@ -837,16 +878,12 @@ class BookingHoldRepository {
 		return 1 === $result;
 	}
 
-	private function begin_authorized( int $booking_id, int $actor_id ) {
+	private function begin_authorized( int $venue_id, int $actor_id ) {
 		$started = $this->begin();
 		if ( is_wp_error( $started ) ) {
 			return $started;
 		}
-		$booking = $this->bookings->get( $booking_id );
-		if ( ! is_array( $booking ) ) {
-			return $this->rollback( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
-		}
-		return $this->lock_and_authorize_venue( $booking['venue_term_id'], $actor_id );
+		return $this->lock_and_authorize_venue( $venue_id, $actor_id );
 	}
 
 	private function begin_venue_authorized( int $venue_id, int $actor_id ) {
@@ -856,12 +893,12 @@ class BookingHoldRepository {
 
 	private function lock_and_authorize_venue( int $venue_id, int $actor_id ) {
 		global $wpdb;
-		$table = BookingSchema::memberships_table();
-		$wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $venue_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks exact venue authority.
+		$table  = BookingSchema::memberships_table();
+		$locked = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $venue_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- First transactional read locks and returns current venue authority.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return $this->rollback( new \WP_Error( 'booking_hold_authorization_lock_failed', __( 'Venue booking authority could not be locked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
 		}
-		$allowed = $this->authorization->authorize( $actor_id, $venue_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+		$allowed = $this->authorization->authorize_locked( $actor_id, $venue_id, VenueAuthorization::ACTION_ACCESS_VENUE, (array) $locked );
 		return true === $allowed ? true : $this->rollback( is_wp_error( $allowed ) ? $allowed : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) ) );
 	}
 
@@ -901,7 +938,7 @@ class BookingHoldRepository {
 	}
 
 	private function lock_name( int $venue_id, string $space_key ): string {
-		return 'ecbh:' . sha1( $venue_id . ':' . $space_key );
+		return 'ecbh:' . sha1( BookingSchema::holds_table() . ':' . $venue_id . ':' . $space_key );
 	}
 
 	private function selection( array $booking ) {
@@ -973,12 +1010,23 @@ class BookingHoldRepository {
 			&& $hold['end_at'] === $booking['requested_end_at'];
 	}
 
-	private function has_other_matching_active_hold( array $booking, int $excluded_hold_id, string $now ) {
+	private function has_other_matching_active_hold( array $booking, int $excluded_hold_id ) {
 		global $wpdb;
 		$table = BookingSchema::holds_table();
-		$row   = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at > %s AND id <> %d LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'], $now, $excluded_hold_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact invariant check under the venue-space lock.
+		$row   = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND id <> %d LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'], $excluded_hold_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact database-time invariant check under the venue-space lock.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_hold_invariant_check_failed', __( 'Other active holds could not be checked safely.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return null !== $row;
+	}
+
+	/** Ask MySQL whether one active hold has reached its expiration boundary. */
+	private function hold_is_elapsed( int $hold_id ) {
+		global $wpdb;
+		$table = BookingSchema::holds_table();
+		$row   = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$table} WHERE id = %d AND status = 'active' AND expires_at <= UTC_TIMESTAMP()", $hold_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Database time is authoritative for expiration.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_hold_expiration_check_failed', __( 'The booking hold expiration could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
 		return null !== $row;
 	}

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -1,0 +1,1069 @@
+<?php
+/**
+ * Durable booking holds and venue-space conflict serialization.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Owns hold persistence, expiration, conflicts, and hold-aware transitions. */
+class BookingHoldRepository {
+
+	public const STATUSES        = array( 'active', 'released', 'expired', 'converted' );
+	public const EXPIRY_HOOK     = 'extrachill_events_expire_booking_hold';
+	public const SCHEDULER_GROUP = 'extrachill-events-booking-holds';
+
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var BookingActivityRepository */
+	private $activity;
+	/** @var VenueAuthorization */
+	private $authorization;
+	/** @var VenueBookingConfig */
+	private $config;
+	/** @var bool */
+	private $transaction_active = false;
+
+	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, ?VenueBookingConfig $config = null ) {
+		$this->bookings      = $bookings ? $bookings : new BookingRepository();
+		$this->activity      = $activity ? $activity : new BookingActivityRepository();
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+		$this->config        = $config ? $config : new VenueBookingConfig();
+	}
+
+	/** Register the cleanup callback outside CLI-only bootstrap paths. */
+	public static function register(): void {
+		add_action( self::EXPIRY_HOOK, array( self::class, 'expire_scheduled' ), 10, 2 );
+	}
+
+	/** Action Scheduler callback. Correctness does not depend on this callback running. */
+	public static function expire_scheduled( int $hold_id, int $attempt = 0 ): void {
+		$attempt = max( 0, min( 3, $attempt ) );
+		$result  = ( new self() )->expire( $hold_id );
+		if ( ! is_wp_error( $result ) ) {
+			return;
+		}
+		if ( $attempt < 3 && function_exists( 'as_schedule_single_action' ) ) {
+			try {
+				$scheduled = as_schedule_single_action( time() + ( MINUTE_IN_SECONDS * ( 2 ** $attempt ) ), self::EXPIRY_HOOK, array( $hold_id, $attempt + 1 ), self::SCHEDULER_GROUP, true );
+				if ( ! $scheduled && function_exists( 'do_action' ) ) {
+					do_action( 'extrachill_events_booking_hold_schedule_failed', $hold_id, null, new \RuntimeException( 'Booking hold expiration retry was not scheduled.' ) );
+				}
+			} catch ( \Throwable $throwable ) {
+				if ( function_exists( 'do_action' ) ) {
+					do_action( 'extrachill_events_booking_hold_schedule_failed', $hold_id, null, $throwable );
+				}
+			}
+		}
+		throw new \RuntimeException( 'Booking hold expiration failed.' );
+	}
+
+	/** Persist elapsed selected-hold consequences before normal held-state work. */
+	public function reconcile_booking( array $booking ) {
+		if ( 'held' !== ( $booking['status'] ?? '' ) ) {
+			return $booking;
+		}
+		global $wpdb;
+		$table = BookingSchema::holds_table();
+		$now   = gmdate( 'Y-m-d H:i:s' );
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at <= %s ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'], $now ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Detects only the elapsed exact selected hold before entering the expiry lock.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_hold_reconciliation_failed', __( 'The held booking could not be reconciled.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		if ( ! is_array( $row ) ) {
+			return $booking;
+		}
+		$expired = $this->expire( (int) $row['id'] );
+		if ( is_wp_error( $expired ) ) {
+			return $expired;
+		}
+		$refreshed = $this->bookings->get( $booking['id'] );
+		return is_array( $refreshed ) ? $refreshed : ( is_wp_error( $refreshed ) ? $refreshed : new \WP_Error( 'booking_not_found', __( 'The booking was not found after reconciliation.', 'extrachill-events' ) ) );
+	}
+
+	/** Reconcile bounded stale batches before status filtering and pagination. */
+	public function reconcile_venue( int $venue_id ) {
+		global $wpdb;
+		$venue_id = absint( $venue_id );
+		if ( $venue_id < 1 ) {
+			return new \WP_Error( 'invalid_booking_hold_venue', __( 'A venue is required.', 'extrachill-events' ) );
+		}
+		$bookings  = BookingSchema::bookings_table();
+		$holds     = BookingSchema::holds_table();
+		$processed = 0;
+		do {
+			$now  = gmdate( 'Y-m-d H:i:s' );
+			$rows = $wpdb->get_results( $wpdb->prepare( "SELECT b.* FROM {$bookings} b INNER JOIN {$holds} h ON h.booking_id = b.id AND h.venue_term_id = b.venue_term_id AND h.space_key = b.space_key AND h.start_at = b.requested_start_at AND h.end_at = b.requested_end_at WHERE b.venue_term_id = %d AND b.status = 'held' AND h.status = 'active' AND h.expires_at <= %s ORDER BY b.id ASC LIMIT 100", $venue_id, $now ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Selects only stale exact held aggregates in a bounded batch.
+			if ( '' !== (string) $wpdb->last_error ) {
+				return new \WP_Error( 'booking_hold_venue_reconciliation_failed', __( 'Held bookings for this venue could not be reconciled.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+			}
+			$batch_count = count( (array) $rows );
+			foreach ( (array) $rows as $row ) {
+				$booking = $this->bookings->hydrate( $row );
+				if ( is_wp_error( $booking ) ) {
+					return $booking;
+				}
+				$result = $this->reconcile_booking( $booking );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
+				++$processed;
+			}
+			if ( $processed >= 1000 && 100 === $batch_count ) {
+				$remaining = $this->venue_has_stale_booking( $venue_id, $now );
+				if ( is_wp_error( $remaining ) ) {
+					return $remaining;
+				}
+				if ( $remaining ) {
+					return new \WP_Error(
+						'booking_hold_venue_reconciliation_limit',
+						__( 'More stale held bookings remain for this venue; retry the request.', 'extrachill-events' ),
+						array(
+							'status'    => 503,
+							'processed' => $processed,
+						)
+					);
+				}
+				break;
+			}
+		} while ( 100 === $batch_count );
+		return true;
+	}
+
+	/** Reconcile, then read one booking while exact venue authority is locked. */
+	public function get_booking_authorized( int $booking_id, int $actor_id ) {
+		$booking = $this->bookings->get( $booking_id );
+		if ( ! is_array( $booking ) ) {
+			return is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
+		$allowed = $this->authorize_venue_now( $booking['venue_term_id'], $actor_id );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		// Reconciliation is system invariant maintenance with no operator-authored values. It runs before membership locks to preserve advisory -> membership lock order.
+		$booking = $this->reconcile_booking( $booking );
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+		$started = $this->begin_venue_authorized( $booking['venue_term_id'], $actor_id );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$result = $this->bookings->get( $booking_id );
+		if ( ! is_array( $result ) ) {
+			return $this->rollback( is_wp_error( $result ) ? $result : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+		}
+		$committed = $this->commit();
+		return is_wp_error( $committed ) ? $committed : $result;
+	}
+
+	/** Reconcile, then list bookings while exact venue authority is locked. */
+	public function list_bookings_authorized( array $filters, int $actor_id ) {
+		$venue_id = absint( $filters['venue_term_id'] ?? 0 );
+		$allowed  = $this->authorize_venue_now( $venue_id, $actor_id );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		// System reconciliation stays outside membership transactions; final private output is protected by locked reauthorization below.
+		$reconciled = $this->reconcile_venue( $venue_id );
+		if ( is_wp_error( $reconciled ) ) {
+			return $reconciled;
+		}
+		$started = $this->begin_venue_authorized( $venue_id, $actor_id );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$result = $this->bookings->list( $filters );
+		if ( ! is_array( $result ) ) {
+			return $this->rollback( $result );
+		}
+		$committed = $this->commit();
+		return is_wp_error( $committed ) ? $committed : $result;
+	}
+
+	/** Check whether stale exact held state remains after the operational cap. */
+	private function venue_has_stale_booking( int $venue_id, string $now ) {
+		global $wpdb;
+		$bookings = BookingSchema::bookings_table();
+		$holds    = BookingSchema::holds_table();
+		$row      = $wpdb->get_var( $wpdb->prepare( "SELECT b.id FROM {$bookings} b INNER JOIN {$holds} h ON h.booking_id = b.id AND h.venue_term_id = b.venue_term_id AND h.space_key = b.space_key AND h.start_at = b.requested_start_at AND h.end_at = b.requested_end_at WHERE b.venue_term_id = %d AND b.status = 'held' AND h.status = 'active' AND h.expires_at <= %s LIMIT 1", $venue_id, $now ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Cheap post-cap existence check.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_hold_venue_reconciliation_failed', __( 'Remaining stale held bookings could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return null !== $row;
+	}
+
+	/** Fresh early authorization before any reconciliation mutation. */
+	private function authorize_venue_now( int $venue_id, int $actor_id ) {
+		$allowed = $this->authorization->authorize( $actor_id, $venue_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+		return true === $allowed ? true : ( is_wp_error( $allowed ) ? $allowed : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) ) );
+	}
+
+	/** Create a hold entirely from persisted booking selection fields. */
+	public function create( int $booking_id, int $expected_booking_version, int $actor_id ) {
+		$booking = $this->bookings->get( $booking_id );
+		if ( is_wp_error( $booking ) || ! is_array( $booking ) ) {
+			return is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
+		$booking = $this->reconcile_booking( $booking );
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+		if ( (int) $booking['version'] !== $expected_booking_version ) {
+			return $this->booking_version_conflict( $booking );
+		}
+		$selection = $this->selection( $booking );
+		if ( is_wp_error( $selection ) ) {
+			return $selection;
+		}
+		$lock   = $this->lock_name( $booking['venue_term_id'], $booking['space_key'] );
+		$result = $this->with_lock(
+			$lock,
+			function () use ( $booking_id, $expected_booking_version, $actor_id ) {
+				$started = $this->begin_authorized( $booking_id, $actor_id );
+				if ( is_wp_error( $started ) ) {
+					return $started;
+				}
+				$booking = $this->bookings->get( $booking_id );
+				if ( is_wp_error( $booking ) || ! is_array( $booking ) ) {
+					return $this->rollback( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+				}
+				if ( (int) $booking['version'] !== $expected_booking_version ) {
+					return $this->rollback( $this->booking_version_conflict( $booking ) );
+				}
+				if ( ! in_array( $booking['status'], array( 'negotiating', 'held' ), true ) ) {
+					return $this->rollback(
+						new \WP_Error(
+							'booking_hold_status_forbidden',
+							__( 'Holds can only be created for negotiating or held bookings.', 'extrachill-events' ),
+							array(
+								'status'         => 409,
+								'booking_status' => $booking['status'],
+							)
+						)
+					);
+				}
+				$selection = $this->selection( $booking );
+				if ( is_wp_error( $selection ) ) {
+					return $this->rollback( $selection );
+				}
+				$config = $this->config->get( $booking['venue_term_id'] );
+				if ( is_wp_error( $config ) ) {
+					return $this->rollback( $config );
+				}
+				if ( ! $this->configured_space( $config, $booking['space_key'] ) ) {
+					return $this->rollback( new \WP_Error( 'booking_hold_space_invalid', __( 'The selected booking space is not configured for this venue.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+				}
+				$existing = $this->has_other_matching_active_hold( $booking, 0, gmdate( 'Y-m-d H:i:s' ) );
+				if ( is_wp_error( $existing ) ) {
+					return $this->rollback( $existing );
+				}
+				if ( $existing ) {
+					return $this->rollback( new \WP_Error( 'booking_hold_already_active', __( 'An exact active hold already exists for this booking selection.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+				}
+				$conflict = $this->find_conflict( $booking, 0 );
+				if ( is_wp_error( $conflict ) ) {
+					return $this->rollback( $conflict );
+				}
+				if ( $conflict ) {
+					return $this->rollback( $this->conflict_error( $conflict ) );
+				}
+
+				global $wpdb;
+				$now       = gmdate( 'Y-m-d H:i:s' );
+				$expires   = gmdate( 'Y-m-d H:i:s', time() + ( (int) $config['hold_ttl_minutes'] * MINUTE_IN_SECONDS ) );
+				$bookings  = BookingSchema::bookings_table();
+				$increment = $wpdb->query( $wpdb->prepare( "UPDATE {$bookings} SET version = version + 1, updated_at = %s WHERE id = %d AND version = %d", $now, $booking_id, $expected_booking_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate optimistic mutation.
+				if ( false === $increment ) {
+					return $this->rollback( new \WP_Error( 'booking_hold_booking_update_failed', __( 'The booking could not be updated for the hold.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
+				}
+				if ( 0 === $increment ) {
+					return $this->rollback( $this->booking_version_conflict( $this->bookings->get( $booking_id ) ) );
+				}
+				$row = array(
+					'booking_id'           => $booking_id,
+					'venue_term_id'        => $booking['venue_term_id'],
+					'space_key'            => $booking['space_key'],
+					'start_at'             => $booking['requested_start_at'],
+					'end_at'               => $booking['requested_end_at'],
+					'expires_at'           => $expires,
+					'status'               => 'active',
+					'version'              => 1,
+					'created_by_user_id'   => $actor_id,
+					'created_at'           => $now,
+					'updated_at'           => $now,
+					'released_at'          => null,
+					'released_by_user_id'  => null,
+					'release_reason'       => null,
+					'expired_at'           => null,
+					'converted_at'         => null,
+					'converted_by_user_id' => null,
+				);
+				if ( false === $wpdb->insert( BookingSchema::holds_table(), $row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private hold insert.
+					return $this->rollback( new \WP_Error( 'booking_hold_create_failed', __( 'The booking hold could not be created.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
+				}
+				$hold_id = (int) $wpdb->insert_id;
+				$event   = $this->activity->append(
+					array(
+						'booking_id' => $booking_id,
+						'kind'       => 'hold_created',
+						'actor_type' => 'user',
+						'actor_id'   => $actor_id,
+						'payload'    => array(
+							'hold_id'    => $hold_id,
+							'expires_at' => $expires,
+							'version'    => $expected_booking_version + 1,
+						),
+					)
+				);
+				if ( is_wp_error( $event ) ) {
+					return $this->rollback( $event );
+				}
+				$hold      = $this->hydrate( array_merge( $row, array( 'id' => $hold_id ) ) );
+				$committed = $this->commit();
+				if ( is_wp_error( $committed ) ) {
+					return $committed;
+				}
+				return array(
+					'hold'            => $hold,
+					'booking_version' => $expected_booking_version + 1,
+					'_schedule'       => array( $hold_id, $expires ),
+				);
+			}
+		);
+		if ( is_array( $result ) && isset( $result['_schedule'] ) ) {
+			$this->schedule( $result['_schedule'][0], $result['_schedule'][1] );
+			unset( $result['_schedule'] );
+		}
+		return $result;
+	}
+
+	/** Release one active hold at its optimistic version. Booking version is unchanged. */
+	public function release( int $hold_id, int $expected_version, int $actor_id, string $reason ) {
+		$reason = mb_substr( sanitize_text_field( $reason ), 0, 255 );
+		if ( '' === $reason ) {
+			return new \WP_Error( 'booking_hold_release_reason_required', __( 'A release reason is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$hold = $this->raw_get( $hold_id );
+		if ( is_wp_error( $hold ) || ! is_array( $hold ) ) {
+			return is_wp_error( $hold ) ? $hold : new \WP_Error( 'booking_hold_not_found', __( 'The booking hold was not found.', 'extrachill-events' ) );
+		}
+		if ( 'active' === $hold['status'] && $hold['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) ) {
+			$reconciled = $this->reconcile_hold_booking( $hold );
+			return is_wp_error( $reconciled ) ? $reconciled : $this->hold_not_active_error();
+		}
+		$result = $this->with_lock(
+			$this->lock_name( $hold['venue_term_id'], $hold['space_key'] ),
+			function () use ( $hold_id, $expected_version, $actor_id, $reason ) {
+				$hold = $this->raw_get( $hold_id );
+				if ( is_wp_error( $hold ) || ! is_array( $hold ) ) {
+					return is_wp_error( $hold ) ? $hold : new \WP_Error( 'booking_hold_not_found', __( 'The booking hold was not found.', 'extrachill-events' ) );
+				}
+				$started = $this->begin_authorized( $hold['booking_id'], $actor_id );
+				if ( is_wp_error( $started ) ) {
+					return $started;
+				}
+				$hold = $this->raw_get( $hold_id );
+				if ( is_wp_error( $hold ) || ! is_array( $hold ) ) {
+					return $this->rollback( is_wp_error( $hold ) ? $hold : new \WP_Error( 'booking_hold_not_found', __( 'The booking hold was not found.', 'extrachill-events' ) ) );
+				}
+				$effective = $this->hydrate( $hold );
+				if ( 'active' !== $effective['status'] ) {
+					return $this->rollback( new \WP_Error( 'booking_hold_reconcile_after_release_lock', 'internal' ) );
+				}
+				if ( (int) $hold['version'] !== $expected_version ) {
+					return $this->rollback(
+						new \WP_Error(
+							'booking_hold_version_conflict',
+							__( 'The booking hold changed since it was read.', 'extrachill-events' ),
+							array(
+								'status'          => 409,
+								'current_version' => $hold['version'],
+							)
+						)
+					);
+				}
+				$booking = $this->bookings->get( $hold['booking_id'] );
+				if ( ! is_array( $booking ) ) {
+					return $this->rollback( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+				}
+				if ( 'held' === $booking['status'] && $this->hold_matches_booking( $hold, $booking ) ) {
+					return $this->rollback( new \WP_Error( 'booking_held_hold_release_forbidden', __( 'Transition the held booking before releasing its selected hold.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+				}
+				$released = $this->release_hold( $hold_id, $expected_version, $actor_id, $reason );
+				if ( is_wp_error( $released ) ) {
+					return $this->rollback( $released );
+				}
+				if ( ! $released ) {
+					$latest = $this->raw_get( $hold_id );
+					if ( is_wp_error( $latest ) || ! is_array( $latest ) ) {
+						return $this->rollback( is_wp_error( $latest ) ? $latest : new \WP_Error( 'booking_hold_not_found', __( 'The booking hold was not found.', 'extrachill-events' ) ) );
+					}
+					if ( (int) $latest['version'] !== $expected_version ) {
+						return $this->rollback(
+							new \WP_Error(
+								'booking_hold_version_conflict',
+								__( 'The booking hold changed since it was read.', 'extrachill-events' ),
+								array(
+									'status'          => 409,
+									'current_version' => $latest['version'],
+								)
+							)
+						);
+					}
+					if ( 'active' !== $latest['status'] || $latest['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) ) {
+						return $this->rollback( new \WP_Error( 'booking_hold_reconcile_after_release_lock', 'internal' ) );
+					}
+					return $this->rollback( new \WP_Error( 'booking_hold_update_failed', __( 'The booking hold could not be released.', 'extrachill-events' ) ) );
+				}
+				$event = $this->activity->append(
+					array(
+						'booking_id' => $hold['booking_id'],
+						'kind'       => 'hold_released',
+						'actor_type' => 'user',
+						'actor_id'   => $actor_id,
+						'payload'    => array(
+							'hold_id' => $hold_id,
+							'reason'  => $reason,
+						),
+					)
+				);
+				if ( is_wp_error( $event ) ) {
+					return $this->rollback( $event );
+				}
+				$output    = $this->hydrate(
+					array_merge(
+						$hold,
+						array(
+							'status'              => 'released',
+							'version'             => $expected_version + 1,
+							'updated_at'          => gmdate( 'Y-m-d H:i:s' ),
+							'released_at'         => gmdate( 'Y-m-d H:i:s' ),
+							'released_by_user_id' => $actor_id,
+							'release_reason'      => $reason,
+						)
+					)
+				);
+				$committed = $this->commit();
+				return is_wp_error( $committed ) ? $committed : $output;
+			}
+		);
+		if ( is_wp_error( $result ) && 'booking_hold_reconcile_after_release_lock' === $result->get_error_code() ) {
+			$reconciled = $this->reconcile_hold_booking( $hold );
+			return is_wp_error( $reconciled ) ? $reconciled : $this->hold_not_active_error();
+		}
+		return $result;
+	}
+
+	/** Get one stable hold record. */
+	public function get( int $hold_id ) {
+		$hold = $this->raw_get( $hold_id );
+		return is_array( $hold ) ? $this->hydrate( $hold ) : $hold;
+	}
+
+	/** Read one stored hold without applying its effective elapsed status. */
+	private function raw_get( int $hold_id ) {
+		global $wpdb;
+		$table = BookingSchema::holds_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1", $hold_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Current-prefix private table.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_hold_read_failed', __( 'The booking hold could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return is_array( $row ) ? $this->hydrate( $row, false ) : null;
+	}
+
+	/** List bounded holds after transaction-time exact venue reauthorization. */
+	public function list( array $filters, int $actor_id ) {
+		global $wpdb;
+		$venue_id = absint( $filters['venue_term_id'] ?? 0 );
+		if ( $venue_id < 1 ) {
+			return new \WP_Error( 'invalid_booking_hold_venue', __( 'A venue is required.', 'extrachill-events' ) );
+		}
+		$where  = array( 'venue_term_id = %d' );
+		$values = array( $venue_id );
+		if ( ! empty( $filters['booking_id'] ) ) {
+			$where[]  = 'booking_id = %d';
+			$values[] = absint( $filters['booking_id'] );
+		}
+		$status = $filters['status'] ?? null;
+		if ( ! empty( $status ) ) {
+			if ( ! in_array( $filters['status'], self::STATUSES, true ) ) {
+				return new \WP_Error( 'invalid_booking_hold_status', __( 'The booking hold status is invalid.', 'extrachill-events' ) );
+			}
+		}
+		foreach ( array(
+			'range_start' => 'end_at > %s',
+			'range_end'   => 'start_at < %s',
+		) as $field => $clause ) {
+			if ( ! empty( $filters[ $field ] ) ) {
+				if ( ! $this->valid_datetime( $filters[ $field ] ) ) {
+					return new \WP_Error( 'invalid_booking_hold_datetime', __( 'Hold range filters must use UTC Y-m-d H:i:s format.', 'extrachill-events' ), array( 'field' => $field ) );
+				}
+				$where[]  = $clause;
+				$values[] = $filters[ $field ];
+			}
+		}
+		$limit   = max( 1, min( 100, absint( $filters['limit'] ?? 50 ) ) );
+		$offset  = max( 0, min( 10000, absint( $filters['offset'] ?? 0 ) ) );
+		$started = $this->begin_venue_authorized( $venue_id, $actor_id );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$now = gmdate( 'Y-m-d H:i:s' );
+		if ( 'active' === $status ) {
+			$where[]  = "status = 'active' AND expires_at > %s";
+			$values[] = $now;
+		} elseif ( 'expired' === $status ) {
+			$where[]  = "(status = 'expired' OR (status = 'active' AND expires_at <= %s))";
+			$values[] = $now;
+		} elseif ( ! empty( $status ) ) {
+			$where[]  = 'status = %s';
+			$values[] = $status;
+		}
+		$values[] = $limit;
+		$values[] = $offset;
+		$table    = BookingSchema::holds_table();
+		$sql      = "SELECT * FROM {$table} WHERE " . implode( ' AND ', $where ) . ' ORDER BY created_at DESC, id DESC LIMIT %d OFFSET %d'; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Clauses are internal.
+		$rows     = $wpdb->get_results( $wpdb->prepare( $sql, $values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Values prepared.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return $this->rollback( new \WP_Error( 'booking_hold_list_failed', __( 'Booking holds could not be listed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
+		}
+		$output    = array_map( array( $this, 'hydrate' ), (array) $rows );
+		$committed = $this->commit();
+		return is_wp_error( $committed ) ? $committed : $output;
+	}
+
+	/** Expire an elapsed active hold idempotently under its venue-space lock. */
+	public function expire( int $hold_id ) {
+		$hold = $this->raw_get( $hold_id );
+		if ( ! is_array( $hold ) || 'active' !== $hold['status'] || $hold['expires_at'] > gmdate( 'Y-m-d H:i:s' ) ) {
+			return is_array( $hold ) ? $this->hydrate( $hold ) : $hold;
+		}
+		return $this->with_lock(
+			$this->lock_name( $hold['venue_term_id'], $hold['space_key'] ),
+			function () use ( $hold_id ) {
+				$hold = $this->raw_get( $hold_id );
+				if ( ! is_array( $hold ) || 'active' !== $hold['status'] || $hold['expires_at'] > gmdate( 'Y-m-d H:i:s' ) ) {
+					return is_array( $hold ) ? $this->hydrate( $hold ) : $hold;
+				}
+				global $wpdb;
+				$started = $this->begin();
+				if ( is_wp_error( $started ) ) {
+					return $started;
+				}
+				$hold = $this->raw_get( $hold_id );
+				if ( ! is_array( $hold ) || 'active' !== $hold['status'] || $hold['expires_at'] > gmdate( 'Y-m-d H:i:s' ) ) {
+					$committed = $this->commit();
+					return is_wp_error( $committed ) ? $committed : ( is_array( $hold ) ? $this->hydrate( $hold ) : $hold );
+				}
+				$booking = $this->bookings->get( $hold['booking_id'] );
+				if ( ! is_array( $booking ) ) {
+					return $this->rollback( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+				}
+				$now    = gmdate( 'Y-m-d H:i:s' );
+				$result = $this->update_hold( $hold_id, $hold['version'], 'expired', array( 'expired_at' => gmdate( 'Y-m-d H:i:s' ) ) );
+				if ( is_wp_error( $result ) ) {
+					return $this->rollback( $result );
+				}
+				$event = $this->activity->append(
+					array(
+						'booking_id' => $hold['booking_id'],
+						'kind'       => 'hold_expired',
+						'payload'    => array( 'hold_id' => $hold_id ),
+					)
+				);
+				if ( is_wp_error( $event ) ) {
+					return $this->rollback( $event );
+				}
+				$other_hold = false;
+				if ( 'held' === $booking['status'] && $this->hold_matches_booking( $hold, $booking ) ) {
+					$other_hold = $this->has_other_matching_active_hold( $booking, $hold_id, $now );
+					if ( is_wp_error( $other_hold ) ) {
+						return $this->rollback( $other_hold );
+					}
+				}
+				if ( 'held' === $booking['status'] && $this->hold_matches_booking( $hold, $booking ) && ! $other_hold ) {
+					$table   = BookingSchema::bookings_table();
+					$changed = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = 'negotiating', version = version + 1, updated_at = %s WHERE id = %d AND version = %d AND status = 'held'", $now, $booking['id'], $booking['version'] ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Expiry preserves the held-state invariant optimistically.
+					if ( 1 !== $changed ) {
+						return $this->rollback( false === $changed ? new \WP_Error( 'booking_hold_expiry_booking_update_failed', __( 'The held booking could not be reopened after expiry.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) : $this->booking_version_conflict( $this->bookings->get( $booking['id'] ) ) );
+					}
+					$status_event = $this->activity->append(
+						array(
+							'booking_id' => $booking['id'],
+							'kind'       => 'status_changed',
+							'actor_type' => 'system',
+							'payload'    => array(
+								'from_status' => 'held',
+								'to_status'   => 'negotiating',
+								'reason'      => 'selected_hold_expired',
+								'hold_id'     => $hold_id,
+								'version'     => $booking['version'] + 1,
+							),
+						)
+					);
+					if ( is_wp_error( $status_event ) ) {
+						return $this->rollback( $status_event );
+					}
+				}
+				$output    = $this->hydrate(
+					array_merge(
+						$hold,
+						array(
+							'status'     => 'expired',
+							'version'    => $hold['version'] + 1,
+							'updated_at' => $now,
+							'expired_at' => $now,
+						)
+					)
+				);
+				$committed = $this->commit();
+				if ( is_wp_error( $committed ) ) {
+					return $committed;
+				}
+				return $output;
+			}
+		);
+	}
+
+	/** Apply a hold-aware lifecycle transition as one aggregate mutation. */
+	public function transition( array $booking, string $to_status, int $expected_version, int $actor_id, ?string $note ) {
+		$hold = $this->matching_active_hold( $booking );
+		if ( is_wp_error( $hold ) ) {
+			return $hold;
+		}
+		if ( in_array( $to_status, array( 'held', 'confirmed' ), true ) && ! is_array( $hold ) ) {
+			return new \WP_Error( 'booking_matching_hold_required', __( 'This transition requires an exact active unexpired hold.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$lock = is_array( $hold ) ? $this->lock_name( $hold['venue_term_id'], $hold['space_key'] ) : $this->lock_name( $booking['venue_term_id'], (string) $booking['space_key'] );
+		return $this->with_lock(
+			$lock,
+			function () use ( $booking, $to_status, $expected_version, $actor_id, $note ) {
+				$started = $this->begin_authorized( $booking['id'], $actor_id );
+				if ( is_wp_error( $started ) ) {
+					return $started;
+				}
+				$current = $this->bookings->get( $booking['id'] );
+				if ( ! is_array( $current ) || (int) $current['version'] !== $expected_version ) {
+					return $this->rollback( $this->booking_version_conflict( $current ) );
+				}
+				$hold = $this->matching_active_hold( $current );
+				if ( in_array( $to_status, array( 'held', 'confirmed' ), true ) && ! is_array( $hold ) ) {
+					return $this->rollback( new \WP_Error( 'booking_matching_hold_required', __( 'This transition requires an exact active unexpired hold.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+				}
+				if ( 'confirmed' === $to_status ) {
+					if ( empty( $current['deal']['data'] ) ) {
+						return $this->rollback( new \WP_Error( 'booking_confirmation_deal_required', __( 'Confirmation requires deal terms.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+					}
+					$conflict = $this->find_conflict( $current, $hold['id'] );
+					if ( is_wp_error( $conflict ) ) {
+						return $this->rollback( $conflict );
+					}
+					if ( $conflict ) {
+						return $this->rollback( $this->conflict_error( $conflict ) );
+					}
+				}
+				global $wpdb;
+				$table  = BookingSchema::bookings_table();
+				$now    = gmdate( 'Y-m-d H:i:s' );
+				$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = %s, version = version + 1, updated_at = %s WHERE id = %d AND version = %d", $to_status, $now, $current['id'], $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate transition.
+				if ( 1 !== $result ) {
+					return $this->rollback( false === $result ? new \WP_Error( 'booking_update_failed', __( 'The booking could not be updated.', 'extrachill-events' ) ) : $this->booking_version_conflict( $this->bookings->get( $current['id'] ) ) );
+				}
+				if ( 'confirmed' === $to_status ) {
+					$converted = $this->update_hold(
+						$hold['id'],
+						$hold['version'],
+						'converted',
+						array(
+							'converted_at'         => $now,
+							'converted_by_user_id' => $actor_id,
+						)
+					);
+					if ( is_wp_error( $converted ) ) {
+						return $this->rollback( $converted );
+					}
+					$released = $this->release_booking_holds( $current['id'], $hold['id'], $actor_id, 'alternative_released_on_confirmation' );
+				} elseif ( 'held' === $current['status'] && in_array( $to_status, array( 'negotiating', 'declined', 'withdrawn', 'cancelled' ), true ) ) {
+					$released = $this->release_booking_holds( $current['id'], 0, $actor_id, 'released_on_status_change' );
+				} else {
+					$released = true;
+				}
+				if ( is_wp_error( $released ) ) {
+					return $this->rollback( $released );
+				}
+				$event = $this->activity->append(
+					array(
+						'booking_id' => $current['id'],
+						'kind'       => 'status_changed',
+						'actor_type' => 'user',
+						'actor_id'   => $actor_id,
+						'payload'    => array(
+							'from_status' => $current['status'],
+							'to_status'   => $to_status,
+							'note'        => $note,
+							'hold_id'     => is_array( $hold ) ? $hold['id'] : null,
+							'version'     => $expected_version + 1,
+						),
+					)
+				);
+				if ( is_wp_error( $event ) ) {
+					return $this->rollback( $event );
+				}
+				$output    = array_merge(
+					$current,
+					array(
+						'status'     => $to_status,
+						'version'    => $expected_version + 1,
+						'updated_at' => $now,
+					)
+				);
+				$committed = $this->commit();
+				return is_wp_error( $committed ) ? $committed : $output;
+			}
+		);
+	}
+
+	/** Return an exact active hold; elapsed rows are opportunistically expired and never block. */
+	private function matching_active_hold( array $booking ) {
+		global $wpdb;
+		$table = BookingSchema::holds_table();
+		$now   = gmdate( 'Y-m-d H:i:s' );
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at > %s ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'], $now ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact persisted selection.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_hold_read_failed', __( 'The booking hold could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return is_array( $row ) ? $this->hydrate( $row ) : null;
+	}
+
+	/** Detect hold, confirmed-booking, then canonical published-event conflicts. */
+	private function find_conflict( array $booking, int $excluded_hold_id ) {
+		global $wpdb;
+		$holds = BookingSchema::holds_table();
+		$now   = gmdate( 'Y-m-d H:i:s' );
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT id, booking_id, 'hold' AS conflict_type FROM {$holds} WHERE venue_term_id = %d AND space_key = %s AND status = 'active' AND expires_at > %s AND start_at < %s AND end_at > %s AND booking_id <> %d AND id <> %d LIMIT 1", $booking['venue_term_id'], $booking['space_key'], $now, $booking['requested_end_at'], $booking['requested_start_at'], $booking['id'], $excluded_hold_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serialized overlap check.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_conflict_check_failed', __( 'Booking conflicts could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		if ( is_array( $row ) ) {
+			return $row;
+		}
+		$bookings = BookingSchema::bookings_table();
+		$row      = $wpdb->get_row( $wpdb->prepare( "SELECT id, 'confirmed_booking' AS conflict_type FROM {$bookings} WHERE venue_term_id = %d AND space_key = %s AND status = 'confirmed' AND requested_start_at < %s AND requested_end_at > %s AND id <> %d LIMIT 1", $booking['venue_term_id'], $booking['space_key'], $booking['requested_end_at'], $booking['requested_start_at'], $booking['id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serialized overlap check.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_conflict_check_failed', __( 'Booking conflicts could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		if ( is_array( $row ) ) {
+			return $row;
+		}
+		$timezone_name = get_term_meta( $booking['venue_term_id'], '_venue_timezone', true );
+		try {
+			$timezone = new \DateTimeZone( (string) $timezone_name );
+		} catch ( \Exception $exception ) {
+			return new \WP_Error( 'booking_venue_timezone_invalid', __( 'The venue timezone is missing or invalid, so conflicts cannot be checked safely.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$window    = $this->canonical_local_window( $booking['requested_start_at'], $booking['requested_end_at'], $timezone );
+		$start     = $window['start'];
+		$end       = $window['end'];
+		$dates     = $wpdb->prefix . 'datamachine_event_dates';
+		$post_type = defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events';
+		// Canonical events have no space identity, so a published venue event safely blocks every configured space.
+		$sql = "SELECT p.ID AS id, 'canonical_event' AS conflict_type FROM {$wpdb->posts} p JOIN {$dates} ed ON p.ID = ed.post_id JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE p.post_type = %s AND p.post_status = 'publish' AND tt.taxonomy = 'venue' AND tt.term_id = %d AND p.ID <> %d AND ed.start_datetime < %s AND ((ed.end_datetime IS NOT NULL AND ed.end_datetime > %s) OR (ed.end_datetime IS NULL AND ed.start_datetime >= %s)) LIMIT 1"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Core/current-prefix tables only.
+		$row = $wpdb->get_row( $wpdb->prepare( $sql, $post_type, $booking['venue_term_id'], (int) $booking['event_id'], $end, $start, $start ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Values prepared.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_conflict_check_failed', __( 'Canonical event conflicts could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return is_array( $row ) ? $row : null;
+	}
+
+	private function conflict_error( array $conflict ): \WP_Error {
+		return new \WP_Error(
+			'booking_time_conflict',
+			__( 'The selected venue time is unavailable.', 'extrachill-events' ),
+			array(
+				'status'                       => 409,
+				'conflict'                     => $conflict,
+				'canonical_event_space_policy' => 'venue_wide',
+			)
+		);
+	}
+
+	private function release_booking_holds( int $booking_id, int $except_id, int $actor_id, string $reason ) {
+		global $wpdb;
+		$table   = BookingSchema::holds_table();
+		$now     = gmdate( 'Y-m-d H:i:s' );
+		$expired = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = 'expired', version = version + 1, updated_at = %s, expired_at = %s WHERE booking_id = %d AND status = 'active' AND expires_at <= %s AND id <> %d", $now, $now, $booking_id, $now, $except_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Preserve elapsed alternatives as expired.
+		if ( false === $expired ) {
+			return new \WP_Error( 'booking_hold_expiry_failed', __( 'Elapsed alternative holds could not be expired.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = 'released', version = version + 1, updated_at = %s, released_at = %s, released_by_user_id = %d, release_reason = %s WHERE booking_id = %d AND status = 'active' AND expires_at > %s AND id <> %d", $now, $now, $actor_id, $reason, $booking_id, $now, $except_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate live alternative release.
+		return false === $result ? new \WP_Error( 'booking_hold_release_failed', __( 'Alternative booking holds could not be released.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) : true;
+	}
+
+	private function update_hold( int $hold_id, int $expected_version, string $status, array $fields ) {
+		global $wpdb;
+		$set    = array( 'status = %s', 'version = version + 1', 'updated_at = %s' );
+		$values = array( $status, gmdate( 'Y-m-d H:i:s' ) );
+		foreach ( $fields as $field => $value ) {
+			$set[] = null === $value ? "{$field} = NULL" : ( is_int( $value ) ? "{$field} = %d" : "{$field} = %s" );
+			if ( null !== $value ) {
+				$values[] = $value;
+			}
+		}
+		$values[] = $hold_id;
+		$values[] = $expected_version;
+		$table    = BookingSchema::holds_table();
+		$result   = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET " . implode( ', ', $set ) . ' WHERE id = %d AND version = %d', $values ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Dynamic internal fields determine the prepared value count.
+		if ( false === $result ) {
+			return new \WP_Error( 'booking_hold_update_failed', __( 'The booking hold could not be updated.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return 1 === $result ? true : new \WP_Error( 'booking_hold_version_conflict', __( 'The booking hold changed since it was read.', 'extrachill-events' ), array( 'status' => 409 ) );
+	}
+
+	/** Conditionally release only a still-active, still-unexpired hold. */
+	private function release_hold( int $hold_id, int $expected_version, int $actor_id, string $reason ) {
+		global $wpdb;
+		$table  = BookingSchema::holds_table();
+		$now    = gmdate( 'Y-m-d H:i:s' );
+		$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = 'released', version = version + 1, updated_at = %s, released_at = %s, released_by_user_id = %d, release_reason = %s WHERE id = %d AND version = %d AND status = 'active' AND expires_at > UTC_TIMESTAMP()", $now, $now, $actor_id, $reason, $hold_id, $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- DB-side time closes the release-at-expiry race.
+		if ( false === $result ) {
+			return new \WP_Error( 'booking_hold_update_failed', __( 'The booking hold could not be released.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return 1 === $result;
+	}
+
+	private function begin_authorized( int $booking_id, int $actor_id ) {
+		$started = $this->begin();
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$booking = $this->bookings->get( $booking_id );
+		if ( ! is_array( $booking ) ) {
+			return $this->rollback( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+		}
+		return $this->lock_and_authorize_venue( $booking['venue_term_id'], $actor_id );
+	}
+
+	private function begin_venue_authorized( int $venue_id, int $actor_id ) {
+		$started = $this->begin();
+		return is_wp_error( $started ) ? $started : $this->lock_and_authorize_venue( $venue_id, $actor_id );
+	}
+
+	private function lock_and_authorize_venue( int $venue_id, int $actor_id ) {
+		global $wpdb;
+		$table = BookingSchema::memberships_table();
+		$wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $venue_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks exact venue authority.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return $this->rollback( new \WP_Error( 'booking_hold_authorization_lock_failed', __( 'Venue booking authority could not be locked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
+		}
+		$allowed = $this->authorization->authorize( $actor_id, $venue_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+		return true === $allowed ? true : $this->rollback( is_wp_error( $allowed ) ? $allowed : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) ) );
+	}
+
+	private function with_lock( string $name, callable $callback ) {
+		global $wpdb;
+		$acquired = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $name, 5 ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Required cross-connection advisory lock.
+		if ( 1 !== (int) $acquired || '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error(
+				'booking_hold_lock_not_acquired',
+				__( 'The venue-space booking lock could not be acquired.', 'extrachill-events' ),
+				array(
+					'status'         => 503,
+					'database_error' => $wpdb->last_error,
+				)
+			);
+		}
+		$result = null;
+		try {
+			$result = $callback();
+		} catch ( \Throwable $throwable ) {
+			$error  = new \WP_Error( 'booking_hold_operation_failed', __( 'The booking hold operation failed unexpectedly.', 'extrachill-events' ), array( 'exception' => get_class( $throwable ) ) );
+			$result = $this->transaction_active ? $this->rollback( $error ) : $error;
+		} finally {
+			$released = $wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Always release the acquired lock.
+		}
+		if ( 1 !== (int) $released || '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error(
+				'booking_hold_lock_release_failed',
+				__( 'The venue-space booking lock release could not be confirmed.', 'extrachill-events' ),
+				array(
+					'database_error'   => $wpdb->last_error,
+					'operation_result' => is_wp_error( $result ) ? $result->get_error_code() : 'completed',
+				)
+			);
+		}
+		return $result;
+	}
+
+	private function lock_name( int $venue_id, string $space_key ): string {
+		return 'ecbh:' . sha1( $venue_id . ':' . $space_key );
+	}
+
+	private function selection( array $booking ) {
+		if ( empty( $booking['space_key'] ) || empty( $booking['requested_start_at'] ) || empty( $booking['requested_end_at'] ) ) {
+			return new \WP_Error( 'booking_hold_selection_required', __( 'A persisted booking space and date range are required.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		if ( $booking['requested_end_at'] <= $booking['requested_start_at'] ) {
+			return new \WP_Error( 'invalid_booking_date_range', __( 'The requested end must be later than the requested start.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return true;
+	}
+
+	private function configured_space( array $config, string $space_key ): bool {
+		foreach ( $config['spaces'] as $space ) {
+			if ( $space_key === $space['key'] ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function schedule( int $hold_id, string $expires_at ): void {
+		try {
+			if ( function_exists( 'as_schedule_single_action' ) ) {
+				$scheduled = as_schedule_single_action( strtotime( $expires_at . ' UTC' ), self::EXPIRY_HOOK, array( $hold_id, 0 ), self::SCHEDULER_GROUP, true );
+				if ( ! $scheduled ) {
+					throw new \RuntimeException( 'Booking hold expiration was not scheduled.' );
+				}
+			}
+		} catch ( \Throwable $throwable ) {
+			if ( function_exists( 'do_action' ) ) {
+				do_action( 'extrachill_events_booking_hold_schedule_failed', $hold_id, $expires_at, $throwable );
+			}
+		}
+	}
+
+	private function hydrate( array $row, bool $effective = true ): array {
+		foreach ( array( 'id', 'booking_id', 'venue_term_id', 'version', 'created_by_user_id', 'released_by_user_id', 'converted_by_user_id' ) as $field ) {
+			$row[ $field ] = isset( $row[ $field ] ) ? (int) $row[ $field ] : null;
+		}
+		if ( $effective && 'active' === $row['status'] && $row['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) ) {
+			$row['status']     = 'expired';
+			$row['expired_at'] = null === $row['expired_at'] ? $row['expires_at'] : $row['expired_at'];
+		}
+		return $row;
+	}
+
+	private function reconcile_hold_booking( array $hold ) {
+		$expired = $this->expire( (int) $hold['id'] );
+		if ( is_wp_error( $expired ) ) {
+			return $expired;
+		}
+		$booking = $this->bookings->get( $hold['booking_id'] );
+		if ( ! is_array( $booking ) ) {
+			return is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
+		return $booking;
+	}
+
+	private function hold_not_active_error(): \WP_Error {
+		return new \WP_Error( 'booking_hold_not_active', __( 'Only an active unexpired hold can be released.', 'extrachill-events' ), array( 'status' => 409 ) );
+	}
+
+	private function hold_matches_booking( array $hold, array $booking ): bool {
+		return (int) $hold['booking_id'] === (int) $booking['id']
+			&& (int) $hold['venue_term_id'] === (int) $booking['venue_term_id']
+			&& $hold['space_key'] === $booking['space_key']
+			&& $hold['start_at'] === $booking['requested_start_at']
+			&& $hold['end_at'] === $booking['requested_end_at'];
+	}
+
+	private function has_other_matching_active_hold( array $booking, int $excluded_hold_id, string $now ) {
+		global $wpdb;
+		$table = BookingSchema::holds_table();
+		$row   = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at > %s AND id <> %d LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'], $now, $excluded_hold_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact invariant check under the venue-space lock.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_hold_invariant_check_failed', __( 'Other active holds could not be checked safely.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return null !== $row;
+	}
+
+	private function canonical_local_window( string $start, string $end, \DateTimeZone $timezone ): array {
+		$utc         = new \DateTimeZone( 'UTC' );
+		$start_utc   = new \DateTimeImmutable( $start, $utc );
+		$end_utc     = new \DateTimeImmutable( $end, $utc );
+		$start_local = $start_utc->setTimezone( $timezone );
+		$end_local   = $end_utc->setTimezone( $timezone );
+		$local_start = $start_local->format( 'Y-m-d H:i:s' );
+		$local_end   = $end_local->format( 'Y-m-d H:i:s' );
+		$transitions = $timezone->getTransitions( $start_utc->getTimestamp(), $end_utc->getTimestamp() );
+		if ( is_array( $transitions ) ) {
+			$previous_offset = null;
+			foreach ( $transitions as $transition ) {
+				if ( ! is_array( $transition ) || ! isset( $transition['ts'], $transition['offset'] ) ) {
+					continue;
+				}
+				$new_offset = (int) $transition['offset'];
+				if ( null !== $previous_offset && $new_offset < $previous_offset ) {
+					// The canonical index lacks offsets. Include the entire repeated wall-clock fold conservatively.
+					$fold_start  = gmdate( 'Y-m-d H:i:s', (int) $transition['ts'] + $new_offset );
+					$fold_end    = gmdate( 'Y-m-d H:i:s', (int) $transition['ts'] + $previous_offset );
+					$local_start = min( $local_start, $fold_start );
+					$local_end   = max( $local_end, $fold_end );
+				}
+				$previous_offset = $new_offset;
+			}
+		}
+		return array(
+			'start' => $local_start,
+			'end'   => $local_end,
+		);
+	}
+
+	private function valid_datetime( string $value ): bool {
+		$date = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $value, new \DateTimeZone( 'UTC' ) );
+		return false !== $date && $date->format( 'Y-m-d H:i:s' ) === $value;
+	}
+
+	private function booking_version_conflict( $booking ): \WP_Error {
+		return new \WP_Error(
+			'booking_version_conflict',
+			__( 'The booking changed since it was read.', 'extrachill-events' ),
+			array(
+				'status'          => 409,
+				'current_version' => is_array( $booking ) ? $booking['version'] : null,
+			)
+		);
+	}
+
+	private function begin() {
+		global $wpdb;
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate transaction boundary.
+			return new \WP_Error( 'booking_hold_transaction_start_failed', __( 'The booking hold transaction could not start.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		$this->transaction_active = true;
+		return true;
+	}
+
+	private function commit() {
+		global $wpdb;
+		$result                   = $wpdb->query( 'COMMIT' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate transaction.
+		$this->transaction_active = false;
+		return false === $result ? new \WP_Error( 'booking_hold_transaction_commit_uncertain', __( 'The booking hold transaction outcome could not be confirmed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) : true;
+	}
+
+	private function rollback( \WP_Error $cause ) {
+		global $wpdb;
+		if ( ! $this->transaction_active ) {
+			return $cause;
+		}
+		if ( false === $wpdb->query( 'ROLLBACK' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate transaction.
+			$this->transaction_active = false;
+			return new \WP_Error(
+				'booking_hold_transaction_rollback_failed',
+				__( 'The booking hold transaction could not be rolled back.', 'extrachill-events' ),
+				array(
+					'cause'          => $cause->get_error_code(),
+					'database_error' => $wpdb->last_error,
+				)
+			);
+		}
+		$this->transaction_active = false;
+		return $cause;
+	}
+}

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -70,7 +70,7 @@ class BookingHoldRepository {
 		}
 		global $wpdb;
 		$table = BookingSchema::holds_table();
-		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at <= UTC_TIMESTAMP() ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Detects only the elapsed exact selected hold by database time.
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT *, UTC_TIMESTAMP() AS database_now FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at <= UTC_TIMESTAMP() ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Detects only the elapsed exact selected hold by database time.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_hold_reconciliation_failed', __( 'The held booking could not be reconciled.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
@@ -274,8 +274,12 @@ class BookingHoldRepository {
 				}
 
 				global $wpdb;
-				$now       = gmdate( 'Y-m-d H:i:s' );
-				$expires   = gmdate( 'Y-m-d H:i:s', time() + ( (int) $config['hold_ttl_minutes'] * MINUTE_IN_SECONDS ) );
+				$clock = $wpdb->get_row( $wpdb->prepare( 'SELECT UTC_TIMESTAMP() AS current_at, DATE_ADD(UTC_TIMESTAMP(), INTERVAL %d MINUTE) AS expires_at', (int) $config['hold_ttl_minutes'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- MySQL time defines the complete hold lifetime.
+				if ( '' !== (string) $wpdb->last_error || ! is_array( $clock ) || empty( $clock['current_at'] ) || empty( $clock['expires_at'] ) ) {
+					return $this->rollback( new \WP_Error( 'booking_hold_clock_read_failed', __( 'The booking hold expiration could not be calculated.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
+				}
+				$now       = $clock['current_at'];
+				$expires   = $clock['expires_at'];
 				$bookings  = BookingSchema::bookings_table();
 				$increment = $wpdb->query( $wpdb->prepare( "UPDATE {$bookings} SET version = version + 1, updated_at = %s WHERE id = %d AND version = %d", $now, $booking_id, $expected_booking_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate optimistic mutation.
 				if ( false === $increment ) {
@@ -323,7 +327,15 @@ class BookingHoldRepository {
 				if ( is_wp_error( $event ) ) {
 					return $this->rollback( $event );
 				}
-				$hold      = $this->hydrate( array_merge( $row, array( 'id' => $hold_id ) ) );
+				$hold      = $this->hydrate(
+					array_merge(
+						$row,
+						array(
+							'id'           => $hold_id,
+							'database_now' => $now,
+						)
+					)
+				);
 				$committed = $this->commit();
 				if ( is_wp_error( $committed ) ) {
 					return $committed;
@@ -372,8 +384,11 @@ class BookingHoldRepository {
 				if ( is_wp_error( $hold ) || ! is_array( $hold ) ) {
 					return $this->rollback( is_wp_error( $hold ) ? $hold : new \WP_Error( 'booking_hold_not_found', __( 'The booking hold was not found.', 'extrachill-events' ) ) );
 				}
-				$effective = $this->hydrate( $hold );
-				if ( 'active' !== $effective['status'] ) {
+				$elapsed = $this->hold_is_elapsed( $hold_id );
+				if ( is_wp_error( $elapsed ) ) {
+					return $this->rollback( $elapsed );
+				}
+				if ( 'active' !== $hold['status'] || $elapsed ) {
 					return $this->rollback( new \WP_Error( 'booking_hold_reconcile_after_release_lock', 'internal' ) );
 				}
 				if ( (int) $hold['version'] !== $expected_version ) {
@@ -474,7 +489,7 @@ class BookingHoldRepository {
 	private function raw_get( int $hold_id ) {
 		global $wpdb;
 		$table = BookingSchema::holds_table();
-		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1", $hold_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Current-prefix private table.
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT *, UTC_TIMESTAMP() AS database_now FROM {$table} WHERE id = %d LIMIT 1", $hold_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Current-prefix private table with authoritative clock.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_hold_read_failed', __( 'The booking hold could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
@@ -529,7 +544,7 @@ class BookingHoldRepository {
 		$values[] = $limit;
 		$values[] = $offset;
 		$table    = BookingSchema::holds_table();
-		$sql      = "SELECT * FROM {$table} WHERE " . implode( ' AND ', $where ) . ' ORDER BY created_at DESC, id DESC LIMIT %d OFFSET %d'; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Clauses are internal.
+		$sql      = "SELECT *, UTC_TIMESTAMP() AS database_now FROM {$table} WHERE " . implode( ' AND ', $where ) . ' ORDER BY created_at DESC, id DESC LIMIT %d OFFSET %d'; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Clauses are internal.
 		$rows     = $wpdb->get_results( $wpdb->prepare( $sql, $values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Values prepared.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return $this->rollback( new \WP_Error( 'booking_hold_list_failed', __( 'Booking holds could not be listed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
@@ -750,7 +765,7 @@ class BookingHoldRepository {
 	private function matching_active_hold( array $booking ) {
 		global $wpdb;
 		$table = BookingSchema::holds_table();
-		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact persisted selection by database time.
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT *, UTC_TIMESTAMP() AS database_now FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact persisted selection by database time.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_hold_read_failed', __( 'The booking hold could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
@@ -860,6 +875,9 @@ class BookingHoldRepository {
 			return true;
 		}
 		$latest = $this->raw_get( $hold_id );
+		if ( is_wp_error( $latest ) ) {
+			return $latest;
+		}
 		if ( is_array( $latest ) && (int) $latest['version'] === $expected_version && 'active' === $latest['status'] ) {
 			return new \WP_Error( 'booking_hold_expired_during_confirmation', __( 'The booking hold expired before confirmation completed.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
@@ -976,10 +994,14 @@ class BookingHoldRepository {
 	}
 
 	private function hydrate( array $row, bool $effective = true ): array {
+		$database_now = $row['database_now'] ?? null;
+		if ( $effective ) {
+			unset( $row['database_now'] );
+		}
 		foreach ( array( 'id', 'booking_id', 'venue_term_id', 'version', 'created_by_user_id', 'released_by_user_id', 'converted_by_user_id' ) as $field ) {
 			$row[ $field ] = isset( $row[ $field ] ) ? (int) $row[ $field ] : null;
 		}
-		if ( $effective && 'active' === $row['status'] && $row['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) ) {
+		if ( $effective && null !== $database_now && 'active' === $row['status'] && $row['expires_at'] <= $database_now ) {
 			$row['status']     = 'expired';
 			$row['expired_at'] = null === $row['expired_at'] ? $row['expires_at'] : $row['expired_at'];
 		}

--- a/inc/Core/BookingLifecycle.php
+++ b/inc/Core/BookingLifecycle.php
@@ -57,6 +57,9 @@ class BookingLifecycle {
 	 */
 	private $config;
 
+	/** @var BookingHoldRepository */
+	private $holds;
+
 	/**
 	 * Build the aggregate from its two owned repositories.
 	 *
@@ -65,11 +68,12 @@ class BookingLifecycle {
 	 * @param VenueAuthorization|null        $authorization Exact venue authorization.
 	 * @param VenueBookingConfig|null        $config        Admission configuration.
 	 */
-	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, ?VenueBookingConfig $config = null ) {
+	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, ?VenueBookingConfig $config = null, ?BookingHoldRepository $holds = null ) {
 		$this->bookings      = $bookings ? $bookings : new BookingRepository();
 		$this->activity      = $activity ? $activity : new BookingActivityRepository();
 		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
 		$this->config        = $config ? $config : new VenueBookingConfig();
+		$this->holds         = $holds ? $holds : new BookingHoldRepository( $this->bookings, $this->activity, $this->authorization, $this->config );
 	}
 
 	/**
@@ -181,6 +185,10 @@ class BookingLifecycle {
 		if ( is_wp_error( $current ) || null === $current ) {
 			return is_wp_error( $current ) ? $current : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
 		}
+		$current = $this->holds->reconcile_booking( $current );
+		if ( is_wp_error( $current ) ) {
+			return $current;
+		}
 		if ( (int) $current['version'] !== $expected_version ) {
 			return $this->version_conflict( $current );
 		}
@@ -223,6 +231,10 @@ class BookingLifecycle {
 		$current = $this->bookings->get( $booking_id );
 		if ( is_wp_error( $current ) || null === $current ) {
 			return is_wp_error( $current ) ? $current : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
+		$current = $this->holds->reconcile_booking( $current );
+		if ( is_wp_error( $current ) ) {
+			return $current;
 		}
 		if ( (int) $current['version'] !== $expected_version ) {
 			return $this->version_conflict( $current );
@@ -284,6 +296,10 @@ class BookingLifecycle {
 		if ( is_wp_error( $current ) || null === $current ) {
 			return is_wp_error( $current ) ? $current : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
 		}
+		$current = $this->holds->reconcile_booking( $current );
+		if ( is_wp_error( $current ) ) {
+			return $current;
+		}
 		if ( (int) $current['version'] !== $expected_version ) {
 			return $this->version_conflict( $current );
 		}
@@ -296,6 +312,9 @@ class BookingLifecycle {
 			'to_status'   => $to_status,
 			'note'        => null === $note ? null : mb_substr( sanitize_text_field( $note ), 0, 1000 ),
 		);
+		if ( in_array( $to_status, array( 'held', 'confirmed' ), true ) || ( 'held' === $current['status'] && in_array( $to_status, array( 'negotiating', 'declined', 'withdrawn', 'cancelled' ), true ) ) ) {
+			return $this->holds->transition( $current, $to_status, $expected_version, $actor_id, $payload['note'] );
+		}
 		return $this->mutate( $current, array( 'status' => $to_status ), $expected_version, 'status_changed', $payload, $actor_id );
 	}
 
@@ -318,15 +337,8 @@ class BookingLifecycle {
 				)
 			);
 		}
-		if ( 'held' === $to_status ) {
-			return new \WP_Error(
-				'booking_hold_repository_unavailable',
-				__( 'A booking cannot be held until the active-hold repository is available.', 'extrachill-events' ),
-				array(
-					'status'             => 503,
-					'prerequisite_issue' => 295,
-				)
-			);
+		if ( 'held' === $to_status && ( empty( $booking['requested_start_at'] ) || empty( $booking['requested_end_at'] ) || empty( $booking['space_key'] ) ) ) {
+			return new \WP_Error( 'booking_hold_selection_required', __( 'A hold requires a selected date range and space.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
 		if ( 'confirmed' === $to_status ) {
 			if ( empty( $booking['requested_start_at'] ) || empty( $booking['requested_end_at'] ) || empty( $booking['space_key'] ) ) {
@@ -335,7 +347,7 @@ class BookingLifecycle {
 			if ( empty( $booking['deal']['data'] ) ) {
 				return new \WP_Error( 'booking_confirmation_deal_required', __( 'Confirmation requires deal terms.', 'extrachill-events' ), array( 'status' => 409 ) );
 			}
-			return new \WP_Error( 'booking_conflict_repository_unavailable', __( 'A booking cannot be confirmed until conflict detection is available.', 'extrachill-events' ), array( 'status' => 503 ) );
+			return true;
 		}
 		return true;
 	}

--- a/inc/Core/BookingLifecycle.php
+++ b/inc/Core/BookingLifecycle.php
@@ -492,16 +492,16 @@ class BookingLifecycle {
 		if ( is_wp_error( $started ) ) {
 			return $started;
 		}
-		$table = BookingSchema::memberships_table();
-		$wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $booking['venue_term_id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks exact venue authority range.
+		$table  = BookingSchema::memberships_table();
+		$locked = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $booking['venue_term_id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- First transactional read locks and returns current venue authority.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return $this->rollback( new \WP_Error( 'booking_authorization_lock_failed', __( 'Venue booking authority could not be locked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
 		}
-		$actor_allowed = $this->authorization->authorize( $actor_id, $booking['venue_term_id'], VenueAuthorization::ACTION_ACCESS_VENUE );
+		$actor_allowed = $this->authorization->authorize_locked( $actor_id, $booking['venue_term_id'], VenueAuthorization::ACTION_ACCESS_VENUE, (array) $locked );
 		if ( true !== $actor_allowed ) {
 			return $this->rollback( is_wp_error( $actor_allowed ) ? $actor_allowed : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) ) );
 		}
-		if ( null !== $target_user_id && true !== $this->authorization->authorize( $target_user_id, $booking['venue_term_id'], VenueAuthorization::ACTION_ACCESS_VENUE ) ) {
+		if ( null !== $target_user_id && true !== $this->authorization->authorize_locked( $target_user_id, $booking['venue_term_id'], VenueAuthorization::ACTION_ACCESS_VENUE, (array) $locked ) ) {
 			return $this->rollback( new \WP_Error( 'invalid_booking_assignee', __( 'The assignee is not authorized for this venue.', 'extrachill-events' ), array( 'status' => 403 ) ) );
 		}
 		return true;

--- a/inc/Core/BookingRepository.php
+++ b/inc/Core/BookingRepository.php
@@ -575,8 +575,8 @@ class BookingRepository {
 		if ( is_wp_error( $start ) || is_wp_error( $end ) ) {
 			return is_wp_error( $start ) ? $start : $end;
 		}
-		if ( null !== $start && null !== $end && $end < $start ) {
-			return new \WP_Error( 'invalid_booking_date_range', __( 'The requested end must not precede the requested start.', 'extrachill-events' ) );
+		if ( null !== $start && null !== $end && $end <= $start ) {
+			return new \WP_Error( 'invalid_booking_date_range', __( 'The requested end must be later than the requested start.', 'extrachill-events' ) );
 		}
 		return true;
 	}

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Owns and verifies the site-scoped private booking schema. */
 class BookingSchema {
 
-	public const SCHEMA_VERSION = '4';
+	public const SCHEMA_VERSION = '5';
 	public const VERSION_OPTION = 'extrachill_events_booking_schema_version';
 	public const FAILURE_OPTION = 'extrachill_events_booking_schema_error';
 
@@ -40,6 +40,12 @@ class BookingSchema {
 		return $wpdb->prefix . 'ec_venue_members';
 	}
 
+	/** Get the booking holds table for the current site. */
+	public static function holds_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_booking_holds';
+	}
+
 	/** Create or repair all tables, stamping the version only after verification. */
 	public static function install() {
 		global $wpdb;
@@ -47,6 +53,7 @@ class BookingSchema {
 		$bookings = self::bookings_table();
 		$activity = self::activity_table();
 		$members  = self::memberships_table();
+		$holds    = self::holds_table();
 		$charset  = $wpdb->get_charset_collate();
 
 		$bookings_sql = "CREATE TABLE {$bookings} (
@@ -122,6 +129,31 @@ class BookingSchema {
 			KEY venue_status_owner (venue_term_id, status, is_owner)
 		) ENGINE=InnoDB {$charset};";
 
+		$holds_sql = "CREATE TABLE {$holds} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			booking_id BIGINT UNSIGNED NOT NULL,
+			venue_term_id BIGINT UNSIGNED NOT NULL,
+			space_key VARCHAR(64) NOT NULL,
+			start_at DATETIME NOT NULL,
+			end_at DATETIME NOT NULL,
+			expires_at DATETIME NOT NULL,
+			status VARCHAR(16) NOT NULL DEFAULT 'active',
+			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
+			created_by_user_id BIGINT UNSIGNED NOT NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			released_at DATETIME NULL,
+			released_by_user_id BIGINT UNSIGNED NULL,
+			release_reason VARCHAR(255) NULL,
+			expired_at DATETIME NULL,
+			converted_at DATETIME NULL,
+			converted_by_user_id BIGINT UNSIGNED NULL,
+			PRIMARY KEY (id),
+			KEY venue_space_overlap (venue_term_id, space_key, status, start_at, end_at),
+			KEY booking_status (booking_id, status),
+			KEY status_expiration (status, expires_at)
+		) ENGINE=InnoDB {$charset};";
+
 		$repair = self::drop_conflicting_indexes();
 		if ( is_wp_error( $repair ) ) {
 			self::record_failure( $repair );
@@ -135,7 +167,9 @@ class BookingSchema {
 		$activity_error = (string) $wpdb->last_error;
 		dbDelta( $members_sql );
 		$members_error = (string) $wpdb->last_error;
-		if ( '' !== $bookings_error || '' !== $activity_error || '' !== $members_error ) {
+		dbDelta( $holds_sql );
+		$holds_error = (string) $wpdb->last_error;
+		if ( '' !== $bookings_error || '' !== $activity_error || '' !== $members_error || '' !== $holds_error ) {
 			$error = new \WP_Error(
 				'booking_schema_dbdelta_failed',
 				__( 'The booking schema could not be reconciled.', 'extrachill-events' ),
@@ -143,6 +177,7 @@ class BookingSchema {
 					'bookings_error' => $bookings_error,
 					'activity_error' => $activity_error,
 					'members_error'  => $members_error,
+					'holds_error'    => $holds_error,
 				)
 			);
 			self::record_failure( $error );
@@ -556,6 +591,47 @@ class BookingSchema {
 					'venue_status_owner' => array(
 						'unique'  => false,
 						'columns' => array( 'venue_term_id', 'status', 'is_owner' ),
+					),
+				),
+			),
+			self::holds_table()       => array(
+				'engine'  => 'innodb',
+				'columns' => array(
+					'id'                   => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'booking_id'           => $required( 'bigint unsigned', false ),
+					'venue_term_id'        => $required( 'bigint unsigned', false ),
+					'space_key'            => $required( 'varchar(64)', false ),
+					'start_at'             => $required( 'datetime', false ),
+					'end_at'               => $required( 'datetime', false ),
+					'expires_at'           => $required( 'datetime', false ),
+					'status'               => $required( 'varchar(16)', false, array( 'default' => 'active' ) ),
+					'version'              => $required( 'bigint unsigned', false, array( 'default' => '1' ) ),
+					'created_by_user_id'   => $required( 'bigint unsigned', false ),
+					'created_at'           => $required( 'datetime', false ),
+					'updated_at'           => $required( 'datetime', false ),
+					'released_at'          => $required( 'datetime', true ),
+					'released_by_user_id'  => $required( 'bigint unsigned', true ),
+					'release_reason'       => $required( 'varchar(255)', true ),
+					'expired_at'           => $required( 'datetime', true ),
+					'converted_at'         => $required( 'datetime', true ),
+					'converted_by_user_id' => $required( 'bigint unsigned', true ),
+				),
+				'indexes' => array(
+					'PRIMARY'             => array(
+						'unique'  => true,
+						'columns' => array( 'id' ),
+					),
+					'venue_space_overlap' => array(
+						'unique'  => false,
+						'columns' => array( 'venue_term_id', 'space_key', 'status', 'start_at', 'end_at' ),
+					),
+					'booking_status'      => array(
+						'unique'  => false,
+						'columns' => array( 'booking_id', 'status' ),
+					),
+					'status_expiration'   => array(
+						'unique'  => false,
+						'columns' => array( 'status', 'expires_at' ),
 					),
 				),
 			),

--- a/inc/Core/VenueAuthorization.php
+++ b/inc/Core/VenueAuthorization.php
@@ -43,6 +43,47 @@ class VenueAuthorization {
 
 	/** Authorize one network user for one action at one Events-site venue. */
 	public function authorize( int $user_id, int $venue_term_id, string $action ) {
+		$valid = $this->validate_request( $user_id, $venue_term_id, $action );
+		if ( true !== $valid ) {
+			return $valid;
+		}
+		if ( self::ACTION_MANAGE_MEMBERS === $action && $this->is_administrator( $user_id ) ) {
+			return true;
+		}
+		if ( ! $this->has_feature_access( $user_id ) ) {
+			return $this->denied();
+		}
+
+		$membership = $this->active_membership( $user_id, $venue_term_id );
+		return $this->authorize_membership( $membership, $action );
+	}
+
+	/** Authorize from lock-current membership rows without a consistent-snapshot reread. */
+	public function authorize_locked( int $user_id, int $venue_term_id, string $action, array $locked_memberships ) {
+		$valid = $this->validate_request( $user_id, $venue_term_id, $action );
+		if ( true !== $valid ) {
+			return $valid;
+		}
+		if ( self::ACTION_MANAGE_MEMBERS === $action && $this->is_administrator( $user_id ) ) {
+			return true;
+		}
+		if ( ! $this->has_feature_access( $user_id ) ) {
+			return $this->denied();
+		}
+
+		$membership = null;
+		foreach ( $locked_memberships as $row ) {
+			if ( (int) ( $row['venue_term_id'] ?? 0 ) !== $venue_term_id || (int) ( $row['user_id'] ?? 0 ) !== $user_id ) {
+				continue;
+			}
+			$membership = $this->memberships->hydrate( $row );
+			break;
+		}
+		return $this->authorize_membership( $membership, $action );
+	}
+
+	/** Validate the non-membership portion of one authorization request. */
+	private function validate_request( int $user_id, int $venue_term_id, string $action ) {
 		if ( ! in_array( $action, self::actions(), true ) ) {
 			return new \WP_Error(
 				'invalid_venue_action',
@@ -71,14 +112,11 @@ class VenueAuthorization {
 			return $this->denied();
 		}
 
-		if ( self::ACTION_MANAGE_MEMBERS === $action && $this->is_administrator( $user_id ) ) {
-			return true;
-		}
-		if ( ! $this->has_feature_access( $user_id ) ) {
-			return $this->denied();
-		}
+		return true;
+	}
 
-		$membership = $this->active_membership( $user_id, $venue_term_id );
+	/** Apply action policy to a resolved membership. */
+	private function authorize_membership( $membership, string $action ) {
 		if ( is_wp_error( $membership ) ) {
 			return $membership;
 		}

--- a/inc/Core/VenueAuthorization.php
+++ b/inc/Core/VenueAuthorization.php
@@ -123,6 +123,9 @@ class VenueAuthorization {
 		if ( ! is_array( $membership ) ) {
 			return $this->denied();
 		}
+		if ( self::STATUS_ACTIVE !== ( $membership['status'] ?? '' ) ) {
+			return $this->denied();
+		}
 		if ( self::ACTION_MANAGE_MEMBERS === $action && ! $membership['is_owner'] ) {
 			return $this->denied();
 		}

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -9,6 +9,7 @@
 	<testsuites>
 		<testsuite name="booking-foundation">
 			<file>tests/BookingFoundationTest.php</file>
+			<file>tests/BookingHoldTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -19,15 +19,15 @@ require_once __DIR__ . '/Support/BookingTestHarness.php';
 final class BookingFoundationTest extends TestCase {
 	protected function setUp(): void {
 		$GLOBALS['ec_artist_test'] = array(
-			'blog_id'   => 7,
-			'stack'     => array(),
-			'uuid'      => 0,
-			'options'   => array(),
-			'dbdelta'   => array(),
-			'abilities' => array(),
-			'actions'   => array(),
+			'blog_id'       => 7,
+			'stack'         => array(),
+			'uuid'          => 0,
+			'options'       => array(),
+			'dbdelta'       => array(),
+			'abilities'     => array(),
+			'actions'       => array(),
 			'cache_deletes' => array(),
-			'terms'     => array(
+			'terms'         => array(
 				1 => array(
 					101 => (object) array(
 						'term_id'  => 101,
@@ -48,11 +48,16 @@ final class BookingFoundationTest extends TestCase {
 					),
 				),
 			),
-			'meta'      => array(
+			'meta'          => array(
 				1 => array( 101 => array( '_artist_profile_id' => 501 ) ),
-				7 => array( 55 => array( '_extrachill_booking_config' => array( 'enabled' => true ) ) ),
+				7 => array(
+					55 => array(
+						'_extrachill_booking_config' => array( 'enabled' => true ),
+						'_venue_timezone'            => 'America/New_York',
+					),
+				),
 			),
-			'posts'     => array(
+			'posts'         => array(
 				4 => array(
 					501 => (object) array(
 						'ID'          => 501,
@@ -80,7 +85,7 @@ final class BookingFoundationTest extends TestCase {
 					),
 				),
 			),
-			'post_meta' => array( 4 => array( 501 => array( '_artist_term_id' => 101 ) ) ),
+			'post_meta'     => array( 4 => array( 501 => array( '_artist_term_id' => 101 ) ) ),
 		);
 		$GLOBALS['wpdb']           = new BookingWpdb();
 	}
@@ -286,8 +291,8 @@ final class BookingFoundationTest extends TestCase {
 
 	public function test_aggregate_table_engines_are_repaired_and_failures_are_not_stamped(): void {
 		$this->assertTrue( BookingSchema::install() );
-		$bookings = BookingSchema::bookings_table();
-		$activity = BookingSchema::activity_table();
+		$bookings                              = BookingSchema::bookings_table();
+		$activity                              = BookingSchema::activity_table();
 		$GLOBALS['wpdb']->engines[ $bookings ] = 'MyISAM';
 		$GLOBALS['wpdb']->engines[ $activity ] = 'MyISAM';
 		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '';
@@ -295,8 +300,8 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertSame( 'INNODB', strtoupper( $GLOBALS['wpdb']->engines[ $bookings ] ) );
 		$this->assertSame( 'INNODB', strtoupper( $GLOBALS['wpdb']->engines[ $activity ] ) );
 
-		$GLOBALS['wpdb']->engines[ $bookings ] = 'MyISAM';
-		$GLOBALS['wpdb']->fail_engine_repair = true;
+		$GLOBALS['wpdb']->engines[ $bookings ]                                 = 'MyISAM';
+		$GLOBALS['wpdb']->fail_engine_repair                                   = true;
 		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '';
 		$this->assertSame( 'booking_schema_engine_repair_failed', BookingSchema::maybe_install()->get_error_code() );
 		$this->assertSame( '', get_option( BookingSchema::VERSION_OPTION, '' ) );
@@ -647,7 +652,7 @@ final class BookingFoundationTest extends TestCase {
 				'requested_end_at'   => '2026-08-02 00:00:00',
 			)
 		);
-		$confirmed = $this->create_booking(
+		$confirmed  = $this->create_booking(
 			array(
 				'requested_start_at' => '2026-09-01 00:00:00',
 				'requested_end_at'   => '2026-09-02 00:00:00',
@@ -705,7 +710,7 @@ final class BookingFoundationTest extends TestCase {
 			BookingLifecycle::STATUSES
 		);
 		$this->assertSame( BookingRepository::STATUSES, BookingLifecycle::STATUSES );
-		$allowed = array(
+		$allowed   = array(
 			'submitted'    => array( 'needs_info', 'under_review', 'declined', 'withdrawn' ),
 			'needs_info'   => array( 'submitted', 'under_review', 'declined', 'withdrawn' ),
 			'under_review' => array( 'needs_info', 'negotiating', 'declined', 'withdrawn' ),
@@ -726,7 +731,10 @@ final class BookingFoundationTest extends TestCase {
 						'requested_start_at' => '2026-08-01 20:00:00',
 						'requested_end_at'   => '2026-08-01 23:00:00',
 						'space_key'          => 'main-room',
-						'deal'               => array( 'version' => 1, 'data' => array( 'type' => 'guarantee' ) ),
+						'deal'               => array(
+							'version' => 1,
+							'data'    => array( 'type' => 'guarantee' ),
+						),
 					),
 					$to
 				);
@@ -741,15 +749,24 @@ final class BookingFoundationTest extends TestCase {
 
 	public function test_missing_hold_and_conflict_substrates_fail_closed(): void {
 		$lifecycle = new BookingLifecycle();
-		$booking   = array( 'status' => 'negotiating', 'requested_start_at' => null, 'requested_end_at' => null, 'space_key' => null, 'deal' => null );
-		$this->assertSame( 'booking_hold_repository_unavailable', $lifecycle->validate_transition( $booking, 'held' )->get_error_code() );
+		$booking   = array(
+			'status'             => 'negotiating',
+			'requested_start_at' => null,
+			'requested_end_at'   => null,
+			'space_key'          => null,
+			'deal'               => null,
+		);
+		$this->assertSame( 'booking_hold_selection_required', $lifecycle->validate_transition( $booking, 'held' )->get_error_code() );
 		$this->assertSame( 'booking_confirmation_selection_required', $lifecycle->validate_transition( $booking, 'confirmed' )->get_error_code() );
 		$booking['requested_start_at'] = '2026-08-01 20:00:00';
 		$booking['requested_end_at']   = '2026-08-01 23:00:00';
 		$booking['space_key']          = 'main-room';
 		$this->assertSame( 'booking_confirmation_deal_required', $lifecycle->validate_transition( $booking, 'confirmed' )->get_error_code() );
-		$booking['deal'] = array( 'version' => 1, 'data' => array( 'type' => 'guarantee' ) );
-		$this->assertSame( 'booking_conflict_repository_unavailable', $lifecycle->validate_transition( $booking, 'confirmed' )->get_error_code() );
+		$booking['deal'] = array(
+			'version' => 1,
+			'data'    => array( 'type' => 'guarantee' ),
+		);
+		$this->assertTrue( $lifecycle->validate_transition( $booking, 'confirmed' ) );
 	}
 
 	public function test_inquiry_creation_is_atomic_anonymous_and_race_idempotent(): void {
@@ -760,11 +777,16 @@ final class BookingFoundationTest extends TestCase {
 			'artist_name'     => 'New Band',
 			'intake'          => array( 'draw' => 100 ),
 		);
-		$first = $lifecycle->create_inquiry( $input );
+		$first     = $lifecycle->create_inquiry( $input );
 		$this->assertSame( 'submitted', $first['status'] );
 		$this->assertNull( $first['submitter_user_id'] );
 		$this->assertSame( $first['id'], $lifecycle->create_inquiry( $input )['id'] );
-		$reordered = array( 'intake' => array( 'draw' => 100 ), 'artist_name' => 'New Band', 'venue_term_id' => 55, 'idempotency_key' => 'request-298' );
+		$reordered = array(
+			'intake'          => array( 'draw' => 100 ),
+			'artist_name'     => 'New Band',
+			'venue_term_id'   => 55,
+			'idempotency_key' => 'request-298',
+		);
 		$this->assertSame( $first['id'], $lifecycle->create_inquiry( $reordered )['id'] );
 		$conflict = $lifecycle->create_inquiry( array_merge( $input, array( 'artist_name' => 'Different Band' ) ) );
 		$this->assertSame( 'booking_idempotency_conflict', $conflict->get_error_code() );
@@ -773,29 +795,47 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertCount( 1, $GLOBALS['wpdb']->rows[ BookingSchema::activity_table() ] );
 
 		$GLOBALS['wpdb']->race_booking_insert = true;
-		$race = $lifecycle->create_inquiry( array_merge( $input, array( 'idempotency_key' => 'request-race' ) ) );
+		$race                                 = $lifecycle->create_inquiry( array_merge( $input, array( 'idempotency_key' => 'request-race' ) ) );
 		$this->assertIsArray( $race );
 		$this->assertSame( 0, $GLOBALS['wpdb']->natural_key_reads_in_transaction, 'The loser must resolve its winner only after rollback.' );
 		$this->assertCount( 2, $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ] );
 		$this->assertCount( 2, $GLOBALS['wpdb']->rows[ BookingSchema::activity_table() ] );
-		$this->assertSame( 'booking_idempotency_conflict', $lifecycle->create_inquiry( array_merge( $input, array( 'idempotency_key' => 'request-race', 'contact_email' => 'other@example.com' ) ) )->get_error_code() );
+		$this->assertSame(
+			'booking_idempotency_conflict',
+			$lifecycle->create_inquiry(
+				array_merge(
+					$input,
+					array(
+						'idempotency_key' => 'request-race',
+						'contact_email'   => 'other@example.com',
+					)
+				)
+			)->get_error_code()
+		);
 		$GLOBALS['wpdb']->race_booking_insert = true;
 		$GLOBALS['wpdb']->race_booking_hash   = str_repeat( '0', 64 );
-		$race_conflict = $lifecycle->create_inquiry( array_merge( $input, array( 'idempotency_key' => 'request-race-mismatch' ) ) );
+		$race_conflict                        = $lifecycle->create_inquiry( array_merge( $input, array( 'idempotency_key' => 'request-race-mismatch' ) ) );
 		$this->assertSame( 'booking_idempotency_conflict', $race_conflict->get_error_code() );
 		$this->assertSame( array( 'status' => 409 ), $race_conflict->get_error_data() );
 		$this->assertSame( 'booking_idempotency_conflict', $lifecycle->create_inquiry( $input, 12 )->get_error_code(), 'Authenticated actor identity must be part of the fingerprint.' );
 
 		$GLOBALS['wpdb']->fail_activity_inserts = true;
-		$result = $lifecycle->create_inquiry( array_merge( $input, array( 'idempotency_key' => 'request-fails' ) ) );
+		$result                                 = $lifecycle->create_inquiry( array_merge( $input, array( 'idempotency_key' => 'request-fails' ) ) );
 		$this->assertSame( 'booking_activity_write_failed', $result->get_error_code() );
 		$this->assertCount( 3, $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ] );
 	}
 
 	public function test_failed_idempotent_insert_without_winner_preserves_database_error(): void {
-		$lifecycle = new BookingLifecycle();
+		$lifecycle                     = new BookingLifecycle();
 		$GLOBALS['wpdb']->fail_inserts = true;
-		$result = $lifecycle->create_inquiry( array( 'idempotency_key' => 'no-winner', 'venue_term_id' => 55, 'intake' => array(), 'artist_name' => 'Band' ) );
+		$result                        = $lifecycle->create_inquiry(
+			array(
+				'idempotency_key' => 'no-winner',
+				'venue_term_id'   => 55,
+				'intake'          => array(),
+				'artist_name'     => 'Band',
+			)
+		);
 		$this->assertSame( 'booking_create_failed', $result->get_error_code() );
 		$this->assertSame( array( 'database_error' => 'simulated insert failure' ), $result->get_error_data() );
 		$this->assertSame( 0, $GLOBALS['wpdb']->natural_key_reads_in_transaction );
@@ -803,7 +843,12 @@ final class BookingFoundationTest extends TestCase {
 
 	public function test_inquiry_admission_requires_enabled_config_but_retry_survives_disable(): void {
 		$lifecycle = new BookingLifecycle();
-		$input     = array( 'idempotency_key' => 'enabled-request', 'venue_term_id' => 55, 'intake' => array(), 'artist_name' => 'Band' );
+		$input     = array(
+			'idempotency_key' => 'enabled-request',
+			'venue_term_id'   => 55,
+			'intake'          => array(),
+			'artist_name'     => 'Band',
+		);
 		$created   = $lifecycle->create_inquiry( $input );
 		$this->assertIsArray( $created );
 		$this->assertSame( 1, $GLOBALS['wpdb']->venue_lock_queries );
@@ -814,7 +859,7 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertSame( 'booking_inquiry_admission_disabled', $lifecycle->create_inquiry( array_merge( $input, array( 'idempotency_key' => 'disabled-request' ) ) )->get_error_code() );
 
 		$GLOBALS['ec_artist_test']['meta'][7][55]['_extrachill_booking_config'] = array( 'enabled' => true );
-		$GLOBALS['wpdb']->after_venue_lock = static function () {
+		$GLOBALS['wpdb']->after_venue_lock                                      = static function () {
 			$GLOBALS['ec_artist_test']['meta'][7][55]['_extrachill_booking_config'] = array( 'enabled' => false );
 		};
 		$this->assertSame( 'booking_inquiry_admission_disabled', $lifecycle->create_inquiry( array_merge( $input, array( 'idempotency_key' => 'disabled-during-lock' ) ) )->get_error_code() );
@@ -825,7 +870,14 @@ final class BookingFoundationTest extends TestCase {
 
 	public function test_inquiry_config_read_failure_rolls_back_after_venue_lock(): void {
 		$lifecycle = new BookingLifecycle( null, null, null, new BookingTestConfig() );
-		$result    = $lifecycle->create_inquiry( array( 'idempotency_key' => 'read-failure', 'venue_term_id' => 55, 'intake' => array(), 'artist_name' => 'Band' ) );
+		$result    = $lifecycle->create_inquiry(
+			array(
+				'idempotency_key' => 'read-failure',
+				'venue_term_id'   => 55,
+				'intake'          => array(),
+				'artist_name'     => 'Band',
+			)
+		);
 		$this->assertSame( 'booking_inquiry_config_read_failed', $result->get_error_code() );
 		$this->assertSame( 1, $GLOBALS['wpdb']->venue_lock_queries );
 		$this->assertSame( 1, $GLOBALS['wpdb']->rollback_queries );
@@ -846,7 +898,7 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertSame( 3, $assigned['version'] );
 
 		$GLOBALS['wpdb']->fail_activity_inserts = true;
-		$result = $lifecycle->transition( $booking['id'], 'negotiating', 3, 12 );
+		$result                                 = $lifecycle->transition( $booking['id'], 'negotiating', 3, 12 );
 		$this->assertSame( 'booking_activity_write_failed', $result->get_error_code() );
 		$current = ( new BookingRepository() )->get( $booking['id'] );
 		$this->assertSame( 'under_review', $current['status'] );
@@ -888,18 +940,18 @@ final class BookingFoundationTest extends TestCase {
 	}
 
 	public function test_transaction_lock_reauthorizes_actor_and_atomic_artist_binding(): void {
-		$authorization = new BookingTestAuthorization();
-		$lifecycle     = new BookingLifecycle( null, null, $authorization );
-		$booking       = $this->create_booking();
+		$authorization                          = new BookingTestAuthorization();
+		$lifecycle                              = new BookingLifecycle( null, null, $authorization );
+		$booking                                = $this->create_booking();
 		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) {
 			unset( $authorization->allowed['12:55'] );
 		};
-		$denied = $lifecycle->transition( $booking['id'], 'under_review', 1, 12 );
+		$denied                                 = $lifecycle->transition( $booking['id'], 'under_review', 1, 12 );
 		$this->assertSame( 'venue_action_forbidden', $denied->get_error_code() );
 		$this->assertSame( 1, ( new BookingRepository() )->get( $booking['id'] )['version'] );
 
 		$authorization->allowed['12:55'] = true;
-		$bound = $lifecycle->bind_artist( $booking['id'], 101, 501, 1, 12 );
+		$bound                           = $lifecycle->bind_artist( $booking['id'], 101, 501, 1, 12 );
 		$this->assertSame( 101, $bound['artist_term_id'] );
 		$this->assertSame( 501, $bound['artist_profile_id'] );
 		$this->assertSame( 'Canonical Artist', $bound['artist_name'] );
@@ -915,13 +967,13 @@ final class BookingFoundationTest extends TestCase {
 	}
 
 	public function test_assignment_target_is_reauthorized_after_venue_lock(): void {
-		$authorization = new BookingTestAuthorization( array( '20:55' => true ) );
-		$lifecycle     = new BookingLifecycle( null, null, $authorization );
-		$booking       = $this->create_booking();
+		$authorization                          = new BookingTestAuthorization( array( '20:55' => true ) );
+		$lifecycle                              = new BookingLifecycle( null, null, $authorization );
+		$booking                                = $this->create_booking();
 		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) {
 			unset( $authorization->allowed['20:55'] );
 		};
-		$result = $lifecycle->assign( $booking['id'], 20, 1, 12 );
+		$result                                 = $lifecycle->assign( $booking['id'], 20, 1, 12 );
 		$this->assertSame( 'invalid_booking_assignee', $result->get_error_code() );
 		$current = ( new BookingRepository() )->get( $booking['id'] );
 		$this->assertNull( $current['assignee_user_id'] );
@@ -929,14 +981,19 @@ final class BookingFoundationTest extends TestCase {
 	}
 
 	public function test_transaction_control_failures_are_explicit(): void {
-		$lifecycle = new BookingLifecycle();
-		$input     = array( 'idempotency_key' => 'transaction-test', 'venue_term_id' => 55, 'artist_name' => 'New Band', 'intake' => array() );
+		$lifecycle                               = new BookingLifecycle();
+		$input                                   = array(
+			'idempotency_key' => 'transaction-test',
+			'venue_term_id'   => 55,
+			'artist_name'     => 'New Band',
+			'intake'          => array(),
+		);
 		$GLOBALS['wpdb']->fail_transaction_start = true;
 		$this->assertSame( 'booking_transaction_start_failed', $lifecycle->create_inquiry( $input )->get_error_code() );
 
 		$GLOBALS['wpdb']->fail_transaction_start  = false;
 		$GLOBALS['wpdb']->fail_transaction_commit = true;
-		$rollbacks_before = $GLOBALS['wpdb']->rollback_queries;
+		$rollbacks_before                         = $GLOBALS['wpdb']->rollback_queries;
 		$this->assertSame( 'booking_transaction_commit_uncertain', $lifecycle->create_inquiry( $input )->get_error_code() );
 		$this->assertSame( $rollbacks_before, $GLOBALS['wpdb']->rollback_queries );
 
@@ -964,6 +1021,11 @@ final class BookingFoundationTest extends TestCase {
 		);
 		$this->assertFalse( $registered['extrachill/create-booking-inquiry']['meta']['show_in_rest'] );
 		$this->assertTrue( $registered['extrachill/list-venue-bookings']['meta']['show_in_rest'] );
+		foreach ( array( 'extrachill/list-venue-bookings', 'extrachill/get-venue-booking' ) as $reconciling_ability ) {
+			$this->assertFalse( $registered[ $reconciling_ability ]['meta']['annotations']['readonly'] );
+			$this->assertTrue( $registered[ $reconciling_ability ]['meta']['annotations']['idempotent'] );
+			$this->assertFalse( $registered[ $reconciling_ability ]['meta']['annotations']['destructive'] );
+		}
 		foreach ( $registered as $definition ) {
 			$this->assertFalse( $definition['input_schema']['additionalProperties'] );
 			$this->assertFalse( $definition['output_schema']['additionalProperties'] ?? false );
@@ -974,14 +1036,20 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertSame( array( 'booking_id', 'to_status', 'expected_version' ), $registered['extrachill/transition-venue-booking']['input_schema']['required'] );
 		$this->assertSame( array( 'booking_id', 'expected_version' ), $registered['extrachill/bind-venue-booking-artist']['input_schema']['required'] );
 		$this->assertSame( array( 'public_id', 'venue_term_id', 'submitted_at' ), $registered['extrachill/create-booking-inquiry']['output_schema']['required'] );
-		$receipt_input = array( 'idempotency_key' => 'public-receipt', 'venue_term_id' => 55, 'intake' => array(), 'artist_name' => 'Private Band', 'contact_email' => 'private@example.com' );
+		$receipt_input = array(
+			'idempotency_key' => 'public-receipt',
+			'venue_term_id'   => 55,
+			'intake'          => array(),
+			'artist_name'     => 'Private Band',
+			'contact_email'   => 'private@example.com',
+		);
 		$receipt       = call_user_func( $registered['extrachill/create-booking-inquiry']['execute_callback'], $receipt_input );
 		$this->assertSame( array( 'public_id', 'venue_term_id', 'submitted_at' ), array_keys( $receipt ) );
 		$this->assertArrayNotHasKey( 'id', $receipt );
 		$this->assertArrayNotHasKey( 'status', $receipt );
 		$this->assertArrayNotHasKey( 'contact_email', $receipt );
 		$stored = reset( $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ] );
-		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $stored['id'] ]['status'] = 'under_review';
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $stored['id'] ]['status']        = 'under_review';
 		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $stored['id'] ]['contact_email'] = 'changed@example.com';
 		$this->assertSame( $receipt, call_user_func( $registered['extrachill/create-booking-inquiry']['execute_callback'], $receipt_input ) );
 

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -13,6 +13,7 @@ use ExtraChillEvents\Core\BookingLifecycle;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\VenueBookingConfig;
+use ExtraChillEvents\Core\VenueAuthorization;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
@@ -207,6 +208,30 @@ final class BookingHoldTest extends TestCase {
 		$this->assertSame( 'expired', $holds->expire( $id )['status'] );
 		$this->assertSame( 'expired', $holds->expire( $id )['status'] );
 		$this->assertSame( 2, $holds->get( $id )['version'] );
+	}
+
+	public function test_hold_lifetime_and_effective_expiry_use_database_time(): void {
+		$GLOBALS['wpdb']->database_now = '2034-01-01 00:00:00';
+
+		$holds   = $this->holds();
+		$booking = $this->booking( '2034-08-01 20:00:00', '2034-08-01 23:00:00' );
+		$created = $holds->create( $booking['id'], 1, 12 );
+		$this->assertSame( '2034-01-01 00:00:00', $created['hold']['created_at'] );
+		$this->assertSame( '2034-01-01 00:30:00', $created['hold']['expires_at'] );
+
+		$GLOBALS['wpdb']->database_now = '2034-01-01 00:30:00';
+		$this->assertSame( 'expired', $holds->get( $created['hold']['id'] )['status'] );
+		$this->assertSame( 'booking_hold_not_active', $holds->release( $created['hold']['id'], 1, 12, 'database expiry' )->get_error_code() );
+	}
+
+	public function test_hold_creation_returns_database_clock_errors(): void {
+		$holds   = $this->holds();
+		$booking = $this->booking( '2034-09-01 20:00:00', '2034-09-01 23:00:00' );
+		$GLOBALS['wpdb']->fail_clock_reads = true;
+
+		$result = $holds->create( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_hold_clock_read_failed', $result->get_error_code() );
+		$this->assertSame( 1, ( new BookingRepository() )->get( $booking['id'] )['version'] );
 	}
 
 	public function test_elapsed_holds_are_effectively_expired_in_get_list_and_release(): void {
@@ -561,6 +586,7 @@ final class BookingHoldTest extends TestCase {
 	}
 
 	public function test_mutations_deny_lock_current_revoked_membership(): void {
+		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = BookingSchema::SCHEMA_VERSION;
 		$authorization = new BookingTestAuthorization();
 		$authorization->require_locked_membership = true;
 		$holds         = new BookingHoldRepository( null, null, $authorization );
@@ -568,27 +594,33 @@ final class BookingHoldTest extends TestCase {
 		$booking       = $this->booking( '2031-11-01 20:00:00', '2031-11-01 23:00:00' );
 		$membership_table = BookingSchema::memberships_table();
 		$GLOBALS['wpdb']->rows[ $membership_table ][1] = array(
-			'id'                  => 1,
-			'venue_term_id'       => 55,
-			'user_id'             => 12,
-			'status'              => 'active',
+			'id'                 => 1,
+			'venue_term_id'      => 55,
+			'user_id'            => 12,
+			'is_owner'           => 1,
+			'status'             => VenueAuthorization::STATUS_ACTIVE,
+			'version'            => 1,
+			'created_by_user_id' => 12,
+			'created_at'         => '2030-01-01 00:00:00',
+			'updated_at'         => '2030-01-01 00:00:00',
+			'revoked_at'         => null,
 		);
 		$revoke = static function () use ( $membership_table ) {
-			$GLOBALS['wpdb']->rows[ $membership_table ][1]['status'] = 'revoked';
+			$GLOBALS['wpdb']->rows[ $membership_table ][1]['status'] = VenueAuthorization::STATUS_REVOKED;
 		};
 		$GLOBALS['wpdb']->after_membership_lock = $revoke;
 		$this->assertSame( 'venue_action_forbidden', $holds->create( $booking['id'], 1, 12 )->get_error_code() );
 
-		$GLOBALS['wpdb']->rows[ $membership_table ][1]['status'] = 'active';
+		$GLOBALS['wpdb']->rows[ $membership_table ][1]['status'] = VenueAuthorization::STATUS_ACTIVE;
 		$created = $holds->create( $booking['id'], 1, 12 );
 		$GLOBALS['wpdb']->after_membership_lock = $revoke;
 		$this->assertSame( 'venue_action_forbidden', $holds->release( $created['hold']['id'], 1, 12, 'revoked' )->get_error_code() );
 
-		$GLOBALS['wpdb']->rows[ $membership_table ][1]['status'] = 'active';
+		$GLOBALS['wpdb']->rows[ $membership_table ][1]['status'] = VenueAuthorization::STATUS_ACTIVE;
 		$GLOBALS['wpdb']->after_membership_lock = $revoke;
 		$this->assertSame( 'venue_action_forbidden', $lifecycle->transition( $booking['id'], 'held', 2, 12 )->get_error_code() );
 
-		$GLOBALS['wpdb']->rows[ $membership_table ][1]['status'] = 'active';
+		$GLOBALS['wpdb']->rows[ $membership_table ][1]['status'] = VenueAuthorization::STATUS_ACTIVE;
 		$lifecycle->transition( $booking['id'], 'held', 2, 12 );
 		$GLOBALS['wpdb']->after_membership_lock = $revoke;
 		$this->assertSame( 'venue_action_forbidden', $lifecycle->transition( $booking['id'], 'confirmed', 3, 12 )->get_error_code() );
@@ -683,6 +715,22 @@ final class BookingHoldTest extends TestCase {
 		$this->assertSame( 'held', ( new BookingRepository() )->get( $booking['id'] )['status'] );
 		$this->assertSame( 3, ( new BookingRepository() )->get( $booking['id'] )['version'] );
 		$this->assertSame( 'active', $GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $created['hold']['id'] ]['status'] );
+	}
+
+	public function test_confirmation_propagates_conversion_diagnostic_read_errors(): void {
+		$holds     = $this->holds();
+		$lifecycle = new BookingLifecycle( null, null, null, null, $holds );
+		$booking   = $this->booking( '2032-12-01 20:00:00', '2032-12-01 23:00:00' );
+		$created   = $holds->create( $booking['id'], 1, 12 );
+		$lifecycle->transition( $booking['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->elapse_hold_before_conversion_update = $created['hold']['id'];
+		$GLOBALS['wpdb']->fail_read_after_conversion_update    = true;
+
+		$result = $lifecycle->transition( $booking['id'], 'confirmed', 3, 12 );
+		$this->assertSame( 'booking_hold_read_failed', $result->get_error_code() );
+		$GLOBALS['wpdb']->reads_before_failure = null;
+		$this->assertSame( 'held', ( new BookingRepository() )->get( $booking['id'] )['status'] );
+		$this->assertSame( 3, ( new BookingRepository() )->get( $booking['id'] )['version'] );
 	}
 
 	public function test_leaving_held_releases_remaining_active_holds(): void {

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -1,0 +1,671 @@
+<?php
+/**
+ * Booking hold, conflict, and hold-aware lifecycle tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Abilities\VenueBookingHoldAbilities;
+use ExtraChillEvents\Abilities\VenueBookingAbilities;
+use ExtraChillEvents\Core\BookingActivityRepository;
+use ExtraChillEvents\Core\BookingHoldRepository;
+use ExtraChillEvents\Core\BookingLifecycle;
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\VenueBookingConfig;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
+final class BookingHoldTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id'       => 7,
+			'stack'         => array(),
+			'uuid'          => 0,
+			'options'       => array(),
+			'dbdelta'       => array(),
+			'abilities'     => array(),
+			'actions'       => array(),
+			'fired_actions' => array(),
+			'scheduled'     => array(),
+			'cache_deletes' => array(),
+			'terms'         => array(
+				7 => array(
+					55 => (object) array(
+						'term_id'  => 55,
+						'taxonomy' => 'venue',
+						'name'     => 'The Room',
+					),
+				),
+			),
+			'meta'          => array(
+				7 => array(
+					55 => array(
+						'_venue_timezone'            => 'America/New_York',
+						VenueBookingConfig::META_KEY => array(
+							'enabled'          => true,
+							'hold_ttl_minutes' => 30,
+							'spaces'           => array(
+								array(
+									'key'        => 'main-room',
+									'name'       => 'Main Room',
+									'is_default' => true,
+								),
+								array(
+									'key'  => 'patio',
+									'name' => 'Patio',
+								),
+							),
+						),
+					),
+				),
+			),
+			'posts'         => array(),
+			'post_meta'     => array(),
+		);
+		$GLOBALS['wpdb']           = new BookingWpdb();
+	}
+
+	private function booking( string $start = '2030-08-01 20:00:00', string $end = '2030-08-01 23:00:00', string $space = 'main-room', array $overrides = array() ) {
+		$booking = ( new BookingRepository() )->create(
+			array_merge(
+				array(
+					'venue_term_id'      => 55,
+					'artist_name'        => 'Test Band',
+					'intake'             => array(),
+					'deal'               => array( 'type' => 'guarantee' ),
+					'space_key'          => $space,
+					'requested_start_at' => $start,
+					'requested_end_at'   => $end,
+				),
+				$overrides
+			)
+		);
+		if ( is_array( $booking ) ) {
+			$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['status'] = $overrides['status'] ?? 'negotiating';
+			$booking['status'] = $overrides['status'] ?? 'negotiating';
+		}
+		return $booking;
+	}
+
+	private function holds(): BookingHoldRepository {
+		return new BookingHoldRepository( null, null, new BookingTestAuthorization() );
+	}
+
+	private function seed_held_venue( int $count, bool $elapsed ): array {
+		$holds     = $this->holds();
+		$lifecycle = new BookingLifecycle( null, null, null, null, $holds );
+		$booking   = $this->booking( '2032-01-01 20:00:00', '2032-01-01 23:00:00' );
+		$hold      = $holds->create( $booking['id'], 1, 12 );
+		$lifecycle->transition( $booking['id'], 'held', 2, 12 );
+		$booking_row = $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ];
+		$hold_row    = $GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $hold['hold']['id'] ];
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ] = array();
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ]    = array();
+		for ( $id = 1; $id <= $count; ++$id ) {
+			$booking_row['id']        = $id;
+			$booking_row['public_id'] = sprintf( '123e4567-e89b-42d3-a456-%012d', $id );
+			$hold_row['id']           = $id;
+			$hold_row['booking_id']   = $id;
+			$hold_row['expires_at']   = $elapsed ? gmdate( 'Y-m-d H:i:s' ) : '2035-01-01 00:00:00';
+			$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $id ] = $booking_row;
+			$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $id ]    = $hold_row;
+		}
+		return array( $holds, $lifecycle );
+	}
+
+	public function test_schema_v5_installs_site_scoped_holds_contract(): void {
+		$this->assertSame( '5', BookingSchema::SCHEMA_VERSION );
+		$this->assertTrue( BookingSchema::install() );
+		$table = BookingSchema::holds_table();
+		$this->assertSame( 'wp_7_ec_booking_holds', $table );
+		$this->assertSame( 'InnoDB', $GLOBALS['wpdb']->engines[ $table ] );
+		$this->assertSame( array( 'venue_term_id', 'space_key', 'status', 'start_at', 'end_at' ), $GLOBALS['wpdb']->schemas[ $table ]['indexes']['venue_space_overlap']['columns'] );
+		$this->assertTrue( BookingSchema::health() );
+	}
+
+	public function test_ranges_are_strict_and_half_open_boundaries_do_not_conflict(): void {
+		$this->assertSame( 'invalid_booking_date_range', $this->booking( '2030-08-01 20:00:00', '2030-08-01 20:00:00' )->get_error_code() );
+		$holds = $this->holds();
+		$first = $this->booking();
+		$this->assertSame( 2, $holds->create( $first['id'], 1, 12 )['booking_version'] );
+		$adjacent = $this->booking( '2030-08-01 23:00:00', '2030-08-02 01:00:00' );
+		$this->assertSame( 'active', $holds->create( $adjacent['id'], 1, 12 )['hold']['status'] );
+		$patio = $this->booking( '2030-08-01 23:00:00', '2030-08-02 01:00:00', 'patio' );
+		$this->assertSame( 'active', $holds->create( $patio['id'], 1, 12 )['hold']['status'] );
+		$this->assertSame( $GLOBALS['wpdb']->lock_names[0][1], $GLOBALS['wpdb']->lock_names[2][1], 'The same venue-space must produce the same lock name.' );
+		$this->assertNotSame( $GLOBALS['wpdb']->lock_names[0][1], $GLOBALS['wpdb']->lock_names[4][1], 'Different spaces must not share a lock.' );
+		$this->assertLessThanOrEqual( 64, strlen( $GLOBALS['wpdb']->lock_names[0][1] ) );
+	}
+
+	public function test_same_space_conflicts_different_space_succeeds_and_elapsed_never_blocks(): void {
+		$holds   = $this->holds();
+		$first   = $this->booking();
+		$created = $holds->create( $first['id'], 1, 12 );
+		$overlap = $this->booking( '2030-08-01 22:00:00', '2030-08-02 00:00:00' );
+		$this->assertSame( 'booking_time_conflict', $holds->create( $overlap['id'], 1, 12 )->get_error_code() );
+		$different = $this->booking( '2030-08-01 22:00:00', '2030-08-02 00:00:00', 'patio' );
+		$this->assertSame( 'active', $holds->create( $different['id'], 1, 12 )['hold']['status'] );
+
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $created['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$retry = $holds->create( $overlap['id'], 1, 12 );
+		$this->assertSame( 'active', $retry['hold']['status'], 'An exactly elapsed hold must not block even before cleanup.' );
+	}
+
+	public function test_duplicate_exact_active_hold_is_rejected_without_booking_mutation(): void {
+		$holds   = $this->holds();
+		$booking = $this->booking();
+		$holds->create( $booking['id'], 1, 12 );
+		$duplicate = $holds->create( $booking['id'], 2, 12 );
+		$this->assertSame( 'booking_hold_already_active', $duplicate->get_error_code() );
+		$this->assertSame( 409, $duplicate->get_error_data()['status'] );
+		$this->assertSame( 2, ( new BookingRepository() )->get( $booking['id'] )['version'] );
+		$this->assertCount( 1, $GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ] );
+	}
+
+	public function test_release_is_optimistic_audited_and_does_not_increment_booking_version(): void {
+		$holds   = $this->holds();
+		$booking = $this->booking();
+		$created = $holds->create( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_hold_version_conflict', $holds->release( $created['hold']['id'], 2, 12, 'changed plans' )->get_error_code() );
+		$released = $holds->release( $created['hold']['id'], 1, 12, 'changed plans' );
+		$this->assertSame( 'released', $released['status'] );
+		$this->assertSame( 'changed plans', $released['release_reason'] );
+		$this->assertSame( 2, ( new BookingRepository() )->get( $booking['id'] )['version'], 'Release is hold-local and intentionally leaves the booking version unchanged.' );
+		$this->assertSame( 'hold_released', ( new BookingActivityRepository() )->list_for_booking( $booking['id'] )[0]['kind'] );
+		$empty = $this->booking( '2030-09-01 20:00:00', '2030-09-01 23:00:00' );
+		$empty_hold = $holds->create( $empty['id'], 1, 12 );
+		$this->assertSame( 'booking_hold_release_reason_required', $holds->release( $empty_hold['hold']['id'], 1, 12, '<b></b>' )->get_error_code() );
+	}
+
+	public function test_hold_creation_is_restricted_to_operational_statuses(): void {
+		$holds = $this->holds();
+		foreach ( array( 'submitted', 'needs_info', 'under_review', 'confirmed', 'declined', 'withdrawn', 'cancelled', 'completed' ) as $status ) {
+			$booking = $this->booking( '2031-01-01 20:00:00', '2031-01-01 23:00:00', 'main-room', array( 'status' => $status ) );
+			$result  = $holds->create( $booking['id'], 1, 12 );
+			$this->assertSame( 'booking_hold_status_forbidden', $result->get_error_code(), $status );
+			$this->assertSame( 409, $result->get_error_data()['status'] );
+		}
+	}
+
+	public function test_scheduler_cleanup_is_idempotent_and_exact_expiry_is_elapsed(): void {
+		$holds   = $this->holds();
+		$booking = $this->booking();
+		$created = $holds->create( $booking['id'], 1, 12 );
+		$this->assertCount( 1, $GLOBALS['ec_artist_test']['scheduled'] );
+		$this->assertSame( BookingHoldRepository::EXPIRY_HOOK, $GLOBALS['ec_artist_test']['scheduled'][0]['hook'] );
+		$this->assertSame( array( $created['hold']['id'], 0 ), $GLOBALS['ec_artist_test']['scheduled'][0]['args'] );
+		$id = $created['hold']['id'];
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $id ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$this->assertSame( 'expired', $holds->expire( $id )['status'] );
+		$this->assertSame( 'expired', $holds->expire( $id )['status'] );
+		$this->assertSame( 2, $holds->get( $id )['version'] );
+	}
+
+	public function test_elapsed_holds_are_effectively_expired_in_get_list_and_release(): void {
+		$holds   = $this->holds();
+		$booking = $this->booking();
+		$created = $holds->create( $booking['id'], 1, 12 );
+		$id      = $created['hold']['id'];
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $id ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$this->assertSame( 'expired', $holds->get( $id )['status'] );
+		$this->assertSame( $holds->get( $id )['expires_at'], $holds->get( $id )['expired_at'] );
+		$this->assertCount( 0, $holds->list( array( 'venue_term_id' => 55, 'status' => 'active' ), 12 ) );
+		$expired = $holds->list( array( 'venue_term_id' => 55, 'status' => 'expired' ), 12 );
+		$this->assertSame( array( 'expired' ), array_column( $expired, 'status' ) );
+		$this->assertSame( 'expired', $holds->list( array( 'venue_term_id' => 55 ), 12 )[0]['status'] );
+		$this->assertSame( 'booking_hold_not_active', $holds->release( $id, 1, 12, 'too late' )->get_error_code() );
+		$this->assertSame( 'expired', $GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $id ]['status'], 'Release must persist elapsed state before returning not-active.' );
+	}
+
+	public function test_expiring_selected_hold_reopens_held_booking_but_alternative_expiry_does_not(): void {
+		$holds     = $this->holds();
+		$lifecycle = new BookingLifecycle( null, null, null, null, $holds );
+		$booking   = $this->booking();
+		$selected  = $holds->create( $booking['id'], 1, 12 );
+		$lifecycle->transition( $booking['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $selected['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		BookingHoldRepository::expire_scheduled( $selected['hold']['id'] );
+		$this->assertSame( 'expired', $holds->get( $selected['hold']['id'] )['status'] );
+		$reopened = ( new BookingRepository() )->get( $booking['id'] );
+		$this->assertSame( 'negotiating', $reopened['status'] );
+		$this->assertSame( 4, $reopened['version'] );
+		$activity = ( new BookingActivityRepository() )->list_for_booking( $booking['id'] );
+		$this->assertSame( array( 'status_changed', 'hold_expired', 'status_changed', 'hold_created' ), array_column( $activity, 'kind' ) );
+
+		$replacement = $holds->create( $booking['id'], 4, 12 );
+		$lifecycle->transition( $booking['id'], 'held', 5, 12 );
+		$alternative              = $replacement['hold'];
+		$alternative['id']        = 3;
+		$alternative['space_key'] = 'patio';
+		$alternative['expires_at']= gmdate( 'Y-m-d H:i:s' );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][3] = $alternative;
+		$holds->expire( 3 );
+		$this->assertSame( 'held', ( new BookingRepository() )->get( $booking['id'] )['status'] );
+	}
+
+	public function test_create_reconciles_elapsed_held_booking_before_replacement(): void {
+		$holds     = $this->holds();
+		$lifecycle = new BookingLifecycle( null, null, null, null, $holds );
+		$booking   = $this->booking();
+		$selected  = $holds->create( $booking['id'], 1, 12 );
+		$lifecycle->transition( $booking['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $selected['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$stale = $holds->create( $booking['id'], 3, 12 );
+		$this->assertSame( 'booking_version_conflict', $stale->get_error_code() );
+		$this->assertSame( 4, $stale->get_error_data()['current_version'] );
+		$this->assertSame( 'negotiating', ( new BookingRepository() )->get( $booking['id'] )['status'] );
+		$replacement = $holds->create( $booking['id'], 4, 12 );
+		$this->assertSame( 'active', $replacement['hold']['status'] );
+		$this->assertSame( 5, $replacement['booking_version'] );
+	}
+
+	public function test_transition_reconciles_elapsed_held_booking_before_validation(): void {
+		$holds     = $this->holds();
+		$lifecycle = new BookingLifecycle( null, null, null, null, $holds );
+		$booking   = $this->booking();
+		$selected  = $holds->create( $booking['id'], 1, 12 );
+		$lifecycle->transition( $booking['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $selected['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$result = $lifecycle->transition( $booking['id'], 'confirmed', 3, 12 );
+		$this->assertSame( 'booking_version_conflict', $result->get_error_code() );
+		$this->assertSame( 4, $result->get_error_data()['current_version'] );
+		$this->assertSame( 'negotiating', ( new BookingRepository() )->get( $booking['id'] )['status'] );
+	}
+
+	public function test_authoritative_booking_get_and_list_reconcile_elapsed_held_state(): void {
+		$holds         = $this->holds();
+		$lifecycle     = new BookingLifecycle( null, null, null, null, $holds );
+		$authorization = new BookingTestAuthorization();
+		$abilities     = new VenueBookingAbilities( new BookingRepository(), $lifecycle, $authorization, $holds );
+
+		$first      = $this->booking();
+		$first_hold = $holds->create( $first['id'], 1, 12 );
+		$lifecycle->transition( $first['id'], 'held', 2, 12 );
+		$unchanged = $holds->reconcile_booking( ( new BookingRepository() )->get( $first['id'] ) );
+		$this->assertSame( 'held', $unchanged['status'] );
+		$this->assertSame( 3, $unchanged['version'] );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $first_hold['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$read = $abilities->get_booking( array( 'booking_id' => $first['id'] ) );
+		$this->assertSame( 'negotiating', $read['status'] );
+		$this->assertSame( 4, $read['version'] );
+
+		$second      = $this->booking( '2030-09-01 20:00:00', '2030-09-01 23:00:00' );
+		$second_hold = $holds->create( $second['id'], 1, 12 );
+		$lifecycle->transition( $second['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $second_hold['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$list = $abilities->list_bookings( array( 'venue_term_id' => 55 ) );
+		$by_id = array_column( $list, null, 'id' );
+		$this->assertSame( 'negotiating', $by_id[ $second['id'] ]['status'] );
+		$this->assertSame( 4, $by_id[ $second['id'] ]['version'] );
+	}
+
+	public function test_booking_list_reconciles_before_status_filter_and_pagination(): void {
+		$holds         = $this->holds();
+		$lifecycle     = new BookingLifecycle( null, null, null, null, $holds );
+		$authorization = new BookingTestAuthorization();
+		$abilities     = new VenueBookingAbilities( new BookingRepository(), $lifecycle, $authorization, $holds );
+		$first         = $this->booking( '2031-02-01 20:00:00', '2031-02-01 23:00:00' );
+		$first_hold    = $holds->create( $first['id'], 1, 12 );
+		$lifecycle->transition( $first['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $first_hold['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$second      = $this->booking( '2031-03-01 20:00:00', '2031-03-01 23:00:00' );
+		$second_hold = $holds->create( $second['id'], 1, 12 );
+		$lifecycle->transition( $second['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $second_hold['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+
+		$page_one = $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'negotiating', 'limit' => 1, 'offset' => 0 ) );
+		$page_two = $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'negotiating', 'limit' => 1, 'offset' => 1 ) );
+		$this->assertSame( array( $second['id'] ), array_column( $page_one, 'id' ) );
+		$this->assertSame( array( $first['id'] ), array_column( $page_two, 'id' ) );
+		$this->assertSame( array(), $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'held' ) ) );
+	}
+
+	public function test_more_than_five_hundred_valid_held_bookings_do_not_block_listing(): void {
+		list( $holds, $lifecycle ) = $this->seed_held_venue( 501, false );
+		$abilities = new VenueBookingAbilities( new BookingRepository(), $lifecycle, new BookingTestAuthorization(), $holds );
+		$result    = $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'held', 'limit' => 1 ) );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'held', $result[0]['status'] );
+	}
+
+	public function test_stale_held_batches_make_forward_progress_before_filters(): void {
+		list( $holds, $lifecycle ) = $this->seed_held_venue( 101, true );
+		$abilities = new VenueBookingAbilities( new BookingRepository(), $lifecycle, new BookingTestAuthorization(), $holds );
+		$first_page = $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'negotiating', 'limit' => 100, 'offset' => 0 ) );
+		$second_page = $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'negotiating', 'limit' => 100, 'offset' => 100 ) );
+		$this->assertCount( 100, $first_page );
+		$this->assertCount( 1, $second_page );
+		$this->assertSame( array(), $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'held' ) ) );
+		$this->assertCount( 101, array_filter( $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ], static function ( $booking ) { return 'negotiating' === $booking['status']; } ) );
+	}
+
+	public function test_exact_reconciliation_safety_cap_succeeds_when_no_stale_rows_remain(): void {
+		list( $holds ) = $this->seed_held_venue( 1000, true );
+		$this->assertTrue( $holds->reconcile_venue( 55 ) );
+		$this->assertCount( 1000, array_filter( $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ], static function ( $booking ) { return 'negotiating' === $booking['status']; } ) );
+	}
+
+	public function test_over_reconciliation_safety_cap_is_retryable_only_when_stale_remains(): void {
+		list( $holds ) = $this->seed_held_venue( 1001, true );
+		$result = $holds->reconcile_venue( 55 );
+		$this->assertSame( 'booking_hold_venue_reconciliation_limit', $result->get_error_code() );
+		$this->assertSame( 503, $result->get_error_data()['status'] );
+		$this->assertSame( 1000, $result->get_error_data()['processed'] );
+		$this->assertCount( 1, array_filter( $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ], static function ( $booking ) { return 'held' === $booking['status']; } ) );
+	}
+
+	public function test_assign_and_bind_reconcile_before_expected_version_checks(): void {
+		$holds         = $this->holds();
+		$lifecycle     = new BookingLifecycle( null, null, null, null, $holds );
+		$assigned      = $this->booking( '2031-04-01 20:00:00', '2031-04-01 23:00:00' );
+		$assigned_hold = $holds->create( $assigned['id'], 1, 12 );
+		$lifecycle->transition( $assigned['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $assigned_hold['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$assign_result = $lifecycle->assign( $assigned['id'], null, 3, 12 );
+		$this->assertSame( 'booking_version_conflict', $assign_result->get_error_code() );
+		$this->assertSame( 4, $assign_result->get_error_data()['current_version'] );
+
+		$bound      = $this->booking( '2031-05-01 20:00:00', '2031-05-01 23:00:00' );
+		$bound_hold = $holds->create( $bound['id'], 1, 12 );
+		$lifecycle->transition( $bound['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $bound_hold['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$bind_result = $lifecycle->bind_artist( $bound['id'], null, null, 3, 12 );
+		$this->assertSame( 'booking_version_conflict', $bind_result->get_error_code() );
+		$this->assertSame( 4, $bind_result->get_error_data()['current_version'] );
+	}
+
+	public function test_elapsed_selected_release_reconciles_before_and_after_lock(): void {
+		$holds      = $this->holds();
+		$lifecycle  = new BookingLifecycle( null, null, null, null, $holds );
+		$pre        = $this->booking( '2031-06-01 20:00:00', '2031-06-01 23:00:00' );
+		$pre_hold   = $holds->create( $pre['id'], 1, 12 );
+		$lifecycle->transition( $pre['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $pre_hold['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$this->assertSame( 'booking_hold_not_active', $holds->release( $pre_hold['hold']['id'], 1, 12, 'elapsed' )->get_error_code() );
+		$this->assertSame( 'negotiating', ( new BookingRepository() )->get( $pre['id'] )['status'] );
+
+		$raced      = $this->booking( '2031-07-01 20:00:00', '2031-07-01 23:00:00' );
+		$raced_hold = $holds->create( $raced['id'], 1, 12 );
+		$lifecycle->transition( $raced['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->elapse_hold_after_membership_lock = $raced_hold['hold']['id'];
+		$this->assertSame( 'booking_hold_not_active', $holds->release( $raced_hold['hold']['id'], 1, 12, 'elapsed during lock' )->get_error_code() );
+		$this->assertSame( 'negotiating', ( new BookingRepository() )->get( $raced['id'] )['status'] );
+
+		$write_race      = $this->booking( '2031-07-02 20:00:00', '2031-07-02 23:00:00' );
+		$write_race_hold = $holds->create( $write_race['id'], 1, 12 );
+		$GLOBALS['wpdb']->elapse_hold_before_release_update = $write_race_hold['hold']['id'];
+		$this->assertSame( 'booking_hold_not_active', $holds->release( $write_race_hold['hold']['id'], 1, 12, 'elapsed at write' )->get_error_code() );
+		$this->assertSame( 'expired', $GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $write_race_hold['hold']['id'] ]['status'] );
+		$this->assertSame( 'negotiating', ( new BookingRepository() )->get( $write_race['id'] )['status'] );
+	}
+
+	public function test_booking_get_and_list_reauthorize_under_membership_lock(): void {
+		$authorization = new BookingTestAuthorization();
+		$holds         = new BookingHoldRepository( null, null, $authorization );
+		$lifecycle     = new BookingLifecycle( null, null, $authorization, null, $holds );
+		$abilities     = new VenueBookingAbilities( new BookingRepository(), $lifecycle, $authorization, $holds );
+		$booking       = $this->booking( '2031-09-01 20:00:00', '2031-09-01 23:00:00' );
+		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) {
+			unset( $authorization->allowed['12:55'] );
+		};
+		$get = $abilities->get_booking( array( 'booking_id' => $booking['id'] ) );
+		$this->assertSame( 'venue_action_forbidden', $get->get_error_code() );
+		$this->assertInstanceOf( WP_Error::class, $get );
+
+		$authorization->allowed['12:55'] = true;
+		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) {
+			unset( $authorization->allowed['12:55'] );
+		};
+		$list = $abilities->list_bookings( array( 'venue_term_id' => 55 ) );
+		$this->assertSame( 'venue_action_forbidden', $list->get_error_code() );
+		$this->assertInstanceOf( WP_Error::class, $list );
+	}
+
+	public function test_booking_get_and_list_deny_before_reconciliation_mutation(): void {
+		$authorization = new BookingTestAuthorization();
+		$holds         = new BookingHoldRepository( null, null, $authorization );
+		$lifecycle     = new BookingLifecycle( null, null, $authorization, null, $holds );
+		$abilities     = new VenueBookingAbilities( new BookingRepository(), $lifecycle, $authorization, $holds );
+		$booking       = $this->booking( '2031-10-01 20:00:00', '2031-10-01 23:00:00' );
+		$created       = $holds->create( $booking['id'], 1, 12 );
+		$lifecycle->transition( $booking['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $created['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		unset( $authorization->allowed['12:55'] );
+
+		$get = $abilities->get_booking( array( 'booking_id' => $booking['id'] ) );
+		$this->assertSame( 'venue_action_forbidden', $get->get_error_code() );
+		$this->assertSame( 'held', ( new BookingRepository() )->get( $booking['id'] )['status'] );
+		$this->assertSame( 'active', $GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $created['hold']['id'] ]['status'] );
+
+		$list = $abilities->list_bookings( array( 'venue_term_id' => 55 ) );
+		$this->assertSame( 'venue_action_forbidden', $list->get_error_code() );
+		$this->assertSame( 'held', ( new BookingRepository() )->get( $booking['id'] )['status'] );
+		$this->assertSame( 'active', $GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $created['hold']['id'] ]['status'] );
+	}
+
+	public function test_selected_hold_cannot_be_explicitly_released_while_held(): void {
+		$holds     = $this->holds();
+		$lifecycle = new BookingLifecycle( null, null, null, null, $holds );
+		$booking   = $this->booking();
+		$created   = $holds->create( $booking['id'], 1, 12 );
+		$lifecycle->transition( $booking['id'], 'held', 2, 12 );
+		$result = $holds->release( $created['hold']['id'], 1, 12, 'direct release' );
+		$this->assertSame( 'booking_held_hold_release_forbidden', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
+		$this->assertSame( 'held', ( new BookingRepository() )->get( $booking['id'] )['status'] );
+	}
+
+	public function test_advisory_lock_failures_release_and_transaction_rollback_are_explicit(): void {
+		$holds                            = $this->holds();
+		$booking                          = $this->booking();
+		$GLOBALS['wpdb']->get_lock_result = 0;
+		$this->assertSame( 'booking_hold_lock_not_acquired', $holds->create( $booking['id'], 1, 12 )->get_error_code() );
+		$this->assertArrayNotHasKey( BookingSchema::holds_table(), $GLOBALS['wpdb']->rows );
+
+		$GLOBALS['wpdb']->get_lock_result       = 1;
+		$GLOBALS['wpdb']->fail_activity_inserts = true;
+		$this->assertSame( 'booking_activity_write_failed', $holds->create( $booking['id'], 1, 12 )->get_error_code() );
+		$this->assertSame( 1, ( new BookingRepository() )->get( $booking['id'] )['version'] );
+		$this->assertSame( 'release', end( $GLOBALS['wpdb']->lock_names )[0] );
+
+		$GLOBALS['wpdb']->fail_activity_inserts = false;
+		$GLOBALS['wpdb']->release_lock_result   = 0;
+		$this->assertSame( 'booking_hold_lock_release_failed', $holds->create( $booking['id'], 1, 12 )->get_error_code() );
+	}
+
+	public function test_uncertain_commit_is_not_followed_by_a_false_rollback_claim(): void {
+		$holds                                      = $this->holds();
+		$booking                                    = $this->booking();
+		$GLOBALS['wpdb']->fail_transaction_commit   = true;
+		$rollbacks                                  = $GLOBALS['wpdb']->rollback_queries;
+		$result                                     = $holds->create( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_hold_transaction_commit_uncertain', $result->get_error_code() );
+		$this->assertSame( $rollbacks, $GLOBALS['wpdb']->rollback_queries );
+		$this->assertSame( 'release', end( $GLOBALS['wpdb']->lock_names )[0] );
+	}
+
+	public function test_scheduler_failure_after_commit_does_not_fail_or_rollback_create(): void {
+		$holds                                      = $this->holds();
+		$booking                                    = $this->booking();
+		$GLOBALS['ec_artist_test']['throw_scheduler'] = true;
+		$rollbacks                                  = $GLOBALS['wpdb']->rollback_queries;
+		$result                                     = $holds->create( $booking['id'], 1, 12 );
+		$this->assertSame( 'active', $result['hold']['status'] );
+		$this->assertSame( 2, $result['booking_version'] );
+		$this->assertSame( $rollbacks, $GLOBALS['wpdb']->rollback_queries );
+		$this->assertCount( 1, $GLOBALS['ec_artist_test']['fired_actions']['extrachill_events_booking_hold_schedule_failed'] );
+	}
+
+	public function test_scheduler_zero_return_is_diagnostic_but_create_remains_committed(): void {
+		$holds                                      = $this->holds();
+		$booking                                    = $this->booking();
+		$GLOBALS['ec_artist_test']['scheduler_zero'] = true;
+		$result                                     = $holds->create( $booking['id'], 1, 12 );
+		$this->assertSame( 'active', $result['hold']['status'] );
+		$this->assertSame( 2, ( new BookingRepository() )->get( $booking['id'] )['version'] );
+		$this->assertCount( 1, $GLOBALS['ec_artist_test']['fired_actions']['extrachill_events_booking_hold_schedule_failed'] );
+	}
+
+	public function test_failed_scheduled_expiry_retries_and_throws_visible_failure(): void {
+		$holds   = $this->holds();
+		$booking = $this->booking();
+		$created = $holds->create( $booking['id'], 1, 12 );
+		$GLOBALS['ec_artist_test']['scheduled'] = array();
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $created['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$GLOBALS['wpdb']->get_lock_result = 0;
+		try {
+			BookingHoldRepository::expire_scheduled( $created['hold']['id'], 0 );
+			$this->fail( 'A failed scheduled expiry must throw.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Booking hold expiration failed.', $exception->getMessage() );
+		}
+		$this->assertCount( 1, $GLOBALS['ec_artist_test']['scheduled'] );
+		$this->assertSame( array( $created['hold']['id'], 1 ), $GLOBALS['ec_artist_test']['scheduled'][0]['args'] );
+	}
+
+	public function test_failed_expiry_retry_zero_return_fires_diagnostic_and_throws(): void {
+		$holds   = $this->holds();
+		$booking = $this->booking( '2031-08-01 20:00:00', '2031-08-01 23:00:00' );
+		$created = $holds->create( $booking['id'], 1, 12 );
+		$GLOBALS['ec_artist_test']['scheduled'] = array();
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $created['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
+		$GLOBALS['wpdb']->get_lock_result = 0;
+		$GLOBALS['ec_artist_test']['scheduler_zero'] = true;
+		try {
+			BookingHoldRepository::expire_scheduled( $created['hold']['id'], 0 );
+			$this->fail( 'A failed expiry with an unscheduled retry must throw.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Booking hold expiration failed.', $exception->getMessage() );
+		}
+		$this->assertCount( 1, $GLOBALS['ec_artist_test']['fired_actions']['extrachill_events_booking_hold_schedule_failed'] );
+		$this->assertSame( array(), $GLOBALS['ec_artist_test']['scheduled'] );
+	}
+
+	public function test_authority_is_rechecked_inside_lock(): void {
+		$authorization                          = new BookingTestAuthorization();
+		$holds                                  = new BookingHoldRepository( null, null, $authorization );
+		$booking                                = $this->booking();
+		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) {
+			unset( $authorization->allowed['12:55'] );
+		};
+		$this->assertSame( 'venue_action_forbidden', $holds->create( $booking['id'], 1, 12 )->get_error_code() );
+		$this->assertSame( 1, ( new BookingRepository() )->get( $booking['id'] )['version'] );
+	}
+
+	public function test_list_reauthorizes_after_lock_and_rolls_back_on_revocation(): void {
+		$authorization                          = new BookingTestAuthorization();
+		$holds                                  = new BookingHoldRepository( null, null, $authorization );
+		$booking                                = $this->booking();
+		$holds->create( $booking['id'], 1, 12 );
+		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) {
+			unset( $authorization->allowed['12:55'] );
+		};
+		$before = $GLOBALS['wpdb']->rollback_queries;
+		$result = $holds->list( array( 'venue_term_id' => 55 ), 12 );
+		$this->assertSame( 'venue_action_forbidden', $result->get_error_code() );
+		$this->assertSame( $before + 1, $GLOBALS['wpdb']->rollback_queries );
+	}
+
+	public function test_confirmed_booking_and_canonical_event_conflicts_use_half_open_local_time(): void {
+		$holds     = $this->holds();
+		$confirmed = $this->booking();
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $confirmed['id'] ]['status'] = 'confirmed';
+		$overlap = $this->booking( '2030-08-01 22:00:00', '2030-08-02 00:00:00' );
+		$this->assertSame( 'confirmed_booking', $holds->create( $overlap['id'], 1, 12 )->get_error_data()['conflict']['conflict_type'] );
+
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $confirmed['id'] ]['status'] = 'cancelled';
+		$GLOBALS['wpdb']->event_dates[] = array(
+			'post_id'        => 900,
+			'venue_term_id'  => 55,
+			'post_status'    => 'publish',
+			'start_datetime' => '2030-08-01 18:30:00',
+			'end_datetime'   => '2030-08-01 19:30:00',
+		);
+		$this->assertSame( 'canonical_event', $holds->create( $overlap['id'], 1, 12 )->get_error_data()['conflict']['conflict_type'], '22:00 UTC converts to 18:00 EDT.' );
+		$GLOBALS['wpdb']->event_dates[0]['post_status'] = 'draft';
+		$this->assertSame( 'active', $holds->create( $overlap['id'], 1, 12 )['hold']['status'] );
+		$GLOBALS['wpdb']->event_dates = array(
+			array(
+				'post_id'       => 902,
+				'venue_term_id' => 55,
+				'post_status'   => 'publish',
+				'start_datetime'=> '2030-11-03 01:05:00',
+				'end_datetime'  => null,
+			),
+		);
+		$dst = $this->booking( '2030-11-03 06:00:00', '2030-11-03 07:00:00' );
+		$this->assertSame( 'canonical_event', $holds->create( $dst['id'], 1, 12 )->get_error_data()['conflict']['conflict_type'], '06:00 UTC converts to the repeated 01:00 hour after the DST fallback.' );
+		$crossing_fold = $this->booking( '2030-11-03 05:45:00', '2030-11-03 06:15:00' );
+		$this->assertSame( 'canonical_event', $holds->create( $crossing_fold['id'], 1, 12 )->get_error_data()['conflict']['conflict_type'], 'The local window must include the early segment of the repeated fold.' );
+
+		$GLOBALS['ec_artist_test']['meta'][7][55]['_venue_timezone'] = 'Not/AZone';
+		$next = $this->booking( '2030-09-01 20:00:00', '2030-09-01 22:00:00' );
+		$this->assertSame( 'booking_venue_timezone_invalid', $holds->create( $next['id'], 1, 12 )->get_error_code() );
+	}
+
+	public function test_lifecycle_requires_exact_hold_converts_selected_and_releases_alternatives(): void {
+		$holds     = $this->holds();
+		$lifecycle = new BookingLifecycle( null, null, null, null, $holds );
+		$booking   = $this->booking();
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['status'] = 'negotiating';
+		$this->assertSame( 'booking_matching_hold_required', $lifecycle->transition( $booking['id'], 'held', 1, 12 )->get_error_code() );
+		$created = $holds->create( $booking['id'], 1, 12 );
+		$alternative                 = $created['hold'];
+		$alternative['id']           = 2;
+		$alternative['space_key']    = 'patio';
+		$alternative['version']      = 1;
+		$alternative['expires_at']   = gmdate( 'Y-m-d H:i:s' );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][2] = $alternative;
+		$held    = $lifecycle->transition( $booking['id'], 'held', 2, 12 );
+		$this->assertSame( 'held', $held['status'] );
+		$confirmed = $lifecycle->transition( $booking['id'], 'confirmed', 3, 12 );
+		$this->assertSame( 'confirmed', $confirmed['status'] );
+		$this->assertSame( 'converted', $holds->get( $created['hold']['id'] )['status'] );
+		$this->assertSame( 'expired', $holds->get( 2 )['status'] );
+
+		$other = $this->booking();
+		$this->assertSame( 'booking_time_conflict', $holds->create( $other['id'], 1, 12 )->get_error_code(), 'Converted booking remains protected by confirmed-booking overlap.' );
+	}
+
+	public function test_leaving_held_releases_remaining_active_holds(): void {
+		$holds     = $this->holds();
+		$lifecycle = new BookingLifecycle( null, null, null, null, $holds );
+		$booking   = $this->booking();
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['status'] = 'negotiating';
+		$created = $holds->create( $booking['id'], 1, 12 );
+		$lifecycle->transition( $booking['id'], 'held', 2, 12 );
+		$result = $lifecycle->transition( $booking['id'], 'negotiating', 3, 12 );
+		$this->assertSame( 'negotiating', $result['status'] );
+		$this->assertSame( 'released', $holds->get( $created['hold']['id'] )['status'] );
+	}
+
+	public function test_list_is_venue_bounded_and_uses_half_open_range_filters(): void {
+		$holds = $this->holds();
+		$first = $this->booking();
+		$holds->create( $first['id'], 1, 12 );
+		$second = $this->booking( '2030-09-01 20:00:00', '2030-09-01 23:00:00' );
+		$holds->create( $second['id'], 1, 12 );
+		$list = $holds->list( array( 'venue_term_id' => 55, 'range_start' => '2030-08-01 23:00:00', 'range_end' => '2030-09-02 00:00:00', 'limit' => 1 ), 12 );
+		$this->assertCount( 1, $list );
+		$this->assertSame( $second['id'], $list[0]['booking_id'] );
+		$this->assertSame( 'invalid_booking_hold_status', $holds->list( array( 'venue_term_id' => 55, 'status' => 'deleted' ), 12 )->get_error_code() );
+	}
+
+	public function test_abilities_are_strict_rest_visible_and_do_not_enumerate_missing_records(): void {
+		$authorization = new BookingTestAuthorization();
+		$abilities     = new VenueBookingHoldAbilities( null, new BookingRepository(), $authorization );
+		$abilities->register();
+		$registered = $GLOBALS['ec_artist_test']['abilities'];
+		$this->assertSame( array( 'extrachill/create-booking-hold', 'extrachill/release-booking-hold', 'extrachill/list-booking-holds' ), array_keys( $registered ) );
+		foreach ( $registered as $definition ) {
+			$this->assertTrue( $definition['meta']['show_in_rest'] );
+			$this->assertFalse( $definition['input_schema']['additionalProperties'] );
+		}
+		$this->assertSame( BookingHoldRepository::STATUSES, array_slice( $registered['extrachill/list-booking-holds']['input_schema']['properties']['status']['enum'], 0, 4 ) );
+		$this->assertSame( 'venue_action_forbidden', $abilities->can_access_hold( array( 'hold_id' => 999 ) )->get_error_code() );
+		$this->assertSame( array(), $authorization->calls );
+	}
+}

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -138,6 +138,11 @@ final class BookingHoldTest extends TestCase {
 		$this->assertSame( $GLOBALS['wpdb']->lock_names[0][1], $GLOBALS['wpdb']->lock_names[2][1], 'The same venue-space must produce the same lock name.' );
 		$this->assertNotSame( $GLOBALS['wpdb']->lock_names[0][1], $GLOBALS['wpdb']->lock_names[4][1], 'Different spaces must not share a lock.' );
 		$this->assertLessThanOrEqual( 64, strlen( $GLOBALS['wpdb']->lock_names[0][1] ) );
+		$first_lock = $GLOBALS['wpdb']->lock_names[0][1];
+		$GLOBALS['wpdb']->prefix = 'wp_8_';
+		$other_site = $this->booking( '2030-10-01 20:00:00', '2030-10-01 23:00:00' );
+		$holds->create( $other_site['id'], 1, 12 );
+		$this->assertNotSame( $first_lock, $GLOBALS['wpdb']->lock_names[6][1], 'Different site tables must not share advisory locks.' );
 	}
 
 	public function test_same_space_conflicts_different_space_succeeds_and_elapsed_never_blocks(): void {
@@ -555,6 +560,40 @@ final class BookingHoldTest extends TestCase {
 		$this->assertSame( 1, ( new BookingRepository() )->get( $booking['id'] )['version'] );
 	}
 
+	public function test_mutations_deny_lock_current_revoked_membership(): void {
+		$authorization = new BookingTestAuthorization();
+		$authorization->require_locked_membership = true;
+		$holds         = new BookingHoldRepository( null, null, $authorization );
+		$lifecycle     = new BookingLifecycle( null, null, $authorization, null, $holds );
+		$booking       = $this->booking( '2031-11-01 20:00:00', '2031-11-01 23:00:00' );
+		$membership_table = BookingSchema::memberships_table();
+		$GLOBALS['wpdb']->rows[ $membership_table ][1] = array(
+			'id'                  => 1,
+			'venue_term_id'       => 55,
+			'user_id'             => 12,
+			'status'              => 'active',
+		);
+		$revoke = static function () use ( $membership_table ) {
+			$GLOBALS['wpdb']->rows[ $membership_table ][1]['status'] = 'revoked';
+		};
+		$GLOBALS['wpdb']->after_membership_lock = $revoke;
+		$this->assertSame( 'venue_action_forbidden', $holds->create( $booking['id'], 1, 12 )->get_error_code() );
+
+		$GLOBALS['wpdb']->rows[ $membership_table ][1]['status'] = 'active';
+		$created = $holds->create( $booking['id'], 1, 12 );
+		$GLOBALS['wpdb']->after_membership_lock = $revoke;
+		$this->assertSame( 'venue_action_forbidden', $holds->release( $created['hold']['id'], 1, 12, 'revoked' )->get_error_code() );
+
+		$GLOBALS['wpdb']->rows[ $membership_table ][1]['status'] = 'active';
+		$GLOBALS['wpdb']->after_membership_lock = $revoke;
+		$this->assertSame( 'venue_action_forbidden', $lifecycle->transition( $booking['id'], 'held', 2, 12 )->get_error_code() );
+
+		$GLOBALS['wpdb']->rows[ $membership_table ][1]['status'] = 'active';
+		$lifecycle->transition( $booking['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->after_membership_lock = $revoke;
+		$this->assertSame( 'venue_action_forbidden', $lifecycle->transition( $booking['id'], 'confirmed', 3, 12 )->get_error_code() );
+	}
+
 	public function test_list_reauthorizes_after_lock_and_rolls_back_on_revocation(): void {
 		$authorization                          = new BookingTestAuthorization();
 		$holds                                  = new BookingHoldRepository( null, null, $authorization );
@@ -628,6 +667,22 @@ final class BookingHoldTest extends TestCase {
 
 		$other = $this->booking();
 		$this->assertSame( 'booking_time_conflict', $holds->create( $other['id'], 1, 12 )->get_error_code(), 'Converted booking remains protected by confirmed-booking overlap.' );
+	}
+
+	public function test_confirmation_rolls_back_when_hold_expires_at_conversion_boundary(): void {
+		$holds     = $this->holds();
+		$lifecycle = new BookingLifecycle( null, null, null, null, $holds );
+		$booking   = $this->booking( '2031-12-01 20:00:00', '2031-12-01 23:00:00' );
+		$created   = $holds->create( $booking['id'], 1, 12 );
+		$lifecycle->transition( $booking['id'], 'held', 2, 12 );
+		$GLOBALS['wpdb']->elapse_hold_before_conversion_update = $created['hold']['id'];
+
+		$result = $lifecycle->transition( $booking['id'], 'confirmed', 3, 12 );
+		$this->assertSame( 'booking_hold_expired_during_confirmation', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
+		$this->assertSame( 'held', ( new BookingRepository() )->get( $booking['id'] )['status'] );
+		$this->assertSame( 3, ( new BookingRepository() )->get( $booking['id'] )['version'] );
+		$this->assertSame( 'active', $GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $created['hold']['id'] ]['status'] );
 	}
 
 	public function test_leaving_held_releases_remaining_active_holds(): void {

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -7,10 +7,12 @@
 
 use ExtraChillEvents\Core\BookingActivityRepository;
 use ExtraChillEvents\Core\BookingLifecycle;
+use ExtraChillEvents\Core\BookingHoldRepository;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\VenueBookingConfig;
 use ExtraChillEvents\Abilities\VenueBookingAbilities;
+use ExtraChillEvents\Abilities\VenueBookingHoldAbilities;
 use ExtraChillEvents\Core\VenueAuthorization;
 
 if ( ! defined( 'ARRAY_A' ) ) {
@@ -152,7 +154,8 @@ if ( ! function_exists( 'get_current_user_id' ) ) {
 		return 12; }
 }
 if ( ! function_exists( 'add_action' ) ) {
-	function add_action( $hook, $callback ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		unset( $priority, $accepted_args );
 		$GLOBALS['ec_artist_test']['actions'][ $hook ][] = $callback; }
 }
 if ( ! function_exists( 'wp_register_ability' ) ) {
@@ -164,44 +167,70 @@ if ( ! function_exists( 'wp_cache_delete' ) ) {
 		$GLOBALS['ec_artist_test']['cache_deletes'][] = array( $key, $group );
 		return true; }
 }
+if ( ! function_exists( 'as_schedule_single_action' ) ) {
+	function as_schedule_single_action( $timestamp, $hook, $args, $group, $unique = false ) {
+		if ( ! empty( $GLOBALS['ec_artist_test']['throw_scheduler'] ) ) {
+			throw new RuntimeException( 'simulated scheduler failure' );
+		}
+		if ( ! empty( $GLOBALS['ec_artist_test']['scheduler_zero'] ) ) {
+			return 0;
+		}
+		$GLOBALS['ec_artist_test']['scheduled'][] = compact( 'timestamp', 'hook', 'args', 'group', 'unique' );
+		return count( $GLOBALS['ec_artist_test']['scheduled'] );
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook, ...$args ) {
+		$GLOBALS['ec_artist_test']['fired_actions'][ $hook ][] = $args;
+	}
+}
 
 /** Stateful wpdb fake that enforces the persistence contracts under test. */
 final class BookingWpdb {
-	public $prefix                    = 'wp_7_';
-	public $terms                     = 'wp_7_terms';
-	public $insert_id                 = 0;
-	public $last_error                = '';
-	public $rows                      = array();
-	public $schemas                   = array();
-	public $engines                   = array();
-	public $schema_omit               = array();
-	public $schema_queries            = 0;
-	public $dropped_indexes           = array();
-	public $fail_reads                = false;
-	public $fail_activity_reads       = false;
-	public $fail_inserts              = false;
-	public $fail_updates              = false;
-	public $fail_engine_repair        = false;
-	public $race_activity_insert      = false;
-	public $race_booking_insert       = false;
-	public $race_booking_hash         = null;
-	public $race_activity_read_fail   = false;
-	public $race_event_read_fail      = false;
-	public $concurrent_role_migration = false;
-	public $reads_before_failure      = null;
-	public $last_query                = '';
-	public $fail_activity_inserts     = false;
-	public $fail_transaction_start    = false;
-	public $fail_transaction_commit   = false;
-	public $fail_transaction_rollback = false;
-	public $rollback_queries          = 0;
-	public $after_membership_lock     = null;
-	public $after_venue_lock          = null;
-	public $fail_venue_lock           = false;
-	public $venue_lock_queries        = 0;
-	public $transaction_active        = false;
+	public $prefix                           = 'wp_7_';
+	public $terms                            = 'wp_7_terms';
+	public $posts                            = 'wp_7_posts';
+	public $term_relationships               = 'wp_7_term_relationships';
+	public $term_taxonomy                    = 'wp_7_term_taxonomy';
+	public $insert_id                        = 0;
+	public $last_error                       = '';
+	public $rows                             = array();
+	public $schemas                          = array();
+	public $engines                          = array();
+	public $schema_omit                      = array();
+	public $schema_queries                   = 0;
+	public $dropped_indexes                  = array();
+	public $fail_reads                       = false;
+	public $fail_activity_reads              = false;
+	public $fail_inserts                     = false;
+	public $fail_updates                     = false;
+	public $fail_engine_repair               = false;
+	public $race_activity_insert             = false;
+	public $race_booking_insert              = false;
+	public $race_booking_hash                = null;
+	public $race_activity_read_fail          = false;
+	public $race_event_read_fail             = false;
+	public $concurrent_role_migration        = false;
+	public $reads_before_failure             = null;
+	public $last_query                       = '';
+	public $fail_activity_inserts            = false;
+	public $fail_transaction_start           = false;
+	public $fail_transaction_commit          = false;
+	public $fail_transaction_rollback        = false;
+	public $rollback_queries                 = 0;
+	public $after_membership_lock            = null;
+	public $after_venue_lock                 = null;
+	public $fail_venue_lock                  = false;
+	public $venue_lock_queries               = 0;
+	public $transaction_active               = false;
 	public $natural_key_reads_in_transaction = 0;
-	private $transaction_snapshot     = null;
+	public $get_lock_result                  = 1;
+	public $release_lock_result              = 1;
+	public $lock_names                       = array();
+	public $event_dates                      = array();
+	public $elapse_hold_after_membership_lock = null;
+	public $elapse_hold_before_release_update = null;
+	private $transaction_snapshot            = null;
 
 	public function get_charset_collate() {
 		return 'DEFAULT CHARACTER SET utf8mb4'; }
@@ -288,8 +317,8 @@ final class BookingWpdb {
 				$this->rows[ $table ][ $this->insert_id ]['inquiry_request_hash'] = $this->race_booking_hash;
 				$this->race_booking_hash = null;
 			}
-			$activity_table = $this->prefix . 'ec_booking_activity';
-			$activity_id    = count( $this->rows[ $activity_table ] ?? array() ) + 1;
+			$activity_table                                = $this->prefix . 'ec_booking_activity';
+			$activity_id                                   = count( $this->rows[ $activity_table ] ?? array() ) + 1;
 			$this->rows[ $activity_table ][ $activity_id ] = array(
 				'id'              => $activity_id,
 				'booking_id'      => $this->insert_id,
@@ -304,8 +333,8 @@ final class BookingWpdb {
 				'occurred_at'     => gmdate( 'Y-m-d H:i:s' ),
 				'created_at'      => gmdate( 'Y-m-d H:i:s' ),
 			);
-			$this->transaction_snapshot = $this->rows;
-			$this->last_error          = 'simulated concurrent duplicate';
+			$this->transaction_snapshot                    = $this->rows;
+			$this->last_error                              = 'simulated concurrent duplicate';
 			return false;
 		}
 		if ( false !== strpos( $table, 'ec_booking_activity' ) && $this->race_activity_insert ) {
@@ -321,6 +350,35 @@ final class BookingWpdb {
 
 	public function get_var( $query ) {
 		$this->last_error = '';
+		if ( preg_match( "/SELECT GET_LOCK\('([^']+)', (\d+)\)/", $query, $match ) ) {
+			$this->lock_names[] = array( 'get', stripslashes( $match[1] ) );
+			return $this->get_lock_result;
+		}
+		if ( preg_match( "/SELECT RELEASE_LOCK\('([^']+)'\)/", $query, $match ) ) {
+			$this->lock_names[] = array( 'release', stripslashes( $match[1] ) );
+			return $this->release_lock_result;
+		}
+		if ( preg_match( "/SELECT id FROM .*ec_booking_holds WHERE booking_id = (\d+) AND venue_term_id = (\d+) AND space_key = '([^']+)' AND start_at = '([^']+)' AND end_at = '([^']+)'.*expires_at > '([^']+)'.*id <> (\d+)/", $query, $match ) ) {
+			foreach ( $this->rows[ $this->prefix . 'ec_booking_holds' ] ?? array() as $row ) {
+				if ( (int) $row['booking_id'] === (int) $match[1] && (int) $row['venue_term_id'] === (int) $match[2] && $row['space_key'] === stripslashes( $match[3] ) && $row['start_at'] === $match[4] && $row['end_at'] === $match[5] && 'active' === $row['status'] && $row['expires_at'] > $match[6] && (int) $row['id'] !== (int) $match[7] ) {
+					return $row['id'];
+				}
+			}
+			return null;
+		}
+		if ( false !== strpos( $query, 'SELECT b.id FROM' ) && false !== strpos( $query, 'INNER JOIN' ) && preg_match( "/b\.venue_term_id = (\d+).*h\.expires_at <= '([^']+)'/", $query, $stale ) ) {
+			foreach ( $this->rows[ $this->prefix . 'ec_bookings' ] ?? array() as $booking ) {
+				if ( (int) $booking['venue_term_id'] !== (int) $stale[1] || 'held' !== $booking['status'] ) {
+					continue;
+				}
+				foreach ( $this->rows[ $this->prefix . 'ec_booking_holds' ] ?? array() as $hold ) {
+					if ( (int) $hold['booking_id'] === (int) $booking['id'] && (int) $hold['venue_term_id'] === (int) $booking['venue_term_id'] && $hold['space_key'] === $booking['space_key'] && $hold['start_at'] === $booking['requested_start_at'] && $hold['end_at'] === $booking['requested_end_at'] && 'active' === $hold['status'] && $hold['expires_at'] <= $stale[2] ) {
+						return $booking['id'];
+					}
+				}
+			}
+			return null;
+		}
 		if ( preg_match( '/SELECT term_id FROM .* WHERE term_id = (\d+) FOR UPDATE/', $query, $match ) ) {
 			++$this->venue_lock_queries;
 			if ( $this->fail_venue_lock ) {
@@ -360,6 +418,7 @@ final class BookingWpdb {
 			return isset( $this->engines[ $table ] ) ? array( 'Engine' => $this->engines[ $table ] ) : null;
 		}
 		$is_activity = false !== strpos( $query, 'ec_booking_activity' );
+		$is_hold     = false !== strpos( $query, 'ec_booking_holds' );
 		if ( null !== $this->reads_before_failure ) {
 			if ( 0 === $this->reads_before_failure ) {
 				$this->last_error = 'simulated delayed row read failure';
@@ -371,9 +430,67 @@ final class BookingWpdb {
 			$this->last_error = 'simulated row read failure';
 			return null;
 		}
-		$table = $is_activity ? $this->prefix . 'ec_booking_activity' : $this->prefix . 'ec_bookings';
+		$table = $is_activity ? $this->prefix . 'ec_booking_activity' : ( $is_hold ? $this->prefix . 'ec_booking_holds' : $this->prefix . 'ec_bookings' );
 		if ( preg_match( '/WHERE id = (\d+)/', $query, $match ) ) {
 			return $this->rows[ $table ][ (int) $match[1] ] ?? null; }
+		if ( $is_hold && false !== strpos( $query, 'booking_id =' ) ) {
+			foreach ( $this->rows[ $table ] ?? array() as $row ) {
+				if ( preg_match( '/booking_id = (\d+)/', $query, $match ) && (int) $row['booking_id'] !== (int) $match[1] ) {
+					continue;
+				}
+				if ( preg_match( "/venue_term_id = (\d+).*space_key = '([^']+)'.*start_at = '([^']+)'.*end_at = '([^']+)'.*expires_at > '([^']+)'/", $query, $match ) && ( (int) $row['venue_term_id'] !== (int) $match[1] || $row['space_key'] !== stripslashes( $match[2] ) || $row['start_at'] !== $match[3] || $row['end_at'] !== $match[4] || $row['expires_at'] <= $match[5] ) ) {
+					continue;
+				}
+				if ( preg_match( "/venue_term_id = (\d+).*space_key = '([^']+)'.*start_at = '([^']+)'.*end_at = '([^']+)'.*expires_at <= '([^']+)'/", $query, $match ) && ( (int) $row['venue_term_id'] !== (int) $match[1] || $row['space_key'] !== stripslashes( $match[2] ) || $row['start_at'] !== $match[3] || $row['end_at'] !== $match[4] || $row['expires_at'] > $match[5] ) ) {
+					continue;
+				}
+				if ( false !== strpos( $query, "status = 'active'" ) && 'active' !== $row['status'] ) {
+					continue;
+				}
+				return $row;
+			}
+			return null;
+		}
+		if ( $is_hold && false !== strpos( $query, "'hold' AS conflict_type" ) ) {
+			preg_match( "/venue_term_id = (\d+) AND space_key = '([^']+)' AND status = 'active' AND expires_at > '([^']+)' AND start_at < '([^']+)' AND end_at > '([^']+)' AND booking_id <> (\d+) AND id <> (\d+)/", $query, $match );
+			foreach ( $this->rows[ $table ] ?? array() as $row ) {
+				if ( (int) $row['venue_term_id'] === (int) $match[1] && $row['space_key'] === stripslashes( $match[2] ) && 'active' === $row['status'] && $row['expires_at'] > $match[3] && $row['start_at'] < $match[4] && $row['end_at'] > $match[5] && (int) $row['booking_id'] !== (int) $match[6] && (int) $row['id'] !== (int) $match[7] ) {
+					return array(
+						'id'            => $row['id'],
+						'booking_id'    => $row['booking_id'],
+						'conflict_type' => 'hold',
+					);
+				}
+			}
+			return null;
+		}
+		if ( ! $is_hold && false !== strpos( $query, "'confirmed_booking' AS conflict_type" ) ) {
+			preg_match( "/venue_term_id = (\d+) AND space_key = '([^']+)'.*requested_start_at < '([^']+)' AND requested_end_at > '([^']+)' AND id <> (\d+)/", $query, $match );
+			foreach ( $this->rows[ $table ] ?? array() as $row ) {
+				if ( (int) $row['venue_term_id'] === (int) $match[1] && $row['space_key'] === stripslashes( $match[2] ) && 'confirmed' === $row['status'] && $row['requested_start_at'] < $match[3] && $row['requested_end_at'] > $match[4] && (int) $row['id'] !== (int) $match[5] ) {
+					return array(
+						'id'            => $row['id'],
+						'conflict_type' => 'confirmed_booking',
+					);
+				}
+			}
+			return null;
+		}
+		if ( false !== strpos( $query, "'canonical_event' AS conflict_type" ) ) {
+			preg_match( "/tt.term_id = (\d+) AND p.ID <> (\d+) AND ed.start_datetime < '([^']+)'.*ed.end_datetime > '([^']+)'.*ed.start_datetime >= '([^']+)'/", $query, $match );
+			foreach ( $this->event_dates as $event ) {
+				if ( (int) $event['venue_term_id'] !== (int) $match[1] || (int) $event['post_id'] === (int) $match[2] || 'publish' !== $event['post_status'] ) {
+					continue;
+				}
+				if ( $event['start_datetime'] < $match[3] && ( ( null !== $event['end_datetime'] && $event['end_datetime'] > $match[4] ) || ( null === $event['end_datetime'] && $event['start_datetime'] >= $match[5] ) ) ) {
+					return array(
+						'id'            => $event['post_id'],
+						'conflict_type' => 'canonical_event',
+					);
+				}
+			}
+			return null;
+		}
 		if ( preg_match( "/WHERE public_id = '([^']+)'/", $query, $match ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
 				if ( stripslashes( $match[1] ) === $row['public_id'] ) {
@@ -406,6 +523,22 @@ final class BookingWpdb {
 		if ( $this->fail_reads ) {
 			$this->last_error = 'simulated result read failure';
 			return null; }
+		if ( false !== strpos( $query, 'INNER JOIN' ) && false !== strpos( $query, 'ec_booking_holds' ) && preg_match( "/b\.venue_term_id = (\d+).*h\.expires_at <= '([^']+)'/", $query, $stale ) ) {
+			$rows = array();
+			foreach ( $this->rows[ $this->prefix . 'ec_bookings' ] ?? array() as $booking ) {
+				if ( (int) $booking['venue_term_id'] !== (int) $stale[1] || 'held' !== $booking['status'] ) {
+					continue;
+				}
+				foreach ( $this->rows[ $this->prefix . 'ec_booking_holds' ] ?? array() as $hold ) {
+					if ( (int) $hold['booking_id'] === (int) $booking['id'] && (int) $hold['venue_term_id'] === (int) $booking['venue_term_id'] && $hold['space_key'] === $booking['space_key'] && $hold['start_at'] === $booking['requested_start_at'] && $hold['end_at'] === $booking['requested_end_at'] && 'active' === $hold['status'] && $hold['expires_at'] <= $stale[2] ) {
+						$rows[] = $booking;
+						break;
+					}
+				}
+			}
+			usort( $rows, static function ( $left, $right ) { return $left['id'] <=> $right['id']; } );
+			return array_slice( $rows, 0, 100 );
+		}
 		if ( preg_match( '/SHOW COLUMNS FROM `([^`]+)`/', $query, $match ) ) {
 			++$this->schema_queries;
 			$rows = array();
@@ -419,6 +552,16 @@ final class BookingWpdb {
 				$callback                    = $this->after_membership_lock;
 				$this->after_membership_lock = null;
 				$callback();
+			}
+			if ( null !== $this->elapse_hold_after_membership_lock ) {
+				$hold_id = (int) $this->elapse_hold_after_membership_lock;
+				$past    = gmdate( 'Y-m-d H:i:s' );
+				$table   = $this->prefix . 'ec_booking_holds';
+				$this->rows[ $table ][ $hold_id ]['expires_at'] = $past;
+				if ( is_array( $this->transaction_snapshot ) ) {
+					$this->transaction_snapshot[ $table ][ $hold_id ]['expires_at'] = $past;
+				}
+				$this->elapse_hold_after_membership_lock = null;
 			}
 			return array_values( $this->rows[ $this->prefix . 'ec_venue_members' ] ?? array() );
 		}
@@ -438,7 +581,8 @@ final class BookingWpdb {
 			return $rows;
 		}
 		$is_activity = false !== strpos( $query, 'ec_booking_activity' );
-		$table       = $is_activity ? $this->prefix . 'ec_booking_activity' : $this->prefix . 'ec_bookings';
+		$is_hold     = false !== strpos( $query, 'ec_booking_holds' );
+		$table       = $is_activity ? $this->prefix . 'ec_booking_activity' : ( $is_hold ? $this->prefix . 'ec_booking_holds' : $this->prefix . 'ec_bookings' );
 		$rows        = array_values( $this->rows[ $table ] ?? array() );
 		$filters     = array( 'venue_term_id', 'artist_term_id', 'artist_profile_id', 'assignee_user_id', 'booking_id' );
 		foreach ( $filters as $field ) {
@@ -453,7 +597,11 @@ final class BookingWpdb {
 				);
 			}
 		}
-		if ( preg_match( "/status = '([^']+)'/", $query, $filter ) ) {
+		if ( $is_hold && false !== strpos( $query, "(status = 'expired' OR (status = 'active'" ) && preg_match( "/expires_at <= '([^']+)'/", $query, $filter ) ) {
+			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $filter ) { return 'expired' === $row['status'] || ( 'active' === $row['status'] && $row['expires_at'] <= $filter[1] ); } ) );
+		} elseif ( $is_hold && false !== strpos( $query, "status = 'active' AND expires_at >" ) && preg_match( "/expires_at > '([^']+)'/", $query, $filter ) ) {
+			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $filter ) { return 'active' === $row['status'] && $row['expires_at'] > $filter[1]; } ) );
+		} elseif ( preg_match( "/status = '([^']+)'/", $query, $filter ) ) {
 			$rows = array_values(
 				array_filter(
 					$rows,
@@ -479,6 +627,26 @@ final class BookingWpdb {
 					$rows,
 					static function ( $row ) use ( $filter ) {
 						return null !== $row['requested_end_at'] && $row['requested_end_at'] <= stripslashes( $filter[1] );
+					}
+				)
+			);
+		}
+		if ( $is_hold && preg_match( "/end_at > '([^']+)'/", $query, $filter ) ) {
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $filter ) {
+						return $row['end_at'] > stripslashes( $filter[1] );
+					}
+				)
+			);
+		}
+		if ( $is_hold && preg_match( "/start_at < '([^']+)'/", $query, $filter ) ) {
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $filter ) {
+						return $row['start_at'] < stripslashes( $filter[1] );
 					}
 				)
 			);
@@ -580,11 +748,54 @@ final class BookingWpdb {
 		if ( $this->fail_updates ) {
 			$this->last_error = 'simulated update failure';
 			return false; }
-		if ( ! preg_match( '/WHERE id = (\d+) AND version = (\d+)/', $query, $match ) ) {
+		if ( false !== strpos( $query, 'expires_at > UTC_TIMESTAMP()' ) && preg_match( '/UPDATE ([^ ]+).*WHERE id = (\d+) AND version = (\d+)/', $query, $release_hold ) ) {
+			$table    = $release_hold[1];
+			$id       = (int) $release_hold[2];
+			$expected = (int) $release_hold[3];
+			if ( (int) $this->elapse_hold_before_release_update === $id ) {
+				$past = gmdate( 'Y-m-d H:i:s' );
+				$this->rows[ $table ][ $id ]['expires_at'] = $past;
+				if ( is_array( $this->transaction_snapshot ) ) {
+					$this->transaction_snapshot[ $table ][ $id ]['expires_at'] = $past;
+				}
+				$this->elapse_hold_before_release_update = null;
+			}
+			if ( ! isset( $this->rows[ $table ][ $id ] ) || (int) $this->rows[ $table ][ $id ]['version'] !== $expected || 'active' !== $this->rows[ $table ][ $id ]['status'] || $this->rows[ $table ][ $id ]['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) ) {
+				return 0;
+			}
+		}
+		if ( false !== strpos( $query, "SET status = 'expired'" ) && preg_match( "/UPDATE ([^ ]+).*WHERE booking_id = (\d+).*expires_at <= '([^']+)'.*id <> (\d+)/", $query, $expired ) ) {
+			$count = 0;
+			$this->rows[ $expired[1] ] = $this->rows[ $expired[1] ] ?? array();
+			foreach ( $this->rows[ $expired[1] ] as &$row ) {
+				if ( (int) $row['booking_id'] === (int) $expired[2] && 'active' === $row['status'] && $row['expires_at'] <= $expired[3] && (int) $row['id'] !== (int) $expired[4] ) {
+					$row['status']     = 'expired';
+					$row['expired_at'] = $expired[3];
+					++$row['version'];
+					++$count;
+				}
+			}
+			unset( $row );
+			return $count;
+		}
+		if ( false !== strpos( $query, "SET status = 'released'" ) && preg_match( "/UPDATE ([^ ]+).*WHERE booking_id = (\d+).*expires_at > '([^']+)'.*id <> (\d+)/", $query, $release ) ) {
+			$count = 0;
+			$this->rows[ $release[1] ] = $this->rows[ $release[1] ] ?? array();
+			foreach ( $this->rows[ $release[1] ] as &$row ) {
+				if ( (int) $row['booking_id'] === (int) $release[2] && 'active' === $row['status'] && $row['expires_at'] > $release[3] && (int) $row['id'] !== (int) $release[4] ) {
+					$row['status'] = 'released';
+					++$row['version'];
+					++$count;
+				}
+			}
+			unset( $row );
+			return $count;
+		}
+		if ( ! preg_match( '/UPDATE ([^ ]+) SET .*WHERE id = (\d+) AND version = (\d+)/', $query, $match ) ) {
 			return false; }
-		$id       = (int) $match[1];
-		$expected = (int) $match[2];
-		$table    = $this->prefix . 'ec_bookings';
+		$table    = $match[1];
+		$id       = (int) $match[2];
+		$expected = (int) $match[3];
 		if ( ! isset( $this->rows[ $table ][ $id ] ) || (int) $this->rows[ $table ][ $id ]['version'] !== $expected ) {
 			if ( $this->race_event_read_fail ) {
 				$this->reads_before_failure = 1;
@@ -616,12 +827,14 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueMembershipRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueAuthorization.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingActivityRepository.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingHoldRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingLifecycle.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueBookingConfig.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingAbilities.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingHoldAbilities.php';
 
 final class BookingTestAuthorization extends VenueAuthorization {
-	public $calls = array();
+	public $calls   = array();
 	public $allowed = array();
 	public function __construct( array $allowed = array() ) {
 		$this->allowed = array_merge( array( '12:55' => true ), $allowed );

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -230,6 +230,7 @@ final class BookingWpdb {
 	public $event_dates                      = array();
 	public $elapse_hold_after_membership_lock = null;
 	public $elapse_hold_before_release_update = null;
+	public $elapse_hold_before_conversion_update = null;
 	private $transaction_snapshot            = null;
 
 	public function get_charset_collate() {
@@ -350,6 +351,7 @@ final class BookingWpdb {
 
 	public function get_var( $query ) {
 		$this->last_error = '';
+		$database_now = gmdate( 'Y-m-d H:i:s' );
 		if ( preg_match( "/SELECT GET_LOCK\('([^']+)', (\d+)\)/", $query, $match ) ) {
 			$this->lock_names[] = array( 'get', stripslashes( $match[1] ) );
 			return $this->get_lock_result;
@@ -358,21 +360,25 @@ final class BookingWpdb {
 			$this->lock_names[] = array( 'release', stripslashes( $match[1] ) );
 			return $this->release_lock_result;
 		}
-		if ( preg_match( "/SELECT id FROM .*ec_booking_holds WHERE booking_id = (\d+) AND venue_term_id = (\d+) AND space_key = '([^']+)' AND start_at = '([^']+)' AND end_at = '([^']+)'.*expires_at > '([^']+)'.*id <> (\d+)/", $query, $match ) ) {
+		if ( preg_match( "/SELECT id FROM .*ec_booking_holds WHERE id = (\d+) AND status = 'active' AND expires_at <= UTC_TIMESTAMP\(\)/", $query, $match ) ) {
+			$row = $this->rows[ $this->prefix . 'ec_booking_holds' ][ (int) $match[1] ] ?? null;
+			return is_array( $row ) && 'active' === $row['status'] && $row['expires_at'] <= $database_now ? $row['id'] : null;
+		}
+		if ( preg_match( "/SELECT id FROM .*ec_booking_holds WHERE booking_id = (\d+) AND venue_term_id = (\d+) AND space_key = '([^']+)' AND start_at = '([^']+)' AND end_at = '([^']+)'.*expires_at > UTC_TIMESTAMP\(\).*id <> (\d+)/", $query, $match ) ) {
 			foreach ( $this->rows[ $this->prefix . 'ec_booking_holds' ] ?? array() as $row ) {
-				if ( (int) $row['booking_id'] === (int) $match[1] && (int) $row['venue_term_id'] === (int) $match[2] && $row['space_key'] === stripslashes( $match[3] ) && $row['start_at'] === $match[4] && $row['end_at'] === $match[5] && 'active' === $row['status'] && $row['expires_at'] > $match[6] && (int) $row['id'] !== (int) $match[7] ) {
+				if ( (int) $row['booking_id'] === (int) $match[1] && (int) $row['venue_term_id'] === (int) $match[2] && $row['space_key'] === stripslashes( $match[3] ) && $row['start_at'] === $match[4] && $row['end_at'] === $match[5] && 'active' === $row['status'] && $row['expires_at'] > $database_now && (int) $row['id'] !== (int) $match[6] ) {
 					return $row['id'];
 				}
 			}
 			return null;
 		}
-		if ( false !== strpos( $query, 'SELECT b.id FROM' ) && false !== strpos( $query, 'INNER JOIN' ) && preg_match( "/b\.venue_term_id = (\d+).*h\.expires_at <= '([^']+)'/", $query, $stale ) ) {
+		if ( false !== strpos( $query, 'SELECT b.id FROM' ) && false !== strpos( $query, 'INNER JOIN' ) && preg_match( "/b\.venue_term_id = (\d+).*h\.expires_at <= UTC_TIMESTAMP\(\)/", $query, $stale ) ) {
 			foreach ( $this->rows[ $this->prefix . 'ec_bookings' ] ?? array() as $booking ) {
 				if ( (int) $booking['venue_term_id'] !== (int) $stale[1] || 'held' !== $booking['status'] ) {
 					continue;
 				}
 				foreach ( $this->rows[ $this->prefix . 'ec_booking_holds' ] ?? array() as $hold ) {
-					if ( (int) $hold['booking_id'] === (int) $booking['id'] && (int) $hold['venue_term_id'] === (int) $booking['venue_term_id'] && $hold['space_key'] === $booking['space_key'] && $hold['start_at'] === $booking['requested_start_at'] && $hold['end_at'] === $booking['requested_end_at'] && 'active' === $hold['status'] && $hold['expires_at'] <= $stale[2] ) {
+					if ( (int) $hold['booking_id'] === (int) $booking['id'] && (int) $hold['venue_term_id'] === (int) $booking['venue_term_id'] && $hold['space_key'] === $booking['space_key'] && $hold['start_at'] === $booking['requested_start_at'] && $hold['end_at'] === $booking['requested_end_at'] && 'active' === $hold['status'] && $hold['expires_at'] <= $database_now ) {
 						return $booking['id'];
 					}
 				}
@@ -419,6 +425,7 @@ final class BookingWpdb {
 		}
 		$is_activity = false !== strpos( $query, 'ec_booking_activity' );
 		$is_hold     = false !== strpos( $query, 'ec_booking_holds' );
+		$database_now = gmdate( 'Y-m-d H:i:s' );
 		if ( null !== $this->reads_before_failure ) {
 			if ( 0 === $this->reads_before_failure ) {
 				$this->last_error = 'simulated delayed row read failure';
@@ -444,6 +451,12 @@ final class BookingWpdb {
 				if ( preg_match( "/venue_term_id = (\d+).*space_key = '([^']+)'.*start_at = '([^']+)'.*end_at = '([^']+)'.*expires_at <= '([^']+)'/", $query, $match ) && ( (int) $row['venue_term_id'] !== (int) $match[1] || $row['space_key'] !== stripslashes( $match[2] ) || $row['start_at'] !== $match[3] || $row['end_at'] !== $match[4] || $row['expires_at'] > $match[5] ) ) {
 					continue;
 				}
+				if ( false !== strpos( $query, 'expires_at > UTC_TIMESTAMP()' ) && $row['expires_at'] <= $database_now ) {
+					continue;
+				}
+				if ( false !== strpos( $query, 'expires_at <= UTC_TIMESTAMP()' ) && $row['expires_at'] > $database_now ) {
+					continue;
+				}
 				if ( false !== strpos( $query, "status = 'active'" ) && 'active' !== $row['status'] ) {
 					continue;
 				}
@@ -452,9 +465,9 @@ final class BookingWpdb {
 			return null;
 		}
 		if ( $is_hold && false !== strpos( $query, "'hold' AS conflict_type" ) ) {
-			preg_match( "/venue_term_id = (\d+) AND space_key = '([^']+)' AND status = 'active' AND expires_at > '([^']+)' AND start_at < '([^']+)' AND end_at > '([^']+)' AND booking_id <> (\d+) AND id <> (\d+)/", $query, $match );
+			preg_match( "/venue_term_id = (\d+) AND space_key = '([^']+)' AND status = 'active' AND expires_at > UTC_TIMESTAMP\(\) AND start_at < '([^']+)' AND end_at > '([^']+)' AND booking_id <> (\d+) AND id <> (\d+)/", $query, $match );
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
-				if ( (int) $row['venue_term_id'] === (int) $match[1] && $row['space_key'] === stripslashes( $match[2] ) && 'active' === $row['status'] && $row['expires_at'] > $match[3] && $row['start_at'] < $match[4] && $row['end_at'] > $match[5] && (int) $row['booking_id'] !== (int) $match[6] && (int) $row['id'] !== (int) $match[7] ) {
+				if ( (int) $row['venue_term_id'] === (int) $match[1] && $row['space_key'] === stripslashes( $match[2] ) && 'active' === $row['status'] && $row['expires_at'] > $database_now && $row['start_at'] < $match[3] && $row['end_at'] > $match[4] && (int) $row['booking_id'] !== (int) $match[5] && (int) $row['id'] !== (int) $match[6] ) {
 					return array(
 						'id'            => $row['id'],
 						'booking_id'    => $row['booking_id'],
@@ -523,14 +536,14 @@ final class BookingWpdb {
 		if ( $this->fail_reads ) {
 			$this->last_error = 'simulated result read failure';
 			return null; }
-		if ( false !== strpos( $query, 'INNER JOIN' ) && false !== strpos( $query, 'ec_booking_holds' ) && preg_match( "/b\.venue_term_id = (\d+).*h\.expires_at <= '([^']+)'/", $query, $stale ) ) {
+		if ( false !== strpos( $query, 'INNER JOIN' ) && false !== strpos( $query, 'ec_booking_holds' ) && preg_match( "/b\.venue_term_id = (\d+).*h\.expires_at <= UTC_TIMESTAMP\(\)/", $query, $stale ) ) {
 			$rows = array();
 			foreach ( $this->rows[ $this->prefix . 'ec_bookings' ] ?? array() as $booking ) {
 				if ( (int) $booking['venue_term_id'] !== (int) $stale[1] || 'held' !== $booking['status'] ) {
 					continue;
 				}
 				foreach ( $this->rows[ $this->prefix . 'ec_booking_holds' ] ?? array() as $hold ) {
-					if ( (int) $hold['booking_id'] === (int) $booking['id'] && (int) $hold['venue_term_id'] === (int) $booking['venue_term_id'] && $hold['space_key'] === $booking['space_key'] && $hold['start_at'] === $booking['requested_start_at'] && $hold['end_at'] === $booking['requested_end_at'] && 'active' === $hold['status'] && $hold['expires_at'] <= $stale[2] ) {
+					if ( (int) $hold['booking_id'] === (int) $booking['id'] && (int) $hold['venue_term_id'] === (int) $booking['venue_term_id'] && $hold['space_key'] === $booking['space_key'] && $hold['start_at'] === $booking['requested_start_at'] && $hold['end_at'] === $booking['requested_end_at'] && 'active' === $hold['status'] && $hold['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) ) {
 						$rows[] = $booking;
 						break;
 					}
@@ -597,7 +610,13 @@ final class BookingWpdb {
 				);
 			}
 		}
-		if ( $is_hold && false !== strpos( $query, "(status = 'expired' OR (status = 'active'" ) && preg_match( "/expires_at <= '([^']+)'/", $query, $filter ) ) {
+		if ( $is_hold && false !== strpos( $query, "(status = 'expired' OR (status = 'active'" ) && false !== strpos( $query, 'expires_at <= UTC_TIMESTAMP()' ) ) {
+			$now  = gmdate( 'Y-m-d H:i:s' );
+			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $now ) { return 'expired' === $row['status'] || ( 'active' === $row['status'] && $row['expires_at'] <= $now ); } ) );
+		} elseif ( $is_hold && false !== strpos( $query, "status = 'active' AND expires_at > UTC_TIMESTAMP()" ) ) {
+			$now  = gmdate( 'Y-m-d H:i:s' );
+			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $now ) { return 'active' === $row['status'] && $row['expires_at'] > $now; } ) );
+		} elseif ( $is_hold && false !== strpos( $query, "(status = 'expired' OR (status = 'active'" ) && preg_match( "/expires_at <= '([^']+)'/", $query, $filter ) ) {
 			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $filter ) { return 'expired' === $row['status'] || ( 'active' === $row['status'] && $row['expires_at'] <= $filter[1] ); } ) );
 		} elseif ( $is_hold && false !== strpos( $query, "status = 'active' AND expires_at >" ) && preg_match( "/expires_at > '([^']+)'/", $query, $filter ) ) {
 			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $filter ) { return 'active' === $row['status'] && $row['expires_at'] > $filter[1]; } ) );
@@ -760,17 +779,25 @@ final class BookingWpdb {
 				}
 				$this->elapse_hold_before_release_update = null;
 			}
+			if ( false !== strpos( $query, "status = 'converted'" ) && (int) $this->elapse_hold_before_conversion_update === $id ) {
+				$past = gmdate( 'Y-m-d H:i:s' );
+				$this->rows[ $table ][ $id ]['expires_at'] = $past;
+				if ( is_array( $this->transaction_snapshot ) ) {
+					$this->transaction_snapshot[ $table ][ $id ]['expires_at'] = $past;
+				}
+				$this->elapse_hold_before_conversion_update = null;
+			}
 			if ( ! isset( $this->rows[ $table ][ $id ] ) || (int) $this->rows[ $table ][ $id ]['version'] !== $expected || 'active' !== $this->rows[ $table ][ $id ]['status'] || $this->rows[ $table ][ $id ]['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) ) {
 				return 0;
 			}
 		}
-		if ( false !== strpos( $query, "SET status = 'expired'" ) && preg_match( "/UPDATE ([^ ]+).*WHERE booking_id = (\d+).*expires_at <= '([^']+)'.*id <> (\d+)/", $query, $expired ) ) {
+		if ( false !== strpos( $query, "SET status = 'expired'" ) && preg_match( "/UPDATE ([^ ]+).*WHERE booking_id = (\d+).*expires_at <= UTC_TIMESTAMP\(\).*id <> (\d+)/", $query, $expired ) ) {
 			$count = 0;
 			$this->rows[ $expired[1] ] = $this->rows[ $expired[1] ] ?? array();
 			foreach ( $this->rows[ $expired[1] ] as &$row ) {
-				if ( (int) $row['booking_id'] === (int) $expired[2] && 'active' === $row['status'] && $row['expires_at'] <= $expired[3] && (int) $row['id'] !== (int) $expired[4] ) {
+				if ( (int) $row['booking_id'] === (int) $expired[2] && 'active' === $row['status'] && $row['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) && (int) $row['id'] !== (int) $expired[3] ) {
 					$row['status']     = 'expired';
-					$row['expired_at'] = $expired[3];
+					$row['expired_at'] = gmdate( 'Y-m-d H:i:s' );
 					++$row['version'];
 					++$count;
 				}
@@ -778,11 +805,11 @@ final class BookingWpdb {
 			unset( $row );
 			return $count;
 		}
-		if ( false !== strpos( $query, "SET status = 'released'" ) && preg_match( "/UPDATE ([^ ]+).*WHERE booking_id = (\d+).*expires_at > '([^']+)'.*id <> (\d+)/", $query, $release ) ) {
+		if ( false !== strpos( $query, "SET status = 'released'" ) && preg_match( "/UPDATE ([^ ]+).*WHERE booking_id = (\d+).*expires_at > UTC_TIMESTAMP\(\).*id <> (\d+)/", $query, $release ) ) {
 			$count = 0;
 			$this->rows[ $release[1] ] = $this->rows[ $release[1] ] ?? array();
 			foreach ( $this->rows[ $release[1] ] as &$row ) {
-				if ( (int) $row['booking_id'] === (int) $release[2] && 'active' === $row['status'] && $row['expires_at'] > $release[3] && (int) $row['id'] !== (int) $release[4] ) {
+				if ( (int) $row['booking_id'] === (int) $release[2] && 'active' === $row['status'] && $row['expires_at'] > gmdate( 'Y-m-d H:i:s' ) && (int) $row['id'] !== (int) $release[3] ) {
 					$row['status'] = 'released';
 					++$row['version'];
 					++$count;
@@ -836,12 +863,24 @@ require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingHoldAbilities.p
 final class BookingTestAuthorization extends VenueAuthorization {
 	public $calls   = array();
 	public $allowed = array();
+	public $require_locked_membership = false;
 	public function __construct( array $allowed = array() ) {
 		$this->allowed = array_merge( array( '12:55' => true ), $allowed );
 	}
 	public function authorize( int $user_id, int $venue_term_id, string $action ) {
 		$this->calls[] = array( $user_id, $venue_term_id, $action );
 		return ! empty( $this->allowed[ $user_id . ':' . $venue_term_id ] ) ? true : new WP_Error( 'venue_action_forbidden' );
+	}
+	public function authorize_locked( int $user_id, int $venue_term_id, string $action, array $locked_memberships ) {
+		if ( $this->require_locked_membership ) {
+			foreach ( $locked_memberships as $membership ) {
+				if ( $user_id === (int) $membership['user_id'] && $venue_term_id === (int) $membership['venue_term_id'] && VenueAuthorization::STATUS_ACTIVE === $membership['status'] ) {
+					return true;
+				}
+			}
+			return new WP_Error( 'venue_action_forbidden' );
+		}
+		return $this->authorize( $user_id, $venue_term_id, $action );
 	}
 }
 

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -153,6 +153,18 @@ if ( ! function_exists( 'get_current_user_id' ) ) {
 	function get_current_user_id() {
 		return 12; }
 }
+if ( ! function_exists( 'get_userdata' ) ) {
+	function get_userdata( $user_id ) {
+		return (int) $user_id > 0 ? (object) array( 'ID' => (int) $user_id ) : false; }
+}
+if ( ! function_exists( 'user_can' ) ) {
+	function user_can( $user_id, $capability ) {
+		return (int) $user_id > 0 && 'manage_options' !== $capability; }
+}
+if ( ! function_exists( 'ec_feature_available' ) ) {
+	function ec_feature_available( $feature, $user_id ) {
+		return 'venue_booking' === $feature && (int) $user_id > 0; }
+}
 if ( ! function_exists( 'add_action' ) ) {
 	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
 		unset( $priority, $accepted_args );
@@ -231,10 +243,17 @@ final class BookingWpdb {
 	public $elapse_hold_after_membership_lock = null;
 	public $elapse_hold_before_release_update = null;
 	public $elapse_hold_before_conversion_update = null;
+	public $fail_read_after_conversion_update = false;
+	public $fail_clock_reads                  = false;
+	public $database_now                     = null;
 	private $transaction_snapshot            = null;
 
 	public function get_charset_collate() {
 		return 'DEFAULT CHARACTER SET utf8mb4'; }
+
+	private function current_database_time(): string {
+		return null === $this->database_now ? gmdate( 'Y-m-d H:i:s' ) : $this->database_now;
+	}
 
 	public function prepare( $query, ...$args ) {
 		if ( 1 === count( $args ) && is_array( $args[0] ) ) {
@@ -351,7 +370,7 @@ final class BookingWpdb {
 
 	public function get_var( $query ) {
 		$this->last_error = '';
-		$database_now = gmdate( 'Y-m-d H:i:s' );
+		$database_now = $this->current_database_time();
 		if ( preg_match( "/SELECT GET_LOCK\('([^']+)', (\d+)\)/", $query, $match ) ) {
 			$this->lock_names[] = array( 'get', stripslashes( $match[1] ) );
 			return $this->get_lock_result;
@@ -419,13 +438,25 @@ final class BookingWpdb {
 		unset( $output );
 		$this->last_query = $query;
 		$this->last_error = '';
+		if ( false !== strpos( $query, 'DATE_ADD(UTC_TIMESTAMP()' ) ) {
+			if ( $this->fail_reads || $this->fail_clock_reads ) {
+				$this->last_error = 'simulated clock read failure';
+				return null;
+			}
+			preg_match( '/INTERVAL (\d+) MINUTE/', $query, $ttl );
+			$now = $this->current_database_time();
+			return array(
+				'current_at' => $now,
+				'expires_at' => gmdate( 'Y-m-d H:i:s', strtotime( $now . ' UTC' ) + ( (int) $ttl[1] * MINUTE_IN_SECONDS ) ),
+			);
+		}
 		if ( preg_match( "/SHOW TABLE STATUS WHERE Name = '([^']+)'/", $query, $match ) ) {
 			$table = stripslashes( $match[1] );
 			return isset( $this->engines[ $table ] ) ? array( 'Engine' => $this->engines[ $table ] ) : null;
 		}
 		$is_activity = false !== strpos( $query, 'ec_booking_activity' );
 		$is_hold     = false !== strpos( $query, 'ec_booking_holds' );
-		$database_now = gmdate( 'Y-m-d H:i:s' );
+		$database_now = $this->current_database_time();
 		if ( null !== $this->reads_before_failure ) {
 			if ( 0 === $this->reads_before_failure ) {
 				$this->last_error = 'simulated delayed row read failure';
@@ -439,7 +470,11 @@ final class BookingWpdb {
 		}
 		$table = $is_activity ? $this->prefix . 'ec_booking_activity' : ( $is_hold ? $this->prefix . 'ec_booking_holds' : $this->prefix . 'ec_bookings' );
 		if ( preg_match( '/WHERE id = (\d+)/', $query, $match ) ) {
-			return $this->rows[ $table ][ (int) $match[1] ] ?? null; }
+			$row = $this->rows[ $table ][ (int) $match[1] ] ?? null;
+			if ( is_array( $row ) && false !== strpos( $query, 'AS database_now' ) ) {
+				$row['database_now'] = $this->current_database_time();
+			}
+			return $row; }
 		if ( $is_hold && false !== strpos( $query, 'booking_id =' ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
 				if ( preg_match( '/booking_id = (\d+)/', $query, $match ) && (int) $row['booking_id'] !== (int) $match[1] ) {
@@ -459,6 +494,9 @@ final class BookingWpdb {
 				}
 				if ( false !== strpos( $query, "status = 'active'" ) && 'active' !== $row['status'] ) {
 					continue;
+				}
+				if ( false !== strpos( $query, 'AS database_now' ) ) {
+					$row['database_now'] = $this->current_database_time();
 				}
 				return $row;
 			}
@@ -543,7 +581,7 @@ final class BookingWpdb {
 					continue;
 				}
 				foreach ( $this->rows[ $this->prefix . 'ec_booking_holds' ] ?? array() as $hold ) {
-					if ( (int) $hold['booking_id'] === (int) $booking['id'] && (int) $hold['venue_term_id'] === (int) $booking['venue_term_id'] && $hold['space_key'] === $booking['space_key'] && $hold['start_at'] === $booking['requested_start_at'] && $hold['end_at'] === $booking['requested_end_at'] && 'active' === $hold['status'] && $hold['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) ) {
+					if ( (int) $hold['booking_id'] === (int) $booking['id'] && (int) $hold['venue_term_id'] === (int) $booking['venue_term_id'] && $hold['space_key'] === $booking['space_key'] && $hold['start_at'] === $booking['requested_start_at'] && $hold['end_at'] === $booking['requested_end_at'] && 'active' === $hold['status'] && $hold['expires_at'] <= $this->current_database_time() ) {
 						$rows[] = $booking;
 						break;
 					}
@@ -597,6 +635,13 @@ final class BookingWpdb {
 		$is_hold     = false !== strpos( $query, 'ec_booking_holds' );
 		$table       = $is_activity ? $this->prefix . 'ec_booking_activity' : ( $is_hold ? $this->prefix . 'ec_booking_holds' : $this->prefix . 'ec_bookings' );
 		$rows        = array_values( $this->rows[ $table ] ?? array() );
+		if ( false !== strpos( $query, 'AS database_now' ) ) {
+			$database_now = $this->current_database_time();
+			foreach ( $rows as &$row ) {
+				$row['database_now'] = $database_now;
+			}
+			unset( $row );
+		}
 		$filters     = array( 'venue_term_id', 'artist_term_id', 'artist_profile_id', 'assignee_user_id', 'booking_id' );
 		foreach ( $filters as $field ) {
 			if ( preg_match( "/{$field} = (\\d+)/", $query, $filter ) ) {
@@ -611,10 +656,10 @@ final class BookingWpdb {
 			}
 		}
 		if ( $is_hold && false !== strpos( $query, "(status = 'expired' OR (status = 'active'" ) && false !== strpos( $query, 'expires_at <= UTC_TIMESTAMP()' ) ) {
-			$now  = gmdate( 'Y-m-d H:i:s' );
+			$now  = $this->current_database_time();
 			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $now ) { return 'expired' === $row['status'] || ( 'active' === $row['status'] && $row['expires_at'] <= $now ); } ) );
 		} elseif ( $is_hold && false !== strpos( $query, "status = 'active' AND expires_at > UTC_TIMESTAMP()" ) ) {
-			$now  = gmdate( 'Y-m-d H:i:s' );
+			$now  = $this->current_database_time();
 			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $now ) { return 'active' === $row['status'] && $row['expires_at'] > $now; } ) );
 		} elseif ( $is_hold && false !== strpos( $query, "(status = 'expired' OR (status = 'active'" ) && preg_match( "/expires_at <= '([^']+)'/", $query, $filter ) ) {
 			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $filter ) { return 'expired' === $row['status'] || ( 'active' === $row['status'] && $row['expires_at'] <= $filter[1] ); } ) );
@@ -787,7 +832,11 @@ final class BookingWpdb {
 				}
 				$this->elapse_hold_before_conversion_update = null;
 			}
-			if ( ! isset( $this->rows[ $table ][ $id ] ) || (int) $this->rows[ $table ][ $id ]['version'] !== $expected || 'active' !== $this->rows[ $table ][ $id ]['status'] || $this->rows[ $table ][ $id ]['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) ) {
+			if ( false !== strpos( $query, "status = 'converted'" ) && $this->fail_read_after_conversion_update ) {
+				$this->reads_before_failure = 0;
+				$this->fail_read_after_conversion_update = false;
+			}
+			if ( ! isset( $this->rows[ $table ][ $id ] ) || (int) $this->rows[ $table ][ $id ]['version'] !== $expected || 'active' !== $this->rows[ $table ][ $id ]['status'] || $this->rows[ $table ][ $id ]['expires_at'] <= $this->current_database_time() ) {
 				return 0;
 			}
 		}
@@ -795,7 +844,7 @@ final class BookingWpdb {
 			$count = 0;
 			$this->rows[ $expired[1] ] = $this->rows[ $expired[1] ] ?? array();
 			foreach ( $this->rows[ $expired[1] ] as &$row ) {
-				if ( (int) $row['booking_id'] === (int) $expired[2] && 'active' === $row['status'] && $row['expires_at'] <= gmdate( 'Y-m-d H:i:s' ) && (int) $row['id'] !== (int) $expired[3] ) {
+				if ( (int) $row['booking_id'] === (int) $expired[2] && 'active' === $row['status'] && $row['expires_at'] <= $this->current_database_time() && (int) $row['id'] !== (int) $expired[3] ) {
 					$row['status']     = 'expired';
 					$row['expired_at'] = gmdate( 'Y-m-d H:i:s' );
 					++$row['version'];
@@ -809,7 +858,7 @@ final class BookingWpdb {
 			$count = 0;
 			$this->rows[ $release[1] ] = $this->rows[ $release[1] ] ?? array();
 			foreach ( $this->rows[ $release[1] ] as &$row ) {
-				if ( (int) $row['booking_id'] === (int) $release[2] && 'active' === $row['status'] && $row['expires_at'] > gmdate( 'Y-m-d H:i:s' ) && (int) $row['id'] !== (int) $release[3] ) {
+				if ( (int) $row['booking_id'] === (int) $release[2] && 'active' === $row['status'] && $row['expires_at'] > $this->current_database_time() && (int) $row['id'] !== (int) $release[3] ) {
 					$row['status'] = 'released';
 					++$row['version'];
 					++$count;
@@ -865,6 +914,7 @@ final class BookingTestAuthorization extends VenueAuthorization {
 	public $allowed = array();
 	public $require_locked_membership = false;
 	public function __construct( array $allowed = array() ) {
+		parent::__construct();
 		$this->allowed = array_merge( array( '12:55' => true ), $allowed );
 	}
 	public function authorize( int $user_id, int $venue_term_id, string $action ) {
@@ -873,12 +923,7 @@ final class BookingTestAuthorization extends VenueAuthorization {
 	}
 	public function authorize_locked( int $user_id, int $venue_term_id, string $action, array $locked_memberships ) {
 		if ( $this->require_locked_membership ) {
-			foreach ( $locked_memberships as $membership ) {
-				if ( $user_id === (int) $membership['user_id'] && $venue_term_id === (int) $membership['venue_term_id'] && VenueAuthorization::STATUS_ACTIVE === $membership['status'] ) {
-					return true;
-				}
-			}
-			return new WP_Error( 'venue_action_forbidden' );
+			return parent::authorize_locked( $user_id, $venue_term_id, $action, $locked_memberships );
 		}
 		return $this->authorize( $user_id, $venue_term_id, $action );
 	}

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -473,6 +473,12 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->assertTrue( $authorization->can( 3, 55, VenueAuthorization::ACTION_MANAGE_MEMBERS ) );
 		$this->assertFalse( $authorization->can( 4, 56, VenueAuthorization::ACTION_ACCESS_VENUE ) );
 		$this->assertFalse( $authorization->can( 5, 56, VenueAuthorization::ACTION_ACCESS_VENUE ) );
+		$locked = array_values( $GLOBALS['wpdb']->rows['wp_7_ec_venue_members'] );
+		$this->assertSame( 'venue_action_forbidden', $authorization->authorize_locked( 4, 56, VenueAuthorization::ACTION_ACCESS_VENUE, $locked )->get_error_code() );
+		$this->assertSame( 'venue_action_forbidden', $authorization->authorize_locked( 5, 56, VenueAuthorization::ACTION_ACCESS_VENUE, $locked )->get_error_code() );
+		$this->assertSame( 'venue_action_forbidden', $authorization->authorize_locked( 4, 56, VenueAuthorization::ACTION_MANAGE_MEMBERS, $locked )->get_error_code() );
+		$this->assertSame( 'venue_action_forbidden', $authorization->authorize_locked( 5, 56, VenueAuthorization::ACTION_MANAGE_MEMBERS, $locked )->get_error_code() );
+		$this->assertTrue( $authorization->authorize_locked( 6, 56, VenueAuthorization::ACTION_MANAGE_MEMBERS, $locked ) );
 
 		unset( $GLOBALS['venue_membership_test']['team_access'][6] );
 		$this->assertFalse( $authorization->can( 6, 56, VenueAuthorization::ACTION_ACCESS_VENUE ) );


### PR DESCRIPTION
## Summary
- add durable venue-space booking holds with advisory-lock serialization, strict half-open overlap checks, optimistic release, and bounded expiration retries
- integrate holds with booking lifecycle so `held` always has an active exact hold and confirmation atomically converts the selected hold while releasing live alternatives
- authorize booking mutations from lock-current active membership rows before any ordinary transactional booking read can establish a stale InnoDB snapshot
- enforce active, unexpired confirmation conversion in SQL using `UTC_TIMESTAMP()` and namespace advisory locks by site-scoped hold table identity
- derive hold lifetime and effective expiration from MySQL UTC time rather than the PHP process clock
- block conflicts from active holds, confirmed bookings, and canonical published venue events using conservative venue-wide/timezone-aware checks

## Abilities
- `extrachill/create-booking-hold`
- `extrachill/release-booking-hold`
- `extrachill/list-booking-holds`

## Safety
- schema v5 adds site-scoped InnoDB `ec_booking_holds`
- deterministic MySQL-safe venue-space advisory locks serialize hold and confirmation writers without colliding across multisite tables
- elapsed holds never block, and authoritative creation, expiration, hydration, release, and conversion decisions use database time
- normal booking reads/writes reconcile stale `held` state without depending on cron
- Action Scheduler cleanup is best effort with visible bounded retries
- production authorization rejects invited and revoked memberships for every action while retaining owner checks for membership management
- exact venue membership is reauthorized from rows returned by the locking read for private reads and mutations
- final confirmation conversion requires the hold to remain active and satisfy `expires_at > UTC_TIMESTAMP()`; failure rolls back the booking transition with an explicit conflict
- diagnostic read failures after zero-row conversion are propagated rather than masked as version conflicts
- canonical event checks convert UTC windows into venue-local time and conservatively cover DST fallback folds
- canonical events block every venue space because the canonical event model has no `space_key`

## Verification
- booking foundation/lifecycle/holds: 77 tests, 532 assertions
- real venue membership authorization: 12 tests, 93 assertions
- PHP syntax: passed for all modified PHP files
- `git diff --check`: passed
- targeted PHPCS executed and reports existing WordPress-standard debt in the legacy files; no clean configured baseline exists
- PHPStan is not configured in this repository

## Follow-ups / Residual Blockers
- #299 still owns real two-connection MySQL concurrency proof; these regressions are deterministic unit doubles and do not claim that proof
- #334 still blocks canonical publisher serialization; this PR checks existing canonical events but does not close the arbitrary publisher race or add save hooks

Closes #295