### PR TITLE
Add confirmed booking event conversion

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -250,6 +250,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingHoldRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingMutationService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingEventConversionService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingLifecycle.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingConfig.php';
 		\ExtraChillEvents\Core\BookingHoldRepository::register();
@@ -349,6 +350,9 @@ class ExtraChillEvents {
 
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueBookingMutationAbilities.php';
 			new \ExtraChillEvents\Abilities\VenueBookingMutationAbilities();
+
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueBookingEventAbilities.php';
+			new \ExtraChillEvents\Abilities\VenueBookingEventAbilities();
 		}
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/PriorityVenueAbilities.php';

--- a/inc/Abilities/VenueBookingEventAbilities.php
+++ b/inc/Abilities/VenueBookingEventAbilities.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Venue booking event conversion ability.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+use ExtraChillEvents\Core\BookingEventConversionService;
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\VenueAuthorization;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Registers the narrow idempotent booking-to-event contract. */
+class VenueBookingEventAbilities {
+	private static bool $registered = false;
+	/** @var BookingEventConversionService */
+	private $conversion;
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var VenueAuthorization */
+	private $authorization;
+
+	public function __construct( ?BookingEventConversionService $conversion = null, ?BookingRepository $bookings = null, ?VenueAuthorization $authorization = null ) {
+		$this->bookings      = $bookings ? $bookings : new BookingRepository();
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+		$this->conversion    = $conversion ? $conversion : new BookingEventConversionService( $this->bookings, null, null, $this->authorization );
+		if ( ! self::$registered ) {
+			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+			self::$registered = true;
+		}
+	}
+
+	public function register(): void {
+		wp_register_ability(
+			'extrachill/convert-booking-to-event',
+			array(
+				'label'               => __( 'Convert Booking to Event', 'extrachill-events' ),
+				'description'         => __( 'Idempotently converts a confirmed venue booking into its canonical event.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => $this->input_schema(),
+				'output_schema'       => $this->output_schema(),
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => array( $this, 'can_access_booking' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+
+	public function execute( array $input ) {
+		return $this->conversion->convert( (int) $input['booking_id'], (int) $input['expected_version'], get_current_user_id() );
+	}
+
+	/** Missing records deliberately use the same denial as inaccessible records. */
+	public function can_access_booking( array $input ) {
+		$booking = $this->bookings->get( absint( $input['booking_id'] ?? 0 ) );
+		return is_array( $booking ) ? $this->authorization->authorize( get_current_user_id(), $booking['venue_term_id'], VenueAuthorization::ACTION_ACCESS_VENUE ) : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+
+	private function input_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'booking_id'       => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'expected_version' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+			),
+			'required'             => array( 'booking_id', 'expected_version' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function output_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'booking_id'        => array( 'type' => 'integer' ),
+				'booking_version'   => array( 'type' => 'integer' ),
+				'event_id'          => array( 'type' => 'integer' ),
+				'event_url'         => array( 'type' => 'string' ),
+				'event_action'      => array(
+					'type' => 'string',
+					'enum' => array( 'created', 'updated', 'no_change', 'existing' ),
+				),
+				'already_converted' => array( 'type' => 'boolean' ),
+			),
+			'required'             => array( 'booking_id', 'booking_version', 'event_id', 'event_url', 'event_action', 'already_converted' ),
+			'additionalProperties' => false,
+		);
+	}
+}

--- a/inc/Abilities/VenueBookingEventAbilities.php
+++ b/inc/Abilities/VenueBookingEventAbilities.php
@@ -24,11 +24,14 @@ class VenueBookingEventAbilities {
 	private $bookings;
 	/** @var VenueAuthorization */
 	private $authorization;
+	/** @var array|null Exact booking context active during nested event upsert. */
+	private $active_conversion;
 
 	public function __construct( ?BookingEventConversionService $conversion = null, ?BookingRepository $bookings = null, ?VenueAuthorization $authorization = null ) {
 		$this->bookings      = $bookings ? $bookings : new BookingRepository();
 		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
 		$this->conversion    = $conversion ? $conversion : new BookingEventConversionService( $this->bookings, null, null, $this->authorization );
+		add_filter( 'datamachine_events_upsert_event_permission', array( $this, 'can_upsert_booking_event' ), 10, 2 );
 		if ( ! self::$registered ) {
 			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
 			self::$registered = true;
@@ -59,7 +62,31 @@ class VenueBookingEventAbilities {
 	}
 
 	public function execute( array $input ) {
-		return $this->conversion->convert( (int) $input['booking_id'], (int) $input['expected_version'], get_current_user_id() );
+		$booking = $this->bookings->get( (int) $input['booking_id'] );
+		$this->active_conversion = is_array( $booking ) ? $booking : null;
+		try {
+			return $this->conversion->convert( (int) $input['booking_id'], (int) $input['expected_version'], get_current_user_id() );
+		} finally {
+			$this->active_conversion = null;
+		}
+	}
+
+	/** Grant only the exact nested DME write performed by this conversion. */
+	public function can_upsert_booking_event( bool $allowed, array $input ): bool {
+		if ( $allowed ) {
+			return true;
+		}
+		if ( ! is_array( $this->active_conversion )
+			|| BookingEventConversionService::SOURCE !== ( $input['source'] ?? '' )
+			|| $this->active_conversion['public_id'] !== ( $input['source_id'] ?? '' ) ) {
+			return false;
+		}
+
+		return true === $this->authorization->authorize(
+			get_current_user_id(),
+			(int) $this->active_conversion['venue_term_id'],
+			VenueAuthorization::ACTION_ACCESS_VENUE
+		);
 	}
 
 	/** Missing records deliberately use the same denial as inaccessible records. */

--- a/inc/Core/BookingActivityRepository.php
+++ b/inc/Core/BookingActivityRepository.php
@@ -132,6 +132,103 @@ class BookingActivityRepository {
 		return $hydrated;
 	}
 
+	/** Reconstruct and validate the complete activity-backed event conversion state. */
+	public function event_conversion_state( int $booking_id, string $public_id ) {
+		global $wpdb;
+		$table = BookingSchema::activity_table();
+		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND (kind IN ('event_conversion_started', 'event_conversion_failed', 'event_converted') OR idempotency_key LIKE %s) ORDER BY id ASC", $booking_id, 'event-conversion:' . $public_id . ':%' ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Complete narrow conversion history plus colliding keys, never a bounded recent list.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_event_conversion_state_read_failed', __( 'Booking event conversion state could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		$source   = 'extrachill-events-booking';
+		$identity = hash( 'sha256', $source . "\0" . $public_id );
+		$attempts = array();
+		foreach ( (array) $rows as $row ) {
+			$marker = $this->hydrate( $row );
+			if ( is_wp_error( $marker ) ) {
+				return $this->conversion_state_error( 'payload', $row['id'] ?? 0 );
+			}
+			$data    = $marker['payload']['data'];
+			$attempt = $data['attempt'] ?? null;
+			$kind    = $marker['kind'];
+			$key     = sprintf( 'event-conversion:%s:%d:%s', $public_id, (int) $attempt, $kind );
+			if ( ! is_int( $attempt ) || $attempt < 1 || ! in_array( $kind, array( 'event_conversion_started', 'event_conversion_failed', 'event_converted' ), true ) || $marker['idempotency_key'] !== $key || ( $data['source'] ?? null ) !== $source || ( $data['source_id'] ?? null ) !== $public_id || ( $data['source_identity'] ?? null ) !== $identity || isset( $attempts[ $attempt ][ $kind ] ) ) {
+				return $this->conversion_state_error( 'marker', $marker['id'] );
+			}
+			if ( 'event_conversion_started' === $kind && ( ! is_int( $data['expected_version'] ?? null ) || $data['expected_version'] < 1 || null !== $marker['external_id'] ) ) {
+				return $this->conversion_state_error( 'started', $marker['id'] );
+			}
+			if ( 'event_conversion_failed' === $kind && ( ! is_string( $data['upstream_code'] ?? null ) || '' === $data['upstream_code'] || ! array_key_exists( 'upstream_data', $data ) || ! is_bool( $data['retryable'] ?? null ) || null !== $marker['external_id'] ) ) {
+				return $this->conversion_state_error( 'failed', $marker['id'] );
+			}
+			if ( 'event_converted' === $kind && ( ! is_int( $data['event_id'] ?? null ) || $data['event_id'] < 1 || (string) $data['event_id'] !== (string) $marker['external_id'] ) ) {
+				return $this->conversion_state_error( 'completed', $marker['id'] );
+			}
+			$attempts[ $attempt ][ $kind ] = $marker;
+		}
+		if ( empty( $attempts ) ) {
+			return array(
+				'attempt'   => 0,
+				'status'    => 'none',
+				'pending'   => false,
+				'started'   => null,
+				'failed'    => null,
+				'completed' => null,
+			);
+		}
+		ksort( $attempts, SORT_NUMERIC );
+		$expected_attempt     = 1;
+		$latest               = null;
+		$previous_terminal_id = 0;
+		foreach ( $attempts as $attempt => $markers ) {
+			$terminals = (int) isset( $markers['event_conversion_failed'] ) + (int) isset( $markers['event_converted'] );
+			$start_id  = (int) ( $markers['event_conversion_started']['id'] ?? 0 );
+			$terminal  = $markers['event_conversion_failed'] ?? ( $markers['event_converted'] ?? null );
+			if ( $attempt !== $expected_attempt || ! isset( $markers['event_conversion_started'] ) || $terminals > 1 || ( null !== $latest && 'failed' !== $latest['status'] ) || $start_id <= $previous_terminal_id || ( is_array( $terminal ) && (int) $terminal['id'] <= $start_id ) ) {
+				return $this->conversion_state_error( 'sequence', $markers['event_conversion_started']['id'] ?? 0 );
+			}
+			$expected_version = $markers['event_conversion_started']['payload']['data']['expected_version'];
+			if ( isset( $markers['event_conversion_failed'] ) && ( $markers['event_conversion_failed']['payload']['data']['booking_version'] ?? null ) !== $expected_version ) {
+				return $this->conversion_state_error( 'failed_version', $markers['event_conversion_failed']['id'] );
+			}
+			if ( isset( $markers['event_converted'] ) && ( $markers['event_converted']['payload']['data']['version'] ?? null ) !== $expected_version + 1 ) {
+				return $this->conversion_state_error( 'completed_version', $markers['event_converted']['id'] );
+			}
+			$latest               = array(
+				'attempt'   => $attempt,
+				'markers'   => $markers,
+				'terminals' => $terminals,
+				'status'    => isset( $markers['event_conversion_failed'] ) ? 'failed' : ( isset( $markers['event_converted'] ) ? 'completed' : 'pending' ),
+			);
+			$previous_terminal_id = is_array( $terminal ) ? (int) $terminal['id'] : 0;
+			++$expected_attempt;
+		}
+		$markers   = $latest['markers'];
+		$completed = $markers['event_converted'] ?? null;
+		$failed    = $markers['event_conversion_failed'] ?? null;
+		return array(
+			'attempt'   => $latest['attempt'],
+			'status'    => $completed ? 'completed' : ( $failed ? 'failed' : 'pending' ),
+			'pending'   => ! $completed && ! $failed,
+			'started'   => $markers['event_conversion_started'],
+			'failed'    => $failed,
+			'completed' => $completed,
+		);
+	}
+
+	private function conversion_state_error( string $detail, int $activity_id ): \WP_Error {
+		return new \WP_Error(
+			'booking_event_conversion_state_invalid',
+			__( 'Booking event conversion activity is malformed or inconsistent.', 'extrachill-events' ),
+			array(
+				'status'      => 409,
+				'repairable'  => true,
+				'detail'      => $detail,
+				'activity_id' => $activity_id,
+			)
+		);
+	}
+
 	/** Find an existing booking-scoped idempotent activity. */
 	private function find_by_idempotency( int $booking_id, string $key ) {
 		global $wpdb;

--- a/inc/Core/BookingEventConversionService.php
+++ b/inc/Core/BookingEventConversionService.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /** Coordinates the two-phase booking/event handoff without owning DME internals. */
 class BookingEventConversionService {
-	private const SOURCE = 'extrachill-events-booking';
+	public const SOURCE = 'extrachill-events-booking';
 
 	/** @var BookingRepository */
 	private $bookings;

--- a/inc/Core/BookingEventConversionService.php
+++ b/inc/Core/BookingEventConversionService.php
@@ -1,0 +1,673 @@
+<?php
+/**
+ * Confirmed booking to canonical event conversion.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Coordinates the two-phase booking/event handoff without owning DME internals. */
+class BookingEventConversionService {
+	private const SOURCE = 'extrachill-events-booking';
+
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var BookingHoldRepository */
+	private $holds;
+	/** @var BookingActivityRepository */
+	private $activity;
+	/** @var VenueAuthorization */
+	private $authorization;
+	/** @var bool */
+	private $transaction_active = false;
+
+	public function __construct( ?BookingRepository $bookings = null, ?BookingHoldRepository $holds = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null ) {
+		$this->bookings      = $bookings ? $bookings : new BookingRepository();
+		$this->activity      = $activity ? $activity : new BookingActivityRepository();
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+		$this->holds         = $holds ? $holds : new BookingHoldRepository( $this->bookings, $this->activity, $this->authorization );
+	}
+
+	/** Convert a confirmed booking through DME's public idempotent ability. */
+	public function convert( int $booking_id, int $expected_version, int $actor_id ) {
+		$booking = $this->bookings->get( $booking_id );
+		if ( ! is_array( $booking ) ) {
+			return is_wp_error( $booking ) ? $booking : $this->not_found();
+		}
+		$allowed = $this->authorize( $actor_id, $booking['venue_term_id'] );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'data-machine-events/upsert-event' ) : null;
+		if ( ! is_object( $ability ) || ! is_callable( array( $ability, 'execute' ) ) ) {
+			return new \WP_Error(
+				'booking_event_ability_unavailable',
+				__( 'Canonical event conversion is temporarily unavailable.', 'extrachill-events' ),
+				array(
+					'status'    => 503,
+					'retryable' => true,
+				)
+			);
+		}
+
+		$preflight = $this->locked_preflight( $booking_id, $expected_version, $actor_id );
+		if ( is_wp_error( $preflight ) || isset( $preflight['event_action'] ) ) {
+			return $preflight;
+		}
+
+		$upstream = $ability->execute( $preflight['input'] );
+		if ( is_wp_error( $upstream ) ) {
+			return $this->finalize_failure( $booking_id, $actor_id, $preflight['attempt'], $upstream );
+		}
+		$verified = $this->verify_upstream( $upstream, $preflight['booking'] );
+		if ( is_wp_error( $verified ) ) {
+			return $verified;
+		}
+		$verified['attempt'] = $preflight['attempt'];
+
+		return $this->finalize( $booking_id, $expected_version, $actor_id, $verified );
+	}
+
+	/** Complete authorization and data validation under the aggregate locks. */
+	private function locked_preflight( int $booking_id, int $expected_version, int $actor_id ) {
+		$initial = $this->bookings->get( $booking_id );
+		if ( ! is_array( $initial ) ) {
+			return is_wp_error( $initial ) ? $initial : $this->not_found();
+		}
+		$started = $this->begin_authorized( $initial['venue_term_id'], $actor_id );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$booking = $this->bookings->get_for_update( $booking_id );
+		if ( ! is_array( $booking ) ) {
+			return $this->rollback( is_wp_error( $booking ) ? $booking : $this->not_found() );
+		}
+		if ( null !== $booking['event_id'] ) {
+			$existing = $this->existing_result( $booking );
+			if ( is_wp_error( $existing ) ) {
+				return $this->rollback( $existing );
+			}
+			$committed = $this->commit( false );
+			return is_wp_error( $committed ) ? $committed : $existing;
+		}
+		$validated = $this->validate_preflight( $booking, $expected_version );
+		if ( is_wp_error( $validated ) ) {
+			return $this->rollback( $validated );
+		}
+		$state = $this->activity->event_conversion_state( $booking_id, $booking['public_id'] );
+		if ( is_wp_error( $state ) ) {
+			return $this->rollback( $state );
+		}
+		if ( 'completed' === $state['status'] ) {
+			return $this->rollback(
+				new \WP_Error(
+					'booking_event_conversion_state_invalid',
+					__( 'Completed event conversion is missing its booking event claim.', 'extrachill-events' ),
+					array(
+						'status'     => 409,
+						'repairable' => true,
+						'detail'     => 'completed_without_event',
+					)
+				)
+			);
+		}
+		$attempt = $state['pending'] ? $state['attempt'] : $state['attempt'] + 1;
+		if ( ! $state['pending'] ) {
+			$source_identity = hash( 'sha256', self::SOURCE . "\0" . $booking['public_id'] );
+			$intent          = $this->activity->append(
+				array(
+					'booking_id'      => $booking_id,
+					'kind'            => 'event_conversion_started',
+					'actor_type'      => 'user',
+					'actor_id'        => $actor_id,
+					'idempotency_key' => $this->marker_key( $booking['public_id'], $attempt, 'event_conversion_started' ),
+					'payload'         => array(
+						'attempt'          => $attempt,
+						'source'           => self::SOURCE,
+						'source_id'        => $booking['public_id'],
+						'source_identity'  => $source_identity,
+						'expected_version' => $expected_version,
+					),
+				)
+			);
+			if ( is_wp_error( $intent ) ) {
+				return $this->rollback( $intent );
+			}
+			$state = $this->activity->event_conversion_state( $booking_id, $booking['public_id'] );
+			if ( is_wp_error( $state ) || ! $state['pending'] || $attempt !== $state['attempt'] ) {
+				return $this->rollback(
+					is_wp_error( $state ) ? $state : new \WP_Error(
+						'booking_event_conversion_state_invalid',
+						__( 'Booking event conversion start could not be verified.', 'extrachill-events' ),
+						array(
+							'status'     => 409,
+							'repairable' => true,
+						)
+					)
+				);
+			}
+		}
+		$committed = $this->commit( false );
+		return is_wp_error( $committed ) ? $committed : array(
+			'input'   => $validated,
+			'booking' => $booking,
+			'attempt' => $attempt,
+		);
+	}
+
+	/** Claim the external event and append its sole activity in one transaction. */
+	private function finalize( int $booking_id, int $expected_version, int $actor_id, array $upstream ) {
+		$event_id  = $upstream['event_id'];
+		$event_url = $upstream['event_url'];
+		$action    = $upstream['action'];
+		$attempt   = $upstream['attempt'];
+		$initial   = $this->bookings->get( $booking_id );
+		if ( ! is_array( $initial ) ) {
+			return is_wp_error( $initial ) ? $initial : $this->not_found();
+		}
+		$started = $this->begin_authorized( $initial['venue_term_id'], $actor_id );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$booking = $this->bookings->get_for_update( $booking_id );
+		if ( ! is_array( $booking ) ) {
+			return $this->rollback( is_wp_error( $booking ) ? $booking : $this->not_found() );
+		}
+		if ( null !== $booking['event_id'] ) {
+			if ( $event_id !== (int) $booking['event_id'] ) {
+				return $this->rollback( $this->different_event( $booking['event_id'] ) );
+			}
+			$existing  = $this->existing_result( $booking );
+			$committed = is_wp_error( $existing ) ? $this->rollback( $existing ) : $this->commit( true );
+			return is_wp_error( $committed ) ? $committed : $existing;
+		}
+		$validated = $this->validate_preflight( $booking, $expected_version );
+		if ( is_wp_error( $validated ) ) {
+			return $this->rollback( $validated );
+		}
+		$state = $this->activity->event_conversion_state( $booking_id, $booking['public_id'] );
+		if ( is_wp_error( $state ) || ! $state['pending'] || $attempt !== $state['attempt'] ) {
+			return $this->rollback(
+				is_wp_error( $state ) ? $state : new \WP_Error(
+					'booking_event_conversion_state_invalid',
+					__( 'The pending event conversion attempt changed before finalization.', 'extrachill-events' ),
+					array(
+						'status'     => 409,
+						'repairable' => true,
+					)
+				)
+			);
+		}
+		$claimed = $this->bookings->claim_event( $booking_id, $event_id, $expected_version );
+		if ( is_wp_error( $claimed ) ) {
+			if ( 'booking_event_already_linked' === $claimed->get_error_code() ) {
+				return $this->rollback( $this->different_event( $claimed->get_error_data()['event_id'] ?? 0 ) );
+			}
+			return $this->rollback( $claimed );
+		}
+		$event_url = '' !== $event_url ? $event_url : (string) get_permalink( $event_id );
+		$activity  = $this->activity->append(
+			array(
+				'booking_id'      => $booking_id,
+				'kind'            => 'event_converted',
+				'actor_type'      => 'user',
+				'actor_id'        => $actor_id,
+				'idempotency_key' => $this->marker_key( $booking['public_id'], $attempt, 'event_converted' ),
+				'external_id'     => (string) $event_id,
+				'payload'         => array(
+					'attempt'         => $attempt,
+					'event_id'        => $event_id,
+					'event_url'       => $event_url,
+					'source'          => $upstream['source']['name'],
+					'source_id'       => $upstream['source']['id'],
+					'source_identity' => $upstream['source']['identity'],
+					'upstream_action' => $action,
+					'version'         => $expected_version + 1,
+				),
+			)
+		);
+		if ( is_wp_error( $activity ) ) {
+			return $this->rollback( $activity );
+		}
+		$committed = $this->commit( true );
+		return is_wp_error( $committed ) ? $committed : $this->result( $booking_id, $expected_version + 1, $event_id, $event_url, $action, false );
+	}
+
+	/** Persist an explicit failed DME response as the terminal marker for its attempt. */
+	private function finalize_failure( int $booking_id, int $actor_id, int $attempt, \WP_Error $upstream ) {
+		$initial = $this->bookings->get( $booking_id );
+		if ( ! is_array( $initial ) ) {
+			return $this->failure_finalize_error( $upstream, $attempt, is_wp_error( $initial ) ? $initial : $this->not_found() );
+		}
+		$started = $this->begin_authorized( $initial['venue_term_id'], $actor_id );
+		if ( is_wp_error( $started ) ) {
+			return $this->failure_finalize_error( $upstream, $attempt, $started );
+		}
+		$booking = $this->bookings->get_for_update( $booking_id );
+		if ( ! is_array( $booking ) ) {
+			$cause = is_wp_error( $booking ) ? $booking : $this->not_found();
+			return $this->failure_finalize_error( $upstream, $attempt, $this->rollback( $cause ) );
+		}
+		$state = $this->activity->event_conversion_state( $booking_id, $booking['public_id'] );
+		if ( is_wp_error( $state ) || ! $state['pending'] || $attempt !== $state['attempt'] ) {
+			$cause = is_wp_error( $state ) ? $state : new \WP_Error(
+				'booking_event_conversion_state_invalid',
+				__( 'The failed event conversion attempt is no longer pending.', 'extrachill-events' ),
+				array(
+					'status'     => 409,
+					'repairable' => true,
+				)
+			);
+			return $this->failure_finalize_error( $upstream, $attempt, $this->rollback( $cause ) );
+		}
+		$data      = $upstream->get_error_data();
+		$retryable = $this->upstream_retryable( $data );
+		$failed    = $this->activity->append(
+			array(
+				'booking_id'      => $booking_id,
+				'kind'            => 'event_conversion_failed',
+				'actor_type'      => 'user',
+				'actor_id'        => $actor_id,
+				'idempotency_key' => $this->marker_key( $booking['public_id'], $attempt, 'event_conversion_failed' ),
+				'payload'         => array(
+					'attempt'         => $attempt,
+					'source'          => self::SOURCE,
+					'source_id'       => $booking['public_id'],
+					'source_identity' => hash( 'sha256', self::SOURCE . "\0" . $booking['public_id'] ),
+					'upstream_code'   => $upstream->get_error_code(),
+					'upstream_data'   => $data,
+					'retryable'       => $retryable,
+					'booking_version' => $booking['version'],
+				),
+			)
+		);
+		if ( is_wp_error( $failed ) ) {
+			return $this->failure_finalize_error( $upstream, $attempt, $this->rollback( $failed ) );
+		}
+		$verified = $this->activity->event_conversion_state( $booking_id, $booking['public_id'] );
+		if ( is_wp_error( $verified ) || 'failed' !== $verified['status'] || $attempt !== $verified['attempt'] ) {
+			$cause = is_wp_error( $verified ) ? $verified : new \WP_Error(
+				'booking_event_conversion_state_invalid',
+				__( 'The failed event conversion marker could not be verified.', 'extrachill-events' ),
+				array(
+					'status'     => 409,
+					'repairable' => true,
+				)
+			);
+			return $this->failure_finalize_error( $upstream, $attempt, $this->rollback( $cause ) );
+		}
+		$committed = $this->commit( true );
+		if ( is_wp_error( $committed ) ) {
+			return $this->failure_finalize_error( $upstream, $attempt, $committed );
+		}
+		return $this->upstream_error( $upstream, $attempt, $booking['version'] );
+	}
+
+	/** Validate immutable public conversion facts and build deterministic input. */
+	private function validate_preflight( array $booking, int $expected_version ) {
+		if ( (int) $booking['version'] !== $expected_version ) {
+			return new \WP_Error(
+				'booking_version_conflict',
+				__( 'The booking changed since it was read.', 'extrachill-events' ),
+				array(
+					'status'          => 409,
+					'current_version' => $booking['version'],
+				)
+			);
+		}
+		if ( 'confirmed' !== $booking['status'] ) {
+			return new \WP_Error(
+				'booking_event_status_forbidden',
+				__( 'Only confirmed bookings can become events.', 'extrachill-events' ),
+				array(
+					'status'         => 409,
+					'booking_status' => $booking['status'],
+				)
+			);
+		}
+		foreach ( array( 'space_key', 'performance_start_at', 'performance_end_at' ) as $field ) {
+			if ( empty( $booking[ $field ] ) ) {
+				return new \WP_Error(
+					'booking_event_selection_incomplete',
+					__( 'The authoritative booking performance is incomplete.', 'extrachill-events' ),
+					array(
+						'status' => 409,
+						'field'  => $field,
+					)
+				);
+			}
+		}
+		$deal = $booking['confirmed_deal']['data'] ?? null;
+		if ( ! is_array( $deal ) || is_wp_error( BookingMutationService::normalize_deal_document( $deal ) ) || ! BookingMutationService::documents_equal( BookingMutationService::normalize_deal_document( $deal ), $deal ) ) {
+			return new \WP_Error( 'booking_event_confirmed_deal_invalid', __( 'A normalized frozen confirmed deal is required.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$venue = get_term( $booking['venue_term_id'], 'venue' );
+		if ( ! $venue || is_wp_error( $venue ) || 'venue' !== $venue->taxonomy ) {
+			return new \WP_Error( 'booking_event_venue_invalid', __( 'The canonical venue is unavailable.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$metadata = $this->venue_metadata( $booking['venue_term_id'] );
+		if ( is_wp_error( $metadata ) ) {
+			return $metadata;
+		}
+		$holds = $this->holds->converted_for_booking( $booking );
+		if ( is_wp_error( $holds ) ) {
+			return $holds;
+		}
+		if ( 1 !== count( $holds ) ) {
+			return new \WP_Error(
+				'booking_event_converted_hold_invalid',
+				__( 'Exactly one converted hold must match the confirmed performance.', 'extrachill-events' ),
+				array(
+					'status'         => 409,
+					'matching_holds' => count( $holds ),
+				)
+			);
+		}
+		$start = $this->local_datetime( $booking['performance_start_at'], $metadata['venueTimezone'] );
+		$end   = $this->local_datetime( $booking['performance_end_at'], $metadata['venueTimezone'] );
+		if ( is_wp_error( $start ) || is_wp_error( $end ) ) {
+			return is_wp_error( $start ) ? $start : $end;
+		}
+		$event = array_merge(
+			array(
+				'title'         => $booking['artist_name'] . ' at ' . $venue->name,
+				'startDate'     => $start->format( 'Y-m-d' ),
+				'startTime'     => $start->format( 'H:i' ),
+				'endDate'       => $end->format( 'Y-m-d' ),
+				'endTime'       => $end->format( 'H:i' ),
+				'performer'     => $booking['artist_name'],
+				'performerType' => 'PerformingGroup',
+				'venue'         => $venue->name,
+				'eventStatus'   => 'EventScheduled',
+				'eventType'     => 'MusicEvent',
+			),
+			$metadata
+		);
+		$price = $this->public_price( $deal );
+		if ( null !== $price ) {
+			$event['price']         = $price;
+			$event['priceCurrency'] = $deal['currency'];
+		}
+		if ( ! empty( $deal['ticket_url'] ) ) {
+			$event['ticketUrl'] = $deal['ticket_url'];
+		}
+		return array(
+			'source'      => self::SOURCE,
+			'source_id'   => $booking['public_id'],
+			'post_status' => 'publish',
+			'event'       => $event,
+		);
+	}
+
+	/** Require DME to return the exact canonical identity and venue proof requested. */
+	private function verify_upstream( $upstream, array $booking ) {
+		$identity = hash( 'sha256', self::SOURCE . "\0" . $booking['public_id'] );
+		$valid    = is_array( $upstream )
+			&& true === ( $upstream['success'] ?? null )
+			&& 0 < (int) ( $upstream['event_id'] ?? 0 )
+			&& in_array( $upstream['action'] ?? '', array( 'created', 'updated', 'no_change' ), true )
+			&& self::SOURCE === ( $upstream['source']['name'] ?? null )
+			&& ( $upstream['source']['id'] ?? null ) === $booking['public_id']
+			&& ( $upstream['source']['identity'] ?? null ) === $identity
+			&& (int) ( $upstream['normalized']['venue_id'] ?? 0 ) === (int) $booking['venue_term_id']
+			&& 'publish' === ( $upstream['normalized']['post_status'] ?? null );
+		if ( ! $valid ) {
+			return new \WP_Error(
+				'booking_event_upsert_failed',
+				__( 'Canonical event conversion returned an invalid result.', 'extrachill-events' ),
+				array(
+					'status'        => 502,
+					'retryable'     => true,
+					'upstream_code' => 'invalid_response',
+					'upstream_data' => $upstream,
+				)
+			);
+		}
+		return array(
+			'event_id'  => (int) $upstream['event_id'],
+			'event_url' => (string) ( $upstream['event_url'] ?? '' ),
+			'action'    => (string) $upstream['action'],
+			'source'    => $upstream['source'],
+		);
+	}
+
+	/** Read only DME-established canonical venue metadata. */
+	private function venue_metadata( int $venue_id ) {
+		$map    = array(
+			'_venue_address'     => 'venueAddress',
+			'_venue_city'        => 'venueCity',
+			'_venue_state'       => 'venueState',
+			'_venue_zip'         => 'venueZip',
+			'_venue_country'     => 'venueCountry',
+			'_venue_phone'       => 'venuePhone',
+			'_venue_website'     => 'venueWebsite',
+			'_venue_coordinates' => 'venueCoordinates',
+			'_venue_capacity'    => 'venueCapacity',
+			'_venue_timezone'    => 'venueTimezone',
+		);
+		$output = array();
+		foreach ( $map as $meta_key => $event_key ) {
+			$value = get_term_meta( $venue_id, $meta_key, true );
+			if ( '' !== trim( (string) $value ) ) {
+				$output[ $event_key ] = (string) $value;
+			}
+		}
+		foreach ( array( 'venueAddress', 'venueCity', 'venueState', 'venueCountry', 'venueTimezone' ) as $required ) {
+			if ( empty( $output[ $required ] ) ) {
+				return new \WP_Error(
+					'booking_event_venue_incomplete',
+					__( 'Canonical venue metadata is incomplete.', 'extrachill-events' ),
+					array(
+						'status' => 409,
+						'field'  => $required,
+					)
+				);
+			}
+		}
+		try {
+			new \DateTimeZone( $output['venueTimezone'] );
+		} catch ( \Exception $exception ) {
+			return new \WP_Error( 'booking_event_venue_timezone_invalid', __( 'The canonical venue timezone is invalid.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return $output;
+	}
+
+	private function local_datetime( string $value, string $timezone ) {
+		$date = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $value, new \DateTimeZone( 'UTC' ) );
+		if ( false === $date || $date->format( 'Y-m-d H:i:s' ) !== $value ) {
+			return new \WP_Error( 'booking_event_datetime_invalid', __( 'The performance time is not strict UTC.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return $date->setTimezone( new \DateTimeZone( $timezone ) );
+	}
+
+	private function public_price( array $deal ): ?string {
+		$advance = $deal['advance_ticket_price_cents'];
+		$door    = $deal['door_ticket_price_cents'];
+		if ( null === $advance && null === $door ) {
+			return null;
+		}
+		if ( null !== $advance && null !== $door && $advance === $door ) {
+			return number_format( $advance / 100, 2, '.', '' );
+		}
+		if ( null === $door ) {
+			return number_format( $advance / 100, 2, '.', '' ) . ' adv';
+		}
+		if ( null === $advance ) {
+			return number_format( $door / 100, 2, '.', '' ) . ' door';
+		}
+		return number_format( $advance / 100, 2, '.', '' ) . ' adv / ' . number_format( $door / 100, 2, '.', '' ) . ' door';
+	}
+
+	private function begin_authorized( int $venue_id, int $actor_id ) {
+		global $wpdb;
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+			return new \WP_Error( 'booking_event_transaction_start_failed', __( 'The booking event transaction could not start.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		$this->transaction_active = true;
+		$table                    = BookingSchema::memberships_table();
+		$wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $venue_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Existing exact-venue authority lock order.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return $this->rollback( new \WP_Error( 'booking_event_authorization_lock_failed', __( 'Venue booking authority could not be locked.', 'extrachill-events' ) ) );
+		}
+		$allowed = $this->authorize( $actor_id, $venue_id );
+		return is_wp_error( $allowed ) ? $this->rollback( $allowed ) : true;
+	}
+
+	private function authorize( int $actor_id, int $venue_id ) {
+		$allowed = $this->authorization->authorize( $actor_id, $venue_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+		return true === $allowed ? true : ( is_wp_error( $allowed ) ? $allowed : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) ) );
+	}
+
+	private function commit( bool $finalize ) {
+		global $wpdb;
+		$result                   = $wpdb->query( 'COMMIT' );
+		$this->transaction_active = false;
+		if ( false !== $result ) {
+			return true;
+		}
+		return new \WP_Error(
+			$finalize ? 'booking_event_finalize_uncertain' : 'booking_event_preflight_uncertain',
+			__( 'The booking event transaction outcome could not be confirmed.', 'extrachill-events' ),
+			array(
+				'status'         => 503,
+				'retryable'      => true,
+				'database_error' => $wpdb->last_error,
+			)
+		);
+	}
+
+	private function rollback( \WP_Error $cause ) {
+		global $wpdb;
+		if ( ! $this->transaction_active ) {
+			return $cause;
+		}
+		$result                   = $wpdb->query( 'ROLLBACK' );
+		$this->transaction_active = false;
+		return false === $result ? new \WP_Error(
+			'booking_event_transaction_rollback_failed',
+			__( 'The booking event transaction could not be rolled back.', 'extrachill-events' ),
+			array(
+				'cause'          => $cause->get_error_code(),
+				'database_error' => $wpdb->last_error,
+			)
+		) : $cause;
+	}
+
+	private function existing_result( array $booking ) {
+		$post       = get_post( $booking['event_id'] );
+		$type       = defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events';
+		$identity   = hash( 'sha256', self::SOURCE . "\0" . $booking['public_id'] );
+		$venue_ids  = wp_get_object_terms( $booking['event_id'], 'venue', array( 'fields' => 'ids' ) );
+		$conversion = $this->activity->event_conversion_state( $booking['id'], $booking['public_id'] );
+		if ( is_wp_error( $conversion ) ) {
+			return $conversion;
+		}
+		$integrity = array();
+		if ( ! $post || ( $post->post_type ?? null ) !== $type ) {
+			$integrity[] = 'post_type';
+		} elseif ( 'publish' !== $post->post_status ) {
+			$integrity[] = 'post_status';
+		}
+		if ( self::SOURCE !== get_post_meta( $booking['event_id'], '_datamachine_event_source', true ) ) {
+			$integrity[] = 'source_name';
+		}
+		if ( get_post_meta( $booking['event_id'], '_datamachine_event_source_id', true ) !== $booking['public_id'] ) {
+			$integrity[] = 'source_id';
+		}
+		if ( get_post_meta( $booking['event_id'], '_datamachine_event_source_identity', true ) !== $identity ) {
+			$integrity[] = 'source_identity';
+		}
+		if ( is_wp_error( $venue_ids ) || array_map( 'intval', (array) $venue_ids ) !== array( (int) $booking['venue_term_id'] ) ) {
+			$integrity[] = 'venue';
+		}
+		$completed = is_array( $conversion ) ? $conversion['completed'] : null;
+		if ( ! is_array( $completed ) || (int) ( $completed['payload']['data']['event_id'] ?? 0 ) !== (int) $booking['event_id'] || ( $completed['payload']['data']['source_identity'] ?? null ) !== $identity ) {
+			$integrity[] = 'event_converted_activity';
+		}
+		if ( $integrity ) {
+			return new \WP_Error(
+				'booking_event_existing_invalid',
+				__( 'The linked site-local event is invalid.', 'extrachill-events' ),
+				array(
+					'status'     => 409,
+					'repairable' => true,
+					'event_id'   => $booking['event_id'],
+					'integrity'  => $integrity,
+				)
+			);
+		}
+		return $this->result( $booking['id'], $booking['version'], $booking['event_id'], (string) get_permalink( $booking['event_id'] ), 'existing', true );
+	}
+
+	private function result( int $booking_id, int $version, int $event_id, string $url, string $action, bool $existing ): array {
+		return array(
+			'booking_id'        => $booking_id,
+			'booking_version'   => $version,
+			'event_id'          => $event_id,
+			'event_url'         => $url,
+			'event_action'      => $action,
+			'already_converted' => $existing,
+		);
+	}
+
+	private function upstream_error( \WP_Error $error, int $attempt, int $booking_version ): \WP_Error {
+		$data      = $error->get_error_data();
+		$retryable = $this->upstream_retryable( $data );
+		return new \WP_Error(
+			'booking_event_upsert_failed',
+			__( 'Canonical event conversion failed.', 'extrachill-events' ),
+			array(
+				'status'          => $retryable ? 503 : 422,
+				'retryable'       => $retryable,
+				'upstream_code'   => $error->get_error_code(),
+				'upstream_data'   => $data,
+				'attempt'         => $attempt,
+				'booking_version' => $booking_version,
+			)
+		);
+	}
+
+	private function failure_finalize_error( \WP_Error $upstream, int $attempt, \WP_Error $cause ): \WP_Error {
+		return new \WP_Error(
+			'booking_event_failure_finalize_failed',
+			__( 'The failed event conversion attempt could not be finalized.', 'extrachill-events' ),
+			array(
+				'status'        => 503,
+				'retryable'     => true,
+				'attempt'       => $attempt,
+				'upstream_code' => $upstream->get_error_code(),
+				'upstream_data' => $upstream->get_error_data(),
+				'cause'         => $cause->get_error_code(),
+				'cause_data'    => $cause->get_error_data(),
+			)
+		);
+	}
+
+	private function upstream_retryable( $data ): bool {
+		return is_array( $data ) && ( ! empty( $data['retryable'] ) || ! empty( $data['transient'] ) || (int) ( $data['status'] ?? 0 ) >= 500 );
+	}
+
+	private function marker_key( string $public_id, int $attempt, string $kind ): string {
+		return sprintf( 'event-conversion:%s:%d:%s', $public_id, $attempt, $kind );
+	}
+
+	private function different_event( int $event_id ): \WP_Error {
+		return new \WP_Error(
+			'booking_event_already_linked',
+			__( 'The booking is already linked to a different event.', 'extrachill-events' ),
+			array(
+				'status'   => 409,
+				'event_id' => $event_id,
+			)
+		);
+	}
+
+	private function not_found(): \WP_Error {
+		return new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+	}
+}

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -587,6 +587,17 @@ class BookingHoldRepository {
 		return is_array( $hold ) ? $this->hydrate( $hold ) : $hold;
 	}
 
+	/** Read every converted hold matching the booking's authoritative selection. */
+	public function converted_for_booking( array $booking ) {
+		global $wpdb;
+		$table = BookingSchema::holds_table();
+		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND venue_term_id = %d AND space_key = %s AND start_at = %s AND end_at = %s AND status = 'converted' AND converted_at IS NOT NULL ORDER BY id ASC", $booking['id'], $booking['venue_term_id'], $booking['space_key'], $booking['performance_start_at'], $booking['performance_end_at'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Focused exact converted-selection read.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_converted_hold_read_failed', __( 'The converted booking hold could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return array_map( array( $this, 'hydrate' ), (array) $rows );
+	}
+
 	/** Read one stored hold without applying its effective elapsed status. */
 	private function raw_get( int $hold_id ) {
 		global $wpdb;

--- a/inc/Core/BookingLifecycle.php
+++ b/inc/Core/BookingLifecycle.php
@@ -252,6 +252,23 @@ class BookingLifecycle {
 		if ( is_wp_error( $started ) ) {
 			return $started;
 		}
+		$locked = $this->bookings->get_for_update( $booking_id );
+		if ( ! is_array( $locked ) ) {
+			return $this->rollback( is_wp_error( $locked ) ? $locked : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+		}
+		if ( (int) $locked['version'] !== $expected_version ) {
+			return $this->rollback( $this->version_conflict( $locked ) );
+		}
+		$conversion = $this->check_event_conversion_pending( $locked );
+		if ( is_wp_error( $conversion ) ) {
+			return $this->rollback( $conversion );
+		}
+		if ( null !== $locked['event_id'] ) {
+			return $this->rollback( new \WP_Error( 'booking_event_artist_frozen', __( 'Public event performer identity is frozen; use the event correction path to synchronize artist changes.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+		}
+		if ( ( $locked['artist_term_id'] && null !== $term_id && $locked['artist_term_id'] !== $term_id ) || ( $locked['artist_profile_id'] && null !== $profile_id && $locked['artist_profile_id'] !== $profile_id ) ) {
+			return $this->rollback( new \WP_Error( 'booking_artist_already_bound', __( 'Existing booking artist bindings cannot be replaced implicitly.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+		}
 		$changes = array();
 		if ( null !== $term_id ) {
 			$changes['artist_term_id'] = $term_id;
@@ -374,8 +391,20 @@ class BookingLifecycle {
 		if ( is_wp_error( $started ) ) {
 			return $started;
 		}
-		$set    = array();
-		$values = array();
+		$locked = $this->bookings->get_for_update( $current['id'] );
+		if ( ! is_array( $locked ) ) {
+			return $this->rollback( is_wp_error( $locked ) ? $locked : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+		}
+		if ( (int) $locked['version'] !== $expected_version ) {
+			return $this->rollback( $this->version_conflict( $locked ) );
+		}
+		$conversion = $this->check_event_conversion_pending( $locked );
+		if ( is_wp_error( $conversion ) ) {
+			return $this->rollback( $conversion );
+		}
+		$current = $locked;
+		$set     = array();
+		$values  = array();
 		foreach ( $changes as $column => $value ) {
 			if ( null === $value ) {
 				$set[] = "{$column} = NULL";
@@ -426,6 +455,17 @@ class BookingLifecycle {
 		}
 		$committed = $this->commit();
 		return is_wp_error( $committed ) ? $committed : $this->bookings->get( $current['id'] );
+	}
+
+	/** Fail closed before any lifecycle-owned version change while conversion runs. */
+	private function check_event_conversion_pending( array $booking ) {
+		$state = $this->activity->event_conversion_state( $booking['id'], $booking['public_id'] );
+		if ( is_wp_error( $state ) ) {
+			return $state;
+		}
+		return $state['pending']
+			? new \WP_Error( 'booking_event_conversion_pending', __( 'The booking cannot change while event conversion is pending.', 'extrachill-events' ), array( 'status' => 409 ) )
+			: true;
 	}
 
 	/** Start the aggregate transaction. */

--- a/inc/Core/BookingRepository.php
+++ b/inc/Core/BookingRepository.php
@@ -180,6 +180,21 @@ class BookingRepository {
 		return is_array( $row ) ? $this->hydrate( $row ) : null;
 	}
 
+	/** Read and lock one booking inside an existing transaction. */
+	public function get_for_update( int $id ) {
+		global $wpdb;
+		$id = $this->positive_id( $id, 'booking_id', false );
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+		$table = BookingSchema::bookings_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1 FOR UPDATE", $id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate row lock inside a caller-owned transaction.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_read_failed', __( 'The booking could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return is_array( $row ) ? $this->hydrate( $row ) : null;
+	}
+
 	/** List bookings for one venue with bounded optional filters. */
 	public function list( array $filters ) {
 		global $wpdb;

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -11,6 +11,7 @@
 			<file>tests/BookingFoundationTest.php</file>
 			<file>tests/BookingHoldTest.php</file>
 			<file>tests/BookingMutationTest.php</file>
+			<file>tests/BookingEventConversionTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/BookingEventConversionTest.php
+++ b/tests/BookingEventConversionTest.php
@@ -233,6 +233,32 @@ final class BookingEventConversionTest extends TestCase {
 		$this->assertSame( 55, $authorization->calls[0][1] );
 	}
 
+	public function test_nested_dme_permission_is_scoped_to_the_active_booking_conversion(): void {
+		$booking       = $this->booking();
+		$authorization = new BookingTestAuthorization();
+		$wrapper       = null;
+		$this->install_ability(
+			function ( array $input ) use ( &$wrapper ): array {
+				$this->assertTrue( $wrapper->can_upsert_booking_event( false, $input ) );
+				$this->assertFalse( $wrapper->can_upsert_booking_event( false, array_merge( $input, array( 'source_id' => 'another-booking' ) ) ) );
+				$this->add_event( 901 );
+				$this->add_event_source_proof( 901, $input );
+				return $this->upstream_result( $input );
+			}
+		);
+		$wrapper = new VenueBookingEventAbilities( $this->service( $authorization ), null, $authorization );
+
+		$result = $wrapper->execute( array( 'booking_id' => $booking['id'], 'expected_version' => 1 ) );
+
+		$this->assertSame( 901, $result['event_id'] );
+		$this->assertFalse(
+			$wrapper->can_upsert_booking_event(
+				false,
+				array( 'source' => BookingEventConversionService::SOURCE, 'source_id' => $booking['public_id'] )
+			)
+		);
+	}
+
 	public function test_success_maps_only_canonical_public_data_and_claims_once(): void {
 		$ability = $GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event'];
 		$booking = $this->booking();

--- a/tests/BookingEventConversionTest.php
+++ b/tests/BookingEventConversionTest.php
@@ -1,0 +1,719 @@
+<?php
+/**
+ * Confirmed booking to canonical event conversion tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Abilities\VenueBookingEventAbilities;
+use ExtraChillEvents\Core\BookingActivityRepository;
+use ExtraChillEvents\Core\BookingEventConversionService;
+use ExtraChillEvents\Core\BookingLifecycle;
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\BookingSchema;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
+final class BookingConversionAbilityFake {
+	public $calls = array();
+	public $callback;
+	public function __construct( callable $callback ) {
+		$this->callback = $callback;
+	}
+	public function execute( $input ) {
+		$this->calls[] = $input;
+		return call_user_func( $this->callback, $input );
+	}
+}
+
+final class BookingEventConversionTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id'         => 7,
+			'stack'           => array(),
+			'uuid'            => 0,
+			'options'         => array(),
+			'dbdelta'         => array(),
+			'abilities'       => array(),
+			'ability_objects' => array(),
+			'actions'         => array(),
+			'fired_actions'   => array(),
+			'scheduled'       => array(),
+			'cache_deletes'   => array(),
+			'permalinks'      => array( 7 => array() ),
+			'event_venues'    => array( 7 => array() ),
+			'terms'           => array(
+				1 => array(
+					101 => (object) array( 'term_id' => 101, 'taxonomy' => 'artist', 'name' => 'Canonical Artist' ),
+				),
+				7 => array(
+					55 => (object) array( 'term_id' => 55, 'taxonomy' => 'venue', 'name' => 'The Canonical Room' ),
+				),
+			),
+			'meta'            => array(
+				1 => array(
+					101 => array( '_artist_profile_id' => 501 ),
+				),
+				7 => array(
+					55 => array(
+						'_venue_address'     => '123 King Street',
+						'_venue_city'        => 'Charleston',
+						'_venue_state'       => 'SC',
+						'_venue_zip'         => '29401',
+						'_venue_country'     => 'US',
+						'_venue_phone'       => '843-555-0100',
+						'_venue_website'     => 'https://venue.example',
+						'_venue_coordinates' => '32.7765,-79.9311',
+						'_venue_capacity'    => '500',
+						'_venue_timezone'    => 'America/New_York',
+					),
+				),
+			),
+			'posts'           => array(
+				4 => array(
+					501 => (object) array( 'ID' => 501, 'post_type' => 'artist_profile', 'post_status' => 'publish', 'post_title' => 'Canonical Artist' ),
+				),
+				7 => array(),
+			),
+			'post_meta'       => array( 4 => array( 501 => array( '_artist_term_id' => 101 ) ) ),
+		);
+		$GLOBALS['wpdb'] = new BookingWpdb();
+		$this->install_ability();
+	}
+
+	private function deal( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'version'                    => 1,
+				'type'                       => 'guarantee',
+				'guarantee_cents'            => 100000,
+				'revenue_share_basis_points' => 1500,
+				'revenue_share_basis'        => 'gross_ticket_sales',
+				'currency'                   => 'USD',
+				'capacity'                   => 300,
+				'advance_ticket_price_cents' => 2000,
+				'door_ticket_price_cents'    => 2500,
+				'ticket_fee_cents'           => 300,
+				'tickets_on_sale_at'         => '2030-01-01 15:00:00',
+				'ticket_url'                  => 'https://tickets.example/test-band',
+				'additional_terms'            => 'Private merch and settlement terms.',
+			),
+			$overrides
+		);
+	}
+
+	private function booking( array $overrides = array(), bool $with_hold = true ): array {
+		$data    = array_merge(
+			array(
+				'venue_term_id'        => 55,
+				'artist_name'          => 'Test Band',
+				'intake'               => array( 'private_contact' => 'hidden' ),
+				'contact_email'        => 'private@example.com',
+				'space_key'            => 'main-room',
+				'performance_start_at' => '2030-03-10 00:00:00',
+				'performance_end_at'   => '2030-03-10 03:00:00',
+				'confirmed_deal'       => $this->deal(),
+			),
+			$overrides
+		);
+		$booking = ( new BookingRepository() )->create( $data );
+		$row     =& $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ];
+		$row['status'] = $overrides['status'] ?? 'confirmed';
+		$booking       = ( new BookingRepository() )->get( $booking['id'] );
+		if ( $with_hold ) {
+			$this->add_converted_hold( $booking );
+		}
+		return $booking;
+	}
+
+	private function add_converted_hold( array $booking, array $overrides = array() ): void {
+		$now = gmdate( 'Y-m-d H:i:s' );
+		$GLOBALS['wpdb']->insert(
+			BookingSchema::holds_table(),
+			array_merge(
+				array(
+					'booking_id' => $booking['id'], 'venue_term_id' => $booking['venue_term_id'], 'space_key' => $booking['space_key'],
+					'start_at' => $booking['performance_start_at'], 'end_at' => $booking['performance_end_at'], 'expires_at' => $now,
+					'status' => 'converted', 'version' => 2, 'created_by_user_id' => 12, 'created_at' => $now, 'updated_at' => $now,
+					'released_at' => null, 'released_by_user_id' => null, 'release_reason' => null, 'expired_at' => null,
+					'converted_at' => $now, 'converted_by_user_id' => 12,
+				),
+				$overrides
+			)
+		);
+	}
+
+	private function install_ability( ?callable $callback = null ): BookingConversionAbilityFake {
+		$callback = $callback ? $callback : function ( $input ) {
+			$this->add_event( 901 );
+			$this->add_event_source_proof( 901, $input );
+			return $this->upstream_result( $input );
+		};
+		$ability = new BookingConversionAbilityFake( $callback );
+		$GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event'] = $ability;
+		return $ability;
+	}
+
+	private function add_event( int $id, string $type = 'data_machine_events', string $status = 'publish' ): void {
+		$GLOBALS['ec_artist_test']['posts'][7][ $id ] = (object) array( 'ID' => $id, 'post_type' => $type, 'post_status' => $status, 'post_title' => 'Canonical Event' );
+		$GLOBALS['ec_artist_test']['permalinks'][7][ $id ] = 'https://events.example/event/' . $id;
+	}
+
+	private function add_event_source_proof( int $id, array $input, ?int $venue_id = null ): void {
+		$identity = hash( 'sha256', $input['source'] . "\0" . $input['source_id'] );
+		$GLOBALS['ec_artist_test']['post_meta'][7][ $id ] = array(
+			'_datamachine_event_source'          => $input['source'],
+			'_datamachine_event_source_id'       => $input['source_id'],
+			'_datamachine_event_source_identity' => $identity,
+		);
+		$GLOBALS['ec_artist_test']['event_venues'][7][ $id ] = array( null === $venue_id ? 55 : $venue_id );
+	}
+
+	private function upstream_result( array $input, array $overrides = array() ): array {
+		$result = array(
+			'success'   => true,
+			'event_id'  => 901,
+			'event_url' => 'https://events.example/test-band',
+			'action'    => 'created',
+			'source'    => array(
+				'name'     => $input['source'],
+				'id'       => $input['source_id'],
+				'identity' => hash( 'sha256', $input['source'] . "\0" . $input['source_id'] ),
+			),
+			'normalized' => array( 'venue_id' => 55, 'post_status' => 'publish' ),
+		);
+		return array_replace_recursive( $result, $overrides );
+	}
+
+	private function add_completed_conversion( array $booking, int $event_id = 901 ): void {
+		$identity = hash( 'sha256', 'extrachill-events-booking' . "\0" . $booking['public_id'] );
+		$state    = ( new BookingActivityRepository() )->event_conversion_state( $booking['id'], $booking['public_id'] );
+		$attempt  = is_array( $state ) && $state['attempt'] > 0 ? $state['attempt'] : 1;
+		if ( 0 === $state['attempt'] ) {
+			( new BookingActivityRepository() )->append(
+				array(
+					'booking_id'      => $booking['id'],
+					'kind'            => 'event_conversion_started',
+					'idempotency_key' => sprintf( 'event-conversion:%s:%d:event_conversion_started', $booking['public_id'], $attempt ),
+					'payload'         => array( 'attempt' => $attempt, 'source' => 'extrachill-events-booking', 'source_id' => $booking['public_id'], 'source_identity' => $identity, 'expected_version' => $booking['version'] ),
+				)
+			);
+		}
+		( new BookingActivityRepository() )->append(
+			array(
+				'booking_id'      => $booking['id'],
+				'kind'            => 'event_converted',
+				'idempotency_key' => sprintf( 'event-conversion:%s:%d:event_converted', $booking['public_id'], $attempt ),
+				'external_id'     => (string) $event_id,
+				'payload'         => array( 'attempt' => $attempt, 'source' => 'extrachill-events-booking', 'source_id' => $booking['public_id'], 'source_identity' => $identity, 'event_id' => $event_id, 'version' => $booking['version'] + 1 ),
+			)
+		);
+	}
+
+	private function service( ?BookingTestAuthorization $authorization = null ): BookingEventConversionService {
+		return new BookingEventConversionService( null, null, null, $authorization ? $authorization : new BookingTestAuthorization() );
+	}
+
+	public function test_strict_ability_contract_and_non_enumerating_exact_venue_permission(): void {
+		$authorization = new BookingTestAuthorization();
+		$ability       = new VenueBookingEventAbilities( $this->service( $authorization ), null, $authorization );
+		$ability->register();
+		$definition = $GLOBALS['ec_artist_test']['abilities']['extrachill/convert-booking-to-event'];
+		$this->assertSame( array( 'booking_id', 'expected_version' ), $definition['input_schema']['required'] );
+		$this->assertFalse( $definition['input_schema']['additionalProperties'] );
+		$this->assertFalse( $definition['output_schema']['additionalProperties'] );
+		$this->assertSame( array( 'created', 'updated', 'no_change', 'existing' ), $definition['output_schema']['properties']['event_action']['enum'] );
+		$this->assertTrue( $definition['meta']['show_in_rest'] );
+		$this->assertTrue( $definition['meta']['annotations']['idempotent'] );
+		$this->assertFalse( $definition['meta']['annotations']['destructive'] );
+		$this->assertSame( 'venue_action_forbidden', $ability->can_access_booking( array( 'booking_id' => 999 ) )->get_error_code() );
+		$booking = $this->booking();
+		$this->assertTrue( $ability->can_access_booking( array( 'booking_id' => $booking['id'] ) ) );
+		$this->assertSame( 55, $authorization->calls[0][1] );
+	}
+
+	public function test_success_maps_only_canonical_public_data_and_claims_once(): void {
+		$ability = $GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event'];
+		$booking = $this->booking();
+		$result  = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( array( 'booking_id', 'booking_version', 'event_id', 'event_url', 'event_action', 'already_converted' ), array_keys( $result ) );
+		$this->assertSame( 2, $result['booking_version'] );
+		$this->assertSame( 'created', $result['event_action'] );
+		$this->assertFalse( $result['already_converted'] );
+		$input = $ability->calls[0];
+		$this->assertSame( 'extrachill-events-booking', $input['source'] );
+		$this->assertSame( $booking['public_id'], $input['source_id'] );
+		$this->assertSame( 'publish', $input['post_status'] );
+		$this->assertArrayNotHasKey( 'post_author', $input );
+		$this->assertSame( 'Test Band at The Canonical Room', $input['event']['title'] );
+		$this->assertSame( 'Test Band', $input['event']['performer'] );
+		$this->assertSame( 'PerformingGroup', $input['event']['performerType'] );
+		$this->assertSame( 'The Canonical Room', $input['event']['venue'] );
+		$this->assertSame( '123 King Street', $input['event']['venueAddress'] );
+		$this->assertSame( 'Charleston', $input['event']['venueCity'] );
+		$this->assertSame( 'SC', $input['event']['venueState'] );
+		$this->assertSame( '29401', $input['event']['venueZip'] );
+		$this->assertSame( 'US', $input['event']['venueCountry'] );
+		$this->assertSame( '843-555-0100', $input['event']['venuePhone'] );
+		$this->assertSame( 'https://venue.example', $input['event']['venueWebsite'] );
+		$this->assertSame( '32.7765,-79.9311', $input['event']['venueCoordinates'] );
+		$this->assertSame( '500', $input['event']['venueCapacity'] );
+		$this->assertSame( 'America/New_York', $input['event']['venueTimezone'] );
+		$this->assertSame( '2030-03-09', $input['event']['startDate'] );
+		$this->assertSame( '19:00', $input['event']['startTime'] );
+		$this->assertSame( '22:00', $input['event']['endTime'] );
+		$this->assertSame( '20.00 adv / 25.00 door', $input['event']['price'] );
+		$this->assertSame( 'USD', $input['event']['priceCurrency'] );
+		$this->assertSame( 'https://tickets.example/test-band', $input['event']['ticketUrl'] );
+		foreach ( array( 'guarantee_cents', 'revenue_share_basis_points', 'ticket_fee_cents', 'additional_terms', 'space_key', 'contact_email', 'intake', 'production' ) as $private ) {
+			$this->assertArrayNotHasKey( $private, $input['event'] );
+		}
+		$activity = ( new BookingActivityRepository() )->list_for_booking( $booking['id'] );
+		$this->assertCount( 2, $activity );
+		$this->assertSame( 'event_converted', $activity[0]['kind'] );
+		$this->assertSame( 901, $activity[0]['payload']['data']['event_id'] );
+		$this->assertSame( 2, $activity[0]['payload']['data']['version'] );
+		$this->assertSame( 'event_conversion_started', $activity[1]['kind'] );
+		$this->assertGreaterThanOrEqual( 2, $GLOBALS['wpdb']->booking_lock_queries );
+	}
+
+	/** @dataProvider priceProvider */
+	public function test_public_price_cases( $advance, $door, $expected ): void {
+		$ability = $this->install_ability();
+		$booking = $this->booking( array( 'confirmed_deal' => $this->deal( array( 'advance_ticket_price_cents' => $advance, 'door_ticket_price_cents' => $door ) ) ) );
+		$this->service()->convert( $booking['id'], 1, 12 );
+		$event = $ability->calls[0]['event'];
+		if ( null === $expected ) {
+			$this->assertArrayNotHasKey( 'price', $event );
+			$this->assertArrayNotHasKey( 'priceCurrency', $event );
+		} else {
+			$this->assertSame( $expected, $event['price'] );
+		}
+	}
+
+	public static function priceProvider(): array {
+		return array( 'absent' => array( null, null, null ), 'equal' => array( 2000, 2000, '20.00' ), 'advance' => array( 2000, null, '20.00 adv' ), 'door' => array( null, 2500, '25.00 door' ), 'different' => array( 2000, 2500, '20.00 adv / 25.00 door' ) );
+	}
+
+	public function test_independent_timezone_mapping_handles_overnight_and_dst(): void {
+		$ability = $this->install_ability();
+		$overnight = $this->booking( array( 'performance_start_at' => '2030-01-02 04:30:00', 'performance_end_at' => '2030-01-02 07:30:00' ) );
+		$this->service()->convert( $overnight['id'], 1, 12 );
+		$this->assertSame( array( '2030-01-01', '23:30', '2030-01-02', '02:30' ), array_values( array_intersect_key( $ability->calls[0]['event'], array_flip( array( 'startDate', 'startTime', 'endDate', 'endTime' ) ) ) ) );
+		$dst = $this->booking( array( 'performance_start_at' => '2030-03-10 06:30:00', 'performance_end_at' => '2030-03-10 07:30:00' ) );
+		$this->service()->convert( $dst['id'], 1, 12 );
+		$this->assertSame( '01:30', $ability->calls[1]['event']['startTime'] );
+		$this->assertSame( '03:30', $ability->calls[1]['event']['endTime'] );
+	}
+
+	public function test_preflight_fails_closed_for_status_selection_deal_venue_timezone_and_converted_hold(): void {
+		$cases = array();
+		$cases[] = array( $this->booking( array( 'status' => 'held' ) ), 'booking_event_status_forbidden' );
+		$cases[] = array( $this->booking( array( 'space_key' => null ), false ), 'booking_event_selection_incomplete' );
+		$invalid_deal = $this->booking();
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $invalid_deal['id'] ]['confirmed_deal_payload'] = null;
+		$cases[] = array( $invalid_deal, 'booking_event_confirmed_deal_invalid' );
+		$no_hold = $this->booking( array(), false );
+		$cases[] = array( $no_hold, 'booking_event_converted_hold_invalid' );
+		foreach ( $cases as $case ) {
+			$this->assertSame( $case[1], $this->service()->convert( $case[0]['id'], 1, 12 )->get_error_code() );
+		}
+		$multiple = $this->booking();
+		$this->add_converted_hold( $multiple );
+		$this->assertSame( 'booking_event_converted_hold_invalid', $this->service()->convert( $multiple['id'], 1, 12 )->get_error_code() );
+		$timezone = $this->booking();
+		$GLOBALS['ec_artist_test']['meta'][7][55]['_venue_timezone'] = 'Not/AZone';
+		$this->assertSame( 'booking_event_venue_timezone_invalid', $this->service()->convert( $timezone['id'], 1, 12 )->get_error_code() );
+		$GLOBALS['ec_artist_test']['meta'][7][55]['_venue_timezone'] = 'America/New_York';
+		unset( $GLOBALS['ec_artist_test']['meta'][7][55]['_venue_address'] );
+		$this->assertSame( 'booking_event_venue_incomplete', $this->service()->convert( $timezone['id'], 1, 12 )->get_error_code() );
+		$GLOBALS['ec_artist_test']['meta'][7][55]['_venue_address'] = '123 King Street';
+		unset( $GLOBALS['ec_artist_test']['terms'][7][55] );
+		$this->assertSame( 'booking_event_venue_invalid', $this->service()->convert( $timezone['id'], 1, 12 )->get_error_code() );
+		$this->assertCount( 0, $GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event']->calls );
+	}
+
+	public function test_rollback_failure_is_explicit(): void {
+		$booking = $this->booking( array( 'status' => 'held' ) );
+		$GLOBALS['wpdb']->fail_transaction_rollback = true;
+		$error = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_event_transaction_rollback_failed', $error->get_error_code() );
+		$this->assertSame( 'booking_event_status_forbidden', $error->get_error_data()['cause'] );
+	}
+
+	public function test_missing_and_upstream_errors_preserve_retryability_without_booking_mutation(): void {
+		$booking = $this->booking();
+		unset( $GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event'] );
+		$error = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_event_ability_unavailable', $error->get_error_code() );
+		$this->assertSame( 503, $error->get_error_data()['status'] );
+		$state = ( new BookingActivityRepository() )->event_conversion_state( $booking['id'], $booking['public_id'] );
+		$this->assertSame( 'none', $state['status'] );
+		$this->assertFalse( $state['pending'] );
+		$ability = $this->install_ability( static function () { return new WP_Error( 'upstream_busy', 'busy', array( 'status' => 503, 'retryable' => true ) ); } );
+		$error   = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_event_upsert_failed', $error->get_error_code() );
+		$this->assertSame( 'upstream_busy', $error->get_error_data()['upstream_code'] );
+		$this->assertTrue( $error->get_error_data()['retryable'] );
+		$this->assertSame( 1, $error->get_error_data()['attempt'] );
+		$this->assertNull( ( new BookingRepository() )->get( $booking['id'] )['event_id'] );
+		$this->assertCount( 1, $ability->calls );
+		$state = ( new BookingActivityRepository() )->event_conversion_state( $booking['id'], $booking['public_id'] );
+		$this->assertFalse( $state['pending'] );
+		$this->assertSame( 'failed', $state['status'] );
+		$this->assertSame( 1, $state['attempt'] );
+		$this->assertNotNull( $state['started'] );
+		$this->assertNull( $state['completed'] );
+		$this->assertCount( 1, array_filter( ( new BookingActivityRepository() )->list_for_booking( $booking['id'] ), static function ( $activity ) { return 'event_conversion_started' === $activity['kind']; } ) );
+	}
+
+	public function test_start_activity_failure_rolls_back_and_prevents_external_call(): void {
+		$booking = $this->booking();
+		$ability = $GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event'];
+		$GLOBALS['wpdb']->fail_activity_kinds = array( 'event_conversion_started' );
+		$error = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_activity_write_failed', $error->get_error_code() );
+		$this->assertCount( 0, $ability->calls );
+		$this->assertFalse( ( new BookingActivityRepository() )->event_conversion_state( $booking['id'], $booking['public_id'] )['pending'] );
+	}
+
+	public function test_missing_ability_does_not_block_cancellation(): void {
+		$booking = $this->booking();
+		unset( $GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event'] );
+		$this->assertSame( 'booking_event_ability_unavailable', $this->service()->convert( $booking['id'], 1, 12 )->get_error_code() );
+		$lifecycle = new BookingLifecycle( null, null, new BookingTestAuthorization() );
+		$result    = $lifecycle->transition( $booking['id'], 'cancelled', 1, 12 );
+		$this->assertSame( 'cancelled', $result['status'] );
+	}
+
+	public function test_pending_invalid_response_blocks_confirmed_cancellation_and_completion_under_lock(): void {
+		$booking = $this->booking();
+		$this->install_ability( function ( $input ) { return $this->upstream_result( $input, array( 'success' => false ) ); } );
+		$this->assertSame( 'booking_event_upsert_failed', $this->service()->convert( $booking['id'], 1, 12 )->get_error_code() );
+		$lifecycle = new BookingLifecycle( null, null, new BookingTestAuthorization() );
+		foreach ( array( 'cancelled', 'completed' ) as $status ) {
+			$error = $lifecycle->transition( $booking['id'], $status, 1, 12 );
+			$this->assertSame( 'booking_event_conversion_pending', $error->get_error_code(), $status );
+			$this->assertSame( 409, $error->get_error_data()['status'], $status );
+			$this->assertSame( 'confirmed', ( new BookingRepository() )->get( $booking['id'] )['status'], $status );
+		}
+		$this->assertGreaterThanOrEqual( 3, $GLOBALS['wpdb']->booking_lock_queries );
+	}
+
+	public function test_pending_conversion_blocks_assignment_and_artist_binding_without_mutation(): void {
+		$booking = $this->booking();
+		$this->install_ability( function ( $input ) { return $this->upstream_result( $input, array( 'success' => false ) ); } );
+		$this->service()->convert( $booking['id'], 1, 12 );
+		$authorization = new BookingTestAuthorization( array( '20:55' => true ) );
+		$lifecycle     = new BookingLifecycle( null, null, $authorization );
+		$before        = ( new BookingActivityRepository() )->list_for_booking( $booking['id'] );
+		$assigned      = $lifecycle->assign( $booking['id'], 20, 1, 12 );
+		$this->assertSame( 'booking_event_conversion_pending', $assigned->get_error_code() );
+		$bound = $lifecycle->bind_artist( $booking['id'], 101, 501, 1, 12 );
+		$this->assertSame( 'booking_event_conversion_pending', $bound->get_error_code() );
+		$current = ( new BookingRepository() )->get( $booking['id'] );
+		$this->assertSame( 1, $current['version'] );
+		$this->assertNull( $current['assignee_user_id'] );
+		$this->assertNull( $current['artist_term_id'] );
+		$this->assertNull( $current['artist_profile_id'] );
+		$this->assertCount( count( $before ), ( new BookingActivityRepository() )->list_for_booking( $booking['id'] ) );
+		$this->assertGreaterThanOrEqual( 2, $GLOBALS['wpdb']->booking_lock_queries );
+	}
+
+	public function test_failed_state_allows_binding_while_completed_state_allows_only_private_assignment(): void {
+		$failed = $this->booking();
+		$this->install_ability( static function () { return new WP_Error( 'failed', 'failed', array( 'status' => 422 ) ); } );
+		$this->service()->convert( $failed['id'], 1, 12 );
+		$lifecycle = new BookingLifecycle( null, null, new BookingTestAuthorization( array( '20:55' => true ) ) );
+		$assigned  = $lifecycle->assign( $failed['id'], 20, 1, 12 );
+		$this->assertSame( 2, $assigned['version'] );
+		$bound = $lifecycle->bind_artist( $failed['id'], 101, 501, 2, 12 );
+		$this->assertSame( 3, $bound['version'] );
+		$failed_state = ( new BookingActivityRepository() )->event_conversion_state( $failed['id'], $failed['public_id'] );
+		$this->assertSame( 'failed', $failed_state['status'] );
+		$this->assertFalse( $failed_state['pending'] );
+
+		$completed = $this->booking();
+		$this->install_ability();
+		$this->service()->convert( $completed['id'], 1, 12 );
+		$assigned = $lifecycle->assign( $completed['id'], 20, 2, 12 );
+		$this->assertSame( 3, $assigned['version'] );
+		$activity_count = count( ( new BookingActivityRepository() )->list_for_booking( $completed['id'] ) );
+		$bound = $lifecycle->bind_artist( $completed['id'], 101, 501, 3, 12 );
+		$this->assertSame( 'booking_event_artist_frozen', $bound->get_error_code() );
+		$this->assertSame( 409, $bound->get_error_data()['status'] );
+		$current = ( new BookingRepository() )->get( $completed['id'] );
+		$this->assertSame( 3, $current['version'] );
+		$this->assertSame( 20, $current['assignee_user_id'] );
+		$this->assertNull( $current['artist_term_id'] );
+		$this->assertNull( $current['artist_profile_id'] );
+		$this->assertCount( $activity_count, ( new BookingActivityRepository() )->list_for_booking( $completed['id'] ) );
+		$completed_state = ( new BookingActivityRepository() )->event_conversion_state( $completed['id'], $completed['public_id'] );
+		$this->assertSame( 'completed', $completed_state['status'] );
+		$this->assertFalse( $completed_state['pending'] );
+		$this->assertSame( 'existing', $this->service()->convert( $completed['id'], 1, 12 )['event_action'] );
+	}
+
+	/** @dataProvider explicitUpstreamErrorProvider */
+	public function test_explicit_upstream_errors_finalize_attempt_and_unblock_lifecycle( array $data, bool $retryable ): void {
+		$booking = $this->booking();
+		$this->install_ability( static function () use ( $data ) { return new WP_Error( 'explicit_failure', 'failed', $data ); } );
+		$error = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_event_upsert_failed', $error->get_error_code() );
+		$this->assertSame( $retryable, $error->get_error_data()['retryable'] );
+		$state = ( new BookingActivityRepository() )->event_conversion_state( $booking['id'], $booking['public_id'] );
+		$this->assertSame( 'failed', $state['status'] );
+		$this->assertFalse( $state['pending'] );
+		$this->assertSame( $retryable, $state['failed']['payload']['data']['retryable'] );
+		$result = ( new BookingLifecycle( null, null, new BookingTestAuthorization() ) )->transition( $booking['id'], 'cancelled', 1, 12 );
+		$this->assertSame( 'cancelled', $result['status'] );
+	}
+
+	public static function explicitUpstreamErrorProvider(): array {
+		return array( 'retryable' => array( array( 'status' => 503, 'retryable' => true ), true ), 'nonretryable' => array( array( 'status' => 422 ), false ) );
+	}
+
+	public function test_retry_after_failure_starts_attempt_two_and_succeeds(): void {
+		$booking = $this->booking();
+		$this->install_ability( static function () { return new WP_Error( 'first_failed', 'failed', array( 'status' => 422 ) ); } );
+		$this->service()->convert( $booking['id'], 1, 12 );
+		$this->install_ability( function ( $input ) { return $this->upstream_result( $input, array( 'success' => false ) ); } );
+		$this->service()->convert( $booking['id'], 1, 12 );
+		$pending = ( new BookingActivityRepository() )->event_conversion_state( $booking['id'], $booking['public_id'] );
+		$this->assertSame( 2, $pending['attempt'] );
+		$this->assertTrue( $pending['pending'] );
+		$error = ( new BookingLifecycle( null, null, new BookingTestAuthorization() ) )->transition( $booking['id'], 'cancelled', 1, 12 );
+		$this->assertSame( 'booking_event_conversion_pending', $error->get_error_code() );
+		$ability = $this->install_ability();
+		$result  = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'created', $result['event_action'] );
+		$this->assertCount( 1, $ability->calls );
+		$state = ( new BookingActivityRepository() )->event_conversion_state( $booking['id'], $booking['public_id'] );
+		$this->assertSame( 'completed', $state['status'] );
+		$this->assertSame( 2, $state['attempt'] );
+		$this->assertSame( 2, $state['completed']['payload']['data']['attempt'] );
+		$this->assertSame( 'existing', $this->service()->convert( $booking['id'], 1, 12 )['event_action'] );
+	}
+
+	public function test_failure_marker_transaction_failure_preserves_upstream_and_pending_attempt(): void {
+		$booking = $this->booking();
+		$GLOBALS['wpdb']->fail_activity_kinds = array( 'event_conversion_failed' );
+		$this->install_ability( static function () { return new WP_Error( 'explicit_failure', 'failed', array( 'status' => 422 ) ); } );
+		$error = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_event_failure_finalize_failed', $error->get_error_code() );
+		$this->assertSame( 'explicit_failure', $error->get_error_data()['upstream_code'] );
+		$this->assertSame( 1, $error->get_error_data()['attempt'] );
+		$state = ( new BookingActivityRepository() )->event_conversion_state( $booking['id'], $booking['public_id'] );
+		$this->assertTrue( $state['pending'] );
+		$this->assertSame( 1, $state['attempt'] );
+	}
+
+	public function test_unverified_upstream_source_venue_and_status_are_retryable_and_never_claimed(): void {
+		$booking = $this->booking();
+		$cases   = array(
+			array( 'success' => false ),
+			array( 'source' => array( 'name' => 'wrong-source' ) ),
+			array( 'source' => array( 'id' => 'wrong-id' ) ),
+			array( 'source' => array( 'identity' => 'wrong-identity' ) ),
+			array( 'normalized' => array( 'venue_id' => 999 ) ),
+			array( 'normalized' => array( 'post_status' => 'draft' ) ),
+		);
+		foreach ( $cases as $override ) {
+			$this->install_ability( function ( $input ) use ( $override ) { return $this->upstream_result( $input, $override ); } );
+			$error = $this->service()->convert( $booking['id'], 1, 12 );
+			$this->assertSame( 'booking_event_upsert_failed', $error->get_error_code() );
+			$this->assertSame( 502, $error->get_error_data()['status'] );
+			$this->assertTrue( $error->get_error_data()['retryable'] );
+			$this->assertNull( ( new BookingRepository() )->get( $booking['id'] )['event_id'] );
+		}
+		$activities = ( new BookingActivityRepository() )->list_for_booking( $booking['id'] );
+		$this->assertCount( 1, $activities );
+		$this->assertSame( 'event_conversion_started', $activities[0]['kind'] );
+		$state = ( new BookingActivityRepository() )->event_conversion_state( $booking['id'], $booking['public_id'] );
+		$this->assertSame( 1, $state['attempt'] );
+		$this->assertTrue( $state['pending'] );
+	}
+
+	public function test_malformed_and_colliding_conversion_markers_fail_closed(): void {
+		$repository = new BookingActivityRepository();
+		$booking    = $this->booking();
+		$identity   = hash( 'sha256', 'extrachill-events-booking' . "\0" . $booking['public_id'] );
+		$repository->append( array( 'booking_id' => $booking['id'], 'kind' => 'event_conversion_started', 'idempotency_key' => sprintf( 'event-conversion:%s:1:event_conversion_started', $booking['public_id'] ), 'payload' => array( 'attempt' => 1, 'source' => 'wrong', 'source_id' => $booking['public_id'], 'source_identity' => $identity, 'expected_version' => 1 ) ) );
+		$this->assertSame( 'booking_event_conversion_state_invalid', $repository->event_conversion_state( $booking['id'], $booking['public_id'] )->get_error_code() );
+
+		$booking = $this->booking();
+		$identity = hash( 'sha256', 'extrachill-events-booking' . "\0" . $booking['public_id'] );
+		$repository->append( array( 'booking_id' => $booking['id'], 'kind' => 'event_conversion_started', 'idempotency_key' => sprintf( 'event-conversion:%s:1:event_conversion_started', $booking['public_id'] ), 'payload' => array( 'attempt' => 1, 'source' => 'extrachill-events-booking', 'source_id' => $booking['public_id'], 'source_identity' => $identity, 'expected_version' => 1 ) ) );
+		$repository->append( array( 'booking_id' => $booking['id'], 'kind' => 'event_converted', 'idempotency_key' => sprintf( 'event-conversion:%s:1:event_converted', $booking['public_id'] ), 'payload' => array( 'attempt' => 1, 'source' => 'extrachill-events-booking', 'source_id' => $booking['public_id'], 'source_identity' => $identity, 'event_id' => 901 ) ) );
+		$this->assertSame( 'booking_event_conversion_state_invalid', $repository->event_conversion_state( $booking['id'], $booking['public_id'] )->get_error_code() );
+
+		$booking = $this->booking();
+		$identity = hash( 'sha256', 'extrachill-events-booking' . "\0" . $booking['public_id'] );
+		$repository->append( array( 'booking_id' => $booking['id'], 'kind' => 'event_conversion_started', 'idempotency_key' => sprintf( 'event-conversion:%s:1:event_conversion_started', $booking['public_id'] ), 'payload' => array( 'attempt' => 1, 'source' => 'extrachill-events-booking', 'source_id' => $booking['public_id'], 'source_identity' => $identity, 'expected_version' => 1 ) ) );
+		$repository->append( array( 'booking_id' => $booking['id'], 'kind' => 'event_conversion_failed', 'idempotency_key' => sprintf( 'event-conversion:%s:1:event_conversion_failed', $booking['public_id'] ), 'payload' => array( 'attempt' => 1, 'source' => 'extrachill-events-booking', 'source_id' => $booking['public_id'], 'source_identity' => $identity, 'upstream_code' => 'failed', 'retryable' => false ) ) );
+		$this->assertSame( 'booking_event_conversion_state_invalid', $repository->event_conversion_state( $booking['id'], $booking['public_id'] )->get_error_code() );
+
+		$booking = $this->booking();
+		$repository->append( array( 'booking_id' => $booking['id'], 'kind' => 'status_changed', 'idempotency_key' => sprintf( 'event-conversion:%s:1:event_conversion_started', $booking['public_id'] ), 'payload' => array() ) );
+		$error = $repository->event_conversion_state( $booking['id'], $booking['public_id'] );
+		$this->assertSame( 'booking_event_conversion_state_invalid', $error->get_error_code() );
+		$this->assertTrue( $error->get_error_data()['repairable'] );
+	}
+
+	public function test_immediate_retry_returns_existing_without_dme_call_even_with_stale_version(): void {
+		$ability = $GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event'];
+		$booking = $this->booking();
+		$this->service()->convert( $booking['id'], 1, 12 );
+		$result = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'existing', $result['event_action'] );
+		$this->assertTrue( $result['already_converted'] );
+		$this->assertSame( 2, $result['booking_version'] );
+		$this->assertCount( 1, $ability->calls );
+		$this->assertCount( 2, ( new BookingActivityRepository() )->list_for_booking( $booking['id'] ) );
+		$state = ( new BookingActivityRepository() )->event_conversion_state( $booking['id'], $booking['public_id'] );
+		$this->assertSame( 1, $state['completed']['payload']['data']['attempt'] );
+	}
+
+	public function test_external_success_activity_failure_rolls_back_claim_and_retry_reuses_event(): void {
+		$booking = $this->booking();
+		$GLOBALS['wpdb']->fail_activity_kinds = array( 'event_converted' );
+		$error = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_activity_write_failed', $error->get_error_code() );
+		$this->assertNull( ( new BookingRepository() )->get( $booking['id'] )['event_id'] );
+		$GLOBALS['wpdb']->fail_activity_kinds = array();
+		$ability = $this->install_ability( function ( $input ) {
+			$this->add_event( 901 );
+			$this->add_event_source_proof( 901, $input );
+			return $this->upstream_result( $input, array( 'action' => 'no_change' ) );
+		} );
+		$result  = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'no_change', $result['event_action'] );
+		$this->assertSame( 901, $result['event_id'] );
+		$this->assertCount( 1, $ability->calls );
+	}
+
+	public function test_locked_authorization_revocation_is_enforced_in_preflight_and_finalize(): void {
+		$authorization = new BookingTestAuthorization();
+		$booking       = $this->booking();
+		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) { $authorization->allowed['12:55'] = false; };
+		$this->assertSame( 'venue_action_forbidden', $this->service( $authorization )->convert( $booking['id'], 1, 12 )->get_error_code() );
+		$authorization = new BookingTestAuthorization();
+		$booking       = $this->booking();
+		$this->install_ability( function ( $input ) use ( $authorization ) {
+			$this->add_event( 901 );
+			$this->add_event_source_proof( 901, $input );
+			$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) { $authorization->allowed['12:55'] = false; };
+			return $this->upstream_result( $input );
+		} );
+		$this->assertSame( 'venue_action_forbidden', $this->service( $authorization )->convert( $booking['id'], 1, 12 )->get_error_code() );
+		$this->assertNull( ( new BookingRepository() )->get( $booking['id'] )['event_id'] );
+		$this->assertTrue( ( new BookingActivityRepository() )->event_conversion_state( $booking['id'], $booking['public_id'] )['pending'] );
+	}
+
+	public function test_same_event_concurrent_finalize_returns_existing_and_different_event_fails(): void {
+		$booking = $this->booking();
+		$this->install_ability( function ( $input ) use ( $booking ) {
+			$this->add_event( 901 );
+			$this->add_event_source_proof( 901, $input );
+			$GLOBALS['wpdb']->after_membership_lock = function () use ( $booking ) {
+				$GLOBALS['wpdb']->simulate_external_commit(
+					function () use ( $booking ) {
+						$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['event_id'] = 901;
+						$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['version']  = 2;
+						$this->add_completed_conversion( $booking, 901 );
+					}
+				);
+			};
+			return $this->upstream_result( $input );
+		} );
+		$this->assertSame( 'existing', $this->service()->convert( $booking['id'], 1, 12 )['event_action'] );
+		$booking = $this->booking();
+		$this->install_ability( function ( $input ) use ( $booking ) {
+			$this->add_event( 901 ); $this->add_event( 902 );
+			$this->add_event_source_proof( 901, $input );
+			$this->add_event_source_proof( 902, $input );
+			$GLOBALS['wpdb']->after_membership_lock = function () use ( $booking ) {
+				$GLOBALS['wpdb']->simulate_external_commit(
+					function () use ( $booking ) {
+						$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['event_id'] = 902;
+						$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['version']  = 2;
+						$this->add_completed_conversion( $booking, 902 );
+					}
+				);
+			};
+			return $this->upstream_result( $input );
+		} );
+		$error = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_event_already_linked', $error->get_error_code() );
+		$this->assertSame( 409, $error->get_error_data()['status'] );
+	}
+
+	public function test_finalize_commit_uncertainty_never_rolls_back_external_event(): void {
+		$booking = $this->booking();
+		$this->install_ability( function ( $input ) {
+			$this->add_event( 901 );
+			$this->add_event_source_proof( 901, $input );
+			$GLOBALS['wpdb']->fail_transaction_commit = true;
+			return $this->upstream_result( $input );
+		} );
+		$error = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_event_finalize_uncertain', $error->get_error_code() );
+		$this->assertTrue( $error->get_error_data()['retryable'] );
+		$this->assertSame( 0, $GLOBALS['wpdb']->rollback_queries );
+		$this->assertNotNull( get_post( 901 ) );
+	}
+
+	public function test_existing_event_must_be_a_valid_site_local_dme_post(): void {
+		$booking = $this->booking();
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['event_id'] = 901;
+		$this->add_event( 901, 'post' );
+		$this->assertSame( 'booking_event_existing_invalid', $this->service()->convert( $booking['id'], 999, 12 )->get_error_code() );
+		$this->add_event( 901 );
+		$input = array( 'source' => 'extrachill-events-booking', 'source_id' => $booking['public_id'] );
+		$this->add_event_source_proof( 901, $input );
+		$this->add_completed_conversion( $booking );
+		$result = $this->service()->convert( $booking['id'], 999, 12 );
+		$this->assertSame( 'existing', $result['event_action'] );
+		$this->assertCount( 0, $GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event']->calls );
+	}
+
+	public function test_existing_draft_private_wrong_source_wrong_venue_and_missing_activity_are_rejected(): void {
+		$booking = $this->booking();
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['event_id'] = 901;
+		$input = array( 'source' => 'extrachill-events-booking', 'source_id' => $booking['public_id'] );
+		$this->add_event( 901, 'data_machine_events', 'draft' );
+		$this->add_event_source_proof( 901, $input );
+		$this->add_completed_conversion( $booking );
+		$error = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertContains( 'post_status', $error->get_error_data()['integrity'] );
+		$GLOBALS['ec_artist_test']['posts'][7][901]->post_status = 'private';
+		$this->assertSame( 'booking_event_existing_invalid', $this->service()->convert( $booking['id'], 1, 12 )->get_error_code() );
+		$GLOBALS['ec_artist_test']['posts'][7][901]->post_status = 'publish';
+		$GLOBALS['ec_artist_test']['post_meta'][7][901]['_datamachine_event_source'] = 'wrong';
+		$error = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertContains( 'source_name', $error->get_error_data()['integrity'] );
+		$GLOBALS['ec_artist_test']['post_meta'][7][901]['_datamachine_event_source'] = 'extrachill-events-booking';
+		$GLOBALS['ec_artist_test']['event_venues'][7][901] = array( 999 );
+		$error = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertContains( 'venue', $error->get_error_data()['integrity'] );
+
+		$missing = $this->booking();
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $missing['id'] ]['event_id'] = 902;
+		$this->add_event( 902 );
+		$this->add_event_source_proof( 902, array( 'source' => 'extrachill-events-booking', 'source_id' => $missing['public_id'] ) );
+		$error = $this->service()->convert( $missing['id'], 1, 12 );
+		$this->assertSame( 'booking_event_existing_invalid', $error->get_error_code() );
+		$this->assertContains( 'event_converted_activity', $error->get_error_data()['integrity'] );
+		$this->assertTrue( $error->get_error_data()['repairable'] );
+	}
+
+	public function test_nested_dme_permission_error_runs_honestly_and_is_wrapped(): void {
+		$booking = $this->booking();
+		$this->install_ability( static function () { return new WP_Error( 'dme_write_forbidden', 'forbidden', array( 'status' => 403 ) ); } );
+		$error = $this->service()->convert( $booking['id'], 1, 12 );
+		$this->assertSame( 'booking_event_upsert_failed', $error->get_error_code() );
+		$this->assertSame( 422, $error->get_error_data()['status'] );
+		$this->assertSame( 'dme_write_forbidden', $error->get_error_data()['upstream_code'] );
+	}
+}

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -9,12 +9,14 @@ use ExtraChillEvents\Core\BookingActivityRepository;
 use ExtraChillEvents\Core\BookingLifecycle;
 use ExtraChillEvents\Core\BookingHoldRepository;
 use ExtraChillEvents\Core\BookingMutationService;
+use ExtraChillEvents\Core\BookingEventConversionService;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\VenueBookingConfig;
 use ExtraChillEvents\Abilities\VenueBookingAbilities;
 use ExtraChillEvents\Abilities\VenueBookingHoldAbilities;
 use ExtraChillEvents\Abilities\VenueBookingMutationAbilities;
+use ExtraChillEvents\Abilities\VenueBookingEventAbilities;
 use ExtraChillEvents\Core\VenueAuthorization;
 
 if ( ! defined( 'ARRAY_A' ) ) {
@@ -138,6 +140,15 @@ if ( ! function_exists( 'get_post_meta' ) ) {
 		return $state['post_meta'][ $state['blog_id'] ][ $post_id ][ $key ] ?? '';
 	}
 }
+if ( ! function_exists( 'wp_get_object_terms' ) ) {
+	function wp_get_object_terms( $post_id, $taxonomy, $args = array() ) {
+		if ( 'venue' !== $taxonomy ) {
+			return array();
+		}
+		$ids = $GLOBALS['ec_artist_test']['event_venues'][ get_current_blog_id() ][ $post_id ] ?? array();
+		return ( $args['fields'] ?? '' ) === 'ids' ? $ids : array();
+	}
+}
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( $key, $default = false ) {
 		return $GLOBALS['ec_artist_test']['options'][ $key ] ?? $default; }
@@ -179,6 +190,14 @@ if ( ! function_exists( 'add_action' ) ) {
 if ( ! function_exists( 'wp_register_ability' ) ) {
 	function wp_register_ability( $name, $definition ) {
 		$GLOBALS['ec_artist_test']['abilities'][ $name ] = $definition; }
+}
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( $name ) {
+		return $GLOBALS['ec_artist_test']['ability_objects'][ $name ] ?? null; }
+}
+if ( ! function_exists( 'get_permalink' ) ) {
+	function get_permalink( $post_id ) {
+		return $GLOBALS['ec_artist_test']['permalinks'][ get_current_blog_id() ][ $post_id ] ?? 'https://events.example/event/' . (int) $post_id; }
 }
 if ( ! function_exists( 'wp_cache_delete' ) ) {
 	function wp_cache_delete( $key, $group = '' ) {
@@ -232,6 +251,7 @@ final class BookingWpdb {
 	public $reads_before_failure              = null;
 	public $last_query                        = '';
 	public $fail_activity_inserts             = false;
+	public $fail_activity_kinds               = array();
 	public $fail_transaction_start            = false;
 	public $fail_transaction_commit           = false;
 	public $fail_transaction_rollback         = false;
@@ -246,6 +266,7 @@ final class BookingWpdb {
 	public $release_lock_result               = 1;
 	public $lock_names                        = array();
 	public $event_dates                       = array();
+	public $booking_lock_queries              = 0;
 	public $elapse_hold_after_membership_lock = null;
 	public $elapse_hold_before_release_update = null;
 	public $elapse_hold_before_conversion_update = null;
@@ -314,7 +335,7 @@ final class BookingWpdb {
 
 	public function insert( $table, $row ) {
 		$this->last_error = '';
-		if ( $this->fail_inserts || ( $this->fail_activity_inserts && false !== strpos( $table, 'ec_booking_activity' ) ) ) {
+		if ( $this->fail_inserts || ( false !== strpos( $table, 'ec_booking_activity' ) && ( $this->fail_activity_inserts || in_array( $row['kind'] ?? '', $this->fail_activity_kinds, true ) ) ) ) {
 			$this->last_error = 'simulated insert failure';
 			return false;
 		}
@@ -372,6 +393,14 @@ final class BookingWpdb {
 			return false;
 		}
 		return 1;
+	}
+
+	/** Make a simulated second-connection commit survive this connection's rollback. */
+	public function simulate_external_commit( callable $write ): void {
+		$write();
+		if ( is_array( $this->transaction_snapshot ) ) {
+			$this->transaction_snapshot = $this->rows;
+		}
 	}
 
 	public function get_var( $query ) {
@@ -475,6 +504,9 @@ final class BookingWpdb {
 			return null;
 		}
 		$table = $is_activity ? $this->prefix . 'ec_booking_activity' : ( $is_hold ? $this->prefix . 'ec_booking_holds' : $this->prefix . 'ec_bookings' );
+		if ( ! $is_activity && ! $is_hold && false !== strpos( $query, 'FOR UPDATE' ) ) {
+			++$this->booking_lock_queries;
+		}
 		if ( preg_match( '/WHERE id = (\d+)/', $query, $match ) ) {
 			$row = $this->rows[ $table ][ (int) $match[1] ] ?? null;
 			if ( is_array( $row ) && false !== strpos( $query, 'AS database_now' ) ) {
@@ -652,6 +684,27 @@ final class BookingWpdb {
 				$row['database_now'] = $database_now;
 			}
 			unset( $row );
+		}
+		if ( $is_activity && false !== strpos( $query, "kind IN ('event_conversion_started', 'event_conversion_failed', 'event_converted')" ) ) {
+			preg_match( "/idempotency_key LIKE '([^']+)%'/", $query, $key_prefix );
+			$prefix = isset( $key_prefix[1] ) ? stripslashes( $key_prefix[1] ) : '';
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $prefix ) {
+						return in_array( $row['kind'], array( 'event_conversion_started', 'event_conversion_failed', 'event_converted' ), true ) || ( '' !== $prefix && 0 === strpos( (string) $row['idempotency_key'], $prefix ) );
+					}
+				)
+			);
+			usort( $rows, static function ( $left, $right ) { return $left['id'] <=> $right['id']; } );
+		}
+		if ( $is_hold && false !== strpos( $query, "status = 'converted'" ) ) {
+			foreach ( array( 'space_key', 'start_at', 'end_at' ) as $field ) {
+				if ( preg_match( "/{$field} = '([^']+)'/", $query, $exact ) ) {
+					$rows = array_values( array_filter( $rows, static function ( $row ) use ( $field, $exact ) { return $row[ $field ] === stripslashes( $exact[1] ); } ) );
+				}
+			}
+			$rows = array_values( array_filter( $rows, static function ( $row ) { return null !== $row['converted_at']; } ) );
 		}
 		$filters     = array( 'venue_term_id', 'artist_term_id', 'artist_profile_id', 'assignee_user_id', 'booking_id' );
 		foreach ( $filters as $field ) {
@@ -925,11 +978,13 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingActivityRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingHoldRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingMutationService.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingEventConversionService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingLifecycle.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueBookingConfig.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingHoldAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingMutationAbilities.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingEventAbilities.php';
 
 final class BookingTestAuthorization extends VenueAuthorization {
 	public $calls   = array();


### PR DESCRIPTION
## Summary
- convert confirmed venue bookings into canonical DME events through the public upsert ability
- preserve durable conversion attempts and strict source, venue, publication, and completion proof
- grant nested DME authorization only during the exact already-authorized booking conversion context

## Verification
- booking conversion suite: 31 tests, 225 assertions passed
- full booking suite previously: 111 tests, 881 assertions passed
- authorization suite: 12 tests, 88 assertions passed

## Merge Order
1. Extra-Chill/data-machine#2972 for crash-safe identity reservation
2. Extra-Chill/data-machine-events#531 for ability-scoped nested authorization
3. This PR

Closes #297
Related: Extra-Chill/data-machine-events#527, Extra-Chill/data-machine-events#528.