### PR TITLE
Add booking detail and deal mutations

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -249,6 +249,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingHoldRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingMutationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingLifecycle.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingConfig.php';
 		\ExtraChillEvents\Core\BookingHoldRepository::register();
@@ -345,6 +346,9 @@ class ExtraChillEvents {
 
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueBookingHoldAbilities.php';
 			new \ExtraChillEvents\Abilities\VenueBookingHoldAbilities();
+
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueBookingMutationAbilities.php';
+			new \ExtraChillEvents\Abilities\VenueBookingMutationAbilities();
 		}
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/PriorityVenueAbilities.php';

--- a/inc/Abilities/VenueBookingAbilities.php
+++ b/inc/Abilities/VenueBookingAbilities.php
@@ -634,12 +634,17 @@ class VenueBookingAbilities {
 				'door_ticket_price_cents'    => $nullable_money,
 				'ticket_fee_cents'           => $nullable_money,
 				'tickets_on_sale_at'         => $this->nullable_datetime_schema(),
+				'ticket_url'                 => array(
+					'type'      => array( 'string', 'null' ),
+					'format'    => 'uri',
+					'maxLength' => 2048,
+				),
 				'additional_terms'           => array(
 					'type'      => array( 'string', 'null' ),
 					'maxLength' => 10000,
 				),
 			),
-			'required'             => array( 'version', 'type', 'guarantee_cents', 'revenue_share_basis_points', 'revenue_share_basis', 'currency', 'capacity', 'advance_ticket_price_cents', 'door_ticket_price_cents', 'ticket_fee_cents', 'tickets_on_sale_at', 'additional_terms' ),
+			'required'             => array( 'version', 'type', 'guarantee_cents', 'revenue_share_basis_points', 'revenue_share_basis', 'currency', 'capacity', 'advance_ticket_price_cents', 'door_ticket_price_cents', 'ticket_fee_cents', 'tickets_on_sale_at', 'ticket_url', 'additional_terms' ),
 			'additionalProperties' => false,
 		);
 	}

--- a/inc/Abilities/VenueBookingAbilities.php
+++ b/inc/Abilities/VenueBookingAbilities.php
@@ -49,9 +49,9 @@ class VenueBookingAbilities {
 	/**
 	 * Build and hook the booking ability surface.
 	 *
-	 * @param BookingRepository|null  $bookings      Booking reads.
-	 * @param BookingLifecycle|null   $lifecycle     Booking mutations.
-	 * @param VenueAuthorization|null $authorization Venue authorization.
+	 * @param BookingRepository|null     $bookings      Booking reads.
+	 * @param BookingLifecycle|null      $lifecycle     Booking mutations.
+	 * @param VenueAuthorization|null    $authorization Venue authorization.
 	 * @param BookingHoldRepository|null $holds     Hold reconciliation.
 	 */
 	public function __construct( ?BookingRepository $bookings = null, ?BookingLifecycle $lifecycle = null, ?VenueAuthorization $authorization = null, ?BookingHoldRepository $holds = null ) {
@@ -371,48 +371,48 @@ class VenueBookingAbilities {
 		return array(
 			'type'                 => 'object',
 			'properties'           => array(
-				'idempotency_key'    => array(
+				'idempotency_key'     => array(
 					'type'      => 'string',
 					'minLength' => 1,
 					'maxLength' => 191,
 				),
-				'venue_term_id'      => array(
+				'venue_term_id'       => array(
 					'type'    => 'integer',
 					'minimum' => 1,
 				),
-				'artist_term_id'     => array(
+				'artist_term_id'      => array(
 					'type'    => array( 'integer', 'null' ),
 					'minimum' => 1,
 				),
-				'artist_profile_id'  => array(
+				'artist_profile_id'   => array(
 					'type'    => array( 'integer', 'null' ),
 					'minimum' => 1,
 				),
-				'artist_name'        => array(
+				'artist_name'         => array(
 					'type'      => 'string',
 					'minLength' => 1,
 					'maxLength' => 255,
 				),
-				'contact_name'       => array(
+				'contact_name'        => array(
 					'type'      => array( 'string', 'null' ),
 					'maxLength' => 255,
 				),
-				'contact_email'      => array(
+				'contact_email'       => array(
 					'type'      => array( 'string', 'null' ),
 					'format'    => 'email',
 					'maxLength' => 255,
 				),
-				'contact_phone'      => array(
+				'contact_phone'       => array(
 					'type'      => array( 'string', 'null' ),
 					'maxLength' => 64,
 				),
-				'space_key'          => array(
+				'requested_space_key' => array(
 					'type'      => array( 'string', 'null' ),
 					'maxLength' => 64,
 				),
-				'requested_start_at' => $this->nullable_datetime_schema(),
-				'requested_end_at'   => $this->nullable_datetime_schema(),
-				'intake'             => array(
+				'requested_start_at'  => $this->nullable_datetime_schema(),
+				'requested_end_at'    => $this->nullable_datetime_schema(),
+				'intake'              => array(
 					'type'                 => 'object',
 					'additionalProperties' => true,
 				),
@@ -478,7 +478,7 @@ class VenueBookingAbilities {
 	}
 
 	/** Return the stable hydrated booking output schema. */
-	private function booking_schema(): array {
+	public function booking_schema(): array {
 		$nullable_id     = array(
 			'type'    => array( 'integer', 'null' ),
 			'minimum' => 1,
@@ -487,44 +487,49 @@ class VenueBookingAbilities {
 		return array(
 			'type'                 => 'object',
 			'properties'           => array(
-				'id'                 => array(
+				'id'                   => array(
 					'type'    => 'integer',
 					'minimum' => 1,
 				),
-				'public_id'          => array(
+				'public_id'            => array(
 					'type'   => 'string',
 					'format' => 'uuid',
 				),
-				'venue_term_id'      => array(
+				'venue_term_id'        => array(
 					'type'    => 'integer',
 					'minimum' => 1,
 				),
-				'artist_term_id'     => $nullable_id,
-				'artist_profile_id'  => $nullable_id,
-				'artist_name'        => array( 'type' => 'string' ),
-				'submitter_user_id'  => $nullable_id,
-				'contact_name'       => $nullable_string,
-				'contact_email'      => $nullable_string,
-				'contact_phone'      => $nullable_string,
-				'space_key'          => $nullable_string,
-				'status'             => array(
+				'artist_term_id'       => $nullable_id,
+				'artist_profile_id'    => $nullable_id,
+				'artist_name'          => array( 'type' => 'string' ),
+				'submitter_user_id'    => $nullable_id,
+				'contact_name'         => $nullable_string,
+				'contact_email'        => $nullable_string,
+				'contact_phone'        => $nullable_string,
+				'requested_space_key'  => $nullable_string,
+				'space_key'            => $nullable_string,
+				'status'               => array(
 					'type' => 'string',
 					'enum' => BookingLifecycle::STATUSES,
 				),
-				'version'            => array(
+				'version'              => array(
 					'type'    => 'integer',
 					'minimum' => 1,
 				),
-				'assignee_user_id'   => $nullable_id,
-				'requested_start_at' => $this->nullable_datetime_schema(),
-				'requested_end_at'   => $this->nullable_datetime_schema(),
-				'intake'             => $this->payload_schema( false ),
-				'deal'               => $this->payload_schema( true ),
-				'event_id'           => $nullable_id,
-				'created_at'         => array( 'type' => 'string' ),
-				'updated_at'         => array( 'type' => 'string' ),
+				'assignee_user_id'     => $nullable_id,
+				'requested_start_at'   => $this->nullable_datetime_schema(),
+				'requested_end_at'     => $this->nullable_datetime_schema(),
+				'performance_start_at' => $this->nullable_datetime_schema(),
+				'performance_end_at'   => $this->nullable_datetime_schema(),
+				'intake'               => $this->payload_schema( false ),
+				'production'           => $this->payload_schema( true, $this->production_document_schema() ),
+				'deal'                 => $this->payload_schema( true, $this->deal_document_schema() ),
+				'confirmed_deal'       => $this->payload_schema( true, $this->deal_document_schema() ),
+				'event_id'             => $nullable_id,
+				'created_at'           => array( 'type' => 'string' ),
+				'updated_at'           => array( 'type' => 'string' ),
 			),
-			'required'             => array( 'id', 'public_id', 'venue_term_id', 'artist_term_id', 'artist_profile_id', 'artist_name', 'submitter_user_id', 'contact_name', 'contact_email', 'contact_phone', 'space_key', 'status', 'version', 'assignee_user_id', 'requested_start_at', 'requested_end_at', 'intake', 'deal', 'event_id', 'created_at', 'updated_at' ),
+			'required'             => array( 'id', 'public_id', 'venue_term_id', 'artist_term_id', 'artist_profile_id', 'artist_name', 'submitter_user_id', 'contact_name', 'contact_email', 'contact_phone', 'requested_space_key', 'space_key', 'status', 'version', 'assignee_user_id', 'requested_start_at', 'requested_end_at', 'performance_start_at', 'performance_end_at', 'intake', 'production', 'deal', 'confirmed_deal', 'event_id', 'created_at', 'updated_at' ),
 			'additionalProperties' => false,
 		);
 	}
@@ -534,7 +539,7 @@ class VenueBookingAbilities {
 	 *
 	 * @param bool $nullable Whether null is accepted.
 	 */
-	private function payload_schema( bool $nullable ): array {
+	private function payload_schema( bool $nullable, ?array $data_schema = null ): array {
 		$schema = array(
 			'type'                 => 'object',
 			'properties'           => array(
@@ -542,7 +547,7 @@ class VenueBookingAbilities {
 					'type' => 'integer',
 					'enum' => array( 1 ),
 				),
-				'data'    => array(
+				'data'    => $data_schema ? $data_schema : array(
 					'type'                 => 'object',
 					'additionalProperties' => true,
 				),
@@ -554,6 +559,89 @@ class VenueBookingAbilities {
 			$schema['type'] = array( 'object', 'null' );
 		}
 		return $schema;
+	}
+
+	/** Strict production data-document schema shared by mutations and output. */
+	public function production_document_schema(): array {
+		$list = array(
+			'type'     => 'array',
+			'maxItems' => 50,
+			'items'    => array(
+				'type'      => 'string',
+				'minLength' => 1,
+				'maxLength' => 500,
+			),
+		);
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'version'              => array(
+					'type' => 'integer',
+					'enum' => array( 1 ),
+				),
+				'support_requirements' => $list,
+				'support_offers'       => $list,
+				'production_notes'     => array(
+					'type'      => array( 'string', 'null' ),
+					'maxLength' => 10000,
+				),
+			),
+			'required'             => array( 'version', 'support_requirements', 'support_offers', 'production_notes' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	/** Strict complete draft/confirmed deal data-document schema. */
+	public function deal_document_schema(): array {
+		$nullable_money = array(
+			'type'    => array( 'integer', 'null' ),
+			'minimum' => 0,
+		);
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'version'                    => array(
+					'type' => 'integer',
+					'enum' => array( 1 ),
+				),
+				'type'                       => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 32,
+				),
+				'guarantee_cents'            => array(
+					'type'    => 'integer',
+					'minimum' => 0,
+				),
+				'revenue_share_basis_points' => array(
+					'type'    => 'integer',
+					'minimum' => 0,
+					'maximum' => 10000,
+				),
+				'revenue_share_basis'        => array(
+					'type' => 'string',
+					'enum' => array( 'gross_ticket_sales', 'net_ticket_sales', 'door_receipts' ),
+				),
+				'currency'                   => array(
+					'type'    => 'string',
+					'pattern' => '^[A-Z]{3}$',
+				),
+				'capacity'                   => array(
+					'type'    => array( 'integer', 'null' ),
+					'minimum' => 1,
+				),
+				'advance_ticket_price_cents' => $nullable_money,
+				'door_ticket_price_cents'    => $nullable_money,
+				'ticket_fee_cents'           => $nullable_money,
+				'tickets_on_sale_at'         => $this->nullable_datetime_schema(),
+				'additional_terms'           => array(
+					'type'      => array( 'string', 'null' ),
+					'maxLength' => 10000,
+				),
+			),
+			'required'             => array( 'version', 'type', 'guarantee_cents', 'revenue_share_basis_points', 'revenue_share_basis', 'currency', 'capacity', 'advance_ticket_price_cents', 'door_ticket_price_cents', 'ticket_fee_cents', 'tickets_on_sale_at', 'additional_terms' ),
+			'additionalProperties' => false,
+		);
 	}
 
 	/** Return the UTC database datetime schema. */

--- a/inc/Abilities/VenueBookingMutationAbilities.php
+++ b/inc/Abilities/VenueBookingMutationAbilities.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Authorized booking detail and deal mutation abilities.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+use ExtraChillEvents\Core\BookingMutationService;
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\VenueAuthorization;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Registers the four focused operator mutation contracts. */
+class VenueBookingMutationAbilities {
+	private static bool $registered = false;
+	/** @var BookingMutationService */
+	private $mutations;
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var VenueAuthorization */
+	private $authorization;
+	/** @var VenueBookingAbilities */
+	private $schemas;
+
+	public function __construct( ?BookingMutationService $mutations = null, ?BookingRepository $bookings = null, ?VenueAuthorization $authorization = null, ?VenueBookingAbilities $schemas = null ) {
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+		$this->bookings      = $bookings ? $bookings : new BookingRepository();
+		$this->mutations     = $mutations ? $mutations : new BookingMutationService( $this->bookings, null, $this->authorization );
+		$this->schemas       = $schemas ? $schemas : new VenueBookingAbilities( $this->bookings, null, $this->authorization );
+		if ( ! self::$registered ) {
+			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+			self::$registered = true;
+		}
+	}
+
+	public function register(): void {
+		$this->register_ability( 'extrachill/correct-venue-booking-intake', __( 'Correct Venue Booking Intake', 'extrachill-events' ), $this->intake_schema(), 'correct_intake' );
+		$this->register_ability( 'extrachill/select-venue-booking-performance', __( 'Select Venue Booking Performance', 'extrachill-events' ), $this->performance_schema(), 'select_performance' );
+		$this->register_ability( 'extrachill/update-venue-booking-production', __( 'Update Venue Booking Production', 'extrachill-events' ), $this->document_input( 'production', $this->schemas->production_document_schema() ), 'update_production' );
+		$this->register_ability( 'extrachill/update-venue-booking-deal', __( 'Update Venue Booking Deal', 'extrachill-events' ), $this->document_input( 'deal', $this->schemas->deal_document_schema() ), 'update_deal' );
+	}
+
+	private function register_ability( string $name, string $label, array $input, string $callback ): void {
+		wp_register_ability(
+			$name,
+			array(
+				'label'               => $label,
+				'description'         => $label,
+				'category'            => 'extrachill-events',
+				'input_schema'        => $input,
+				'output_schema'       => $this->schemas->booking_schema(),
+				'execute_callback'    => array( $this, $callback ),
+				'permission_callback' => array( $this, 'can_access_booking' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => false,
+						'idempotent'  => false,
+						'destructive' => true,
+					),
+				),
+			)
+		);
+	}
+
+	public function correct_intake( array $input ) {
+		$id      = (int) $input['booking_id'];
+		$version = (int) $input['expected_version'];
+		unset( $input['booking_id'], $input['expected_version'] );
+		$result = $this->mutations->correct_intake( $id, $version, $input, get_current_user_id() );
+		return is_array( $result ) ? $this->schemas->present( $result ) : $result;
+	}
+
+	public function select_performance( array $input ) {
+		$result = $this->mutations->select_performance( (int) $input['booking_id'], (int) $input['expected_version'], (string) $input['space_key'], (string) $input['start_at'], (string) $input['end_at'], get_current_user_id() );
+		return is_array( $result ) ? $this->schemas->present( $result ) : $result;
+	}
+
+	public function update_production( array $input ) {
+		$result = $this->mutations->update_production( (int) $input['booking_id'], (int) $input['expected_version'], $input['production'], get_current_user_id() );
+		return is_array( $result ) ? $this->schemas->present( $result ) : $result;
+	}
+
+	public function update_deal( array $input ) {
+		$result = $this->mutations->update_deal( (int) $input['booking_id'], (int) $input['expected_version'], $input['deal'], get_current_user_id() );
+		return is_array( $result ) ? $this->schemas->present( $result ) : $result;
+	}
+
+	public function can_access_booking( array $input ) {
+		$booking = $this->bookings->get( absint( $input['booking_id'] ?? 0 ) );
+		return is_array( $booking ) ? $this->authorization->authorize( get_current_user_id(), $booking['venue_term_id'], VenueAuthorization::ACTION_ACCESS_VENUE ) : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+
+	private function base_properties(): array {
+		return array(
+			'booking_id'       => array(
+				'type'    => 'integer',
+				'minimum' => 1,
+			),
+			'expected_version' => array(
+				'type'    => 'integer',
+				'minimum' => 1,
+			),
+		);
+	}
+
+	private function intake_schema(): array {
+		$properties = array_merge(
+			$this->base_properties(),
+			array(
+				'contact_name'        => array(
+					'type'      => array( 'string', 'null' ),
+					'maxLength' => 255,
+				),
+				'contact_email'       => array(
+					'type'      => array( 'string', 'null' ),
+					'format'    => 'email',
+					'maxLength' => 255,
+				),
+				'contact_phone'       => array(
+					'type'      => array( 'string', 'null' ),
+					'maxLength' => 64,
+				),
+				'requested_space_key' => array(
+					'type'      => array( 'string', 'null' ),
+					'maxLength' => 64,
+				),
+				'requested_start_at'  => $this->datetime(),
+				'requested_end_at'    => $this->datetime(),
+				'intake'              => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
+			)
+		);
+		return array(
+			'type'                 => 'object',
+			'properties'           => $properties,
+			'required'             => array( 'booking_id', 'expected_version' ),
+			'minProperties'        => 3,
+			'additionalProperties' => false,
+		);
+	}
+
+	private function performance_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array_merge(
+				$this->base_properties(),
+				array(
+					'space_key' => array(
+						'type'      => 'string',
+						'minLength' => 1,
+						'maxLength' => 64,
+					),
+					'start_at'  => $this->datetime( false ),
+					'end_at'    => $this->datetime( false ),
+				)
+			),
+			'required'             => array( 'booking_id', 'expected_version', 'space_key', 'start_at', 'end_at' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function document_input( string $key, array $schema ): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array_merge( $this->base_properties(), array( $key => $schema ) ),
+			'required'             => array( 'booking_id', 'expected_version', $key ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function datetime( bool $nullable = true ): array {
+		return array(
+			'type'    => $nullable ? array( 'string', 'null' ) : 'string',
+			'pattern' => '^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$',
+		);
+	}
+}

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -70,7 +70,7 @@ class BookingHoldRepository {
 		}
 		global $wpdb;
 		$table = BookingSchema::holds_table();
-		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT *, UTC_TIMESTAMP() AS database_now FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at <= UTC_TIMESTAMP() ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Detects only the elapsed exact selected hold by database time.
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT *, UTC_TIMESTAMP() AS database_now FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at <= UTC_TIMESTAMP() ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['performance_start_at'], $booking['performance_end_at'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Detects only the elapsed exact selected hold by database time.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_hold_reconciliation_failed', __( 'The held booking could not be reconciled.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
@@ -96,7 +96,7 @@ class BookingHoldRepository {
 		$holds     = BookingSchema::holds_table();
 		$processed = 0;
 		do {
-			$rows = $wpdb->get_results( $wpdb->prepare( "SELECT b.* FROM {$bookings} b INNER JOIN {$holds} h ON h.booking_id = b.id AND h.venue_term_id = b.venue_term_id AND h.space_key = b.space_key AND h.start_at = b.requested_start_at AND h.end_at = b.requested_end_at WHERE b.venue_term_id = %d AND b.status = 'held' AND h.status = 'active' AND h.expires_at <= UTC_TIMESTAMP() ORDER BY b.id ASC LIMIT 100", $venue_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Selects only stale exact held aggregates by database time.
+			$rows = $wpdb->get_results( $wpdb->prepare( "SELECT b.* FROM {$bookings} b INNER JOIN {$holds} h ON h.booking_id = b.id AND h.venue_term_id = b.venue_term_id AND h.space_key = b.space_key AND h.start_at = b.performance_start_at AND h.end_at = b.performance_end_at WHERE b.venue_term_id = %d AND b.status = 'held' AND h.status = 'active' AND h.expires_at <= UTC_TIMESTAMP() ORDER BY b.id ASC LIMIT 100", $venue_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Selects only stale exact held aggregates by database time.
 			if ( '' !== (string) $wpdb->last_error ) {
 				return new \WP_Error( 'booking_hold_venue_reconciliation_failed', __( 'Held bookings for this venue could not be reconciled.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 			}
@@ -189,7 +189,7 @@ class BookingHoldRepository {
 		global $wpdb;
 		$bookings = BookingSchema::bookings_table();
 		$holds    = BookingSchema::holds_table();
-		$row      = $wpdb->get_var( $wpdb->prepare( "SELECT b.id FROM {$bookings} b INNER JOIN {$holds} h ON h.booking_id = b.id AND h.venue_term_id = b.venue_term_id AND h.space_key = b.space_key AND h.start_at = b.requested_start_at AND h.end_at = b.requested_end_at WHERE b.venue_term_id = %d AND b.status = 'held' AND h.status = 'active' AND h.expires_at <= UTC_TIMESTAMP() LIMIT 1", $venue_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Cheap database-time post-cap existence check.
+		$row      = $wpdb->get_var( $wpdb->prepare( "SELECT b.id FROM {$bookings} b INNER JOIN {$holds} h ON h.booking_id = b.id AND h.venue_term_id = b.venue_term_id AND h.space_key = b.space_key AND h.start_at = b.performance_start_at AND h.end_at = b.performance_end_at WHERE b.venue_term_id = %d AND b.status = 'held' AND h.status = 'active' AND h.expires_at <= UTC_TIMESTAMP() LIMIT 1", $venue_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Cheap database-time post-cap existence check.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_hold_venue_reconciliation_failed', __( 'Remaining stale held bookings could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
@@ -200,6 +200,107 @@ class BookingHoldRepository {
 	private function authorize_venue_now( int $venue_id, int $actor_id ) {
 		$allowed = $this->authorization->authorize( $actor_id, $venue_id, VenueAuthorization::ACTION_ACCESS_VENUE );
 		return true === $allowed ? true : ( is_wp_error( $allowed ) ? $allowed : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) ) );
+	}
+
+	/** Select the authoritative performance under the venue-space conflict lock. */
+	public function select_performance( int $booking_id, int $expected_version, string $space_key, string $start_at, string $end_at, int $actor_id ) {
+		$booking = $this->bookings->get( $booking_id );
+		if ( ! is_array( $booking ) ) {
+			return is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
+		$allowed = $this->authorize_venue_now( $booking['venue_term_id'], $actor_id );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		$space_key = mb_substr( sanitize_key( $space_key ), 0, 64 );
+		if ( '' === $space_key || ! $this->valid_datetime( $start_at ) || ! $this->valid_datetime( $end_at ) || $end_at <= $start_at ) {
+			return new \WP_Error( 'invalid_booking_performance', __( 'A configured space and strict UTC performance range are required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return $this->with_lock(
+			$this->lock_name( $booking['venue_term_id'], $space_key ),
+			function () use ( $booking_id, $expected_version, $space_key, $start_at, $end_at, $actor_id ) {
+				$started = $this->begin_authorized( $booking_id, $actor_id );
+				if ( is_wp_error( $started ) ) {
+					return $started;
+				}
+				$current = $this->bookings->get( $booking_id );
+				if ( ! is_array( $current ) ) {
+					return $this->rollback( is_wp_error( $current ) ? $current : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+				}
+				if ( (int) $current['version'] !== $expected_version ) {
+					return $this->rollback( $this->booking_version_conflict( $current ) );
+				}
+				if ( ! in_array( $current['status'], array( 'under_review', 'negotiating' ), true ) ) {
+					return $this->rollback(
+						new \WP_Error(
+							'booking_performance_status_forbidden',
+							__( 'Performance selection is not allowed in the current booking status.', 'extrachill-events' ),
+							array(
+								'status'         => 409,
+								'booking_status' => $current['status'],
+							)
+						)
+					);
+				}
+				global $wpdb;
+				$locked_venue = $wpdb->get_var( $wpdb->prepare( "SELECT term_id FROM {$wpdb->terms} WHERE term_id = %d FOR UPDATE", $current['venue_term_id'] ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serializes configured-space reads.
+				if ( '' !== (string) $wpdb->last_error || (int) $locked_venue !== (int) $current['venue_term_id'] ) {
+					return $this->rollback( new \WP_Error( 'booking_performance_venue_lock_failed', __( 'The venue performance configuration could not be locked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
+				}
+				wp_cache_delete( $current['venue_term_id'], 'term_meta' );
+				$config = $this->config->get( $current['venue_term_id'] );
+				if ( is_wp_error( $config ) ) {
+					return $this->rollback( $config );
+				}
+				if ( ! $this->configured_space( $config, $space_key ) ) {
+					return $this->rollback( new \WP_Error( 'booking_performance_space_invalid', __( 'The selected booking space is not configured for this venue.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+				}
+				$proposed                         = $current;
+				$proposed['space_key']            = $space_key;
+				$proposed['performance_start_at'] = $start_at;
+				$proposed['performance_end_at']   = $end_at;
+				$conflict                         = $this->find_conflict( $proposed, 0 );
+				if ( is_wp_error( $conflict ) || $conflict ) {
+					return $this->rollback( is_wp_error( $conflict ) ? $conflict : $this->conflict_error( $conflict ) );
+				}
+				if ( $current['space_key'] === $space_key && $current['performance_start_at'] === $start_at && $current['performance_end_at'] === $end_at ) {
+					$committed = $this->commit();
+					return is_wp_error( $committed ) ? $committed : $current;
+				}
+				$now    = gmdate( 'Y-m-d H:i:s' );
+				$table  = BookingSchema::bookings_table();
+				$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET space_key = %s, performance_start_at = %s, performance_end_at = %s, version = version + 1, updated_at = %s WHERE id = %d AND version = %d", $space_key, $start_at, $end_at, $now, $booking_id, $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Atomic authoritative selection.
+				if ( 1 !== $result ) {
+					return $this->rollback( false === $result ? new \WP_Error( 'booking_performance_update_failed', __( 'The performance selection could not be saved.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) : $this->booking_version_conflict( $this->bookings->get( $booking_id ) ) );
+				}
+				$event = $this->activity->append(
+					array(
+						'booking_id' => $booking_id,
+						'kind'       => 'performance_selected',
+						'actor_type' => 'user',
+						'actor_id'   => $actor_id,
+						'payload'    => array(
+							'before'  => array(
+								'space_key' => $current['space_key'],
+								'start_at'  => $current['performance_start_at'],
+								'end_at'    => $current['performance_end_at'],
+							),
+							'after'   => array(
+								'space_key' => $space_key,
+								'start_at'  => $start_at,
+								'end_at'    => $end_at,
+							),
+							'version' => $expected_version + 1,
+						),
+					)
+				);
+				if ( is_wp_error( $event ) ) {
+					return $this->rollback( $event );
+				}
+				$committed = $this->commit();
+				return is_wp_error( $committed ) ? $committed : $this->bookings->get( $booking_id );
+			}
+		);
 	}
 
 	/** Create a hold entirely from persisted booking selection fields. */
@@ -292,8 +393,8 @@ class BookingHoldRepository {
 					'booking_id'           => $booking_id,
 					'venue_term_id'        => $booking['venue_term_id'],
 					'space_key'            => $booking['space_key'],
-					'start_at'             => $booking['requested_start_at'],
-					'end_at'               => $booking['requested_end_at'],
+					'start_at'             => $booking['performance_start_at'],
+					'end_at'               => $booking['performance_end_at'],
 					'expires_at'           => $expires,
 					'status'               => 'active',
 					'version'              => 1,
@@ -692,6 +793,10 @@ class BookingHoldRepository {
 					if ( empty( $current['deal']['data'] ) ) {
 						return $this->rollback( new \WP_Error( 'booking_confirmation_deal_required', __( 'Confirmation requires deal terms.', 'extrachill-events' ), array( 'status' => 409 ) ) );
 					}
+					$normalized_deal = BookingMutationService::normalize_deal_document( $current['deal']['data'] );
+					if ( is_wp_error( $normalized_deal ) || ! BookingMutationService::documents_equal( $normalized_deal, $current['deal']['data'] ) ) {
+						return $this->rollback( new \WP_Error( 'booking_confirmation_deal_invalid', __( 'Confirmation requires a normalized complete draft deal.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+					}
 					$conflict = $this->find_conflict( $current, $hold['id'] );
 					if ( is_wp_error( $conflict ) ) {
 						return $this->rollback( $conflict );
@@ -701,9 +806,13 @@ class BookingHoldRepository {
 					}
 				}
 				global $wpdb;
-				$table  = BookingSchema::bookings_table();
-				$now    = gmdate( 'Y-m-d H:i:s' );
-				$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = %s, version = version + 1, updated_at = %s WHERE id = %d AND version = %d", $to_status, $now, $current['id'], $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate transition.
+				$table = BookingSchema::bookings_table();
+				$now   = gmdate( 'Y-m-d H:i:s' );
+				if ( 'confirmed' === $to_status ) {
+					$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = %s, confirmed_deal_payload = deal_payload, version = version + 1, updated_at = %s WHERE id = %d AND version = %d AND confirmed_deal_payload IS NULL", $to_status, $now, $current['id'], $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Freezes the exact stored draft while transitioning.
+				} else {
+					$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = %s, version = version + 1, updated_at = %s WHERE id = %d AND version = %d", $to_status, $now, $current['id'], $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate transition.
+				}
 				if ( 1 !== $result ) {
 					return $this->rollback( false === $result ? new \WP_Error( 'booking_update_failed', __( 'The booking could not be updated.', 'extrachill-events' ) ) : $this->booking_version_conflict( $this->bookings->get( $current['id'] ) ) );
 				}
@@ -732,15 +841,16 @@ class BookingHoldRepository {
 				$event = $this->activity->append(
 					array(
 						'booking_id' => $current['id'],
-						'kind'       => 'status_changed',
+						'kind'       => 'confirmed' === $to_status ? 'deal_confirmed' : 'status_changed',
 						'actor_type' => 'user',
 						'actor_id'   => $actor_id,
 						'payload'    => array(
-							'from_status' => $current['status'],
-							'to_status'   => $to_status,
-							'note'        => $note,
-							'hold_id'     => is_array( $hold ) ? $hold['id'] : null,
-							'version'     => $expected_version + 1,
+							'from_status'    => $current['status'],
+							'to_status'      => $to_status,
+							'note'           => $note,
+							'hold_id'        => is_array( $hold ) ? $hold['id'] : null,
+							'confirmed_deal' => 'confirmed' === $to_status ? $current['deal'] : null,
+							'version'        => $expected_version + 1,
 						),
 					)
 				);
@@ -750,9 +860,10 @@ class BookingHoldRepository {
 				$output    = array_merge(
 					$current,
 					array(
-						'status'     => $to_status,
-						'version'    => $expected_version + 1,
-						'updated_at' => $now,
+						'status'         => $to_status,
+						'version'        => $expected_version + 1,
+						'updated_at'     => $now,
+						'confirmed_deal' => 'confirmed' === $to_status ? $current['deal'] : $current['confirmed_deal'],
 					)
 				);
 				$committed = $this->commit();
@@ -765,7 +876,7 @@ class BookingHoldRepository {
 	private function matching_active_hold( array $booking ) {
 		global $wpdb;
 		$table = BookingSchema::holds_table();
-		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT *, UTC_TIMESTAMP() AS database_now FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact persisted selection by database time.
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT *, UTC_TIMESTAMP() AS database_now FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() ORDER BY id DESC LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['performance_start_at'], $booking['performance_end_at'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact persisted selection by database time.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_hold_read_failed', __( 'The booking hold could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
@@ -776,7 +887,7 @@ class BookingHoldRepository {
 	private function find_conflict( array $booking, int $excluded_hold_id ) {
 		global $wpdb;
 		$holds = BookingSchema::holds_table();
-		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT id, booking_id, 'hold' AS conflict_type FROM {$holds} WHERE venue_term_id = %d AND space_key = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND start_at < %s AND end_at > %s AND booking_id <> %d AND id <> %d LIMIT 1", $booking['venue_term_id'], $booking['space_key'], $booking['requested_end_at'], $booking['requested_start_at'], $booking['id'], $excluded_hold_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serialized database-time overlap check.
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT id, booking_id, 'hold' AS conflict_type FROM {$holds} WHERE venue_term_id = %d AND space_key = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND start_at < %s AND end_at > %s AND booking_id <> %d AND id <> %d LIMIT 1", $booking['venue_term_id'], $booking['space_key'], $booking['performance_end_at'], $booking['performance_start_at'], $booking['id'], $excluded_hold_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serialized database-time overlap check.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_conflict_check_failed', __( 'Booking conflicts could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
@@ -784,7 +895,7 @@ class BookingHoldRepository {
 			return $row;
 		}
 		$bookings = BookingSchema::bookings_table();
-		$row      = $wpdb->get_row( $wpdb->prepare( "SELECT id, 'confirmed_booking' AS conflict_type FROM {$bookings} WHERE venue_term_id = %d AND space_key = %s AND status = 'confirmed' AND requested_start_at < %s AND requested_end_at > %s AND id <> %d LIMIT 1", $booking['venue_term_id'], $booking['space_key'], $booking['requested_end_at'], $booking['requested_start_at'], $booking['id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serialized overlap check.
+		$row      = $wpdb->get_row( $wpdb->prepare( "SELECT id, 'confirmed_booking' AS conflict_type FROM {$bookings} WHERE venue_term_id = %d AND space_key = %s AND status = 'confirmed' AND performance_start_at < %s AND performance_end_at > %s AND id <> %d LIMIT 1", $booking['venue_term_id'], $booking['space_key'], $booking['performance_end_at'], $booking['performance_start_at'], $booking['id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serialized overlap check.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_conflict_check_failed', __( 'Booking conflicts could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
@@ -797,7 +908,7 @@ class BookingHoldRepository {
 		} catch ( \Exception $exception ) {
 			return new \WP_Error( 'booking_venue_timezone_invalid', __( 'The venue timezone is missing or invalid, so conflicts cannot be checked safely.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
-		$window    = $this->canonical_local_window( $booking['requested_start_at'], $booking['requested_end_at'], $timezone );
+		$window    = $this->canonical_local_window( $booking['performance_start_at'], $booking['performance_end_at'], $timezone );
 		$start     = $window['start'];
 		$end       = $window['end'];
 		$dates     = $wpdb->prefix . 'datamachine_event_dates';
@@ -960,11 +1071,11 @@ class BookingHoldRepository {
 	}
 
 	private function selection( array $booking ) {
-		if ( empty( $booking['space_key'] ) || empty( $booking['requested_start_at'] ) || empty( $booking['requested_end_at'] ) ) {
+		if ( empty( $booking['space_key'] ) || empty( $booking['performance_start_at'] ) || empty( $booking['performance_end_at'] ) ) {
 			return new \WP_Error( 'booking_hold_selection_required', __( 'A persisted booking space and date range are required.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
-		if ( $booking['requested_end_at'] <= $booking['requested_start_at'] ) {
-			return new \WP_Error( 'invalid_booking_date_range', __( 'The requested end must be later than the requested start.', 'extrachill-events' ), array( 'status' => 409 ) );
+		if ( $booking['performance_end_at'] <= $booking['performance_start_at'] ) {
+			return new \WP_Error( 'invalid_booking_date_range', __( 'The performance end must be later than the performance start.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
 		return true;
 	}
@@ -1028,14 +1139,14 @@ class BookingHoldRepository {
 		return (int) $hold['booking_id'] === (int) $booking['id']
 			&& (int) $hold['venue_term_id'] === (int) $booking['venue_term_id']
 			&& $hold['space_key'] === $booking['space_key']
-			&& $hold['start_at'] === $booking['requested_start_at']
-			&& $hold['end_at'] === $booking['requested_end_at'];
+			&& $hold['start_at'] === $booking['performance_start_at']
+			&& $hold['end_at'] === $booking['performance_end_at'];
 	}
 
 	private function has_other_matching_active_hold( array $booking, int $excluded_hold_id ) {
 		global $wpdb;
 		$table = BookingSchema::holds_table();
-		$row   = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND id <> %d LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['requested_start_at'], $booking['requested_end_at'], $excluded_hold_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact database-time invariant check under the venue-space lock.
+		$row   = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND id <> %d LIMIT 1", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['performance_start_at'], $booking['performance_end_at'], $excluded_hold_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact database-time invariant check under the venue-space lock.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_hold_invariant_check_failed', __( 'Other active holds could not be checked safely.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -216,10 +216,11 @@ class BookingHoldRepository {
 		if ( '' === $space_key || ! $this->valid_datetime( $start_at ) || ! $this->valid_datetime( $end_at ) || $end_at <= $start_at ) {
 			return new \WP_Error( 'invalid_booking_performance', __( 'A configured space and strict UTC performance range are required.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
+		$venue_id = (int) $booking['venue_term_id'];
 		return $this->with_lock(
 			$this->lock_name( $booking['venue_term_id'], $space_key ),
-			function () use ( $booking_id, $expected_version, $space_key, $start_at, $end_at, $actor_id ) {
-				$started = $this->begin_authorized( $booking_id, $actor_id );
+			function () use ( $booking_id, $expected_version, $space_key, $start_at, $end_at, $actor_id, $venue_id ) {
+				$started = $this->begin_authorized( $venue_id, $actor_id );
 				if ( is_wp_error( $started ) ) {
 					return $started;
 				}

--- a/inc/Core/BookingLifecycle.php
+++ b/inc/Core/BookingLifecycle.php
@@ -83,6 +83,7 @@ class BookingLifecycle {
 	 * @param int|null $actor_id Authenticated submitter, when present.
 	 */
 	public function create_inquiry( array $data, ?int $actor_id = null ) {
+		unset( $data['space_key'], $data['performance_start_at'], $data['performance_end_at'], $data['production'], $data['deal'], $data['confirmed_deal'] );
 		$key = mb_substr( sanitize_text_field( (string) ( $data['idempotency_key'] ?? '' ) ), 0, 191 );
 		if ( '' === $key ) {
 			return new \WP_Error( 'booking_idempotency_key_required', __( 'Inquiry creation requires an idempotency key.', 'extrachill-events' ), array( 'status' => 400 ) );
@@ -337,15 +338,19 @@ class BookingLifecycle {
 				)
 			);
 		}
-		if ( 'held' === $to_status && ( empty( $booking['requested_start_at'] ) || empty( $booking['requested_end_at'] ) || empty( $booking['space_key'] ) ) ) {
+		if ( 'held' === $to_status && ( empty( $booking['performance_start_at'] ) || empty( $booking['performance_end_at'] ) || empty( $booking['space_key'] ) ) ) {
 			return new \WP_Error( 'booking_hold_selection_required', __( 'A hold requires a selected date range and space.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
 		if ( 'confirmed' === $to_status ) {
-			if ( empty( $booking['requested_start_at'] ) || empty( $booking['requested_end_at'] ) || empty( $booking['space_key'] ) ) {
+			if ( empty( $booking['performance_start_at'] ) || empty( $booking['performance_end_at'] ) || empty( $booking['space_key'] ) ) {
 				return new \WP_Error( 'booking_confirmation_selection_required', __( 'Confirmation requires a selected date range and space.', 'extrachill-events' ), array( 'status' => 409 ) );
 			}
 			if ( empty( $booking['deal']['data'] ) ) {
 				return new \WP_Error( 'booking_confirmation_deal_required', __( 'Confirmation requires deal terms.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			$normalized_deal = BookingMutationService::normalize_deal_document( $booking['deal']['data'] );
+			if ( is_wp_error( $normalized_deal ) || ! BookingMutationService::documents_equal( $normalized_deal, $booking['deal']['data'] ) ) {
+				return new \WP_Error( 'booking_confirmation_deal_invalid', __( 'Confirmation requires a normalized complete draft deal.', 'extrachill-events' ), array( 'status' => 409 ) );
 			}
 			return true;
 		}

--- a/inc/Core/BookingMutationService.php
+++ b/inc/Core/BookingMutationService.php
@@ -1,0 +1,467 @@
+<?php
+/**
+ * Authorized booking intake, production, and deal mutations.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Owns the domain-specific mutable booking documents. */
+class BookingMutationService {
+
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var BookingActivityRepository */
+	private $activity;
+	/** @var VenueAuthorization */
+	private $authorization;
+	/** @var BookingHoldRepository */
+	private $holds;
+	/** @var bool */
+	private $transaction_active = false;
+
+	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, ?BookingHoldRepository $holds = null ) {
+		$this->bookings      = $bookings ? $bookings : new BookingRepository();
+		$this->activity      = $activity ? $activity : new BookingActivityRepository();
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+		$this->holds         = $holds ? $holds : new BookingHoldRepository( $this->bookings, $this->activity, $this->authorization );
+	}
+
+	/** Correct one or more private intake facts as a single revision. */
+	public function correct_intake( int $booking_id, int $expected_version, array $changes, int $actor_id ) {
+		$allowed_fields = array( 'contact_name', 'contact_email', 'contact_phone', 'requested_space_key', 'requested_start_at', 'requested_end_at', 'intake' );
+		$changes        = array_intersect_key( $changes, array_flip( $allowed_fields ) );
+		if ( empty( $changes ) ) {
+			return new \WP_Error( 'booking_intake_correction_required', __( 'At least one intake correction is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$normalized = array();
+		foreach ( $changes as $field => $value ) {
+			if ( 'contact_email' === $field ) {
+				if ( null === $value || '' === $value ) {
+					$value = null;
+				} else {
+					$value = sanitize_email( (string) $value );
+					if ( '' === $value ) {
+						return new \WP_Error( 'invalid_booking_contact_email', __( 'The contact email is invalid.', 'extrachill-events' ), array( 'status' => 400 ) );
+					}
+					$value = mb_substr( $value, 0, 255 );
+				}
+			} elseif ( in_array( $field, array( 'contact_name', 'contact_phone' ), true ) ) {
+				$value = null === $value ? null : mb_substr( sanitize_text_field( (string) $value ), 0, 'contact_phone' === $field ? 64 : 255 );
+				$value = '' === $value ? null : $value;
+			} elseif ( 'requested_space_key' === $field ) {
+				$value = null === $value ? null : mb_substr( sanitize_key( (string) $value ), 0, 64 );
+				$value = '' === $value ? null : $value;
+			} elseif ( in_array( $field, array( 'requested_start_at', 'requested_end_at' ), true ) ) {
+				$value = $this->datetime( $value, $field );
+				if ( is_wp_error( $value ) ) {
+					return $value;
+				}
+			} elseif ( 'intake' === $field ) {
+				if ( ! is_array( $value ) ) {
+					return new \WP_Error( 'invalid_booking_intake', __( 'Intake must be an object.', 'extrachill-events' ), array( 'status' => 400 ) );
+				}
+				$value = $this->encode( $value, 'intake' );
+				if ( is_wp_error( $value ) ) {
+					return $value;
+				}
+				$field = 'intake_payload';
+			}
+			$normalized[ $field ] = $value;
+		}
+		return $this->mutate(
+			$booking_id,
+			$expected_version,
+			$actor_id,
+			array( 'submitted', 'needs_info', 'under_review', 'negotiating' ),
+			$normalized,
+			'intake_corrected',
+			function ( array $current, array $next ) use ( $changes ) {
+				$start = $next['requested_start_at'];
+				$end   = $next['requested_end_at'];
+				if ( null !== $start && null !== $end && $end <= $start ) {
+					return new \WP_Error( 'invalid_booking_date_range', __( 'The requested end must be later than the requested start.', 'extrachill-events' ), array( 'status' => 400 ) );
+				}
+				return array( 'changed_fields' => array_keys( $changes ) );
+			}
+		);
+	}
+
+	/** Replace the complete production document. */
+	public function update_production( int $booking_id, int $expected_version, array $document, int $actor_id ) {
+		$normalized = self::normalize_production_document( $document );
+		return is_wp_error( $normalized ) ? $normalized : $this->replace_document( $booking_id, $expected_version, $actor_id, array( 'under_review', 'negotiating', 'held' ), 'production_payload', 'production', $normalized, 'production_updated', false );
+	}
+
+	/** Replace the complete draft deal document. */
+	public function update_deal( int $booking_id, int $expected_version, array $document, int $actor_id ) {
+		$normalized = self::normalize_deal_document( $document );
+		return is_wp_error( $normalized ) ? $normalized : $this->replace_document( $booking_id, $expected_version, $actor_id, array( 'negotiating', 'held' ), 'deal_payload', 'deal', $normalized, 'deal_draft_updated', true );
+	}
+
+	/** Delegate scheduling to the hold-owned lock and conflict path. */
+	public function select_performance( int $booking_id, int $expected_version, string $space_key, string $start_at, string $end_at, int $actor_id ) {
+		return $this->holds->select_performance( $booking_id, $expected_version, $space_key, $start_at, $end_at, $actor_id );
+	}
+
+	/** Normalize the strict production replacement document. */
+	public static function normalize_production_document( array $document ) {
+		$fields = array( 'version', 'support_requirements', 'support_offers', 'production_notes' );
+		if ( array_diff( $fields, array_keys( $document ) ) || array_diff( array_keys( $document ), $fields ) || 1 !== $document['version'] ) {
+			return new \WP_Error( 'invalid_booking_production', __( 'The production document is invalid.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$output = array( 'version' => 1 );
+		foreach ( array( 'support_requirements', 'support_offers' ) as $field ) {
+			$items = $document[ $field ] ?? null;
+			if ( ! is_array( $items ) || count( $items ) > 50 ) {
+				return new \WP_Error(
+					'invalid_booking_production',
+					__( 'Production support lists must contain at most 50 items.', 'extrachill-events' ),
+					array(
+						'field'  => $field,
+						'status' => 400,
+					)
+				);
+			}
+			$output[ $field ] = array();
+			foreach ( $items as $item ) {
+				if ( ! is_string( $item ) ) {
+					return new \WP_Error(
+						'invalid_booking_production',
+						__( 'Production support items must be strings.', 'extrachill-events' ),
+						array(
+							'field'  => $field,
+							'status' => 400,
+						)
+					);
+				}
+				$item = mb_substr( sanitize_text_field( $item ), 0, 500 );
+				if ( '' === $item ) {
+					return new \WP_Error(
+						'invalid_booking_production',
+						__( 'Production support items cannot be empty.', 'extrachill-events' ),
+						array(
+							'field'  => $field,
+							'status' => 400,
+						)
+					);
+				}
+				$output[ $field ][] = $item;
+			}
+		}
+		$notes = $document['production_notes'] ?? null;
+		if ( null !== $notes && ! is_string( $notes ) ) {
+			return new \WP_Error( 'invalid_booking_production', __( 'Production notes must be a string or null.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$notes                      = null === $notes ? null : mb_substr( sanitize_textarea_field( $notes ), 0, 10000 );
+		$output['production_notes'] = '' === $notes ? null : $notes;
+		return $output;
+	}
+
+	/** Normalize the strict complete draft-deal document. */
+	public static function normalize_deal_document( array $document ) {
+		$fields = array( 'version', 'type', 'guarantee_cents', 'revenue_share_basis_points', 'revenue_share_basis', 'currency', 'capacity', 'advance_ticket_price_cents', 'door_ticket_price_cents', 'ticket_fee_cents', 'tickets_on_sale_at', 'additional_terms' );
+		if ( array_diff( $fields, array_keys( $document ) ) || array_diff( array_keys( $document ), $fields ) || 1 !== $document['version'] ) {
+			return new \WP_Error( 'invalid_booking_deal', __( 'The complete version 1 deal document is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		if ( ! is_string( $document['type'] ) || ! is_string( $document['revenue_share_basis'] ) || ! is_string( $document['currency'] ) ) {
+			return new \WP_Error( 'invalid_booking_deal', __( 'The deal text fields are invalid.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$type = mb_substr( sanitize_key( $document['type'] ), 0, 32 );
+		if ( '' === $type || ! self::strict_integer( $document['guarantee_cents'], 0 ) || ! self::strict_integer( $document['revenue_share_basis_points'], 0, 10000 ) ) {
+			return new \WP_Error( 'invalid_booking_deal', __( 'The deal financial terms are invalid.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$basis = sanitize_key( $document['revenue_share_basis'] );
+		if ( ! in_array( $basis, array( 'gross_ticket_sales', 'net_ticket_sales', 'door_receipts' ), true ) ) {
+			return new \WP_Error( 'invalid_booking_deal', __( 'The revenue share basis is invalid.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$currency = strtoupper( sanitize_text_field( $document['currency'] ) );
+		if ( ! preg_match( '/^[A-Z]{3}$/', $currency ) ) {
+			return new \WP_Error( 'invalid_booking_deal', __( 'The deal currency is invalid.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		foreach ( array(
+			'capacity'                   => 1,
+			'advance_ticket_price_cents' => 0,
+			'door_ticket_price_cents'    => 0,
+			'ticket_fee_cents'           => 0,
+		) as $field => $minimum ) {
+			if ( null !== $document[ $field ] && ! self::strict_integer( $document[ $field ], $minimum ) ) {
+				return new \WP_Error(
+					'invalid_booking_deal',
+					__( 'A deal ticket setting is invalid.', 'extrachill-events' ),
+					array(
+						'field'  => $field,
+						'status' => 400,
+					)
+				);
+			}
+		}
+		$on_sale = $document['tickets_on_sale_at'];
+		if ( null !== $on_sale && ! self::valid_datetime( $on_sale ) ) {
+			return new \WP_Error( 'invalid_booking_deal', __( 'The ticket on-sale time must be a UTC datetime.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$terms = $document['additional_terms'];
+		if ( null !== $terms && ! is_string( $terms ) ) {
+			return new \WP_Error( 'invalid_booking_deal', __( 'Additional terms must be a string or null.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return array(
+			'version'                    => 1,
+			'type'                       => $type,
+			'guarantee_cents'            => $document['guarantee_cents'],
+			'revenue_share_basis_points' => $document['revenue_share_basis_points'],
+			'revenue_share_basis'        => $basis,
+			'currency'                   => $currency,
+			'capacity'                   => $document['capacity'],
+			'advance_ticket_price_cents' => $document['advance_ticket_price_cents'],
+			'door_ticket_price_cents'    => $document['door_ticket_price_cents'],
+			'ticket_fee_cents'           => $document['ticket_fee_cents'],
+			'tickets_on_sale_at'         => $on_sale,
+			'additional_terms'           => null === $terms || '' === sanitize_textarea_field( $terms ) ? null : mb_substr( sanitize_textarea_field( $terms ), 0, 10000 ),
+		);
+	}
+
+	/** Compare JSON-like documents without treating object key order as data. */
+	public static function documents_equal( $left, $right ): bool {
+		return self::canonical_document( $left ) === self::canonical_document( $right );
+	}
+
+	private function replace_document( int $booking_id, int $expected_version, int $actor_id, array $statuses, string $column, string $key, array $document, string $kind, bool $reject_confirmed ) {
+		$encoded = $this->encode( $document, $key );
+		if ( is_wp_error( $encoded ) ) {
+			return $encoded;
+		}
+		return $this->mutate(
+			$booking_id,
+			$expected_version,
+			$actor_id,
+			$statuses,
+			array( $column => $encoded ),
+			$kind,
+			function ( array $current ) use ( $reject_confirmed ) {
+				return $reject_confirmed && null !== $current['confirmed_deal']
+					? new \WP_Error( 'booking_deal_already_confirmed', __( 'Confirmed deal terms are frozen.', 'extrachill-events' ), array( 'status' => 409 ) )
+					: array();
+			}
+		);
+	}
+
+	private function mutate( int $booking_id, int $expected_version, int $actor_id, array $statuses, array $changes, string $kind, callable $validate ) {
+		$current = $this->bookings->get( $booking_id );
+		if ( ! is_array( $current ) ) {
+			return is_wp_error( $current ) ? $current : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
+		$allowed = $this->authorization->authorize( $actor_id, $current['venue_term_id'], VenueAuthorization::ACTION_ACCESS_VENUE );
+		if ( true !== $allowed ) {
+			return is_wp_error( $allowed ) ? $allowed : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) );
+		}
+		$started = $this->begin_authorized( $current['venue_term_id'], $actor_id );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$current = $this->bookings->get( $booking_id );
+		if ( ! is_array( $current ) ) {
+			return $this->rollback( is_wp_error( $current ) ? $current : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+		}
+		if ( (int) $current['version'] !== $expected_version ) {
+			return $this->rollback(
+				new \WP_Error(
+					'booking_version_conflict',
+					__( 'The booking changed since it was read.', 'extrachill-events' ),
+					array(
+						'status'          => 409,
+						'current_version' => $current['version'],
+					)
+				)
+			);
+		}
+		if ( ! in_array( $current['status'], $statuses, true ) ) {
+			return $this->rollback(
+				new \WP_Error(
+					'booking_mutation_status_forbidden',
+					__( 'This booking mutation is not allowed in the current status.', 'extrachill-events' ),
+					array(
+						'status'         => 409,
+						'booking_status' => $current['status'],
+					)
+				)
+			);
+		}
+		$next = $current;
+		foreach ( $changes as $column => $value ) {
+			$key          = substr( $column, -8 ) === '_payload' ? substr( $column, 0, -8 ) : $column;
+			$next[ $key ] = substr( $column, -8 ) === '_payload' ? json_decode( $value, true ) : $value;
+		}
+		$validation = $validate( $current, $next );
+		if ( is_wp_error( $validation ) ) {
+			return $this->rollback( $validation );
+		}
+		$changed = array();
+		foreach ( $changes as $column => $value ) {
+			$key = substr( $column, -8 ) === '_payload' ? substr( $column, 0, -8 ) : $column;
+			if ( ! self::documents_equal( $current[ $key ], $next[ $key ] ) ) {
+				$changed[ $column ] = $value;
+			}
+		}
+		if ( empty( $changed ) ) {
+			$committed = $this->commit();
+			return is_wp_error( $committed ) ? $committed : $current;
+		}
+		if ( 'intake_corrected' === $kind ) {
+			$validation['changed_fields'] = array_map(
+				static function ( string $column ): string {
+					return 'intake_payload' === $column ? 'intake' : $column;
+				},
+				array_keys( $changed )
+			);
+		}
+		global $wpdb;
+		$set    = array();
+		$values = array();
+		foreach ( $changed as $column => $value ) {
+			$set[] = null === $value ? "{$column} = NULL" : "{$column} = %s";
+			if ( null !== $value ) {
+				$values[] = $value;
+			}
+		}
+		$now      = gmdate( 'Y-m-d H:i:s' );
+		$set[]    = 'version = version + 1';
+		$set[]    = 'updated_at = %s';
+		$values[] = $now;
+		$values[] = $booking_id;
+		$values[] = $expected_version;
+		$table    = BookingSchema::bookings_table();
+		$result   = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET " . implode( ', ', $set ) . ' WHERE id = %d AND version = %d', $values ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Internal columns determine the prepared value count.
+		if ( 1 !== $result ) {
+			return $this->rollback( false === $result ? new \WP_Error( 'booking_mutation_update_failed', __( 'The booking mutation could not be saved.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) : new \WP_Error( 'booking_version_conflict', __( 'The booking changed since it was read.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+		}
+		$before = array();
+		$after  = array();
+		foreach ( $changed as $column => $value ) {
+			$key            = substr( $column, -8 ) === '_payload' ? substr( $column, 0, -8 ) : $column;
+			$before[ $key ] = $current[ $key ];
+			$after[ $key ]  = $next[ $key ];
+		}
+		$event = $this->activity->append(
+			array(
+				'booking_id' => $booking_id,
+				'kind'       => $kind,
+				'actor_type' => 'user',
+				'actor_id'   => $actor_id,
+				'payload'    => array_merge(
+					(array) $validation,
+					array(
+						'before'  => $before,
+						'after'   => $after,
+						'version' => $expected_version + 1,
+					)
+				),
+			)
+		);
+		if ( is_wp_error( $event ) ) {
+			return $this->rollback( $event );
+		}
+		$committed = $this->commit();
+		return is_wp_error( $committed ) ? $committed : $this->bookings->get( $booking_id );
+	}
+
+	private function begin_authorized( int $venue_id, int $actor_id ) {
+		global $wpdb;
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate boundary.
+			return new \WP_Error( 'booking_mutation_transaction_start_failed', __( 'The booking mutation transaction could not start.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		$this->transaction_active = true;
+		$table                    = BookingSchema::memberships_table();
+		$wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $venue_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact venue authority lock.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return $this->rollback( new \WP_Error( 'booking_mutation_authorization_lock_failed', __( 'Venue booking authority could not be locked.', 'extrachill-events' ) ) );
+		}
+		$allowed = $this->authorization->authorize( $actor_id, $venue_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+		return true === $allowed ? true : $this->rollback( is_wp_error( $allowed ) ? $allowed : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) ) );
+	}
+
+	private function encode( array $data, string $field ) {
+		$json = wp_json_encode(
+			array(
+				'version' => 1,
+				'data'    => $data,
+			)
+		);
+		return false === $json ? new \WP_Error(
+			'booking_payload_encode_failed',
+			__( 'Booking payload JSON encoding failed.', 'extrachill-events' ),
+			array(
+				'field'      => $field,
+				'json_error' => json_last_error_msg(),
+			)
+		) : $json;
+	}
+
+	private function datetime( $value, string $field ) {
+		if ( null === $value || '' === $value ) {
+			return null;
+		}
+		return self::valid_datetime( $value ) ? $value : new \WP_Error(
+			'invalid_booking_datetime',
+			__( 'Booking datetimes must use UTC Y-m-d H:i:s format.', 'extrachill-events' ),
+			array(
+				'field'  => $field,
+				'status' => 400,
+			)
+		);
+	}
+
+	private static function valid_datetime( $value ): bool {
+		if ( ! is_string( $value ) ) {
+			return false;
+		}
+		$date = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $value, new \DateTimeZone( 'UTC' ) );
+		return false !== $date && $date->format( 'Y-m-d H:i:s' ) === $value;
+	}
+
+	private static function strict_integer( $value, int $minimum, ?int $maximum = null ): bool {
+		return is_int( $value ) && $value >= $minimum && ( null === $maximum || $value <= $maximum );
+	}
+
+	private static function canonical_document( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+		$is_list = array() === $value || array_keys( $value ) === range( 0, count( $value ) - 1 );
+		if ( ! $is_list ) {
+			ksort( $value );
+		}
+		foreach ( $value as $key => $item ) {
+			$value[ $key ] = self::canonical_document( $item );
+		}
+		return $value;
+	}
+
+	private function commit() {
+		global $wpdb;
+		$result                   = $wpdb->query( 'COMMIT' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate boundary.
+		$this->transaction_active = false;
+		return false === $result ? new \WP_Error( 'booking_mutation_transaction_commit_uncertain', __( 'The booking mutation transaction outcome could not be confirmed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) : true;
+	}
+
+	private function rollback( \WP_Error $cause ) {
+		global $wpdb;
+		if ( ! $this->transaction_active ) {
+			return $cause;
+		}
+		$result                   = $wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate boundary.
+		$this->transaction_active = false;
+		return false === $result ? new \WP_Error(
+			'booking_mutation_transaction_rollback_failed',
+			__( 'The booking mutation transaction could not be rolled back.', 'extrachill-events' ),
+			array(
+				'cause'          => $cause->get_error_code(),
+				'database_error' => $wpdb->last_error,
+			)
+		) : $cause;
+	}
+}

--- a/inc/Core/BookingMutationService.php
+++ b/inc/Core/BookingMutationService.php
@@ -165,7 +165,7 @@ class BookingMutationService {
 
 	/** Normalize the strict complete draft-deal document. */
 	public static function normalize_deal_document( array $document ) {
-		$fields = array( 'version', 'type', 'guarantee_cents', 'revenue_share_basis_points', 'revenue_share_basis', 'currency', 'capacity', 'advance_ticket_price_cents', 'door_ticket_price_cents', 'ticket_fee_cents', 'tickets_on_sale_at', 'additional_terms' );
+		$fields = array( 'version', 'type', 'guarantee_cents', 'revenue_share_basis_points', 'revenue_share_basis', 'currency', 'capacity', 'advance_ticket_price_cents', 'door_ticket_price_cents', 'ticket_fee_cents', 'tickets_on_sale_at', 'ticket_url', 'additional_terms' );
 		if ( array_diff( $fields, array_keys( $document ) ) || array_diff( array_keys( $document ), $fields ) || 1 !== $document['version'] ) {
 			return new \WP_Error( 'invalid_booking_deal', __( 'The complete version 1 deal document is required.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
@@ -205,6 +205,10 @@ class BookingMutationService {
 		if ( null !== $on_sale && ! self::valid_datetime( $on_sale ) ) {
 			return new \WP_Error( 'invalid_booking_deal', __( 'The ticket on-sale time must be a UTC datetime.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
+		$ticket_url = $document['ticket_url'];
+		if ( null !== $ticket_url && ( ! is_string( $ticket_url ) || false === filter_var( $ticket_url, FILTER_VALIDATE_URL ) || ! preg_match( '#^https?://#i', $ticket_url ) ) ) {
+			return new \WP_Error( 'invalid_booking_deal', __( 'The ticket URL must be a valid HTTP or HTTPS URL.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
 		$terms = $document['additional_terms'];
 		if ( null !== $terms && ! is_string( $terms ) ) {
 			return new \WP_Error( 'invalid_booking_deal', __( 'Additional terms must be a string or null.', 'extrachill-events' ), array( 'status' => 400 ) );
@@ -221,6 +225,7 @@ class BookingMutationService {
 			'door_ticket_price_cents'    => $document['door_ticket_price_cents'],
 			'ticket_fee_cents'           => $document['ticket_fee_cents'],
 			'tickets_on_sale_at'         => $on_sale,
+			'ticket_url'                 => $ticket_url,
 			'additional_terms'           => null === $terms || '' === sanitize_textarea_field( $terms ) ? null : mb_substr( sanitize_textarea_field( $terms ), 0, 10000 ),
 		);
 	}

--- a/inc/Core/BookingRepository.php
+++ b/inc/Core/BookingRepository.php
@@ -58,6 +58,12 @@ class BookingRepository {
 		if ( is_wp_error( $dates ) ) {
 			return $dates;
 		}
+		$performance_start = $this->datetime( $data['performance_start_at'] ?? null, 'performance_start_at' );
+		$performance_end   = $this->datetime( $data['performance_end_at'] ?? null, 'performance_end_at' );
+		$performance_dates = $this->validate_date_range( $performance_start, $performance_end, 'performance' );
+		if ( is_wp_error( $performance_dates ) ) {
+			return $performance_dates;
+		}
 
 		$intake = $this->encode_payload( $data['intake'] ?? array(), 'intake' );
 		if ( is_wp_error( $intake ) ) {
@@ -65,9 +71,35 @@ class BookingRepository {
 		}
 		$deal = null;
 		if ( array_key_exists( 'deal', $data ) ) {
-			$deal = $this->encode_payload( $data['deal'], 'deal' );
+			$deal_document = is_array( $data['deal'] ) ? BookingMutationService::normalize_deal_document( $data['deal'] ) : new \WP_Error( 'invalid_booking_deal', __( 'The complete version 1 deal document is required.', 'extrachill-events' ) );
+			if ( is_wp_error( $deal_document ) ) {
+				return $deal_document;
+			}
+			$deal = $this->encode_payload( $deal_document, 'deal' );
 			if ( is_wp_error( $deal ) ) {
 				return $deal;
+			}
+		}
+		$production = null;
+		if ( array_key_exists( 'production', $data ) ) {
+			$production_document = is_array( $data['production'] ) ? BookingMutationService::normalize_production_document( $data['production'] ) : new \WP_Error( 'invalid_booking_production', __( 'The production document is invalid.', 'extrachill-events' ) );
+			if ( is_wp_error( $production_document ) ) {
+				return $production_document;
+			}
+			$production = $this->encode_payload( $production_document, 'production' );
+			if ( is_wp_error( $production ) ) {
+				return $production;
+			}
+		}
+		$confirmed_deal = null;
+		if ( array_key_exists( 'confirmed_deal', $data ) ) {
+			$confirmed_document = is_array( $data['confirmed_deal'] ) ? BookingMutationService::normalize_deal_document( $data['confirmed_deal'] ) : new \WP_Error( 'invalid_booking_deal', __( 'The complete version 1 confirmed deal document is required.', 'extrachill-events' ) );
+			if ( is_wp_error( $confirmed_document ) ) {
+				return $confirmed_document;
+			}
+			$confirmed_deal = $this->encode_payload( $confirmed_document, 'confirmed_deal' );
+			if ( is_wp_error( $confirmed_deal ) ) {
+				return $confirmed_deal;
 			}
 		}
 
@@ -88,14 +120,19 @@ class BookingRepository {
 			'contact_phone'           => $this->nullable_text( $data['contact_phone'] ?? null, 64 ),
 			'inquiry_idempotency_key' => $this->nullable_text( $data['inquiry_idempotency_key'] ?? null, 191 ),
 			'inquiry_request_hash'    => $request_hash,
+			'requested_space_key'     => $this->nullable_key( $data['requested_space_key'] ?? null, 64 ),
 			'space_key'               => $this->nullable_key( $data['space_key'] ?? null, 64 ),
 			'status'                  => 'submitted',
 			'version'                 => 1,
 			'assignee_user_id'        => $ids['assignee_user_id'],
 			'requested_start_at'      => $start,
 			'requested_end_at'        => $end,
+			'performance_start_at'    => $performance_start,
+			'performance_end_at'      => $performance_end,
 			'intake_payload'          => $intake,
+			'production_payload'      => $production,
 			'deal_payload'            => $deal,
+			'confirmed_deal_payload'  => $confirmed_deal,
 			'event_id'                => null,
 			'created_at'              => $now,
 			'updated_at'              => $now,
@@ -239,7 +276,7 @@ class BookingRepository {
 			}
 		}
 
-		$allowed = array( 'artist_term_id', 'artist_profile_id', 'artist_name', 'contact_name', 'contact_email', 'contact_phone', 'space_key', 'assignee_user_id', 'requested_start_at', 'requested_end_at', 'intake', 'deal' );
+		$allowed = array( 'artist_term_id', 'artist_profile_id', 'artist_name' );
 		$changes = array_intersect_key( $changes, array_flip( $allowed ) );
 		if ( empty( $changes ) ) {
 			return new \WP_Error( 'empty_booking_update', __( 'No supported booking fields were supplied.', 'extrachill-events' ) );
@@ -247,34 +284,15 @@ class BookingRepository {
 
 		$normalized = array();
 		foreach ( $changes as $key => $value ) {
-			if ( 'intake' === $key || 'deal' === $key ) {
-				$value = $this->encode_payload( $value, $key );
-			} elseif ( in_array( $key, array( 'artist_term_id', 'artist_profile_id', 'assignee_user_id' ), true ) ) {
+			if ( in_array( $key, array( 'artist_term_id', 'artist_profile_id' ), true ) ) {
 				$value = $this->positive_id( $value, $key, true );
-			} elseif ( in_array( $key, array( 'requested_start_at', 'requested_end_at' ), true ) ) {
-				$value = $this->datetime( $value, $key );
 			} elseif ( 'artist_name' === $key ) {
 				$value = $this->required_text( $value, $key, 255 );
-			} elseif ( 'contact_name' === $key ) {
-				$value = $this->nullable_text( $value, 255 );
-			} elseif ( 'contact_email' === $key ) {
-				$value = $this->nullable_email( $value );
-			} elseif ( 'contact_phone' === $key ) {
-				$value = $this->nullable_text( $value, 64 );
-			} elseif ( 'space_key' === $key ) {
-				$value = $this->nullable_key( $value, 64 );
 			}
 			if ( is_wp_error( $value ) ) {
 				return $value;
 			}
-			$normalized[ 'intake' === $key || 'deal' === $key ? $key . '_payload' : $key ] = $value;
-		}
-
-		$start = array_key_exists( 'requested_start_at', $normalized ) ? $normalized['requested_start_at'] : $current['requested_start_at'];
-		$end   = array_key_exists( 'requested_end_at', $normalized ) ? $normalized['requested_end_at'] : $current['requested_end_at'];
-		$dates = $this->validate_date_range( $start, $end );
-		if ( is_wp_error( $dates ) ) {
-			return $dates;
+			$normalized[ $key ] = $value;
 		}
 
 		$result = $this->conditional_update( $id, $expected, $normalized, '' );
@@ -476,8 +494,10 @@ class BookingRepository {
 			$row[ $key ] = isset( $row[ $key ] ) ? (int) $row[ $key ] : null;
 		}
 		foreach ( array(
-			'intake' => false,
-			'deal'   => true,
+			'intake'         => false,
+			'production'     => true,
+			'deal'           => true,
+			'confirmed_deal' => true,
 		) as $key => $nullable ) {
 			$decoded = $this->decode_payload( $row[ $key . '_payload' ] ?? null, $key, $nullable );
 			if ( is_wp_error( $decoded ) ) {
@@ -571,12 +591,12 @@ class BookingRepository {
 		return $date->format( 'Y-m-d H:i:s' );
 	}
 
-	private function validate_date_range( $start, $end ) {
+	private function validate_date_range( $start, $end, string $kind = 'requested' ) {
 		if ( is_wp_error( $start ) || is_wp_error( $end ) ) {
 			return is_wp_error( $start ) ? $start : $end;
 		}
 		if ( null !== $start && null !== $end && $end <= $start ) {
-			return new \WP_Error( 'invalid_booking_date_range', __( 'The requested end must be later than the requested start.', 'extrachill-events' ) );
+			return new \WP_Error( 'invalid_booking_date_range', 'performance' === $kind ? __( 'The performance end must be later than the performance start.', 'extrachill-events' ) : __( 'The requested end must be later than the requested start.', 'extrachill-events' ) );
 		}
 		return true;
 	}

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Owns and verifies the site-scoped private booking schema. */
 class BookingSchema {
 
-	public const SCHEMA_VERSION = '5';
+	public const SCHEMA_VERSION = '6';
 	public const VERSION_OPTION = 'extrachill_events_booking_schema_version';
 	public const FAILURE_OPTION = 'extrachill_events_booking_schema_error';
 
@@ -69,14 +69,19 @@ class BookingSchema {
 			contact_phone VARCHAR(64) NULL,
 			inquiry_idempotency_key VARCHAR(191) NULL,
 			inquiry_request_hash CHAR(64) NULL,
+			requested_space_key VARCHAR(64) NULL,
 			space_key VARCHAR(64) NULL,
 			status VARCHAR(32) NOT NULL DEFAULT 'submitted',
 			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
 			assignee_user_id BIGINT UNSIGNED NULL,
 			requested_start_at DATETIME NULL,
 			requested_end_at DATETIME NULL,
+			performance_start_at DATETIME NULL,
+			performance_end_at DATETIME NULL,
 			intake_payload LONGTEXT NOT NULL,
+			production_payload LONGTEXT NULL,
 			deal_payload LONGTEXT NULL,
+			confirmed_deal_payload LONGTEXT NULL,
 			event_id BIGINT UNSIGNED NULL,
 			created_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL,
@@ -86,6 +91,7 @@ class BookingSchema {
 			UNIQUE KEY venue_inquiry_idempotency (venue_term_id, inquiry_idempotency_key),
 			KEY venue_status_created (venue_term_id, status, created_at),
 			KEY venue_requested_start (venue_term_id, requested_start_at),
+			KEY venue_performance_start (venue_term_id, performance_start_at),
 			KEY artist_term_created (artist_term_id, created_at),
 			KEY artist_profile_created (artist_profile_id, created_at),
 			KEY assignee_status (assignee_user_id, status),
@@ -467,14 +473,19 @@ class BookingSchema {
 					'contact_phone'           => $required( 'varchar(64)', true ),
 					'inquiry_idempotency_key' => $required( 'varchar(191)', true ),
 					'inquiry_request_hash'    => $required( 'char(64)', true ),
+					'requested_space_key'     => $required( 'varchar(64)', true ),
 					'space_key'               => $required( 'varchar(64)', true ),
 					'status'                  => $required( 'varchar(32)', false, array( 'default' => 'submitted' ) ),
 					'version'                 => $required( 'bigint unsigned', false, array( 'default' => '1' ) ),
 					'assignee_user_id'        => $required( 'bigint unsigned', true ),
 					'requested_start_at'      => $required( 'datetime', true ),
 					'requested_end_at'        => $required( 'datetime', true ),
+					'performance_start_at'    => $required( 'datetime', true ),
+					'performance_end_at'      => $required( 'datetime', true ),
 					'intake_payload'          => $required( 'longtext', false ),
+					'production_payload'      => $required( 'longtext', true ),
 					'deal_payload'            => $required( 'longtext', true ),
+					'confirmed_deal_payload'  => $required( 'longtext', true ),
 					'event_id'                => $required( 'bigint unsigned', true ),
 					'created_at'              => $required( 'datetime', false ),
 					'updated_at'              => $required( 'datetime', false ),
@@ -503,6 +514,10 @@ class BookingSchema {
 					'venue_requested_start'     => array(
 						'unique'  => false,
 						'columns' => array( 'venue_term_id', 'requested_start_at' ),
+					),
+					'venue_performance_start'   => array(
+						'unique'  => false,
+						'columns' => array( 'venue_term_id', 'performance_start_at' ),
 					),
 					'artist_term_created'       => array(
 						'unique'  => false,

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -10,6 +10,7 @@
 		<testsuite name="booking-foundation">
 			<file>tests/BookingFoundationTest.php</file>
 			<file>tests/BookingHoldTest.php</file>
+			<file>tests/BookingMutationTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -324,7 +324,7 @@ final class BookingFoundationTest extends TestCase {
 
 		$booking = $this->create_booking();
 		$result  = ( new BookingRepository() )->update( $booking['id'], array( 'deal' => $recursive ), 1 );
-		$this->assertSame( 'booking_payload_encode_failed', $result->get_error_code() );
+		$this->assertSame( 'empty_booking_update', $result->get_error_code(), 'Generic repository updates cannot bypass deal policy.' );
 		$this->assertSame( 1, ( new BookingRepository() )->get( $booking['id'] )['version'] );
 		$result = ( new BookingActivityRepository() )->append(
 			array(
@@ -457,7 +457,7 @@ final class BookingFoundationTest extends TestCase {
 	public function test_event_claim_distinguishes_stale_version_and_missing_booking(): void {
 		$repository = new BookingRepository();
 		$booking    = $this->create_booking();
-		$updated    = $repository->update( $booking['id'], array( 'contact_name' => 'Updated' ), 1 );
+		$updated    = $repository->update( $booking['id'], array( 'artist_name' => 'Updated' ), 1 );
 		$this->assertSame( 2, $updated['version'] );
 		$this->assertSame( 'booking_version_conflict', $repository->claim_event( $booking['id'], 900, 1 )->get_error_code() );
 		$GLOBALS['wpdb']->race_event_read_fail = true;
@@ -632,13 +632,10 @@ final class BookingFoundationTest extends TestCase {
 			1
 		);
 		$this->assertSame( 255, strlen( $updated['artist_name'] ) );
-		$this->assertSame( 64, strlen( $updated['space_key'] ) );
+		$this->assertNull( $updated['space_key'], 'Generic updates cannot bypass scheduling policy.' );
 		$this->assertSame( 'submitted', $updated['status'] );
 		$this->assertSame(
-			array(
-				'one' => 1,
-				'two' => 2,
-			),
+			array( 'draw' => 100 ),
 			$updated['intake']['data']
 		);
 	}
@@ -697,8 +694,8 @@ final class BookingFoundationTest extends TestCase {
 		$repository = new BookingRepository();
 		$this->assertSame( 'booking_not_found', $repository->update( 999, array( 'contact_name' => 'Reviewing' ), 1 )->get_error_code() );
 		$booking = $this->create_booking();
-		$repository->update( $booking['id'], array( 'contact_name' => 'Reviewing' ), 1 );
-		$this->assertSame( 'booking_version_conflict', $repository->update( $booking['id'], array( 'contact_name' => 'Accepted' ), 1 )->get_error_code() );
+		$repository->update( $booking['id'], array( 'artist_name' => 'Reviewing' ), 1 );
+		$this->assertSame( 'booking_version_conflict', $repository->update( $booking['id'], array( 'artist_name' => 'Accepted' ), 1 )->get_error_code() );
 		$GLOBALS['wpdb']->fail_reads = true;
 		$this->assertSame( 'booking_read_failed', $repository->get( $booking['id'] )->get_error_code() );
 		$this->assertSame( 'booking_list_failed', $repository->list( array( 'venue_term_id' => 55 ) )->get_error_code() );
@@ -727,13 +724,26 @@ final class BookingFoundationTest extends TestCase {
 			foreach ( BookingLifecycle::STATUSES as $to ) {
 				$result = $lifecycle->validate_transition(
 					array(
-						'status'             => $from,
-						'requested_start_at' => '2026-08-01 20:00:00',
-						'requested_end_at'   => '2026-08-01 23:00:00',
-						'space_key'          => 'main-room',
-						'deal'               => array(
+						'status'               => $from,
+						'performance_start_at' => '2026-08-01 20:00:00',
+						'performance_end_at'   => '2026-08-01 23:00:00',
+						'space_key'            => 'main-room',
+						'deal'                 => array(
 							'version' => 1,
-							'data'    => array( 'type' => 'guarantee' ),
+							'data'    => array(
+								'version'                 => 1,
+								'type'                    => 'guarantee',
+								'guarantee_cents'         => 0,
+								'revenue_share_basis_points' => 0,
+								'revenue_share_basis'     => 'gross_ticket_sales',
+								'currency'                => 'USD',
+								'capacity'                => null,
+								'advance_ticket_price_cents' => null,
+								'door_ticket_price_cents' => null,
+								'ticket_fee_cents'        => null,
+								'tickets_on_sale_at'      => null,
+								'additional_terms'        => null,
+							),
 						),
 					),
 					$to
@@ -750,21 +760,34 @@ final class BookingFoundationTest extends TestCase {
 	public function test_missing_hold_and_conflict_substrates_fail_closed(): void {
 		$lifecycle = new BookingLifecycle();
 		$booking   = array(
-			'status'             => 'negotiating',
-			'requested_start_at' => null,
-			'requested_end_at'   => null,
-			'space_key'          => null,
-			'deal'               => null,
+			'status'               => 'negotiating',
+			'performance_start_at' => null,
+			'performance_end_at'   => null,
+			'space_key'            => null,
+			'deal'                 => null,
 		);
 		$this->assertSame( 'booking_hold_selection_required', $lifecycle->validate_transition( $booking, 'held' )->get_error_code() );
 		$this->assertSame( 'booking_confirmation_selection_required', $lifecycle->validate_transition( $booking, 'confirmed' )->get_error_code() );
-		$booking['requested_start_at'] = '2026-08-01 20:00:00';
-		$booking['requested_end_at']   = '2026-08-01 23:00:00';
-		$booking['space_key']          = 'main-room';
+		$booking['performance_start_at'] = '2026-08-01 20:00:00';
+		$booking['performance_end_at']   = '2026-08-01 23:00:00';
+		$booking['space_key']            = 'main-room';
 		$this->assertSame( 'booking_confirmation_deal_required', $lifecycle->validate_transition( $booking, 'confirmed' )->get_error_code() );
 		$booking['deal'] = array(
 			'version' => 1,
-			'data'    => array( 'type' => 'guarantee' ),
+			'data'    => array(
+				'version'                    => 1,
+				'type'                       => 'guarantee',
+				'guarantee_cents'            => 0,
+				'revenue_share_basis_points' => 0,
+				'revenue_share_basis'        => 'gross_ticket_sales',
+				'currency'                   => 'USD',
+				'capacity'                   => null,
+				'advance_ticket_price_cents' => null,
+				'door_ticket_price_cents'    => null,
+				'ticket_fee_cents'           => null,
+				'tickets_on_sale_at'         => null,
+				'additional_terms'           => null,
+			),
 		);
 		$this->assertTrue( $lifecycle->validate_transition( $booking, 'confirmed' ) );
 	}

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -742,6 +742,7 @@ final class BookingFoundationTest extends TestCase {
 								'door_ticket_price_cents' => null,
 								'ticket_fee_cents'        => null,
 								'tickets_on_sale_at'      => null,
+								'ticket_url'               => null,
 								'additional_terms'        => null,
 							),
 						),
@@ -786,6 +787,7 @@ final class BookingFoundationTest extends TestCase {
 				'door_ticket_price_cents'    => null,
 				'ticket_fee_cents'           => null,
 				'tickets_on_sale_at'         => null,
+				'ticket_url'                  => null,
 				'additional_terms'           => null,
 			),
 		);

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -88,6 +88,7 @@ final class BookingHoldTest extends TestCase {
 						'door_ticket_price_cents'    => null,
 						'ticket_fee_cents'           => null,
 						'tickets_on_sale_at'         => null,
+						'ticket_url'                  => null,
 						'additional_terms'           => null,
 					),
 					'space_key'            => $space,

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -73,13 +73,26 @@ final class BookingHoldTest extends TestCase {
 		$booking = ( new BookingRepository() )->create(
 			array_merge(
 				array(
-					'venue_term_id'      => 55,
-					'artist_name'        => 'Test Band',
-					'intake'             => array(),
-					'deal'               => array( 'type' => 'guarantee' ),
-					'space_key'          => $space,
-					'requested_start_at' => $start,
-					'requested_end_at'   => $end,
+					'venue_term_id'        => 55,
+					'artist_name'          => 'Test Band',
+					'intake'               => array(),
+					'deal'                 => array(
+						'version'                    => 1,
+						'type'                       => 'guarantee',
+						'guarantee_cents'            => 100000,
+						'revenue_share_basis_points' => 0,
+						'revenue_share_basis'        => 'gross_ticket_sales',
+						'currency'                   => 'USD',
+						'capacity'                   => null,
+						'advance_ticket_price_cents' => null,
+						'door_ticket_price_cents'    => null,
+						'ticket_fee_cents'           => null,
+						'tickets_on_sale_at'         => null,
+						'additional_terms'           => null,
+					),
+					'space_key'            => $space,
+					'performance_start_at' => $start,
+					'performance_end_at'   => $end,
 				),
 				$overrides
 			)
@@ -117,8 +130,8 @@ final class BookingHoldTest extends TestCase {
 		return array( $holds, $lifecycle );
 	}
 
-	public function test_schema_v5_installs_site_scoped_holds_contract(): void {
-		$this->assertSame( '5', BookingSchema::SCHEMA_VERSION );
+	public function test_schema_v6_installs_site_scoped_holds_contract(): void {
+		$this->assertSame( '6', BookingSchema::SCHEMA_VERSION );
 		$this->assertTrue( BookingSchema::install() );
 		$table = BookingSchema::holds_table();
 		$this->assertSame( 'wp_7_ec_booking_holds', $table );
@@ -181,7 +194,7 @@ final class BookingHoldTest extends TestCase {
 		$this->assertSame( 'changed plans', $released['release_reason'] );
 		$this->assertSame( 2, ( new BookingRepository() )->get( $booking['id'] )['version'], 'Release is hold-local and intentionally leaves the booking version unchanged.' );
 		$this->assertSame( 'hold_released', ( new BookingActivityRepository() )->list_for_booking( $booking['id'] )[0]['kind'] );
-		$empty = $this->booking( '2030-09-01 20:00:00', '2030-09-01 23:00:00' );
+		$empty      = $this->booking( '2030-09-01 20:00:00', '2030-09-01 23:00:00' );
 		$empty_hold = $holds->create( $empty['id'], 1, 12 );
 		$this->assertSame( 'booking_hold_release_reason_required', $holds->release( $empty_hold['hold']['id'], 1, 12, '<b></b>' )->get_error_code() );
 	}
@@ -242,8 +255,23 @@ final class BookingHoldTest extends TestCase {
 		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $id ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
 		$this->assertSame( 'expired', $holds->get( $id )['status'] );
 		$this->assertSame( $holds->get( $id )['expires_at'], $holds->get( $id )['expired_at'] );
-		$this->assertCount( 0, $holds->list( array( 'venue_term_id' => 55, 'status' => 'active' ), 12 ) );
-		$expired = $holds->list( array( 'venue_term_id' => 55, 'status' => 'expired' ), 12 );
+		$this->assertCount(
+			0,
+			$holds->list(
+				array(
+					'venue_term_id' => 55,
+					'status'        => 'active',
+				),
+				12
+			)
+		);
+		$expired = $holds->list(
+			array(
+				'venue_term_id' => 55,
+				'status'        => 'expired',
+			),
+			12
+		);
 		$this->assertSame( array( 'expired' ), array_column( $expired, 'status' ) );
 		$this->assertSame( 'expired', $holds->list( array( 'venue_term_id' => 55 ), 12 )[0]['status'] );
 		$this->assertSame( 'booking_hold_not_active', $holds->release( $id, 1, 12, 'too late' )->get_error_code() );
@@ -267,10 +295,10 @@ final class BookingHoldTest extends TestCase {
 
 		$replacement = $holds->create( $booking['id'], 4, 12 );
 		$lifecycle->transition( $booking['id'], 'held', 5, 12 );
-		$alternative              = $replacement['hold'];
-		$alternative['id']        = 3;
-		$alternative['space_key'] = 'patio';
-		$alternative['expires_at']= gmdate( 'Y-m-d H:i:s' );
+		$alternative               = $replacement['hold'];
+		$alternative['id']         = 3;
+		$alternative['space_key']  = 'patio';
+		$alternative['expires_at'] = gmdate( 'Y-m-d H:i:s' );
 		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][3] = $alternative;
 		$holds->expire( 3 );
 		$this->assertSame( 'held', ( new BookingRepository() )->get( $booking['id'] )['status'] );
@@ -326,7 +354,7 @@ final class BookingHoldTest extends TestCase {
 		$second_hold = $holds->create( $second['id'], 1, 12 );
 		$lifecycle->transition( $second['id'], 'held', 2, 12 );
 		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $second_hold['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
-		$list = $abilities->list_bookings( array( 'venue_term_id' => 55 ) );
+		$list  = $abilities->list_bookings( array( 'venue_term_id' => 55 ) );
 		$by_id = array_column( $list, null, 'id' );
 		$this->assertSame( 'negotiating', $by_id[ $second['id'] ]['status'] );
 		$this->assertSame( 4, $by_id[ $second['id'] ]['version'] );
@@ -346,45 +374,119 @@ final class BookingHoldTest extends TestCase {
 		$lifecycle->transition( $second['id'], 'held', 2, 12 );
 		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $second_hold['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
 
-		$page_one = $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'negotiating', 'limit' => 1, 'offset' => 0 ) );
-		$page_two = $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'negotiating', 'limit' => 1, 'offset' => 1 ) );
+		$page_one = $abilities->list_bookings(
+			array(
+				'venue_term_id' => 55,
+				'status'        => 'negotiating',
+				'limit'         => 1,
+				'offset'        => 0,
+			)
+		);
+		$page_two = $abilities->list_bookings(
+			array(
+				'venue_term_id' => 55,
+				'status'        => 'negotiating',
+				'limit'         => 1,
+				'offset'        => 1,
+			)
+		);
 		$this->assertSame( array( $second['id'] ), array_column( $page_one, 'id' ) );
 		$this->assertSame( array( $first['id'] ), array_column( $page_two, 'id' ) );
-		$this->assertSame( array(), $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'held' ) ) );
+		$this->assertSame(
+			array(),
+			$abilities->list_bookings(
+				array(
+					'venue_term_id' => 55,
+					'status'        => 'held',
+				)
+			)
+		);
 	}
 
 	public function test_more_than_five_hundred_valid_held_bookings_do_not_block_listing(): void {
 		list( $holds, $lifecycle ) = $this->seed_held_venue( 501, false );
-		$abilities = new VenueBookingAbilities( new BookingRepository(), $lifecycle, new BookingTestAuthorization(), $holds );
-		$result    = $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'held', 'limit' => 1 ) );
+		$abilities                 = new VenueBookingAbilities( new BookingRepository(), $lifecycle, new BookingTestAuthorization(), $holds );
+		$result                    = $abilities->list_bookings(
+			array(
+				'venue_term_id' => 55,
+				'status'        => 'held',
+				'limit'         => 1,
+			)
+		);
 		$this->assertCount( 1, $result );
 		$this->assertSame( 'held', $result[0]['status'] );
 	}
 
 	public function test_stale_held_batches_make_forward_progress_before_filters(): void {
 		list( $holds, $lifecycle ) = $this->seed_held_venue( 101, true );
-		$abilities = new VenueBookingAbilities( new BookingRepository(), $lifecycle, new BookingTestAuthorization(), $holds );
-		$first_page = $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'negotiating', 'limit' => 100, 'offset' => 0 ) );
-		$second_page = $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'negotiating', 'limit' => 100, 'offset' => 100 ) );
+		$abilities                 = new VenueBookingAbilities( new BookingRepository(), $lifecycle, new BookingTestAuthorization(), $holds );
+		$first_page                = $abilities->list_bookings(
+			array(
+				'venue_term_id' => 55,
+				'status'        => 'negotiating',
+				'limit'         => 100,
+				'offset'        => 0,
+			)
+		);
+		$second_page               = $abilities->list_bookings(
+			array(
+				'venue_term_id' => 55,
+				'status'        => 'negotiating',
+				'limit'         => 100,
+				'offset'        => 100,
+			)
+		);
 		$this->assertCount( 100, $first_page );
 		$this->assertCount( 1, $second_page );
-		$this->assertSame( array(), $abilities->list_bookings( array( 'venue_term_id' => 55, 'status' => 'held' ) ) );
-		$this->assertCount( 101, array_filter( $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ], static function ( $booking ) { return 'negotiating' === $booking['status']; } ) );
+		$this->assertSame(
+			array(),
+			$abilities->list_bookings(
+				array(
+					'venue_term_id' => 55,
+					'status'        => 'held',
+				)
+			)
+		);
+		$this->assertCount(
+			101,
+			array_filter(
+				$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ],
+				static function ( $booking ) {
+					return 'negotiating' === $booking['status'];
+				}
+			)
+		);
 	}
 
 	public function test_exact_reconciliation_safety_cap_succeeds_when_no_stale_rows_remain(): void {
 		list( $holds ) = $this->seed_held_venue( 1000, true );
 		$this->assertTrue( $holds->reconcile_venue( 55 ) );
-		$this->assertCount( 1000, array_filter( $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ], static function ( $booking ) { return 'negotiating' === $booking['status']; } ) );
+		$this->assertCount(
+			1000,
+			array_filter(
+				$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ],
+				static function ( $booking ) {
+					return 'negotiating' === $booking['status'];
+				}
+			)
+		);
 	}
 
 	public function test_over_reconciliation_safety_cap_is_retryable_only_when_stale_remains(): void {
 		list( $holds ) = $this->seed_held_venue( 1001, true );
-		$result = $holds->reconcile_venue( 55 );
+		$result        = $holds->reconcile_venue( 55 );
 		$this->assertSame( 'booking_hold_venue_reconciliation_limit', $result->get_error_code() );
 		$this->assertSame( 503, $result->get_error_data()['status'] );
 		$this->assertSame( 1000, $result->get_error_data()['processed'] );
-		$this->assertCount( 1, array_filter( $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ], static function ( $booking ) { return 'held' === $booking['status']; } ) );
+		$this->assertCount(
+			1,
+			array_filter(
+				$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ],
+				static function ( $booking ) {
+					return 'held' === $booking['status'];
+				}
+			)
+		);
 	}
 
 	public function test_assign_and_bind_reconcile_before_expected_version_checks(): void {
@@ -408,10 +510,10 @@ final class BookingHoldTest extends TestCase {
 	}
 
 	public function test_elapsed_selected_release_reconciles_before_and_after_lock(): void {
-		$holds      = $this->holds();
-		$lifecycle  = new BookingLifecycle( null, null, null, null, $holds );
-		$pre        = $this->booking( '2031-06-01 20:00:00', '2031-06-01 23:00:00' );
-		$pre_hold   = $holds->create( $pre['id'], 1, 12 );
+		$holds     = $this->holds();
+		$lifecycle = new BookingLifecycle( null, null, null, null, $holds );
+		$pre       = $this->booking( '2031-06-01 20:00:00', '2031-06-01 23:00:00' );
+		$pre_hold  = $holds->create( $pre['id'], 1, 12 );
 		$lifecycle->transition( $pre['id'], 'held', 2, 12 );
 		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $pre_hold['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
 		$this->assertSame( 'booking_hold_not_active', $holds->release( $pre_hold['hold']['id'], 1, 12, 'elapsed' )->get_error_code() );
@@ -433,23 +535,23 @@ final class BookingHoldTest extends TestCase {
 	}
 
 	public function test_booking_get_and_list_reauthorize_under_membership_lock(): void {
-		$authorization = new BookingTestAuthorization();
-		$holds         = new BookingHoldRepository( null, null, $authorization );
-		$lifecycle     = new BookingLifecycle( null, null, $authorization, null, $holds );
-		$abilities     = new VenueBookingAbilities( new BookingRepository(), $lifecycle, $authorization, $holds );
-		$booking       = $this->booking( '2031-09-01 20:00:00', '2031-09-01 23:00:00' );
+		$authorization                          = new BookingTestAuthorization();
+		$holds                                  = new BookingHoldRepository( null, null, $authorization );
+		$lifecycle                              = new BookingLifecycle( null, null, $authorization, null, $holds );
+		$abilities                              = new VenueBookingAbilities( new BookingRepository(), $lifecycle, $authorization, $holds );
+		$booking                                = $this->booking( '2031-09-01 20:00:00', '2031-09-01 23:00:00' );
 		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) {
 			unset( $authorization->allowed['12:55'] );
 		};
-		$get = $abilities->get_booking( array( 'booking_id' => $booking['id'] ) );
+		$get                                    = $abilities->get_booking( array( 'booking_id' => $booking['id'] ) );
 		$this->assertSame( 'venue_action_forbidden', $get->get_error_code() );
 		$this->assertInstanceOf( WP_Error::class, $get );
 
-		$authorization->allowed['12:55'] = true;
+		$authorization->allowed['12:55']        = true;
 		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) {
 			unset( $authorization->allowed['12:55'] );
 		};
-		$list = $abilities->list_bookings( array( 'venue_term_id' => 55 ) );
+		$list                                   = $abilities->list_bookings( array( 'venue_term_id' => 55 ) );
 		$this->assertSame( 'venue_action_forbidden', $list->get_error_code() );
 		$this->assertInstanceOf( WP_Error::class, $list );
 	}
@@ -507,22 +609,22 @@ final class BookingHoldTest extends TestCase {
 	}
 
 	public function test_uncertain_commit_is_not_followed_by_a_false_rollback_claim(): void {
-		$holds                                      = $this->holds();
-		$booking                                    = $this->booking();
-		$GLOBALS['wpdb']->fail_transaction_commit   = true;
-		$rollbacks                                  = $GLOBALS['wpdb']->rollback_queries;
-		$result                                     = $holds->create( $booking['id'], 1, 12 );
+		$holds                                    = $this->holds();
+		$booking                                  = $this->booking();
+		$GLOBALS['wpdb']->fail_transaction_commit = true;
+		$rollbacks                                = $GLOBALS['wpdb']->rollback_queries;
+		$result                                   = $holds->create( $booking['id'], 1, 12 );
 		$this->assertSame( 'booking_hold_transaction_commit_uncertain', $result->get_error_code() );
 		$this->assertSame( $rollbacks, $GLOBALS['wpdb']->rollback_queries );
 		$this->assertSame( 'release', end( $GLOBALS['wpdb']->lock_names )[0] );
 	}
 
 	public function test_scheduler_failure_after_commit_does_not_fail_or_rollback_create(): void {
-		$holds                                      = $this->holds();
-		$booking                                    = $this->booking();
+		$holds                                        = $this->holds();
+		$booking                                      = $this->booking();
 		$GLOBALS['ec_artist_test']['throw_scheduler'] = true;
-		$rollbacks                                  = $GLOBALS['wpdb']->rollback_queries;
-		$result                                     = $holds->create( $booking['id'], 1, 12 );
+		$rollbacks                                    = $GLOBALS['wpdb']->rollback_queries;
+		$result                                       = $holds->create( $booking['id'], 1, 12 );
 		$this->assertSame( 'active', $result['hold']['status'] );
 		$this->assertSame( 2, $result['booking_version'] );
 		$this->assertSame( $rollbacks, $GLOBALS['wpdb']->rollback_queries );
@@ -530,19 +632,19 @@ final class BookingHoldTest extends TestCase {
 	}
 
 	public function test_scheduler_zero_return_is_diagnostic_but_create_remains_committed(): void {
-		$holds                                      = $this->holds();
-		$booking                                    = $this->booking();
+		$holds                                       = $this->holds();
+		$booking                                     = $this->booking();
 		$GLOBALS['ec_artist_test']['scheduler_zero'] = true;
-		$result                                     = $holds->create( $booking['id'], 1, 12 );
+		$result                                      = $holds->create( $booking['id'], 1, 12 );
 		$this->assertSame( 'active', $result['hold']['status'] );
 		$this->assertSame( 2, ( new BookingRepository() )->get( $booking['id'] )['version'] );
 		$this->assertCount( 1, $GLOBALS['ec_artist_test']['fired_actions']['extrachill_events_booking_hold_schedule_failed'] );
 	}
 
 	public function test_failed_scheduled_expiry_retries_and_throws_visible_failure(): void {
-		$holds   = $this->holds();
-		$booking = $this->booking();
-		$created = $holds->create( $booking['id'], 1, 12 );
+		$holds                                  = $this->holds();
+		$booking                                = $this->booking();
+		$created                                = $holds->create( $booking['id'], 1, 12 );
 		$GLOBALS['ec_artist_test']['scheduled'] = array();
 		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $created['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
 		$GLOBALS['wpdb']->get_lock_result = 0;
@@ -557,12 +659,12 @@ final class BookingHoldTest extends TestCase {
 	}
 
 	public function test_failed_expiry_retry_zero_return_fires_diagnostic_and_throws(): void {
-		$holds   = $this->holds();
-		$booking = $this->booking( '2031-08-01 20:00:00', '2031-08-01 23:00:00' );
-		$created = $holds->create( $booking['id'], 1, 12 );
+		$holds                                  = $this->holds();
+		$booking                                = $this->booking( '2031-08-01 20:00:00', '2031-08-01 23:00:00' );
+		$created                                = $holds->create( $booking['id'], 1, 12 );
 		$GLOBALS['ec_artist_test']['scheduled'] = array();
 		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $created['hold']['id'] ]['expires_at'] = gmdate( 'Y-m-d H:i:s' );
-		$GLOBALS['wpdb']->get_lock_result = 0;
+		$GLOBALS['wpdb']->get_lock_result            = 0;
 		$GLOBALS['ec_artist_test']['scheduler_zero'] = true;
 		try {
 			BookingHoldRepository::expire_scheduled( $created['hold']['id'], 0 );
@@ -627,15 +729,15 @@ final class BookingHoldTest extends TestCase {
 	}
 
 	public function test_list_reauthorizes_after_lock_and_rolls_back_on_revocation(): void {
-		$authorization                          = new BookingTestAuthorization();
-		$holds                                  = new BookingHoldRepository( null, null, $authorization );
-		$booking                                = $this->booking();
+		$authorization = new BookingTestAuthorization();
+		$holds         = new BookingHoldRepository( null, null, $authorization );
+		$booking       = $this->booking();
 		$holds->create( $booking['id'], 1, 12 );
 		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) {
 			unset( $authorization->allowed['12:55'] );
 		};
-		$before = $GLOBALS['wpdb']->rollback_queries;
-		$result = $holds->list( array( 'venue_term_id' => 55 ), 12 );
+		$before                                 = $GLOBALS['wpdb']->rollback_queries;
+		$result                                 = $holds->list( array( 'venue_term_id' => 55 ), 12 );
 		$this->assertSame( 'venue_action_forbidden', $result->get_error_code() );
 		$this->assertSame( $before + 1, $GLOBALS['wpdb']->rollback_queries );
 	}
@@ -660,14 +762,14 @@ final class BookingHoldTest extends TestCase {
 		$this->assertSame( 'active', $holds->create( $overlap['id'], 1, 12 )['hold']['status'] );
 		$GLOBALS['wpdb']->event_dates = array(
 			array(
-				'post_id'       => 902,
-				'venue_term_id' => 55,
-				'post_status'   => 'publish',
-				'start_datetime'=> '2030-11-03 01:05:00',
-				'end_datetime'  => null,
+				'post_id'        => 902,
+				'venue_term_id'  => 55,
+				'post_status'    => 'publish',
+				'start_datetime' => '2030-11-03 01:05:00',
+				'end_datetime'   => null,
 			),
 		);
-		$dst = $this->booking( '2030-11-03 06:00:00', '2030-11-03 07:00:00' );
+		$dst                          = $this->booking( '2030-11-03 06:00:00', '2030-11-03 07:00:00' );
 		$this->assertSame( 'canonical_event', $holds->create( $dst['id'], 1, 12 )->get_error_data()['conflict']['conflict_type'], '06:00 UTC converts to the repeated 01:00 hour after the DST fallback.' );
 		$crossing_fold = $this->booking( '2030-11-03 05:45:00', '2030-11-03 06:15:00' );
 		$this->assertSame( 'canonical_event', $holds->create( $crossing_fold['id'], 1, 12 )->get_error_data()['conflict']['conflict_type'], 'The local window must include the early segment of the repeated fold.' );
@@ -683,14 +785,14 @@ final class BookingHoldTest extends TestCase {
 		$booking   = $this->booking();
 		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['status'] = 'negotiating';
 		$this->assertSame( 'booking_matching_hold_required', $lifecycle->transition( $booking['id'], 'held', 1, 12 )->get_error_code() );
-		$created = $holds->create( $booking['id'], 1, 12 );
-		$alternative                 = $created['hold'];
-		$alternative['id']           = 2;
-		$alternative['space_key']    = 'patio';
-		$alternative['version']      = 1;
-		$alternative['expires_at']   = gmdate( 'Y-m-d H:i:s' );
+		$created                   = $holds->create( $booking['id'], 1, 12 );
+		$alternative               = $created['hold'];
+		$alternative['id']         = 2;
+		$alternative['space_key']  = 'patio';
+		$alternative['version']    = 1;
+		$alternative['expires_at'] = gmdate( 'Y-m-d H:i:s' );
 		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][2] = $alternative;
-		$held    = $lifecycle->transition( $booking['id'], 'held', 2, 12 );
+		$held = $lifecycle->transition( $booking['id'], 'held', 2, 12 );
 		$this->assertSame( 'held', $held['status'] );
 		$confirmed = $lifecycle->transition( $booking['id'], 'confirmed', 3, 12 );
 		$this->assertSame( 'confirmed', $confirmed['status'] );
@@ -751,10 +853,27 @@ final class BookingHoldTest extends TestCase {
 		$holds->create( $first['id'], 1, 12 );
 		$second = $this->booking( '2030-09-01 20:00:00', '2030-09-01 23:00:00' );
 		$holds->create( $second['id'], 1, 12 );
-		$list = $holds->list( array( 'venue_term_id' => 55, 'range_start' => '2030-08-01 23:00:00', 'range_end' => '2030-09-02 00:00:00', 'limit' => 1 ), 12 );
+		$list = $holds->list(
+			array(
+				'venue_term_id' => 55,
+				'range_start'   => '2030-08-01 23:00:00',
+				'range_end'     => '2030-09-02 00:00:00',
+				'limit'         => 1,
+			),
+			12
+		);
 		$this->assertCount( 1, $list );
 		$this->assertSame( $second['id'], $list[0]['booking_id'] );
-		$this->assertSame( 'invalid_booking_hold_status', $holds->list( array( 'venue_term_id' => 55, 'status' => 'deleted' ), 12 )->get_error_code() );
+		$this->assertSame(
+			'invalid_booking_hold_status',
+			$holds->list(
+				array(
+					'venue_term_id' => 55,
+					'status'        => 'deleted',
+				),
+				12
+			)->get_error_code()
+		);
 	}
 
 	public function test_abilities_are_strict_rest_visible_and_do_not_enumerate_missing_records(): void {

--- a/tests/BookingMutationTest.php
+++ b/tests/BookingMutationTest.php
@@ -97,6 +97,7 @@ final class BookingMutationTest extends TestCase {
 				'door_ticket_price_cents'    => 2500,
 				'ticket_fee_cents'           => 300,
 				'tickets_on_sale_at'         => '2030-01-01 15:00:00',
+				'ticket_url'                  => 'https://tickets.example.com/test-band',
 				'additional_terms'           => 'Merch is 100% artist.',
 			),
 			$overrides
@@ -234,7 +235,7 @@ final class BookingMutationTest extends TestCase {
 			$booking = $this->booking( $status );
 			$this->assertSame( 'booking_mutation_status_forbidden', $service->update_deal( $booking['id'], 1, $this->deal(), 12 )->get_error_code(), $status );
 		}
-		foreach ( array( array( 'revenue_share_basis_points' => 10001 ), array( 'currency' => 'US1' ), array( 'capacity' => 0 ), array( 'guarantee_cents' => -1 ), array( 'tickets_on_sale_at' => 'soon' ) ) as $invalid ) {
+		foreach ( array( array( 'revenue_share_basis_points' => 10001 ), array( 'currency' => 'US1' ), array( 'capacity' => 0 ), array( 'guarantee_cents' => -1 ), array( 'tickets_on_sale_at' => 'soon' ), array( 'ticket_url' => 'javascript:alert(1)' ) ) as $invalid ) {
 			$this->assertSame( 'invalid_booking_deal', BookingMutationService::normalize_deal_document( $this->deal( $invalid ) )->get_error_code() );
 		}
 		$this->assertSame( 'invalid_booking_deal', BookingMutationService::normalize_deal_document( $this->deal( array( 'currency' => 123 ) ) )->get_error_code() );

--- a/tests/BookingMutationTest.php
+++ b/tests/BookingMutationTest.php
@@ -1,0 +1,365 @@
+<?php
+/**
+ * Booking detail, production, deal, and performance mutation tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Abilities\VenueBookingMutationAbilities;
+use ExtraChillEvents\Core\BookingActivityRepository;
+use ExtraChillEvents\Core\BookingHoldRepository;
+use ExtraChillEvents\Core\BookingLifecycle;
+use ExtraChillEvents\Core\BookingMutationService;
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\VenueBookingConfig;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
+final class BookingMutationTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id'       => 7,
+			'stack'         => array(),
+			'uuid'          => 0,
+			'options'       => array(),
+			'dbdelta'       => array(),
+			'abilities'     => array(),
+			'actions'       => array(),
+			'fired_actions' => array(),
+			'scheduled'     => array(),
+			'cache_deletes' => array(),
+			'terms'         => array(
+				7 => array(
+					55 => (object) array(
+						'term_id'  => 55,
+						'taxonomy' => 'venue',
+						'name'     => 'The Room',
+					),
+				),
+			),
+			'meta'          => array(
+				7 => array(
+					55 => array(
+						'_venue_timezone'            => 'America/New_York',
+						VenueBookingConfig::META_KEY => array(
+							'enabled'          => true,
+							'hold_ttl_minutes' => 30,
+							'spaces'           => array(
+								array(
+									'key'        => 'main-room',
+									'name'       => 'Main Room',
+									'is_default' => true,
+								),
+								array(
+									'key'  => 'patio',
+									'name' => 'Patio',
+								),
+							),
+						),
+					),
+				),
+			),
+			'posts'         => array(),
+			'post_meta'     => array(),
+		);
+		$GLOBALS['wpdb']           = new BookingWpdb();
+	}
+
+	private function booking( string $status = 'submitted', array $overrides = array() ): array {
+		$booking = ( new BookingRepository() )->create(
+			array_merge(
+				array(
+					'venue_term_id' => 55,
+					'artist_name'   => 'Test Band',
+					'intake'        => array( 'draw' => 50 ),
+				),
+				$overrides
+			)
+		);
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['status'] = $status;
+		$booking['status'] = $status;
+		return $booking;
+	}
+
+	private function deal( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'version'                    => 1,
+				'type'                       => 'guarantee',
+				'guarantee_cents'            => 100000,
+				'revenue_share_basis_points' => 1500,
+				'revenue_share_basis'        => 'gross_ticket_sales',
+				'currency'                   => 'USD',
+				'capacity'                   => 300,
+				'advance_ticket_price_cents' => 2000,
+				'door_ticket_price_cents'    => 2500,
+				'ticket_fee_cents'           => 300,
+				'tickets_on_sale_at'         => '2030-01-01 15:00:00',
+				'additional_terms'           => 'Merch is 100% artist.',
+			),
+			$overrides
+		);
+	}
+
+	private function production(): array {
+		return array(
+			'version'              => 1,
+			'support_requirements' => array( 'Local opener' ),
+			'support_offers'       => array( 'House drums' ),
+			'production_notes'     => 'Six inputs.',
+		);
+	}
+
+	private function service( ?BookingTestAuthorization $authorization = null ): BookingMutationService {
+		return new BookingMutationService( null, null, $authorization ? $authorization : new BookingTestAuthorization() );
+	}
+
+	public function test_schema_and_public_inquiry_separate_requested_from_authoritative_fields(): void {
+		$this->assertSame( '6', BookingSchema::SCHEMA_VERSION );
+		$this->assertTrue( BookingSchema::install() );
+		$columns = $GLOBALS['wpdb']->schemas[ BookingSchema::bookings_table() ]['columns'];
+		foreach ( array( 'requested_space_key', 'performance_start_at', 'performance_end_at', 'production_payload', 'confirmed_deal_payload' ) as $column ) {
+			$this->assertArrayHasKey( $column, $columns );
+		}
+		$this->assertSame( array( 'venue_term_id', 'performance_start_at' ), $GLOBALS['wpdb']->schemas[ BookingSchema::bookings_table() ]['indexes']['venue_performance_start']['columns'] );
+
+		$lifecycle = new BookingLifecycle();
+		$created   = $lifecycle->create_inquiry(
+			array(
+				'idempotency_key'      => 'separation',
+				'venue_term_id'        => 55,
+				'artist_name'          => 'Band',
+				'intake'               => array(),
+				'requested_space_key'  => 'patio',
+				'requested_start_at'   => '2030-02-01 20:00:00',
+				'requested_end_at'     => '2030-02-01 23:00:00',
+				'space_key'            => 'main-room',
+				'performance_start_at' => '2030-03-01 20:00:00',
+				'performance_end_at'   => '2030-03-01 23:00:00',
+				'deal'                 => $this->deal(),
+			)
+		);
+		$this->assertSame( 'patio', $created['requested_space_key'] );
+		$this->assertNull( $created['space_key'] );
+		$this->assertNull( $created['performance_start_at'] );
+		$this->assertNull( $created['deal'] );
+	}
+
+	public function test_intake_status_matrix_null_clearing_noop_stale_and_private_activity(): void {
+		$service = $this->service();
+		foreach ( array( 'submitted', 'needs_info', 'under_review', 'negotiating' ) as $status ) {
+			$booking = $this->booking( $status, array( 'contact_phone' => '843-555-0100' ) );
+			$result  = $service->correct_intake(
+				$booking['id'],
+				1,
+				array(
+					'contact_phone'       => null,
+					'requested_space_key' => ' Patio ',
+				),
+				12
+			);
+			$this->assertNull( $result['contact_phone'], $status );
+			$this->assertSame( 'patio', $result['requested_space_key'], $status );
+			$this->assertSame( 2, $result['version'], $status );
+			$activity = ( new BookingActivityRepository() )->list_for_booking( $booking['id'] )[0];
+			$this->assertSame( 'intake_corrected', $activity['kind'] );
+			$this->assertSame( 12, $activity['actor_id'] );
+			$this->assertArrayHasKey( 'before', $activity['payload']['data'] );
+			$this->assertSame( 'booking_version_conflict', $service->correct_intake( $booking['id'], 1, array( 'contact_name' => 'Stale' ), 12 )->get_error_code() );
+			$noop = $service->correct_intake( $booking['id'], 2, array( 'requested_space_key' => 'patio' ), 12 );
+			$this->assertSame( 2, $noop['version'] );
+		}
+		foreach ( array( 'held', 'confirmed', 'declined', 'withdrawn', 'cancelled', 'completed' ) as $status ) {
+			$booking = $this->booking( $status );
+			$this->assertSame( 'booking_mutation_status_forbidden', $service->correct_intake( $booking['id'], 1, array( 'contact_name' => 'No' ), 12 )->get_error_code(), $status );
+		}
+		$this->assertSame( 'booking_intake_correction_required', $service->correct_intake( 1, 1, array(), 12 )->get_error_code() );
+	}
+
+	public function test_intake_ranges_validate_final_values_and_activity_failure_rolls_back(): void {
+		$service = $this->service();
+		$booking = $this->booking(
+			'under_review',
+			array(
+				'requested_start_at' => '2030-02-01 20:00:00',
+				'requested_end_at'   => '2030-02-01 23:00:00',
+			)
+		);
+		$this->assertSame( 'invalid_booking_date_range', $service->correct_intake( $booking['id'], 1, array( 'requested_end_at' => '2030-02-01 19:00:00' ), 12 )->get_error_code() );
+		$this->assertSame( 'invalid_booking_datetime', $service->correct_intake( $booking['id'], 1, array( 'requested_start_at' => 'tomorrow' ), 12 )->get_error_code() );
+		$GLOBALS['wpdb']->fail_activity_inserts = true;
+		$result                                 = $service->correct_intake( $booking['id'], 1, array( 'contact_name' => 'Changed' ), 12 );
+		$this->assertSame( 'booking_activity_write_failed', $result->get_error_code() );
+		$this->assertNull( ( new BookingRepository() )->get( $booking['id'] )['contact_name'] );
+		$this->assertSame( 1, ( new BookingRepository() )->get( $booking['id'] )['version'] );
+	}
+
+	public function test_production_and_deal_contracts_statuses_bounds_and_noops(): void {
+		$service = $this->service();
+		foreach ( array( 'under_review', 'negotiating', 'held' ) as $status ) {
+			$booking = $this->booking( $status );
+			$result  = $service->update_production( $booking['id'], 1, $this->production(), 12 );
+			$this->assertSame( $this->production(), $result['production']['data'], $status );
+			$this->assertSame( 2, $result['version'] );
+			$this->assertSame( 2, $service->update_production( $booking['id'], 2, $this->production(), 12 )['version'] );
+		}
+		$this->assertSame( 'invalid_booking_production', BookingMutationService::normalize_production_document( array( 'version' => 1 ) )->get_error_code() );
+		$this->assertSame( 'invalid_booking_production', BookingMutationService::normalize_production_document( array( 'version' => 1, 'support_requirements' => array(), 'support_offers' => array() ) )->get_error_code() );
+		$this->assertSame( 'invalid_booking_production', BookingMutationService::normalize_production_document( array( 'version' => 1, 'support_requirements' => array( 7 ), 'support_offers' => array(), 'production_notes' => null ) )->get_error_code() );
+		$this->assertSame(
+			'invalid_booking_production',
+			BookingMutationService::normalize_production_document(
+				array(
+					'version'              => 1,
+					'support_requirements' => array_fill( 0, 51, 'x' ),
+					'support_offers'       => array(),
+					'production_notes'     => null,
+				)
+			)->get_error_code()
+		);
+		foreach ( array( 'submitted', 'needs_info', 'confirmed', 'declined', 'withdrawn', 'cancelled', 'completed' ) as $status ) {
+			$booking = $this->booking( $status );
+			$this->assertSame( 'booking_mutation_status_forbidden', $service->update_production( $booking['id'], 1, $this->production(), 12 )->get_error_code(), $status );
+		}
+
+		foreach ( array( 'negotiating', 'held' ) as $status ) {
+			$booking = $this->booking( $status );
+			$result  = $service->update_deal( $booking['id'], 1, $this->deal(), 12 );
+			$this->assertSame( $this->deal(), $result['deal']['data'], $status );
+			$this->assertSame( 'deal_draft_updated', ( new BookingActivityRepository() )->list_for_booking( $booking['id'] )[0]['kind'] );
+		}
+		foreach ( array( 'submitted', 'needs_info', 'under_review', 'confirmed', 'declined', 'withdrawn', 'cancelled', 'completed' ) as $status ) {
+			$booking = $this->booking( $status );
+			$this->assertSame( 'booking_mutation_status_forbidden', $service->update_deal( $booking['id'], 1, $this->deal(), 12 )->get_error_code(), $status );
+		}
+		foreach ( array( array( 'revenue_share_basis_points' => 10001 ), array( 'currency' => 'US1' ), array( 'capacity' => 0 ), array( 'guarantee_cents' => -1 ), array( 'tickets_on_sale_at' => 'soon' ) ) as $invalid ) {
+			$this->assertSame( 'invalid_booking_deal', BookingMutationService::normalize_deal_document( $this->deal( $invalid ) )->get_error_code() );
+		}
+		$this->assertSame( 'invalid_booking_deal', BookingMutationService::normalize_deal_document( $this->deal( array( 'currency' => 123 ) ) )->get_error_code() );
+		$this->assertSame( 'invalid_booking_deal', ( new BookingRepository() )->create( array( 'venue_term_id' => 55, 'artist_name' => 'Bad Deal', 'intake' => array(), 'deal' => array( 'version' => 1 ) ) )->get_error_code() );
+	}
+
+	public function test_document_object_order_does_not_create_false_revisions(): void {
+		$service = $this->service();
+		$booking = $this->booking( 'under_review', array( 'intake' => array( 'nested' => array( 'one' => 1, 'two' => 2 ) ) ) );
+		$noop    = $service->correct_intake( $booking['id'], 1, array( 'intake' => array( 'nested' => array( 'two' => 2, 'one' => 1 ) ) ), 12 );
+		$this->assertSame( 1, $noop['version'] );
+		$this->assertSame( array(), ( new BookingActivityRepository() )->list_for_booking( $booking['id'] ) );
+
+		$deal = $this->deal();
+		$reordered = array_reverse( $deal, true );
+		$this->assertTrue( BookingMutationService::documents_equal( BookingMutationService::normalize_deal_document( $reordered ), $reordered ) );
+	}
+
+	public function test_locked_reauthorization_and_transaction_failures_are_explicit(): void {
+		$authorization                          = new BookingTestAuthorization();
+		$service                                = $this->service( $authorization );
+		$booking                                = $this->booking( 'negotiating' );
+		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) {
+			unset( $authorization->allowed['12:55'] );
+		};
+		$this->assertSame( 'venue_action_forbidden', $service->update_deal( $booking['id'], 1, $this->deal(), 12 )->get_error_code() );
+		$this->assertSame( 1, ( new BookingRepository() )->get( $booking['id'] )['version'] );
+		$authorization->allowed['12:55']          = true;
+		$GLOBALS['wpdb']->fail_transaction_commit = true;
+		$rollbacks                                = $GLOBALS['wpdb']->rollback_queries;
+		$this->assertSame( 'booking_mutation_transaction_commit_uncertain', $service->update_production( $booking['id'], 1, $this->production(), 12 )->get_error_code() );
+		$this->assertSame( $rollbacks, $GLOBALS['wpdb']->rollback_queries );
+	}
+
+	public function test_performance_selection_checks_config_conflicts_and_own_alternatives(): void {
+		$service = $this->service();
+		foreach ( array( 'under_review', 'negotiating' ) as $status ) {
+			$candidate = $this->booking( $status );
+			$result    = $service->select_performance( $candidate['id'], 1, 'patio', '2033-04-01 20:00:00', '2033-04-01 23:00:00', 12 );
+			$this->assertSame( 'patio', $result['space_key'], $status );
+		}
+		foreach ( array( 'submitted', 'needs_info', 'held', 'confirmed', 'declined', 'withdrawn', 'cancelled', 'completed' ) as $status ) {
+			$candidate = $this->booking( $status );
+			$result    = $service->select_performance( $candidate['id'], 1, 'patio', '2033-05-01 20:00:00', '2033-05-01 23:00:00', 12 );
+			$this->assertSame( 'booking_performance_status_forbidden', $result->get_error_code(), $status );
+		}
+		$booking  = $this->booking( 'under_review' );
+		$selected = $service->select_performance( $booking['id'], 1, 'main-room', '2030-04-01 20:00:00', '2030-04-01 23:00:00', 12 );
+		$this->assertSame( 'main-room', $selected['space_key'] );
+		$this->assertSame( 2, $selected['version'] );
+		$this->assertSame( 2, $service->select_performance( $booking['id'], 2, 'main-room', '2030-04-01 20:00:00', '2030-04-01 23:00:00', 12 )['version'] );
+		$this->assertSame( 'booking_performance_space_invalid', $service->select_performance( $booking['id'], 2, 'closet', '2030-04-02 20:00:00', '2030-04-02 23:00:00', 12 )->get_error_code() );
+		$this->assertSame( 'invalid_booking_performance', $service->select_performance( $booking['id'], 2, 'main-room', '2030-04-02 23:00:00', '2030-04-02 20:00:00', 12 )->get_error_code() );
+		$GLOBALS['wpdb']->after_venue_lock = static function () {
+			$GLOBALS['ec_artist_test']['meta'][7][55][ VenueBookingConfig::META_KEY ]['spaces'] = array(
+				array(
+					'key'        => 'patio',
+					'name'       => 'Patio',
+					'is_default' => true,
+				),
+			);
+		};
+		$this->assertSame( 'booking_performance_space_invalid', $service->select_performance( $booking['id'], 2, 'main-room', '2030-04-03 20:00:00', '2030-04-03 23:00:00', 12 )->get_error_code(), 'The configured space is reread under the venue lock.' );
+		$GLOBALS['ec_artist_test']['meta'][7][55][ VenueBookingConfig::META_KEY ]['spaces'][] = array(
+			'key'  => 'main-room',
+			'name' => 'Main Room',
+		);
+
+		$other = $this->booking(
+			'negotiating',
+			array(
+				'space_key'            => 'main-room',
+				'performance_start_at' => '2030-05-01 20:00:00',
+				'performance_end_at'   => '2030-05-01 23:00:00',
+			)
+		);
+		$holds = new BookingHoldRepository( null, null, new BookingTestAuthorization() );
+		$hold  = $holds->create( $other['id'], 1, 12 );
+		$this->assertSame( 'booking_time_conflict', $service->select_performance( $booking['id'], 2, 'main-room', '2030-05-01 21:00:00', '2030-05-01 22:00:00', 12 )->get_error_code() );
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $hold['hold']['id'] ]['booking_id'] = $booking['id'];
+		$this->assertSame( 3, $service->select_performance( $booking['id'], 2, 'main-room', '2030-05-01 21:00:00', '2030-05-01 22:00:00', 12 )['version'], 'Own alternative holds are excluded.' );
+
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['status'] = 'held';
+		$this->assertSame( 'booking_performance_status_forbidden', $service->select_performance( $booking['id'], 3, 'patio', '2030-06-01 20:00:00', '2030-06-01 23:00:00', 12 )->get_error_code() );
+	}
+
+	public function test_confirmation_freezes_exact_draft_and_rejects_later_mutations(): void {
+		$authorization = new BookingTestAuthorization();
+		$holds         = new BookingHoldRepository( null, null, $authorization );
+		$service       = new BookingMutationService( null, null, $authorization, $holds );
+		$lifecycle     = new BookingLifecycle( null, null, $authorization, null, $holds );
+		$booking       = $this->booking(
+			'negotiating',
+			array(
+				'space_key'            => 'main-room',
+				'performance_start_at' => '2030-07-01 20:00:00',
+				'performance_end_at'   => '2030-07-01 23:00:00',
+			)
+		);
+		$draft         = $service->update_deal( $booking['id'], 1, $this->deal(), 12 );
+		$hold          = $holds->create( $booking['id'], 2, 12 );
+		$held          = $lifecycle->transition( $booking['id'], 'held', 3, 12 );
+		$confirmed     = $lifecycle->transition( $booking['id'], 'confirmed', $held['version'], 12, 'Approved' );
+		$this->assertSame( $draft['deal'], $confirmed['confirmed_deal'] );
+		$this->assertSame( $draft['deal'], ( new BookingRepository() )->get( $booking['id'] )['confirmed_deal'] );
+		$this->assertSame( 'converted', $holds->get( $hold['hold']['id'] )['status'] );
+		$activity = ( new BookingActivityRepository() )->list_for_booking( $booking['id'] )[0];
+		$this->assertSame( 'deal_confirmed', $activity['kind'] );
+		$this->assertSame( $draft['deal'], $activity['payload']['data']['confirmed_deal'] );
+		$this->assertSame( 'booking_mutation_status_forbidden', $service->update_deal( $booking['id'], $confirmed['version'], $this->deal( array( 'guarantee_cents' => 200000 ) ), 12 )->get_error_code() );
+		$this->assertSame( 'booking_performance_status_forbidden', $service->select_performance( $booking['id'], $confirmed['version'], 'patio', '2030-07-02 20:00:00', '2030-07-02 23:00:00', 12 )->get_error_code() );
+	}
+
+	public function test_mutation_abilities_are_strict_visible_scoped_and_private_receipt_stays_small(): void {
+		$authorization = new BookingTestAuthorization();
+		$abilities     = new VenueBookingMutationAbilities( $this->service( $authorization ), new BookingRepository(), $authorization );
+		$abilities->register();
+		$registered = $GLOBALS['ec_artist_test']['abilities'];
+		foreach ( array( 'extrachill/correct-venue-booking-intake', 'extrachill/select-venue-booking-performance', 'extrachill/update-venue-booking-production', 'extrachill/update-venue-booking-deal' ) as $name ) {
+			$this->assertArrayHasKey( $name, $registered );
+			$this->assertTrue( $registered[ $name ]['meta']['show_in_rest'] );
+			$this->assertFalse( $registered[ $name ]['input_schema']['additionalProperties'] );
+			$this->assertFalse( $registered[ $name ]['output_schema']['additionalProperties'] );
+		}
+		$this->assertSame( array( 'booking_id', 'expected_version', 'deal' ), $registered['extrachill/update-venue-booking-deal']['input_schema']['required'] );
+		$this->assertSame( 'venue_action_forbidden', $abilities->can_access_booking( array( 'booking_id' => 999 ) )->get_error_code() );
+	}
+}

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -8,11 +8,13 @@
 use ExtraChillEvents\Core\BookingActivityRepository;
 use ExtraChillEvents\Core\BookingLifecycle;
 use ExtraChillEvents\Core\BookingHoldRepository;
+use ExtraChillEvents\Core\BookingMutationService;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\VenueBookingConfig;
 use ExtraChillEvents\Abilities\VenueBookingAbilities;
 use ExtraChillEvents\Abilities\VenueBookingHoldAbilities;
+use ExtraChillEvents\Abilities\VenueBookingMutationAbilities;
 use ExtraChillEvents\Core\VenueAuthorization;
 
 if ( ! defined( 'ARRAY_A' ) ) {
@@ -56,6 +58,10 @@ if ( ! function_exists( 'sanitize_email' ) ) {
 	function sanitize_email( $value ) {
 		$sanitized = filter_var( trim( (string) $value ), FILTER_VALIDATE_EMAIL );
 		return false === $sanitized ? '' : $sanitized; }
+}
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+	function sanitize_textarea_field( $value ) {
+		return trim( strip_tags( (string) $value ) ); }
 }
 if ( ! function_exists( 'wp_generate_uuid4' ) ) {
 	function wp_generate_uuid4() {
@@ -199,47 +205,47 @@ if ( ! function_exists( 'do_action' ) ) {
 
 /** Stateful wpdb fake that enforces the persistence contracts under test. */
 final class BookingWpdb {
-	public $prefix                           = 'wp_7_';
-	public $terms                            = 'wp_7_terms';
-	public $posts                            = 'wp_7_posts';
-	public $term_relationships               = 'wp_7_term_relationships';
-	public $term_taxonomy                    = 'wp_7_term_taxonomy';
-	public $insert_id                        = 0;
-	public $last_error                       = '';
-	public $rows                             = array();
-	public $schemas                          = array();
-	public $engines                          = array();
-	public $schema_omit                      = array();
-	public $schema_queries                   = 0;
-	public $dropped_indexes                  = array();
-	public $fail_reads                       = false;
-	public $fail_activity_reads              = false;
-	public $fail_inserts                     = false;
-	public $fail_updates                     = false;
-	public $fail_engine_repair               = false;
-	public $race_activity_insert             = false;
-	public $race_booking_insert              = false;
-	public $race_booking_hash                = null;
-	public $race_activity_read_fail          = false;
-	public $race_event_read_fail             = false;
-	public $concurrent_role_migration        = false;
-	public $reads_before_failure             = null;
-	public $last_query                       = '';
-	public $fail_activity_inserts            = false;
-	public $fail_transaction_start           = false;
-	public $fail_transaction_commit          = false;
-	public $fail_transaction_rollback        = false;
-	public $rollback_queries                 = 0;
-	public $after_membership_lock            = null;
-	public $after_venue_lock                 = null;
-	public $fail_venue_lock                  = false;
-	public $venue_lock_queries               = 0;
-	public $transaction_active               = false;
-	public $natural_key_reads_in_transaction = 0;
-	public $get_lock_result                  = 1;
-	public $release_lock_result              = 1;
-	public $lock_names                       = array();
-	public $event_dates                      = array();
+	public $prefix                            = 'wp_7_';
+	public $terms                             = 'wp_7_terms';
+	public $posts                             = 'wp_7_posts';
+	public $term_relationships                = 'wp_7_term_relationships';
+	public $term_taxonomy                     = 'wp_7_term_taxonomy';
+	public $insert_id                         = 0;
+	public $last_error                        = '';
+	public $rows                              = array();
+	public $schemas                           = array();
+	public $engines                           = array();
+	public $schema_omit                       = array();
+	public $schema_queries                    = 0;
+	public $dropped_indexes                   = array();
+	public $fail_reads                        = false;
+	public $fail_activity_reads               = false;
+	public $fail_inserts                      = false;
+	public $fail_updates                      = false;
+	public $fail_engine_repair                = false;
+	public $race_activity_insert              = false;
+	public $race_booking_insert               = false;
+	public $race_booking_hash                 = null;
+	public $race_activity_read_fail           = false;
+	public $race_event_read_fail              = false;
+	public $concurrent_role_migration         = false;
+	public $reads_before_failure              = null;
+	public $last_query                        = '';
+	public $fail_activity_inserts             = false;
+	public $fail_transaction_start            = false;
+	public $fail_transaction_commit           = false;
+	public $fail_transaction_rollback         = false;
+	public $rollback_queries                  = 0;
+	public $after_membership_lock             = null;
+	public $after_venue_lock                  = null;
+	public $fail_venue_lock                   = false;
+	public $venue_lock_queries                = 0;
+	public $transaction_active                = false;
+	public $natural_key_reads_in_transaction  = 0;
+	public $get_lock_result                   = 1;
+	public $release_lock_result               = 1;
+	public $lock_names                        = array();
+	public $event_dates                       = array();
 	public $elapse_hold_after_membership_lock = null;
 	public $elapse_hold_before_release_update = null;
 	public $elapse_hold_before_conversion_update = null;
@@ -397,7 +403,7 @@ final class BookingWpdb {
 					continue;
 				}
 				foreach ( $this->rows[ $this->prefix . 'ec_booking_holds' ] ?? array() as $hold ) {
-					if ( (int) $hold['booking_id'] === (int) $booking['id'] && (int) $hold['venue_term_id'] === (int) $booking['venue_term_id'] && $hold['space_key'] === $booking['space_key'] && $hold['start_at'] === $booking['requested_start_at'] && $hold['end_at'] === $booking['requested_end_at'] && 'active' === $hold['status'] && $hold['expires_at'] <= $database_now ) {
+					if ( (int) $hold['booking_id'] === (int) $booking['id'] && (int) $hold['venue_term_id'] === (int) $booking['venue_term_id'] && $hold['space_key'] === $booking['space_key'] && $hold['start_at'] === $booking['performance_start_at'] && $hold['end_at'] === $booking['performance_end_at'] && 'active' === $hold['status'] && $hold['expires_at'] <= $database_now ) {
 						return $booking['id'];
 					}
 				}
@@ -516,9 +522,9 @@ final class BookingWpdb {
 			return null;
 		}
 		if ( ! $is_hold && false !== strpos( $query, "'confirmed_booking' AS conflict_type" ) ) {
-			preg_match( "/venue_term_id = (\d+) AND space_key = '([^']+)'.*requested_start_at < '([^']+)' AND requested_end_at > '([^']+)' AND id <> (\d+)/", $query, $match );
+			preg_match( "/venue_term_id = (\d+) AND space_key = '([^']+)'.*performance_start_at < '([^']+)' AND performance_end_at > '([^']+)' AND id <> (\d+)/", $query, $match );
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
-				if ( (int) $row['venue_term_id'] === (int) $match[1] && $row['space_key'] === stripslashes( $match[2] ) && 'confirmed' === $row['status'] && $row['requested_start_at'] < $match[3] && $row['requested_end_at'] > $match[4] && (int) $row['id'] !== (int) $match[5] ) {
+				if ( (int) $row['venue_term_id'] === (int) $match[1] && $row['space_key'] === stripslashes( $match[2] ) && 'confirmed' === $row['status'] && $row['performance_start_at'] < $match[3] && $row['performance_end_at'] > $match[4] && (int) $row['id'] !== (int) $match[5] ) {
 					return array(
 						'id'            => $row['id'],
 						'conflict_type' => 'confirmed_booking',
@@ -581,13 +587,18 @@ final class BookingWpdb {
 					continue;
 				}
 				foreach ( $this->rows[ $this->prefix . 'ec_booking_holds' ] ?? array() as $hold ) {
-					if ( (int) $hold['booking_id'] === (int) $booking['id'] && (int) $hold['venue_term_id'] === (int) $booking['venue_term_id'] && $hold['space_key'] === $booking['space_key'] && $hold['start_at'] === $booking['requested_start_at'] && $hold['end_at'] === $booking['requested_end_at'] && 'active' === $hold['status'] && $hold['expires_at'] <= $this->current_database_time() ) {
+					if ( (int) $hold['booking_id'] === (int) $booking['id'] && (int) $hold['venue_term_id'] === (int) $booking['venue_term_id'] && $hold['space_key'] === $booking['space_key'] && $hold['start_at'] === $booking['performance_start_at'] && $hold['end_at'] === $booking['performance_end_at'] && 'active' === $hold['status'] && $hold['expires_at'] <= $this->current_database_time() ) {
 						$rows[] = $booking;
 						break;
 					}
 				}
 			}
-			usort( $rows, static function ( $left, $right ) { return $left['id'] <=> $right['id']; } );
+			usort(
+				$rows,
+				static function ( $left, $right ) {
+					return $left['id'] <=> $right['id'];
+				}
+			);
 			return array_slice( $rows, 0, 100 );
 		}
 		if ( preg_match( '/SHOW COLUMNS FROM `([^`]+)`/', $query, $match ) ) {
@@ -664,7 +675,14 @@ final class BookingWpdb {
 		} elseif ( $is_hold && false !== strpos( $query, "(status = 'expired' OR (status = 'active'" ) && preg_match( "/expires_at <= '([^']+)'/", $query, $filter ) ) {
 			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $filter ) { return 'expired' === $row['status'] || ( 'active' === $row['status'] && $row['expires_at'] <= $filter[1] ); } ) );
 		} elseif ( $is_hold && false !== strpos( $query, "status = 'active' AND expires_at >" ) && preg_match( "/expires_at > '([^']+)'/", $query, $filter ) ) {
-			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $filter ) { return 'active' === $row['status'] && $row['expires_at'] > $filter[1]; } ) );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $filter ) {
+						return 'active' === $row['status'] && $row['expires_at'] > $filter[1];
+					}
+				)
+			);
 		} elseif ( preg_match( "/status = '([^']+)'/", $query, $filter ) ) {
 			$rows = array_values(
 				array_filter(
@@ -817,7 +835,7 @@ final class BookingWpdb {
 			$id       = (int) $release_hold[2];
 			$expected = (int) $release_hold[3];
 			if ( (int) $this->elapse_hold_before_release_update === $id ) {
-				$past = gmdate( 'Y-m-d H:i:s' );
+				$past                                      = gmdate( 'Y-m-d H:i:s' );
 				$this->rows[ $table ][ $id ]['expires_at'] = $past;
 				if ( is_array( $this->transaction_snapshot ) ) {
 					$this->transaction_snapshot[ $table ][ $id ]['expires_at'] = $past;
@@ -880,7 +898,7 @@ final class BookingWpdb {
 		if ( false !== strpos( $query, 'event_id IS NULL' ) && null !== $this->rows[ $table ][ $id ]['event_id'] ) {
 			return 0; }
 		$set = substr( $query, strpos( $query, ' SET ' ) + 5, strpos( $query, ' WHERE ' ) - strpos( $query, ' SET ' ) - 5 );
-		preg_match_all( "/([a-z_]+) = (version \\+ 1|NULL|\\d+|'(?:\\\\.|[^'])*')(?=, [a-z_]+ = |$)/", $set, $assignments, PREG_SET_ORDER );
+		preg_match_all( "/([a-z_]+) = (version \\+ 1|NULL|\\d+|[a-z_]+|'(?:\\\\.|[^'])*')(?=, [a-z_]+ = |$)/", $set, $assignments, PREG_SET_ORDER );
 		foreach ( $assignments as $assignment ) {
 			$column = $assignment[1];
 			$value  = $assignment[2];
@@ -890,6 +908,8 @@ final class BookingWpdb {
 				$this->rows[ $table ][ $id ][ $column ] = null;
 			} elseif ( "'" === substr( $value, 0, 1 ) ) {
 				$this->rows[ $table ][ $id ][ $column ] = stripslashes( substr( $value, 1, -1 ) );
+			} elseif ( preg_match( '/^[a-z_]+$/', $value ) ) {
+				$this->rows[ $table ][ $id ][ $column ] = $this->rows[ $table ][ $id ][ $value ] ?? null;
 			} else {
 				$this->rows[ $table ][ $id ][ $column ] = (int) $value;
 			}
@@ -904,10 +924,12 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueAuthorization.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingActivityRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingHoldRepository.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingMutationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingLifecycle.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueBookingConfig.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingHoldAbilities.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingMutationAbilities.php';
 
 final class BookingTestAuthorization extends VenueAuthorization {
 	public $calls   = array();


### PR DESCRIPTION
## Summary
- separate artist-requested booking facts from authoritative venue performance scheduling
- add venue-scoped intake, performance, production, and complete draft-deal mutation abilities with optimistic concurrency and atomic activity history
- freeze the exact draft deal during hold-aware confirmation and reject illegal post-confirmation changes
- move hold, confirmed-booking, and canonical-event conflict checks to authoritative performance dates

## Safety
- every mutation reauthorizes exact-venue access under the membership lock
- performance selection reuses the hold aggregate's venue/space advisory lock and conflict checks
- no-op replacements do not increment versions or append activity
- activity failures roll back aggregate mutations; uncertain commits do not claim rollback
- public inquiry receipts remain private-data-free

## Verification
- `php /mnt/extrachill-workspace/tmp/opencode/phpunit-11.phar -c phpunit-booking.xml.dist` (81 tests, 659 assertions)
- `php /mnt/extrachill-workspace/tmp/opencode/phpunit-11.phar -c phpunit.xml.dist tests/VenueMembershipAuthorizationTest.php` (12 tests, 88 assertions)
- Homeboy changed-file PHPCS and PHPStan level 7
- PHP syntax and `git diff --check`

## Stack
- stacked on #337 / issue #295 because scheduling mutations reuse its hold lock and conflict aggregate
- real two-connection concurrency proof remains #299
- canonical event writer lock participation remains #334

Closes #311