### PR TITLE
fix: normalize missing venue URLs

### DIFF
--- a/inc/abilities/events-get-venue.php
+++ b/inc/abilities/events-get-venue.php
@@ -137,7 +137,7 @@ function extrachill_events_transform_venue_detail( array $venue ): array {
 		'website'                  => $venue['website'] ?? null,
 		'phone'                    => $venue['phone'] ?? null,
 		'capacity'                 => $venue['capacity'] ?? null,
-		'url'                      => $venue['url'] ?? null,
+		'url'                      => (string) ( $venue['url'] ?? '' ),
 		'event_count'              => isset( $venue['event_count'] ) ? (int) $venue['event_count'] : null,
 		'distance'                 => isset( $venue['distance'] ) ? (float) $venue['distance'] : null,
 		'upcoming_events_at_venue' => $venue['upcoming_events_at_venue'] ?? array(),

--- a/tests/Unit/Abilities/CanonicalAdapterContractsTest.php
+++ b/tests/Unit/Abilities/CanonicalAdapterContractsTest.php
@@ -153,6 +153,7 @@ final class CanonicalAdapterContractsTest extends TestCase {
 		}
 		$this->assertSame( '970 Morrison Dr, Charleston, SC, 29403', $list[0]['formatted_address'] );
 		$this->assertSame( 7, $list[0]['event_count'] );
+		$this->assertSame( '', $detail['url'] );
 	}
 
 	public function test_duplicate_check_delegates_all_identity_evidence_and_returns_canonical_venue(): void {


### PR DESCRIPTION
## Summary

- normalize an absent venue URL to an empty string so the adapter matches its declared output schema
- preserve existing non-empty URL values
- cover the missing URL contract in the canonical adapter test

## Verification

- PHP syntax checks
- focused contract assertion added
- verified through canonical ability output validation in Roadie multisite E2E run `53842385-d805-46e9-8080-a6a11539a6de`

The standalone Homeboy PHPUnit attempt was blocked before test discovery by a stale WordPress archive cache lock; the full composition executed this exact revision successfully.

Closes #343