### PR TITLE
feat: authorize venue profile management

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -250,6 +250,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingLifecycle.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingConfig.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueProfile.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/ArtistUrlImport.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/ArtistUrlImportRoutes.php';
 
@@ -337,6 +338,9 @@ class ExtraChillEvents {
 
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueBookingConfigAbilities.php';
 			new \ExtraChillEvents\Abilities\VenueBookingConfigAbilities();
+
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueProfileAbilities.php';
+			new \ExtraChillEvents\Abilities\VenueProfileAbilities();
 
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueBookingAbilities.php';
 			new \ExtraChillEvents\Abilities\VenueBookingAbilities();

--- a/inc/Abilities/VenueProfileAbilities.php
+++ b/inc/Abilities/VenueProfileAbilities.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Authorized canonical venue profile abilities.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+use ExtraChillEvents\Core\VenueAuthorization;
+use ExtraChillEvents\Core\VenueProfile;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Registers bounded venue profile read and complete-replacement operations. */
+class VenueProfileAbilities {
+
+	/**
+	 * Whether hooks were registered in this request.
+	 *
+	 * @var bool
+	 */
+	private static bool $registered = false;
+
+	/**
+	 * Exact venue membership authorization service.
+	 *
+	 * @var VenueAuthorization
+	 */
+	private $authorization;
+
+	/**
+	 * Canonical profile service.
+	 *
+	 * @var VenueProfile
+	 */
+	private $profiles;
+
+	/**
+	 * Construct the ability registrar.
+	 *
+	 * @param VenueProfile|null       $profiles      Optional profile service.
+	 * @param VenueAuthorization|null $authorization Optional authorization service.
+	 */
+	public function __construct( ?VenueProfile $profiles = null, ?VenueAuthorization $authorization = null ) {
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+		$this->profiles      = $profiles ? $profiles : new VenueProfile( $this->authorization );
+		if ( ! self::$registered ) {
+			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+			self::$registered = true;
+		}
+	}
+
+	/** Register stable read and update contracts. */
+	public function register(): void {
+		$venue_property = array(
+			'type'        => 'integer',
+			'minimum'     => 1,
+			'description' => __( 'Canonical Events-site venue term ID.', 'extrachill-events' ),
+		);
+
+		wp_register_ability(
+			'extrachill/get-venue-profile',
+			array(
+				'label'               => __( 'Get Venue Profile', 'extrachill-events' ),
+				'description'         => __( 'Read the canonical member-facing profile for an authorized venue.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array( 'venue_term_id' => $venue_property ),
+					'required'             => array( 'venue_term_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => $this->document_schema(),
+				'execute_callback'    => array( $this, 'get_profile' ),
+				'permission_callback' => array( $this, 'can_access_venue' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => true,
+						'idempotent'  => true,
+						'destructive' => false,
+					),
+				),
+			)
+		);
+
+		wp_register_ability(
+			'extrachill/update-venue-profile',
+			array(
+				'label'               => __( 'Update Venue Profile', 'extrachill-events' ),
+				'description'         => __( 'Atomically replace the member-editable venue profile at an expected revision.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'venue_term_id'     => $venue_property,
+						'expected_revision' => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'profile'           => $this->profile_schema(),
+					),
+					'required'             => array( 'venue_term_id', 'expected_revision', 'profile' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => $this->document_schema(),
+				'execute_callback'    => array( $this, 'update_profile' ),
+				'permission_callback' => array( $this, 'can_access_venue' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => false,
+						'idempotent'  => false,
+						'destructive' => true,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Authorize the established feature gate and exact active venue membership.
+	 *
+	 * @param array $input Ability input.
+	 * @return true|\WP_Error Authorization result.
+	 */
+	public function can_access_venue( array $input ) {
+		return $this->authorization->authorize(
+			get_current_user_id(),
+			absint( $input['venue_term_id'] ?? 0 ),
+			VenueAuthorization::ACTION_ACCESS_VENUE
+		);
+	}
+
+	/**
+	 * Read one authorized canonical venue profile.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error Profile document or an error.
+	 */
+	public function get_profile( array $input ) {
+		$venue_term_id = absint( $input['venue_term_id'] ?? 0 );
+		$allowed       = $this->authorization->authorize( get_current_user_id(), $venue_term_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+		return is_wp_error( $allowed ) ? $allowed : $this->profiles->get( $venue_term_id );
+	}
+
+	/**
+	 * Replace one authorized canonical venue profile.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error Updated profile document or an error.
+	 */
+	public function update_profile( array $input ) {
+		return $this->profiles->update(
+			absint( $input['venue_term_id'] ?? 0 ),
+			(array) ( $input['profile'] ?? array() ),
+			(int) ( $input['expected_revision'] ?? -1 ),
+			get_current_user_id()
+		);
+	}
+
+	/** Return the strict member-editable profile schema. */
+	private function profile_schema(): array {
+		$nullable_text = static function ( int $max_length ): array {
+			return array(
+				'type'      => 'string',
+				'maxLength' => $max_length,
+			);
+		};
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'name'        => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 191,
+				),
+				'description' => $nullable_text( 10000 ),
+				'address'     => $nullable_text( 255 ),
+				'city'        => $nullable_text( 191 ),
+				'state'       => $nullable_text( 100 ),
+				'zip'         => $nullable_text( 32 ),
+				'country'     => $nullable_text( 100 ),
+				'phone'       => $nullable_text( 64 ),
+				'website'     => array(
+					'type'      => 'string',
+					'maxLength' => 2048,
+				),
+				'capacity'    => array(
+					'type'    => array( 'integer', 'null' ),
+					'minimum' => 1,
+					'maximum' => 1000000,
+				),
+			),
+			'required'             => array( 'name', 'description', 'address', 'city', 'state', 'zip', 'country', 'phone', 'website', 'capacity' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	/** Return the stable versioned output schema. */
+	private function document_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'version'            => array(
+					'type' => 'integer',
+					'enum' => array( VenueProfile::VERSION ),
+				),
+				'venue_term_id'      => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'revision'           => array(
+					'type'    => 'integer',
+					'minimum' => 0,
+				),
+				'updated_by_user_id' => array( 'type' => array( 'integer', 'null' ) ),
+				'updated_at'         => array( 'type' => array( 'string', 'null' ) ),
+				'profile'            => $this->profile_schema(),
+			),
+			'required'             => array( 'version', 'venue_term_id', 'revision', 'updated_by_user_id', 'updated_at', 'profile' ),
+			'additionalProperties' => false,
+		);
+	}
+}

--- a/inc/Core/VenueProfile.php
+++ b/inc/Core/VenueProfile.php
@@ -1,0 +1,600 @@
+<?php
+/**
+ * Authorized canonical venue profile management.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Owns the member-editable boundary, revisions, and audit for venue profiles. */
+class VenueProfile {
+
+	public const STATE_META_KEY   = '_extrachill_venue_profile_state';
+	public const HISTORY_META_KEY = '_extrachill_venue_profile_history';
+	public const VERSION          = 1;
+
+	private const META_FIELDS = array(
+		'address'  => '_venue_address',
+		'city'     => '_venue_city',
+		'state'    => '_venue_state',
+		'zip'      => '_venue_zip',
+		'country'  => '_venue_country',
+		'phone'    => '_venue_phone',
+		'website'  => '_venue_website',
+		'capacity' => '_venue_capacity',
+	);
+
+	private const PROFILE_FIELDS = array(
+		'name',
+		'description',
+		'address',
+		'city',
+		'state',
+		'zip',
+		'country',
+		'phone',
+		'website',
+		'capacity',
+	);
+
+	/**
+	 * Exact venue membership authorization service.
+	 *
+	 * @var VenueAuthorization
+	 */
+	private $authorization;
+
+	/**
+	 * Construct the profile service.
+	 *
+	 * @param VenueAuthorization|null $authorization Optional authorization service.
+	 */
+	public function __construct( ?VenueAuthorization $authorization = null ) {
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+	}
+
+	/**
+	 * Return the stable member-facing profile document for one canonical venue.
+	 *
+	 * @param int $venue_term_id Canonical Events-site venue term ID.
+	 * @return array|\WP_Error Profile document or an error.
+	 */
+	public function get( int $venue_term_id ) {
+		$venue = $this->venue( $venue_term_id );
+		if ( is_wp_error( $venue ) ) {
+			return $venue;
+		}
+
+		$state = $this->state( $venue_term_id );
+		if ( is_wp_error( $state ) ) {
+			return $state;
+		}
+
+		return $this->document( $venue, $state );
+	}
+
+	/**
+	 * Atomically replace all member-editable fields at one expected revision.
+	 *
+	 * @param int   $venue_term_id     Canonical Events-site venue term ID.
+	 * @param array $profile           Complete member-editable profile.
+	 * @param int   $expected_revision Revision observed by the caller.
+	 * @param int   $actor_user_id     Network user performing the update.
+	 * @return array|\WP_Error Updated profile document or an error.
+	 */
+	public function update( int $venue_term_id, array $profile, int $expected_revision, int $actor_user_id ) {
+		global $wpdb;
+
+		$venue = $this->venue( $venue_term_id );
+		if ( is_wp_error( $venue ) ) {
+			return $venue;
+		}
+		if ( $expected_revision < 0 ) {
+			return new \WP_Error( 'invalid_venue_profile_revision', __( 'The expected venue profile revision must be zero or greater.', 'extrachill-events' ) );
+		}
+		$normalized = $this->normalize( $profile );
+		if ( is_wp_error( $normalized ) ) {
+			return $normalized;
+		}
+
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serializes authorization, canonical fields, revision, and audit.
+			return new \WP_Error( 'venue_profile_transaction_failed', __( 'The venue profile transaction could not start.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+
+		$memberships = BookingSchema::memberships_table();
+		$wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$memberships} WHERE venue_term_id = %d AND user_id = %d FOR UPDATE", $venue_term_id, $actor_user_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks this actor's exact venue authority.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return $this->rollback_error( 'venue_profile_authorization_lock_failed', __( 'Venue profile authority could not be locked.', 'extrachill-events' ), $venue_term_id );
+		}
+		$allowed = $this->authorization->authorize( $actor_user_id, $venue_term_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+		if ( is_wp_error( $allowed ) ) {
+			$this->rollback( $venue_term_id );
+			return $allowed;
+		}
+
+		$locked_term = $wpdb->get_var( $wpdb->prepare( "SELECT term_id FROM {$wpdb->terms} WHERE term_id = %d FOR UPDATE", $venue_term_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- One venue lock serializes all profile revisions.
+		if ( '' !== (string) $wpdb->last_error || $venue_term_id !== (int) $locked_term ) {
+			return $this->rollback_error( 'venue_profile_lock_failed', __( 'The venue profile could not be locked.', 'extrachill-events' ), $venue_term_id );
+		}
+		$wpdb->get_results( $wpdb->prepare( "SELECT meta_id FROM {$wpdb->termmeta} WHERE term_id = %d FOR UPDATE", $venue_term_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks the venue's existing metadata range before the complete profile snapshot.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return $this->rollback_error( 'venue_profile_lock_failed', __( 'The venue profile metadata could not be locked.', 'extrachill-events' ), $venue_term_id );
+		}
+
+		$this->clear_cache( $venue_term_id );
+		$current = $this->get( $venue_term_id );
+		if ( is_wp_error( $current ) ) {
+			$this->rollback( $venue_term_id );
+			return $current;
+		}
+		if ( $current['revision'] !== $expected_revision ) {
+			$this->rollback( $venue_term_id );
+			return new \WP_Error(
+				'venue_profile_revision_conflict',
+				__( 'The venue profile changed since it was read.', 'extrachill-events' ),
+				array(
+					'status'           => 409,
+					'current_revision' => $current['revision'],
+				)
+			);
+		}
+
+		$changed_fields = $this->changed_fields( $current['profile'], $normalized );
+		if ( empty( $changed_fields ) ) {
+			if ( false === $wpdb->query( 'COMMIT' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Releases locks after a validated no-op.
+				$this->clear_cache( $venue_term_id );
+				return new \WP_Error( 'venue_profile_commit_uncertain', __( 'The venue profile transaction outcome could not be confirmed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+			}
+			$this->clear_cache( $venue_term_id );
+			return $current;
+		}
+
+		if ( in_array( 'name', $changed_fields, true ) ) {
+			$result = $wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Canonical term write must commit with revision and audit.
+				$wpdb->terms,
+				array( 'name' => $normalized['name'] ),
+				array( 'term_id' => $venue_term_id ),
+				array( '%s' ),
+				array( '%d' )
+			);
+			if ( false === $result || 1 !== $result ) {
+				return $this->rollback_error( 'venue_profile_save_failed', __( 'The venue profile name could not be saved.', 'extrachill-events' ), $venue_term_id );
+			}
+		}
+		if ( in_array( 'description', $changed_fields, true ) ) {
+			$result = $wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Canonical description write must commit with revision and audit.
+				$wpdb->term_taxonomy,
+				array( 'description' => $normalized['description'] ),
+				array(
+					'term_id'  => $venue_term_id,
+					'taxonomy' => 'venue',
+				),
+				array( '%s' ),
+				array( '%d', '%s' )
+			);
+			if ( false === $result || 1 !== $result ) {
+				return $this->rollback_error( 'venue_profile_save_failed', __( 'The venue profile description could not be saved.', 'extrachill-events' ), $venue_term_id );
+			}
+		}
+
+		$meta_changes = array();
+		foreach ( self::META_FIELDS as $field => $meta_key ) {
+			if ( ! in_array( $field, $changed_fields, true ) ) {
+				continue;
+			}
+			$value       = 'capacity' === $field && null !== $normalized[ $field ] ? (string) $normalized[ $field ] : $normalized[ $field ];
+			$meta_change = $this->write_meta( $venue_term_id, $meta_key, $value );
+			if ( is_wp_error( $meta_change ) ) {
+				return $this->rollback_error( 'venue_profile_save_failed', __( 'The venue profile could not be saved.', 'extrachill-events' ), $venue_term_id );
+			}
+			$meta_changes[] = $meta_change;
+		}
+
+		$address_changed = (bool) array_intersect( array( 'address', 'city', 'state', 'zip', 'country' ), $changed_fields );
+		if ( $address_changed ) {
+			$coordinate_change = $this->write_meta( $venue_term_id, '_venue_coordinates', '' );
+			if ( is_wp_error( $coordinate_change ) ) {
+				return $this->rollback_error( 'venue_profile_save_failed', __( 'The venue profile coordinates could not be invalidated.', 'extrachill-events' ), $venue_term_id );
+			}
+			if ( 'none' !== $coordinate_change['operation'] ) {
+				$meta_changes[] = $coordinate_change;
+			}
+		}
+
+		$now          = gmdate( 'Y-m-d H:i:s' );
+		$state        = array(
+			'version'            => self::VERSION,
+			'revision'           => $current['revision'] + 1,
+			'updated_by_user_id' => $actor_user_id,
+			'updated_at'         => $now,
+		);
+		$state_change = $this->write_meta( $venue_term_id, self::STATE_META_KEY, $state );
+		if ( is_wp_error( $state_change ) ) {
+			return $this->rollback_error( 'venue_profile_state_failed', __( 'The venue profile revision could not be saved.', 'extrachill-events' ), $venue_term_id );
+		}
+		$meta_changes[] = $state_change;
+
+		$audit         = array(
+			'version'           => 1,
+			'previous_revision' => $current['revision'],
+			'revision'          => $state['revision'],
+			'actor_user_id'     => $actor_user_id,
+			'changed_fields'    => $changed_fields,
+			'occurred_at'       => $now,
+		);
+		$audit_result  = $wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Audit must commit atomically with canonical profile fields.
+			$wpdb->termmeta,
+			array(
+				'term_id'    => $venue_term_id,
+				'meta_key'   => self::HISTORY_META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Canonical private audit key.
+				'meta_value' => maybe_serialize( $audit ), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Canonical serialized audit document.
+			),
+			array( '%d', '%s', '%s' )
+		);
+		$audit_meta_id = (int) $wpdb->insert_id;
+		if ( false === $audit_result || 1 !== $audit_result || 1 > $audit_meta_id ) {
+			return $this->rollback_error( 'venue_profile_audit_failed', __( 'The venue profile audit record could not be saved.', 'extrachill-events' ), $venue_term_id );
+		}
+		if ( false === $wpdb->query( 'COMMIT' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Commits canonical fields, revision, and audit together.
+			$this->clear_cache( $venue_term_id );
+			return new \WP_Error( 'venue_profile_commit_uncertain', __( 'The venue profile transaction outcome could not be confirmed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+
+		$this->clear_cache( $venue_term_id );
+		$this->dispatch_meta_changes( $venue_term_id, $meta_changes );
+		do_action( 'added_term_meta', $audit_meta_id, $venue_term_id, self::HISTORY_META_KEY, $audit );
+		if ( $address_changed && class_exists( '\DataMachineEvents\Core\Venue_Taxonomy' ) ) {
+			\DataMachineEvents\Core\Venue_Taxonomy::maybe_geocode_venue( $venue_term_id );
+		}
+		if ( function_exists( 'extrachill_events_invalidate_location_venue_cache' ) ) {
+			extrachill_events_invalidate_location_venue_cache( $venue_term_id );
+		}
+		do_action( 'extrachill_events_venue_profile_updated', $venue_term_id, $actor_user_id, $current['profile'], $normalized, $audit );
+
+		return array(
+			'version'            => self::VERSION,
+			'venue_term_id'      => $venue_term_id,
+			'revision'           => $state['revision'],
+			'updated_by_user_id' => $actor_user_id,
+			'updated_at'         => $now,
+			'profile'            => $normalized,
+		);
+	}
+
+	/**
+	 * Normalize and validate the complete member-editable profile.
+	 *
+	 * @param array $profile Complete candidate profile.
+	 * @return array|\WP_Error Normalized profile or an error.
+	 */
+	public function normalize( array $profile ) {
+		$keys       = array_keys( $profile );
+		$unexpected = array_diff( $keys, self::PROFILE_FIELDS );
+		$missing    = array_diff( self::PROFILE_FIELDS, $keys );
+		if ( ! empty( $unexpected ) || ! empty( $missing ) ) {
+			return new \WP_Error(
+				'invalid_venue_profile_fields',
+				__( 'The venue profile must contain exactly the member-editable fields.', 'extrachill-events' ),
+				array(
+					'unexpected_fields' => array_values( $unexpected ),
+					'missing_fields'    => array_values( $missing ),
+				)
+			);
+		}
+
+		$name = $this->text( $profile['name'], 'name', 191, false );
+		if ( is_wp_error( $name ) ) {
+			return $name;
+		}
+		$description = $this->description( $profile['description'] );
+		if ( is_wp_error( $description ) ) {
+			return $description;
+		}
+
+		$limits = array(
+			'address' => 255,
+			'city'    => 191,
+			'state'   => 100,
+			'zip'     => 32,
+			'country' => 100,
+			'phone'   => 64,
+		);
+		$result = array(
+			'name'        => $name,
+			'description' => $description,
+		);
+		foreach ( $limits as $field => $limit ) {
+			$value = $this->text( $profile[ $field ], $field, $limit, true );
+			if ( is_wp_error( $value ) ) {
+				return $value;
+			}
+			$result[ $field ] = $value;
+		}
+		if ( '' !== $result['phone'] && ( ! preg_match( '/[0-9]/', $result['phone'] ) || preg_match( '/[^0-9+(). xX#\-]/', $result['phone'] ) ) ) {
+			return new \WP_Error( 'invalid_venue_profile_value', __( 'The venue phone number is invalid.', 'extrachill-events' ), array( 'field' => 'phone' ) );
+		}
+
+		if ( ! is_string( $profile['website'] ) ) {
+			return new \WP_Error( 'invalid_venue_profile_value', __( 'The venue website must be a string.', 'extrachill-events' ), array( 'field' => 'website' ) );
+		}
+		$website = trim( $profile['website'] );
+		if ( '' !== $website ) {
+			$website = esc_url_raw( $website, array( 'http', 'https' ) );
+			if ( '' === $website || strlen( $website ) > 2048 || ! filter_var( $website, FILTER_VALIDATE_URL ) ) {
+				return new \WP_Error( 'invalid_venue_profile_value', __( 'The venue website must be a valid HTTP or HTTPS URL.', 'extrachill-events' ), array( 'field' => 'website' ) );
+			}
+		}
+		$result['website'] = $website;
+
+		$capacity = $profile['capacity'];
+		if ( null !== $capacity && ( ! is_int( $capacity ) || $capacity < 1 || $capacity > 1000000 ) ) {
+			return new \WP_Error( 'invalid_venue_profile_value', __( 'Venue capacity must be null or an integer between 1 and 1000000.', 'extrachill-events' ), array( 'field' => 'capacity' ) );
+		}
+		$result['capacity'] = $capacity;
+
+		return $result;
+	}
+
+	/**
+	 * Return only public contract metadata and canonical editable fields.
+	 *
+	 * @param \WP_Term $venue Canonical venue term.
+	 * @param array    $state Profile revision state.
+	 * @return array Stable profile document.
+	 */
+	private function document( $venue, array $state ): array {
+		$capacity = get_term_meta( $venue->term_id, self::META_FIELDS['capacity'], true );
+		$profile  = array(
+			'name'        => (string) $venue->name,
+			'description' => (string) $venue->description,
+		);
+		foreach ( self::META_FIELDS as $field => $meta_key ) {
+			if ( 'capacity' !== $field ) {
+				$profile[ $field ] = (string) get_term_meta( $venue->term_id, $meta_key, true );
+			}
+		}
+		$profile['capacity'] = '' === $capacity || null === $capacity ? null : ( ctype_digit( (string) $capacity ) ? (int) $capacity : null );
+
+		return array(
+			'version'            => self::VERSION,
+			'venue_term_id'      => (int) $venue->term_id,
+			'revision'           => $state['revision'],
+			'updated_by_user_id' => $state['updated_by_user_id'],
+			'updated_at'         => $state['updated_at'],
+			'profile'            => $profile,
+		);
+	}
+
+	/**
+	 * Read and validate private profile revision state.
+	 *
+	 * @param int $venue_term_id Canonical venue term ID.
+	 * @return array|\WP_Error Revision state or an error.
+	 */
+	private function state( int $venue_term_id ) {
+		$stored = get_term_meta( $venue_term_id, self::STATE_META_KEY, true );
+		if ( '' === $stored || null === $stored ) {
+			return array(
+				'version'            => self::VERSION,
+				'revision'           => 0,
+				'updated_by_user_id' => null,
+				'updated_at'         => null,
+			);
+		}
+		if ( ! is_array( $stored ) || self::VERSION !== ( $stored['version'] ?? null ) || ! is_int( $stored['revision'] ?? null ) || $stored['revision'] < 0 ) {
+			return new \WP_Error( 'invalid_venue_profile_state', __( 'Stored venue profile state is malformed.', 'extrachill-events' ) );
+		}
+		$actor = $stored['updated_by_user_id'] ?? null;
+		$time  = $stored['updated_at'] ?? null;
+		if ( ( null !== $actor && ( ! is_int( $actor ) || $actor < 1 ) ) || ( null !== $time && ! is_string( $time ) ) ) {
+			return new \WP_Error( 'invalid_venue_profile_state', __( 'Stored venue profile state is malformed.', 'extrachill-events' ) );
+		}
+		return array(
+			'version'            => self::VERSION,
+			'revision'           => $stored['revision'],
+			'updated_by_user_id' => $actor,
+			'updated_at'         => $time,
+		);
+	}
+
+	/**
+	 * Resolve a venue only in the canonical Events-site context.
+	 *
+	 * @param int $venue_term_id Candidate venue term ID.
+	 * @return \WP_Term|\WP_Error Canonical venue term or an error.
+	 */
+	private function venue( int $venue_term_id ) {
+		if ( ! function_exists( 'ec_get_blog_id' ) || ! function_exists( 'get_current_blog_id' ) ) {
+			return new \WP_Error( 'canonical_events_site_required', __( 'The canonical Events site could not be resolved.', 'extrachill-events' ), array( 'status' => 500 ) );
+		}
+		$events_blog_id = (int) ec_get_blog_id( 'events' );
+		if ( 1 > $events_blog_id || (int) get_current_blog_id() !== $events_blog_id ) {
+			return new \WP_Error( 'canonical_events_site_required', __( 'Venue profiles must be resolved on the canonical Events site.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$venue = get_term( $venue_term_id, 'venue' );
+		if ( 1 > $venue_term_id || ! $venue || is_wp_error( $venue ) || 'venue' !== $venue->taxonomy ) {
+			return new \WP_Error( 'invalid_venue_profile_venue', __( 'A valid Events venue term is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return $venue;
+	}
+
+	/**
+	 * Validate and sanitize one bounded plain-text field.
+	 *
+	 * @param mixed  $value       Candidate value.
+	 * @param string $field       Public field name.
+	 * @param int    $limit       Maximum character count.
+	 * @param bool   $allow_empty Whether an empty value is valid.
+	 * @return string|\WP_Error Sanitized text or an error.
+	 */
+	private function text( $value, string $field, int $limit, bool $allow_empty ) {
+		if ( ! is_string( $value ) ) {
+			return new \WP_Error( 'invalid_venue_profile_value', __( 'Venue profile text fields must be strings.', 'extrachill-events' ), array( 'field' => $field ) );
+		}
+		$value = sanitize_text_field( $value );
+		if ( ( ! $allow_empty && '' === $value ) || mb_strlen( $value ) > $limit ) {
+			return new \WP_Error( 'invalid_venue_profile_value', __( 'A venue profile field has an invalid length.', 'extrachill-events' ), array( 'field' => $field ) );
+		}
+		return $value;
+	}
+
+	/**
+	 * Validate and sanitize the bounded rich-text description.
+	 *
+	 * @param mixed $value Candidate description.
+	 * @return string|\WP_Error Sanitized description or an error.
+	 */
+	private function description( $value ) {
+		if ( ! is_string( $value ) ) {
+			return new \WP_Error( 'invalid_venue_profile_value', __( 'The venue description must be a string.', 'extrachill-events' ), array( 'field' => 'description' ) );
+		}
+		$value = wp_kses_post( $value );
+		return mb_strlen( $value ) <= 10000
+			? $value
+			: new \WP_Error( 'invalid_venue_profile_value', __( 'The venue description is too long.', 'extrachill-events' ), array( 'field' => 'description' ) );
+	}
+
+	/**
+	 * List fields changed by a complete replacement.
+	 *
+	 * @param array $current     Current normalized profile.
+	 * @param array $replacement Replacement normalized profile.
+	 * @return string[] Changed public field names.
+	 */
+	private function changed_fields( array $current, array $replacement ): array {
+		$changed = array();
+		foreach ( self::PROFILE_FIELDS as $field ) {
+			if ( $current[ $field ] !== $replacement[ $field ] ) {
+				$changed[] = $field;
+			}
+		}
+		return $changed;
+	}
+
+	/**
+	 * Persist one term-meta value without publishing pre-commit hooks or caches.
+	 *
+	 * @param int    $venue_term_id Venue term ID.
+	 * @param string $meta_key      Canonical private meta key.
+	 * @param mixed  $value         Value to persist, or empty to delete.
+	 * @return array|\WP_Error Deferred hook context or an error.
+	 */
+	private function write_meta( int $venue_term_id, string $meta_key, $value ) {
+		global $wpdb;
+
+		$row = $wpdb->get_row( $wpdb->prepare( "SELECT meta_id, meta_value FROM {$wpdb->termmeta} WHERE term_id = %d AND meta_key = %s ORDER BY meta_id ASC LIMIT 1 FOR UPDATE", $venue_term_id, $meta_key ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reads and locks canonical metadata inside the profile transaction.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'venue_profile_meta_read_failed' );
+		}
+		$old_value = is_array( $row ) ? maybe_unserialize( $row['meta_value'] ) : '';
+		if ( '' === $value || null === $value ) {
+			if ( ! is_array( $row ) ) {
+				return array(
+					'operation' => 'none',
+					'meta_id'   => 0,
+					'key'       => $meta_key,
+					'value'     => $old_value,
+				);
+			}
+			$result = $wpdb->delete( $wpdb->termmeta, array( 'meta_id' => (int) $row['meta_id'] ), array( '%d' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Transactional canonical metadata delete.
+			return false === $result || 1 !== $result
+				? new \WP_Error( 'venue_profile_meta_delete_failed' )
+				: array(
+					'operation' => 'delete',
+					'meta_id'   => (int) $row['meta_id'],
+					'key'       => $meta_key,
+					'value'     => $old_value,
+				);
+		}
+
+		$serialized = maybe_serialize( $value );
+		if ( is_array( $row ) ) {
+			$result  = $wpdb->update( $wpdb->termmeta, array( 'meta_value' => $serialized ), array( 'meta_id' => (int) $row['meta_id'] ), array( '%s' ), array( '%d' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Transactional canonical metadata update.
+			$meta_id = (int) $row['meta_id'];
+			$action  = 'update';
+		} else {
+			// Transactional canonical metadata insert; the key and value are private, bounded profile state.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			$result = $wpdb->insert(
+				$wpdb->termmeta,
+				array(
+					'term_id'    => $venue_term_id,
+					'meta_key'   => $meta_key,
+					'meta_value' => $serialized,
+				),
+				array( '%d', '%s', '%s' )
+			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			$meta_id = (int) $wpdb->insert_id;
+			$action  = 'add';
+		}
+		if ( false === $result || 1 !== $result || 1 > $meta_id ) {
+			return new \WP_Error( 'venue_profile_meta_write_failed' );
+		}
+		return array(
+			'operation' => $action,
+			'meta_id'   => $meta_id,
+			'key'       => $meta_key,
+			'value'     => $value,
+		);
+	}
+
+	/**
+	 * Publish standard metadata hooks only after the transaction commits.
+	 *
+	 * @param int   $venue_term_id Venue term ID.
+	 * @param array $changes       Deferred metadata hook contexts.
+	 */
+	private function dispatch_meta_changes( int $venue_term_id, array $changes ): void {
+		foreach ( $changes as $change ) {
+			if ( 'add' === $change['operation'] ) {
+				do_action( 'added_term_meta', $change['meta_id'], $venue_term_id, $change['key'], $change['value'] );
+			} elseif ( 'update' === $change['operation'] ) {
+				do_action( 'updated_term_meta', $change['meta_id'], $venue_term_id, $change['key'], $change['value'] );
+			} elseif ( 'delete' === $change['operation'] ) {
+				do_action( 'deleted_term_meta', array( $change['meta_id'] ), $venue_term_id, $change['key'], $change['value'] );
+			}
+		}
+	}
+
+	/**
+	 * Roll back and return a database-backed profile error.
+	 *
+	 * @param string $code          Error code.
+	 * @param string $message       Public error message.
+	 * @param int    $venue_term_id Venue whose caches must be cleared.
+	 * @return \WP_Error Rollback error.
+	 */
+	private function rollback_error( string $code, string $message, int $venue_term_id ): \WP_Error {
+		global $wpdb;
+		$database_error = $wpdb->last_error;
+		$this->rollback( $venue_term_id );
+		return new \WP_Error( $code, $message, array( 'database_error' => $database_error ) );
+	}
+
+	/**
+	 * Roll back the active transaction and clear venue caches.
+	 *
+	 * @param int $venue_term_id Venue whose caches must be cleared.
+	 */
+	private function rollback( int $venue_term_id ): void {
+		global $wpdb;
+		$wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Rolls back the complete profile mutation.
+		$this->clear_cache( $venue_term_id );
+	}
+
+	/**
+	 * Clear canonical term and metadata caches.
+	 *
+	 * @param int $venue_term_id Venue term ID.
+	 */
+	private function clear_cache( int $venue_term_id ): void {
+		wp_cache_delete( $venue_term_id, 'term_meta' );
+		clean_term_cache( $venue_term_id, 'venue' );
+	}
+}

--- a/inc/Core/VenueProfile.php
+++ b/inc/Core/VenueProfile.php
@@ -87,7 +87,7 @@ class VenueProfile {
 			return $result;
 		}
 
-		$audit = array(
+		$audit        = array(
 			'version'           => 1,
 			'previous_revision' => $expected_revision,
 			'revision'          => (string) ( $result['revision'] ?? '' ),

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -13,6 +13,7 @@
 			<file>tests/BookingMutationTest.php</file>
 			<file>tests/BookingEventConversionTest.php</file>
 			<file>tests/CanonicalEventPublicationGuardTest.php</file>
+			<file>tests/VenueMembershipAuthorizationTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,5 +27,8 @@
 			<file>tests/Unit/SingleEventNetworkBridgeTest.php</file>
 			<file>tests/Unit/ConcertStatsPublicProfileRenderTest.php</file>
 		</testsuite>
+		<testsuite name="venue-membership-authorization">
+			<file>tests/VenueMembershipAuthorizationTest.php</file>
+		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -7,11 +7,13 @@
 
 use ExtraChillEvents\Abilities\VenueMembershipAbilities;
 use ExtraChillEvents\Abilities\VenueBookingConfigAbilities;
+use ExtraChillEvents\Abilities\VenueProfileAbilities;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\VenueAuthorization;
 use ExtraChillEvents\Core\VenueBookingConfig;
 use ExtraChillEvents\Core\VenueMembershipRepository;
 use ExtraChillEvents\Core\VenueMembershipService;
+use ExtraChillEvents\Core\VenueProfile;
 use PHPUnit\Framework\TestCase;
 
 if ( ! defined( 'ARRAY_A' ) ) {
@@ -54,6 +56,23 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 if ( ! function_exists( 'sanitize_text_field' ) ) {
 	function sanitize_text_field( $value ) {
 		return trim( strip_tags( (string) $value ) ); }
+}
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	function wp_kses_post( $value ) {
+		return strip_tags( (string) $value, '<p><br><strong><em><a>' ); }
+}
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $value, $protocols = null ) {
+		unset( $protocols );
+		return filter_var( trim( (string) $value ), FILTER_VALIDATE_URL ) ? trim( (string) $value ) : ''; }
+}
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id() {
+		return $GLOBALS['venue_membership_test']['current_blog_id']; }
+}
+if ( ! function_exists( 'ec_get_blog_id' ) ) {
+	function ec_get_blog_id( $site ) {
+		return 'events' === $site ? 7 : 0; }
 }
 if ( ! function_exists( 'get_term' ) ) {
 	function get_term( $term_id, $taxonomy = '' ) {
@@ -102,6 +121,58 @@ if ( ! function_exists( 'get_term_meta' ) ) {
 		return $GLOBALS['venue_membership_test']['term_meta'][ $term_id ][ $key ] ?? '';
 	}
 }
+if ( ! function_exists( 'update_term_meta' ) ) {
+	function update_term_meta( $term_id, $key, $value ) {
+		if ( VenueProfile::STATE_META_KEY === $key && ! empty( $GLOBALS['venue_membership_test']['fail_profile_state'] ) ) {
+			return false;
+		}
+		$GLOBALS['venue_membership_test']['term_meta'][ $term_id ][ $key ] = $value;
+		return 1;
+	}
+}
+if ( ! function_exists( 'delete_term_meta' ) ) {
+	function delete_term_meta( $term_id, $key ) {
+		if ( ! isset( $GLOBALS['venue_membership_test']['term_meta'][ $term_id ][ $key ] ) ) {
+			return false;
+		}
+		unset( $GLOBALS['venue_membership_test']['term_meta'][ $term_id ][ $key ] );
+		return true;
+	}
+}
+if ( ! function_exists( 'add_term_meta' ) ) {
+	function add_term_meta( $term_id, $key, $value, $unique = false ) {
+		unset( $unique );
+		if ( VenueProfile::HISTORY_META_KEY === $key && ! empty( $GLOBALS['venue_membership_test']['fail_profile_audit'] ) ) {
+			return false;
+		}
+		$GLOBALS['venue_membership_test']['term_history'][ $term_id ][ $key ][] = $value;
+		return count( $GLOBALS['venue_membership_test']['term_history'][ $term_id ][ $key ] );
+	}
+}
+if ( ! function_exists( 'wp_update_term' ) ) {
+	function wp_update_term( $term_id, $taxonomy, $updates ) {
+		$term = $GLOBALS['venue_membership_test']['terms'][ $term_id ] ?? null;
+		if ( ! $term || $taxonomy !== $term->taxonomy ) {
+			return new WP_Error( 'invalid_term' );
+		}
+		foreach ( array( 'name', 'description' ) as $field ) {
+			if ( array_key_exists( $field, $updates ) ) {
+				$term->{$field} = $updates[ $field ];
+			}
+		}
+		return array( 'term_id' => $term_id );
+	}
+}
+if ( ! function_exists( 'clean_term_cache' ) ) {
+	function clean_term_cache( $term_id, $taxonomy = '' ) {
+		$GLOBALS['venue_membership_test']['term_cache_deletes'][] = array( $term_id, $taxonomy );
+	}
+}
+if ( ! function_exists( 'extrachill_events_invalidate_location_venue_cache' ) ) {
+	function extrachill_events_invalidate_location_venue_cache( int $term_id ) {
+		$GLOBALS['venue_membership_test']['location_cache_deletes'][] = $term_id;
+	}
+}
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( $hook, ...$args ) {
 		$GLOBALS['venue_membership_test']['fired_actions'][ $hook ][] = $args;
@@ -131,6 +202,7 @@ if ( ! function_exists( 'maybe_unserialize' ) ) {
 final class VenueMembershipWpdb {
 	public $prefix                = 'wp_7_';
 	public $terms                 = 'wp_7_terms';
+	public $term_taxonomy         = 'wp_7_term_taxonomy';
 	public $termmeta              = 'wp_7_termmeta';
 	public $insert_id             = 0;
 	public $last_error            = '';
@@ -141,8 +213,11 @@ final class VenueMembershipWpdb {
 	private $snapshot             = null;
 	private $meta_snapshot        = null;
 	private $history_snapshot     = null;
+	private $terms_snapshot       = null;
 	private $meta_values          = array();
 	private $meta_values_snapshot = array();
+	private $meta_records         = array();
+	private $meta_records_snapshot = array();
 
 	public function prepare( $query, ...$args ) {
 		if ( 1 === count( $args ) && is_array( $args[0] ) ) {
@@ -170,10 +245,22 @@ final class VenueMembershipWpdb {
 				$this->last_error = 'simulated config audit failure';
 				return false;
 			}
+			if ( VenueProfile::STATE_META_KEY === $row['meta_key'] && ! empty( $GLOBALS['venue_membership_test']['fail_profile_state'] ) ) {
+				$this->last_error = 'simulated profile state failure';
+				return false;
+			}
+			if ( VenueProfile::HISTORY_META_KEY === $row['meta_key'] && ! empty( $GLOBALS['venue_membership_test']['fail_profile_audit'] ) ) {
+				$this->last_error = 'simulated profile audit failure';
+				return false;
+			}
 			$this->insert_id                       = max( 101, $this->insert_id + 1 );
 			$this->meta_values[ $this->insert_id ] = $row['meta_value'];
+			$this->meta_records[ $this->insert_id ] = array(
+				'term_id'  => (int) $row['term_id'],
+				'meta_key' => $row['meta_key'],
+			);
 			$value                                 = maybe_unserialize( $row['meta_value'] );
-			if ( VenueBookingConfig::HISTORY_META_KEY === $row['meta_key'] ) {
+			if ( in_array( $row['meta_key'], array( VenueBookingConfig::HISTORY_META_KEY, VenueProfile::HISTORY_META_KEY ), true ) ) {
 				$GLOBALS['venue_membership_test']['term_history'][ $row['term_id'] ][ $row['meta_key'] ][] = $value;
 			} else {
 				$GLOBALS['venue_membership_test']['term_meta'][ $row['term_id'] ][ $row['meta_key'] ] = $value;
@@ -206,6 +293,10 @@ final class VenueMembershipWpdb {
 				return null;
 			}
 			$this->meta_values[100] = maybe_serialize( $value );
+			$this->meta_records[100] = array(
+				'term_id'  => (int) $meta_match[1],
+				'meta_key' => stripslashes( $meta_match[2] ),
+			);
 			return array(
 				'meta_id'    => 100,
 				'meta_value' => $this->meta_values[100],
@@ -313,7 +404,9 @@ final class VenueMembershipWpdb {
 			$this->snapshot             = $this->rows;
 			$this->meta_snapshot        = $GLOBALS['venue_membership_test']['term_meta'];
 			$this->history_snapshot     = $GLOBALS['venue_membership_test']['term_history'];
+			$this->terms_snapshot       = unserialize( serialize( $GLOBALS['venue_membership_test']['terms'] ) );
 			$this->meta_values_snapshot = $this->meta_values;
+			$this->meta_records_snapshot = $this->meta_records;
 			if ( is_callable( $this->after_start ) ) {
 				$callback          = $this->after_start;
 				$this->after_start = null;
@@ -321,7 +414,9 @@ final class VenueMembershipWpdb {
 				$this->snapshot             = $this->rows;
 				$this->meta_snapshot        = $GLOBALS['venue_membership_test']['term_meta'];
 				$this->history_snapshot     = $GLOBALS['venue_membership_test']['term_history'];
+				$this->terms_snapshot       = unserialize( serialize( $GLOBALS['venue_membership_test']['terms'] ) );
 				$this->meta_values_snapshot = $this->meta_values;
+				$this->meta_records_snapshot = $this->meta_records;
 			}
 			return 1;
 		}
@@ -329,18 +424,24 @@ final class VenueMembershipWpdb {
 			$this->rows                                       = $this->snapshot;
 			$GLOBALS['venue_membership_test']['term_meta']    = $this->meta_snapshot;
 			$GLOBALS['venue_membership_test']['term_history'] = $this->history_snapshot;
+			$GLOBALS['venue_membership_test']['terms']        = $this->terms_snapshot;
 			$this->meta_values                                = $this->meta_values_snapshot;
+			$this->meta_records                               = $this->meta_records_snapshot;
 			$this->snapshot                                   = null;
 			$this->meta_snapshot                              = null;
 			$this->history_snapshot                           = null;
+			$this->terms_snapshot                             = null;
 			$this->meta_values_snapshot                       = array();
+			$this->meta_records_snapshot                      = array();
 			return 1;
 		}
 		if ( 'COMMIT' === $query ) {
 			$this->snapshot             = null;
 			$this->meta_snapshot        = null;
 			$this->history_snapshot     = null;
+			$this->terms_snapshot       = null;
 			$this->meta_values_snapshot = array();
+			$this->meta_records_snapshot = array();
 			return 1;
 		}
 		if ( ! preg_match( '/WHERE venue_term_id = (\d+) AND user_id = (\d+) AND version = (\d+)/', $query, $match ) ) {
@@ -370,16 +471,41 @@ final class VenueMembershipWpdb {
 	public function update( $table, $data, $where, $format = null, $where_format = null ) {
 		unset( $format, $where_format );
 		$this->last_error = '';
+		if ( $this->terms === $table && isset( $where['term_id'], $data['name'] ) ) {
+			$GLOBALS['venue_membership_test']['terms'][ (int) $where['term_id'] ]->name = $data['name'];
+			return 1;
+		}
+		if ( $this->term_taxonomy === $table && isset( $where['term_id'], $data['description'] ) ) {
+			$GLOBALS['venue_membership_test']['terms'][ (int) $where['term_id'] ]->description = $data['description'];
+			return 1;
+		}
 		if ( $this->termmeta !== $table || ! isset( $where['meta_id'], $data['meta_value'] ) ) {
 			return false;
 		}
-		if ( ! empty( $GLOBALS['venue_membership_test']['fail_config_save'] ) ) {
+		$meta_id = (int) $where['meta_id'];
+		$record  = $this->meta_records[ $meta_id ] ?? null;
+		if ( ! is_array( $record ) ) {
+			return false;
+		}
+		if ( ! empty( $GLOBALS['venue_membership_test']['fail_config_save'] ) || ( VenueProfile::STATE_META_KEY === $record['meta_key'] && ! empty( $GLOBALS['venue_membership_test']['fail_profile_state'] ) ) ) {
 			$this->last_error = 'simulated config write failure';
 			return false;
 		}
-		$meta_id                       = (int) $where['meta_id'];
 		$this->meta_values[ $meta_id ] = $data['meta_value'];
-		$GLOBALS['venue_membership_test']['term_meta'][55][ VenueBookingConfig::META_KEY ] = maybe_unserialize( $data['meta_value'] );
+		$GLOBALS['venue_membership_test']['term_meta'][ $record['term_id'] ][ $record['meta_key'] ] = maybe_unserialize( $data['meta_value'] );
+		return 1;
+	}
+
+	public function delete( $table, $where, $where_format = null ) {
+		unset( $where_format );
+		$this->last_error = '';
+		$meta_id          = (int) ( $where['meta_id'] ?? 0 );
+		$record           = $this->meta_records[ $meta_id ] ?? null;
+		if ( $this->termmeta !== $table || ! is_array( $record ) ) {
+			return false;
+		}
+		unset( $GLOBALS['venue_membership_test']['term_meta'][ $record['term_id'] ][ $record['meta_key'] ] );
+		unset( $this->meta_values[ $meta_id ], $this->meta_records[ $meta_id ] );
 		return 1;
 	}
 
@@ -395,20 +521,26 @@ require_once dirname( __DIR__ ) . '/inc/Core/VenueAuthorization.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueMembershipRepository.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueMembershipService.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueBookingConfig.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VenueProfile.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueMembershipAbilities.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueBookingConfigAbilities.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/VenueProfileAbilities.php';
 
 final class VenueMembershipAuthorizationTest extends TestCase {
 	protected function setUp(): void {
 		$GLOBALS['venue_membership_test'] = array(
 			'terms'             => array(
 				55 => (object) array(
-					'term_id'  => 55,
-					'taxonomy' => 'venue',
+					'term_id'     => 55,
+					'taxonomy'    => 'venue',
+					'name'        => 'The Royal American',
+					'description' => 'Neighborhood venue.',
 				),
 				56 => (object) array(
-					'term_id'  => 56,
-					'taxonomy' => 'venue',
+					'term_id'     => 56,
+					'taxonomy'    => 'venue',
+					'name'        => 'Music Farm',
+					'description' => '',
 				),
 				57 => (object) array(
 					'term_id'  => 57,
@@ -435,6 +567,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			),
 			'feature_available' => true,
 			'current_user_id'   => 1,
+			'current_blog_id'   => 7,
 			'actions'           => array(),
 			'abilities'         => array(),
 			'options'           => array( BookingSchema::VERSION_OPTION => BookingSchema::SCHEMA_VERSION ),
@@ -442,8 +575,12 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			'term_history'      => array(),
 			'fired_actions'     => array(),
 			'cache_deletes'     => array(),
+			'term_cache_deletes' => array(),
+			'location_cache_deletes' => array(),
 			'fail_config_save'  => false,
 			'fail_config_audit' => false,
+			'fail_profile_state' => false,
+			'fail_profile_audit' => false,
 		);
 		$GLOBALS['wpdb']                  = new VenueMembershipWpdb();
 	}
@@ -753,5 +890,174 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->assertSame( 'booking_config_audit_failed', $failed->get_error_code() );
 		$this->assertSame( array(), $GLOBALS['venue_membership_test']['term_meta'] );
 		$this->assertSame( array( 55, 'term_meta' ), $GLOBALS['venue_membership_test']['cache_deletes'][0] );
+	}
+
+	public function test_profile_abilities_authorize_exact_active_venue_members(): void {
+		$this->create_member( 55, 2, true );
+		$this->create_member( 55, 3, false );
+		$this->create_member( 56, 4, true, VenueAuthorization::STATUS_INVITED );
+		$GLOBALS['venue_membership_test']['current_user_id'] = 3;
+
+		$abilities = new VenueProfileAbilities();
+		$abilities->register();
+		$get    = $GLOBALS['venue_membership_test']['abilities']['extrachill/get-venue-profile'];
+		$update = $GLOBALS['venue_membership_test']['abilities']['extrachill/update-venue-profile'];
+
+		$this->assertTrue( call_user_func( $get['permission_callback'], array( 'venue_term_id' => 55 ) ) );
+		$this->assertSame( 'venue_action_forbidden', call_user_func( $get['permission_callback'], array( 'venue_term_id' => 56 ) )->get_error_code() );
+		$this->assertSame( 'venue_action_forbidden', call_user_func( $update['permission_callback'], array( 'venue_term_id' => 56 ) )->get_error_code() );
+		$this->assertSame( 'extrachill-events', $get['category'] );
+		$this->assertTrue( $get['meta']['annotations']['readonly'] );
+		$this->assertTrue( $update['meta']['annotations']['destructive'] );
+		$this->assertFalse( $get['input_schema']['additionalProperties'] );
+		$this->assertFalse( $update['input_schema']['properties']['profile']['additionalProperties'] );
+
+		$GLOBALS['venue_membership_test']['current_user_id'] = 4;
+		$this->assertSame( 'venue_action_forbidden', call_user_func( $get['execute_callback'], array( 'venue_term_id' => 56 ) )->get_error_code() );
+		$GLOBALS['venue_membership_test']['current_user_id'] = 1;
+		$this->assertSame( 'venue_action_forbidden', call_user_func( $get['execute_callback'], array( 'venue_term_id' => 55 ) )->get_error_code() );
+	}
+
+	public function test_profile_read_write_roundtrip_stale_write_and_audit_boundary(): void {
+		$this->create_member( 55, 2, true );
+		$GLOBALS['venue_membership_test']['current_user_id'] = 2;
+		$GLOBALS['venue_membership_test']['term_meta'][55]   = array(
+			'_venue_address'     => '970 Morrison Drive',
+			'_venue_city'        => 'Charleston',
+			'_venue_state'       => 'SC',
+			'_venue_zip'         => '29403',
+			'_venue_country'     => 'US',
+			'_venue_phone'       => '843-555-1212',
+			'_venue_website'     => 'https://theroyalamerican.com',
+			'_venue_capacity'    => '300',
+			'_venue_coordinates' => '32.801,-79.943',
+			'_venue_timezone'    => 'America/New_York',
+			'_ec_priority_venue' => '1',
+		);
+		$abilities = new VenueProfileAbilities();
+		$abilities->register();
+		$get        = $GLOBALS['venue_membership_test']['abilities']['extrachill/get-venue-profile'];
+		$update     = $GLOBALS['venue_membership_test']['abilities']['extrachill/update-venue-profile'];
+
+		$current = call_user_func( $get['execute_callback'], array( 'venue_term_id' => 55 ) );
+		$this->assertSame( 0, $current['revision'] );
+		$this->assertSame( 300, $current['profile']['capacity'] );
+		$this->assertArrayNotHasKey( 'coordinates', $current['profile'] );
+		$this->assertArrayNotHasKey( 'timezone', $current['profile'] );
+		$this->assertArrayNotHasKey( '_ec_priority_venue', $current['profile'] );
+
+		$replacement                = $current['profile'];
+		$replacement['description'] = '<p>Independent venue and neighborhood bar.</p>';
+		$replacement['address']     = '970 Morrison Dr';
+		$replacement['phone']       = '';
+		$replacement['capacity']    = 350;
+		$saved                      = call_user_func(
+			$update['execute_callback'],
+			array(
+				'venue_term_id'     => 55,
+				'expected_revision' => 0,
+				'profile'           => $replacement,
+			)
+		);
+
+		$this->assertSame( 1, $saved['revision'] );
+		$this->assertSame( 2, $saved['updated_by_user_id'] );
+		$this->assertSame( $replacement, $saved['profile'] );
+		$this->assertArrayNotHasKey( '_venue_phone', $GLOBALS['venue_membership_test']['term_meta'][55] );
+		$this->assertArrayNotHasKey( '_venue_coordinates', $GLOBALS['venue_membership_test']['term_meta'][55] );
+		$this->assertSame( 'America/New_York', $GLOBALS['venue_membership_test']['term_meta'][55]['_venue_timezone'] );
+		$this->assertSame( '1', $GLOBALS['venue_membership_test']['term_meta'][55]['_ec_priority_venue'] );
+		$this->assertSame( array( 55 ), $GLOBALS['venue_membership_test']['location_cache_deletes'] );
+
+		$history = $GLOBALS['venue_membership_test']['term_history'][55][ VenueProfile::HISTORY_META_KEY ];
+		$this->assertCount( 1, $history );
+		$this->assertSame( 2, $history[0]['actor_user_id'] );
+		$this->assertSame( array( 'description', 'address', 'phone', 'capacity' ), $history[0]['changed_fields'] );
+		$this->assertArrayNotHasKey( 'profile', $history[0] );
+		$this->assertArrayNotHasKey( 'previous', $history[0] );
+
+		$roundtrip = call_user_func( $get['execute_callback'], array( 'venue_term_id' => 55 ) );
+		$this->assertSame( $saved, $roundtrip );
+		$stale = call_user_func(
+			$update['execute_callback'],
+			array(
+				'venue_term_id'     => 55,
+				'expected_revision' => 0,
+				'profile'           => $replacement,
+			)
+		);
+		$this->assertSame( 'venue_profile_revision_conflict', $stale->get_error_code() );
+		$this->assertSame( 1, $stale->get_error_data()['current_revision'] );
+		$this->assertCount( 1, $GLOBALS['venue_membership_test']['term_history'][55][ VenueProfile::HISTORY_META_KEY ] );
+	}
+
+	public function test_profile_validation_rejects_unknown_missing_and_invalid_values_atomically(): void {
+		$this->create_member( 55, 2, true );
+		$profiles = new VenueProfile();
+		$current  = $profiles->get( 55 );
+		$profile  = $current['profile'];
+
+		$unknown             = $profile;
+		$unknown['timezone'] = 'UTC';
+		$this->assertSame( 'invalid_venue_profile_fields', $profiles->update( 55, $unknown, 0, 2 )->get_error_code() );
+		$missing = $profile;
+		unset( $missing['city'] );
+		$this->assertSame( 'invalid_venue_profile_fields', $profiles->update( 55, $missing, 0, 2 )->get_error_code() );
+		$invalid_website            = $profile;
+		$invalid_website['website'] = 'javascript:alert(1)';
+		$this->assertSame( 'invalid_venue_profile_value', $profiles->update( 55, $invalid_website, 0, 2 )->get_error_code() );
+		$invalid_capacity             = $profile;
+		$invalid_capacity['capacity'] = 0;
+		$this->assertSame( 'invalid_venue_profile_value', $profiles->update( 55, $invalid_capacity, 0, 2 )->get_error_code() );
+		$this->assertArrayNotHasKey( VenueProfile::STATE_META_KEY, $GLOBALS['venue_membership_test']['term_meta'][55] ?? array() );
+		$this->assertArrayNotHasKey( 55, $GLOBALS['venue_membership_test']['term_history'] );
+	}
+
+	public function test_profile_update_reauthorizes_and_audit_failure_rolls_back_every_field(): void {
+		$this->create_member( 55, 2, true );
+		$profiles    = new VenueProfile();
+		$replacement = $profiles->get( 55 )['profile'];
+		$replacement['name']    = 'Updated Name';
+		$replacement['website'] = 'https://example.com';
+
+		$GLOBALS['wpdb']->after_start = static function ( VenueMembershipWpdb $wpdb ): void {
+			foreach ( $wpdb->rows['wp_7_ec_venue_members'] as &$row ) {
+				if ( 2 === (int) $row['user_id'] ) {
+					$row['status'] = VenueAuthorization::STATUS_REVOKED;
+				}
+			}
+			unset( $row );
+		};
+		$denied = $profiles->update( 55, $replacement, 0, 2 );
+		$this->assertSame( 'venue_action_forbidden', $denied->get_error_code() );
+		$this->assertSame( 'The Royal American', $GLOBALS['venue_membership_test']['terms'][55]->name );
+
+		foreach ( $GLOBALS['wpdb']->rows['wp_7_ec_venue_members'] as &$row ) {
+			if ( 2 === (int) $row['user_id'] ) {
+				$row['status'] = VenueAuthorization::STATUS_ACTIVE;
+			}
+		}
+		unset( $row );
+		$GLOBALS['venue_membership_test']['fail_profile_audit'] = true;
+		$failed = $profiles->update( 55, $replacement, 0, 2 );
+		$this->assertSame( 'venue_profile_audit_failed', $failed->get_error_code() );
+		$this->assertSame( 'The Royal American', $GLOBALS['venue_membership_test']['terms'][55]->name );
+		$this->assertArrayNotHasKey( '_venue_website', $GLOBALS['venue_membership_test']['term_meta'][55] ?? array() );
+		$this->assertArrayNotHasKey( VenueProfile::STATE_META_KEY, $GLOBALS['venue_membership_test']['term_meta'][55] ?? array() );
+		$this->assertSame( array(), $GLOBALS['venue_membership_test']['fired_actions'] );
+	}
+
+	public function test_profile_requires_canonical_events_site_and_does_not_change_resolution_inputs_on_noop(): void {
+		$this->create_member( 55, 2, true );
+		$profiles = new VenueProfile();
+		$current  = $profiles->get( 55 );
+		$noop     = $profiles->update( 55, $current['profile'], 0, 2 );
+		$this->assertSame( 0, $noop['revision'] );
+		$this->assertArrayNotHasKey( 55, $GLOBALS['venue_membership_test']['term_history'] );
+		$this->assertSame( 'The Royal American', get_term( 55, 'venue' )->name );
+
+		$GLOBALS['venue_membership_test']['current_blog_id'] = 1;
+		$this->assertSame( 'canonical_events_site_required', $profiles->get( 55 )->get_error_code() );
+		$this->assertSame( 'canonical_events_site_required', $profiles->update( 55, $current['profile'], 0, 2 )->get_error_code() );
 	}
 }

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -531,6 +531,12 @@ require_once dirname( __DIR__ ) . '/inc/Abilities/VenueMembershipAbilities.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueBookingConfigAbilities.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueProfileAbilities.php';
 
+/**
+ * Venue membership and profile composition coverage uses isolated WP doubles.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 final class VenueMembershipAuthorizationTest extends TestCase {
 	protected function setUp(): void {
 		$GLOBALS['venue_membership_test'] = array(
@@ -947,147 +953,56 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->assertSame( 'venue_action_forbidden', call_user_func( $get['execute_callback'], array( 'venue_term_id' => 55 ) )->get_error_code() );
 	}
 
-	public function legacy_profile_read_write_roundtrip_stale_write_and_audit_boundary(): void {
+	public function test_profile_read_delegates_to_dme_after_authorization(): void {
 		$this->create_member( 55, 2, true );
-		$GLOBALS['venue_membership_test']['current_user_id'] = 2;
-		$GLOBALS['venue_membership_test']['term_meta'][55]   = array(
-			'_venue_address'     => '970 Morrison Drive',
-			'_venue_city'        => 'Charleston',
-			'_venue_state'       => 'SC',
-			'_venue_zip'         => '29403',
-			'_venue_country'     => 'US',
-			'_venue_phone'       => '843-555-1212',
-			'_venue_website'     => 'https://theroyalamerican.com',
-			'_venue_capacity'    => '300',
-			'_venue_coordinates' => '32.801,-79.943',
-			'_venue_timezone'    => 'America/New_York',
-			'_ec_priority_venue' => '1',
-		);
-		$abilities = new VenueProfileAbilities();
-		$abilities->register();
-		$get        = $GLOBALS['venue_membership_test']['abilities']['extrachill/get-venue-profile'];
-		$update     = $GLOBALS['venue_membership_test']['abilities']['extrachill/update-venue-profile'];
+		$result = ( new VenueProfile() )->get( 55, 2 );
 
-		$current = call_user_func( $get['execute_callback'], array( 'venue_term_id' => 55 ) );
-		$this->assertSame( 0, $current['revision'] );
-		$this->assertSame( 300, $current['profile']['capacity'] );
-		$this->assertArrayNotHasKey( 'coordinates', $current['profile'] );
-		$this->assertArrayNotHasKey( 'timezone', $current['profile'] );
-		$this->assertArrayNotHasKey( '_ec_priority_venue', $current['profile'] );
-
-		$replacement                = $current['profile'];
-		$replacement['description'] = '<p>Independent venue and neighborhood bar.</p>';
-		$replacement['address']     = '970 Morrison Dr';
-		$replacement['phone']       = '';
-		$replacement['capacity']    = 350;
-		$saved                      = call_user_func(
-			$update['execute_callback'],
-			array(
-				'venue_term_id'     => 55,
-				'expected_revision' => 0,
-				'profile'           => $replacement,
-			)
-		);
-
-		$this->assertSame( 1, $saved['revision'] );
-		$this->assertSame( 2, $saved['updated_by_user_id'] );
-		$this->assertSame( $replacement, $saved['profile'] );
-		$this->assertArrayNotHasKey( '_venue_phone', $GLOBALS['venue_membership_test']['term_meta'][55] );
-		$this->assertArrayNotHasKey( '_venue_coordinates', $GLOBALS['venue_membership_test']['term_meta'][55] );
-		$this->assertSame( 'America/New_York', $GLOBALS['venue_membership_test']['term_meta'][55]['_venue_timezone'] );
-		$this->assertSame( '1', $GLOBALS['venue_membership_test']['term_meta'][55]['_ec_priority_venue'] );
-		$this->assertSame( array( 55 ), $GLOBALS['venue_membership_test']['location_cache_deletes'] );
-
-		$history = $GLOBALS['venue_membership_test']['term_history'][55][ VenueProfile::HISTORY_META_KEY ];
-		$this->assertCount( 1, $history );
-		$this->assertSame( 2, $history[0]['actor_user_id'] );
-		$this->assertSame( array( 'description', 'address', 'phone', 'capacity' ), $history[0]['changed_fields'] );
-		$this->assertArrayNotHasKey( 'profile', $history[0] );
-		$this->assertArrayNotHasKey( 'previous', $history[0] );
-
-		$roundtrip = call_user_func( $get['execute_callback'], array( 'venue_term_id' => 55 ) );
-		$this->assertSame( $saved, $roundtrip );
-		$stale = call_user_func(
-			$update['execute_callback'],
-			array(
-				'venue_term_id'     => 55,
-				'expected_revision' => 0,
-				'profile'           => $replacement,
-			)
-		);
-		$this->assertSame( 'venue_profile_revision_conflict', $stale->get_error_code() );
-		$this->assertSame( 1, $stale->get_error_data()['current_revision'] );
-		$this->assertCount( 1, $GLOBALS['venue_membership_test']['term_history'][55][ VenueProfile::HISTORY_META_KEY ] );
-	}
-
-	public function legacy_profile_validation_rejects_unknown_missing_and_invalid_values_atomically(): void {
-		$this->create_member( 55, 2, true );
-		$profiles = new VenueProfile();
-		$current  = $profiles->get( 55 );
-		$profile  = $current['profile'];
-
-		$unknown             = $profile;
-		$unknown['timezone'] = 'UTC';
-		$this->assertSame( 'invalid_venue_profile_fields', $profiles->update( 55, $unknown, 0, 2 )->get_error_code() );
-		$missing = $profile;
-		unset( $missing['city'] );
-		$this->assertSame( 'invalid_venue_profile_fields', $profiles->update( 55, $missing, 0, 2 )->get_error_code() );
-		$invalid_website            = $profile;
-		$invalid_website['website'] = 'javascript:alert(1)';
-		$this->assertSame( 'invalid_venue_profile_value', $profiles->update( 55, $invalid_website, 0, 2 )->get_error_code() );
-		$invalid_capacity             = $profile;
-		$invalid_capacity['capacity'] = 0;
-		$this->assertSame( 'invalid_venue_profile_value', $profiles->update( 55, $invalid_capacity, 0, 2 )->get_error_code() );
-		$this->assertArrayNotHasKey( VenueProfile::STATE_META_KEY, $GLOBALS['venue_membership_test']['term_meta'][55] ?? array() );
+		$this->assertSame( $GLOBALS['venue_membership_test']['dme_profile'], $result );
 		$this->assertArrayNotHasKey( 55, $GLOBALS['venue_membership_test']['term_history'] );
 	}
 
-	public function legacy_profile_update_reauthorizes_and_audit_failure_rolls_back_every_field(): void {
+	public function test_profile_propagates_dme_validation_errors_without_audit(): void {
 		$this->create_member( 55, 2, true );
-		$profiles    = new VenueProfile();
-		$replacement = $profiles->get( 55 )['profile'];
-		$replacement['name']    = 'Updated Name';
-		$replacement['website'] = 'https://example.com';
-
-		$GLOBALS['wpdb']->after_start = static function ( VenueMembershipWpdb $wpdb ): void {
-			foreach ( $wpdb->rows['wp_7_ec_venue_members'] as &$row ) {
-				if ( 2 === (int) $row['user_id'] ) {
-					$row['status'] = VenueAuthorization::STATUS_REVOKED;
-				}
-			}
-			unset( $row );
+		$GLOBALS['venue_membership_test']['dme_update'] = static function () {
+			return new WP_Error( 'venue_meta_update_failed', 'Canonical owner rejected the mutation.' );
 		};
-		$denied = $profiles->update( 55, $replacement, 0, 2 );
-		$this->assertSame( 'venue_action_forbidden', $denied->get_error_code() );
-		$this->assertSame( 'The Royal American', $GLOBALS['venue_membership_test']['terms'][55]->name );
 
-		foreach ( $GLOBALS['wpdb']->rows['wp_7_ec_venue_members'] as &$row ) {
-			if ( 2 === (int) $row['user_id'] ) {
-				$row['status'] = VenueAuthorization::STATUS_ACTIVE;
-			}
-		}
-		unset( $row );
-		$GLOBALS['venue_membership_test']['fail_profile_audit'] = true;
-		$failed = $profiles->update( 55, $replacement, 0, 2 );
-		$this->assertSame( 'venue_profile_audit_failed', $failed->get_error_code() );
-		$this->assertSame( 'The Royal American', $GLOBALS['venue_membership_test']['terms'][55]->name );
-		$this->assertArrayNotHasKey( '_venue_website', $GLOBALS['venue_membership_test']['term_meta'][55] ?? array() );
-		$this->assertArrayNotHasKey( VenueProfile::STATE_META_KEY, $GLOBALS['venue_membership_test']['term_meta'][55] ?? array() );
-		$this->assertSame( array(), $GLOBALS['venue_membership_test']['fired_actions'] );
+		$result = ( new VenueProfile() )->update( 55, array( 'website' => 'invalid' ), str_repeat( 'a', 64 ), 2 );
+
+		$this->assertSame( 'venue_meta_update_failed', $result->get_error_code() );
+		$this->assertArrayNotHasKey( 55, $GLOBALS['venue_membership_test']['term_history'] );
 	}
 
-	public function legacy_profile_requires_canonical_events_site_and_does_not_change_resolution_inputs_on_noop(): void {
-		$this->create_member( 55, 2, true );
-		$profiles = new VenueProfile();
-		$current  = $profiles->get( 55 );
-		$noop     = $profiles->update( 55, $current['profile'], 0, 2 );
-		$this->assertSame( 0, $noop['revision'] );
-		$this->assertArrayNotHasKey( 55, $GLOBALS['venue_membership_test']['term_history'] );
-		$this->assertSame( 'The Royal American', get_term( 55, 'venue' )->name );
+	public function test_profile_authorization_denial_prevents_dme_mutation(): void {
+		$this->create_member( 55, 2, true, VenueAuthorization::STATUS_REVOKED );
+		$called = false;
+		$GLOBALS['venue_membership_test']['dme_update'] = static function () use ( &$called ) {
+			$called = true;
+			return array();
+		};
 
-		$GLOBALS['venue_membership_test']['current_blog_id'] = 1;
-		$this->assertSame( 'canonical_events_site_required', $profiles->get( 55 )->get_error_code() );
-		$this->assertSame( 'canonical_events_site_required', $profiles->update( 55, $current['profile'], 0, 2 )->get_error_code() );
+		$result = ( new VenueProfile() )->update( 55, array( 'name' => 'Blocked' ), str_repeat( 'a', 64 ), 2 );
+
+		$this->assertSame( 'venue_action_forbidden', $result->get_error_code() );
+		$this->assertFalse( $called );
+	}
+
+	public function test_profile_noop_owner_result_does_not_create_audit(): void {
+		$this->create_member( 55, 2, true );
+		$GLOBALS['venue_membership_test']['dme_update'] = static function ( $term_id ) {
+			return array(
+				'success'        => true,
+				'term_id'        => $term_id,
+				'updated_fields' => array(),
+				'revision'       => str_repeat( 'a', 64 ),
+				'profile'        => $GLOBALS['venue_membership_test']['dme_profile'],
+			);
+		};
+
+		$result = ( new VenueProfile() )->update( 55, array( 'name' => 'The Royal American' ), str_repeat( 'a', 64 ), 2 );
+
+		$this->assertSame( array(), $result['updated_fields'] );
+		$this->assertArrayNotHasKey( 55, $GLOBALS['venue_membership_test']['term_history'] );
 	}
 
 	public function test_profile_composes_dme_contract_and_audits_only_member_fields_across_timezones(): void {


### PR DESCRIPTION
## Summary
- register authorized `extrachill/get-venue-profile` and `extrachill/update-venue-profile` abilities for exact active venue members
- compose canonical reads and mutations over Data Machine Events' public venue profile contract instead of duplicating term/meta SQL, revisions, transactions, geocoding, or timezone behavior
- append Extra Chill actor and changed-field audit records after successful owner mutations, excluding DME-owned derived fields
- merge current `origin/main`, resolving the #347 bootstrap overlap while retaining its booking/publication guard

Closes #310

## Ownership Boundary
Extra Chill Events owns only:
- canonical Events-site enforcement
- feature/capability checks and exact active membership authorization
- actor-aware audit records containing revisions, timestamp, and changed member-editable field names

Data Machine Events owns:
- canonical profile shape and field boundary
- sanitization and WordPress term/meta behavior
- optimistic fingerprint revisions
- advisory locking and transaction handling
- coordinate invalidation, geocoding, and timezone derivation

There is no direct canonical venue SQL or duplicated location mutation logic in `VenueProfile`.

## Dependency
- Requires Extra-Chill/data-machine-events#530.
- The DME PR must merge first because this branch calls `data_machine_events_get_venue_profile()` and `data_machine_events_update_venue_profile()`.

## Main / #347 Integration
Current `origin/main` at `cb96e2c` was merged non-interactively in commit `5a79ecd`. The conflict in `extrachill-events.php` was resolved by loading both `VenueProfile` and #347's `CanonicalEventPublicationGuard`, preserving booking hold registration and all new booking abilities.

## Verification
- `./vendor/bin/phpunit -c phpunit-membership.xml.dist`: 16 tests, 115 assertions
- `./vendor/bin/phpunit -c phpunit-booking.xml.dist`: 147 tests, 1011 assertions
- scoped WordPress PHPCS on `inc/Core/VenueProfile.php` and `inc/Abilities/VenueProfileAbilities.php`: passed with established filename sniffs excluded
- PHP syntax on profile production/test files and plugin bootstrap: passed
- `git diff --check`: passed
- cross-timezone compatibility coverage verifies a DME relocation result may include derived `coordinates`/`timezone` while Extra Chill audits only member-edited address fields

## Residual Risks
- Authorization is checked immediately before calling the generic DME owner contract, but the two plugins intentionally do not share a transaction; membership revocation racing after that check is not serialized with DME's canonical venue lock.
- Extra Chill audit is appended after DME confirms its commit. If audit persistence fails, the ability returns `venue_profile_audit_failed` with `mutation_committed: true` and the committed canonical revision; callers must not blindly retry the mutation.
## Follow-up Test Discovery Repair
Commit `19e6351` replaces the four undiscoverable `legacy_profile_*` methods with `test_profile_*` composition-boundary tests covering authorized DME reads, owner validation-error propagation without audit, authorization denial before owner mutation, and no-op owner results without audit. The fixture-heavy class now uses PHPUnit 9 process isolation with global-state preservation disabled, preventing its WordPress doubles from colliding with booking/default-suite doubles.

`tests/VenueMembershipAuthorizationTest.php` is now listed in both `phpunit.xml.dist` and `phpunit-booking.xml.dist` while remaining available through the focused membership config.

Verification for the follow-up:
- `./vendor/bin/phpunit -c phpunit-membership.xml.dist`: 20 tests, 123 assertions
- `./vendor/bin/phpunit -c phpunit-booking.xml.dist`: 167 tests, 1134 assertions
- `./vendor/bin/phpunit -c phpunit.xml.dist --filter VenueMembershipAuthorizationTest`: 20 tests, 123 assertions
- `./vendor/bin/phpunit -c phpunit-booking.xml.dist --filter VenueMembershipAuthorizationTest`: 20 tests, 123 assertions
- scoped WordPress PHPCS on `inc/Core/VenueProfile.php` and `inc/Abilities/VenueProfileAbilities.php`: passed
- `php -l tests/VenueMembershipAuthorizationTest.php`: passed
- `git diff --check`: passed

The complete unfiltered default config discovers 252 tests, including all 20 venue membership/profile tests, but still reports unrelated pre-existing cross-fixture failures in qualify rechecks, canonical locations/adapters, festival notifications, and concert-stat rendering. The profile selection itself passes through that config; those unrelated default-suite failures are not hidden or converted to skips here.