### PR TITLE
feat: add venue claims and invitations

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -246,6 +246,9 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueAuthorization.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueInvitationToken.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueOnboardingRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueOnboardingService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingHoldRepository.php';
@@ -338,6 +341,9 @@ class ExtraChillEvents {
 		if ( \ExtraChillEvents\Core\BookingSchema::is_ready() ) {
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueMembershipAbilities.php';
 			new \ExtraChillEvents\Abilities\VenueMembershipAbilities();
+
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueOnboardingAbilities.php';
+			new \ExtraChillEvents\Abilities\VenueOnboardingAbilities();
 
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueBookingConfigAbilities.php';
 			new \ExtraChillEvents\Abilities\VenueBookingConfigAbilities();

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -249,6 +249,8 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueInvitationToken.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueOnboardingRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueOnboardingService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueInvitationDeliveryWorker.php';
+		\ExtraChillEvents\Core\VenueInvitationDeliveryWorker::register();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingHoldRepository.php';

--- a/inc/Abilities/VenueOnboardingAbilities.php
+++ b/inc/Abilities/VenueOnboardingAbilities.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Venue claim and invitation abilities.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+use ExtraChillEvents\Core\VenueAuthorization;
+use ExtraChillEvents\Core\VenueOnboardingRepository;
+use ExtraChillEvents\Core\VenueOnboardingService;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Registers the venue onboarding command surface. */
+class VenueOnboardingAbilities {
+
+	/** Whether registration has already been hooked. */
+	private static bool $registered = false;
+
+	/** Venue onboarding policy service. */
+	private $service;
+
+	/** Venue authorization service. */
+	private $authorization;
+
+	/** Build and hook the onboarding abilities. */
+	public function __construct( ?VenueOnboardingService $service = null, ?VenueAuthorization $authorization = null ) {
+		$this->service       = $service ? $service : new VenueOnboardingService();
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+		if ( ! self::$registered ) {
+			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+			self::$registered = true;
+		}
+	}
+
+	/** Register claim and invitation abilities. */
+	public function register(): void {
+		$id = array(
+			'type'    => 'integer',
+			'minimum' => 1,
+		);
+		$this->register_ability( 'extrachill/submit-venue-claim', __( 'Submit Venue Claim', 'extrachill-events' ), array( 'venue_term_id' => $id ), array( 'venue_term_id' ), array( $this, 'submit_claim' ), array( $this, 'is_authenticated' ), false, true );
+		$this->register_ability(
+			'extrachill/review-venue-claim',
+			__( 'Review Venue Claim', 'extrachill-events' ),
+			array(
+				'claim_id'         => $id,
+				'decision'         => array(
+					'type' => 'string',
+					'enum' => array( VenueOnboardingRepository::CLAIM_APPROVED, VenueOnboardingRepository::CLAIM_REJECTED ),
+				),
+				'expected_version' => $id,
+			),
+			array( 'claim_id', 'decision', 'expected_version' ),
+			array( $this, 'review_claim' ),
+			array( $this, 'is_administrator' ),
+			true,
+			true
+		);
+		$this->register_ability(
+			'extrachill/cancel-venue-claim',
+			__( 'Cancel Venue Claim', 'extrachill-events' ),
+			array(
+				'claim_id'         => $id,
+				'expected_version' => $id,
+			),
+			array( 'claim_id', 'expected_version' ),
+			array( $this, 'cancel_claim' ),
+			array( $this, 'is_authenticated' ),
+			true,
+			true
+		);
+		$this->register_ability(
+			'extrachill/list-venue-claims',
+			__( 'List Venue Claims', 'extrachill-events' ),
+			array(
+				'status' => array(
+					'type' => 'string',
+					'enum' => VenueOnboardingRepository::claim_statuses(),
+				),
+			),
+			array(),
+			array( $this, 'list_claims' ),
+			array( $this, 'is_administrator' ),
+			false,
+			false,
+			true
+		);
+
+		$invite_properties = array(
+			'venue_term_id' => $id,
+			'email'         => array(
+				'type'   => 'string',
+				'format' => 'email',
+			),
+			'is_owner'      => array( 'type' => 'boolean' ),
+		);
+		$this->register_ability( 'extrachill/create-venue-invitation', __( 'Create Venue Invitation', 'extrachill-events' ), $invite_properties, array( 'venue_term_id', 'email', 'is_owner' ), array( $this, 'create_invitation' ), array( $this, 'can_manage_venue' ), false, true );
+		$this->register_ability(
+			'extrachill/resend-venue-invitation',
+			__( 'Resend Venue Invitation', 'extrachill-events' ),
+			array(
+				'venue_term_id'    => $id,
+				'invitation_id'    => $id,
+				'expected_version' => $id,
+			),
+			array( 'venue_term_id', 'invitation_id', 'expected_version' ),
+			array( $this, 'resend_invitation' ),
+			array( $this, 'can_manage_venue' ),
+			false,
+			true
+		);
+		$this->register_ability(
+			'extrachill/cancel-venue-invitation',
+			__( 'Cancel Venue Invitation', 'extrachill-events' ),
+			array(
+				'venue_term_id'    => $id,
+				'invitation_id'    => $id,
+				'expected_version' => $id,
+			),
+			array( 'venue_term_id', 'invitation_id', 'expected_version' ),
+			array( $this, 'cancel_invitation' ),
+			array( $this, 'can_manage_venue' ),
+			true,
+			true
+		);
+		$this->register_ability( 'extrachill/list-venue-invitations', __( 'List Venue Invitations', 'extrachill-events' ), array( 'venue_term_id' => $id ), array( 'venue_term_id' ), array( $this, 'list_invitations' ), array( $this, 'can_manage_venue' ), false, false, true );
+		$this->register_ability(
+			'extrachill/respond-to-venue-invitation',
+			__( 'Respond To Venue Invitation', 'extrachill-events' ),
+			array(
+				'invitation_id'    => array(
+					'type'   => 'string',
+					'format' => 'uuid',
+				),
+				'token'            => array(
+					'type'      => 'string',
+					'minLength' => 64,
+					'maxLength' => 64,
+				),
+				'venue_term_id'    => $id,
+				'is_owner'         => array( 'type' => 'boolean' ),
+				'expected_version' => $id,
+				'decision'         => array(
+					'type' => 'string',
+					'enum' => array( VenueOnboardingRepository::INVITE_ACCEPTED, VenueOnboardingRepository::INVITE_REJECTED ),
+				),
+			),
+			array( 'invitation_id', 'token', 'venue_term_id', 'is_owner', 'expected_version', 'decision' ),
+			array( $this, 'respond_to_invitation' ),
+			array( $this, 'is_authenticated' ),
+			true,
+			true
+		);
+	}
+
+	/** Require an authenticated network user. */
+	public function is_authenticated() {
+		return get_current_user_id() > 0 ? true : new \WP_Error( 'venue_action_forbidden', __( 'Authentication is required.', 'extrachill-events' ), array( 'status' => 401 ) );
+	}
+
+	/** Require a network administrator. */
+	public function is_administrator() {
+		return user_can( get_current_user_id(), 'manage_options' ) ? true : new \WP_Error( 'venue_action_forbidden', __( 'Administrator access is required.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+
+	/** Authorize current venue membership management. */
+	public function can_manage_venue( array $input ) {
+		return $this->authorization->authorize( get_current_user_id(), absint( $input['venue_term_id'] ?? 0 ), VenueAuthorization::ACTION_MANAGE_MEMBERS );
+	}
+
+	/** Execute claim submission. */
+	public function submit_claim( array $input ) {
+		return $this->service->submit_claim( get_current_user_id(), absint( $input['venue_term_id'] ?? 0 ) );
+	}
+
+	/** Execute operator claim review. */
+	public function review_claim( array $input ) {
+		return $this->service->review_claim( get_current_user_id(), absint( $input['claim_id'] ?? 0 ), sanitize_key( $input['decision'] ?? '' ), absint( $input['expected_version'] ?? 0 ) );
+	}
+
+	/** Execute claim cancellation. */
+	public function cancel_claim( array $input ) {
+		return $this->service->cancel_claim( get_current_user_id(), absint( $input['claim_id'] ?? 0 ), absint( $input['expected_version'] ?? 0 ) );
+	}
+
+	/** Execute operator claim listing. */
+	public function list_claims( array $input ) {
+		return $this->service->list_claims( get_current_user_id(), sanitize_key( $input['status'] ?? '' ) );
+	}
+
+	/** Execute invitation creation. */
+	public function create_invitation( array $input ) {
+		return $this->service->invite( get_current_user_id(), absint( $input['venue_term_id'] ?? 0 ), (string) ( $input['email'] ?? '' ), (bool) ( $input['is_owner'] ?? false ) );
+	}
+
+	/** Execute invitation resend. */
+	public function resend_invitation( array $input ) {
+		return $this->service->resend( get_current_user_id(), absint( $input['invitation_id'] ?? 0 ), absint( $input['expected_version'] ?? 0 ) );
+	}
+
+	/** Execute invitation cancellation. */
+	public function cancel_invitation( array $input ) {
+		return $this->service->cancel_invitation( get_current_user_id(), absint( $input['invitation_id'] ?? 0 ), absint( $input['expected_version'] ?? 0 ) );
+	}
+
+	/** Execute invitation listing. */
+	public function list_invitations( array $input ) {
+		return $this->service->list_invitations( get_current_user_id(), absint( $input['venue_term_id'] ?? 0 ) );
+	}
+
+	/** Execute an invitation response. */
+	public function respond_to_invitation( array $input ) {
+		return $this->service->respond( get_current_user_id(), sanitize_text_field( $input['invitation_id'] ?? '' ), sanitize_text_field( $input['token'] ?? '' ), absint( $input['venue_term_id'] ?? 0 ), (bool) ( $input['is_owner'] ?? false ), absint( $input['expected_version'] ?? 0 ), sanitize_key( $input['decision'] ?? '' ) );
+	}
+
+	/** Register one onboarding ability contract. */
+	private function register_ability( string $name, string $label, array $properties, array $required, callable $execute, callable $permission, bool $destructive, bool $idempotent, bool $is_readonly = false ): void {
+		wp_register_ability(
+			$name,
+			array(
+				'label'               => $label,
+				'description'         => $label,
+				'category'            => 'extrachill-events',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => $properties,
+					'required'             => $required,
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array( 'type' => array( 'object', 'array' ) ),
+				'execute_callback'    => $execute,
+				'permission_callback' => $permission,
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => $is_readonly,
+						'idempotent'  => $idempotent,
+						'destructive' => $destructive,
+					),
+				),
+			)
+		);
+	}
+}

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -183,6 +183,7 @@ class BookingSchema {
 			status VARCHAR(20) NOT NULL DEFAULT 'pending',
 			token_hash CHAR(64) NOT NULL,
 			email_hash CHAR(64) NOT NULL,
+			account_created TINYINT UNSIGNED NOT NULL DEFAULT '0',
 			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
 			invited_by_user_id BIGINT UNSIGNED NOT NULL,
 			created_at DATETIME NOT NULL,

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -171,7 +171,8 @@ class BookingSchema {
 			UNIQUE KEY public_id (public_id),
 			UNIQUE KEY venue_claimant (venue_term_id, claimant_user_id),
 			KEY status_created (status, created_at),
-			KEY venue_status (venue_term_id, status)
+			KEY venue_status (venue_term_id, status),
+			KEY claimant_status_venue (claimant_user_id, status, venue_term_id)
 		) ENGINE=InnoDB {$charset};";
 
 		$invites_sql = "CREATE TABLE {$invites} (
@@ -184,17 +185,23 @@ class BookingSchema {
 			token_hash CHAR(64) NOT NULL,
 			email_hash CHAR(64) NOT NULL,
 			account_created TINYINT UNSIGNED NOT NULL DEFAULT '0',
+			delivery_id CHAR(36) NOT NULL,
+			delivery_status VARCHAR(20) NOT NULL DEFAULT 'queued',
+			delivery_attempts BIGINT UNSIGNED NOT NULL DEFAULT '0',
 			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
 			invited_by_user_id BIGINT UNSIGNED NOT NULL,
 			created_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL,
 			expires_at DATETIME NOT NULL,
 			resolved_at DATETIME NULL,
+			delivered_at DATETIME NULL,
 			PRIMARY KEY (id),
 			UNIQUE KEY public_id (public_id),
+			UNIQUE KEY delivery_id (delivery_id),
 			UNIQUE KEY venue_user (venue_term_id, user_id),
 			KEY venue_status (venue_term_id, status),
-			KEY status_expiration (status, expires_at)
+			KEY status_expiration (status, expires_at),
+			KEY user_status_venue (user_id, status, venue_term_id)
 		) ENGINE=InnoDB {$charset};";
 
 		$audit_sql = "CREATE TABLE {$audit} (
@@ -711,25 +718,29 @@ class BookingSchema {
 					'resolved_at'         => $required( 'datetime', true ),
 				),
 				'indexes' => array(
-					'PRIMARY'        => array(
+					'PRIMARY'               => array(
 						'unique'  => true,
 						'columns' => array( 'id' ),
 					),
-					'public_id'      => array(
+					'public_id'             => array(
 						'unique'  => true,
 						'columns' => array( 'public_id' ),
 					),
-					'venue_claimant' => array(
+					'venue_claimant'        => array(
 						'unique'  => true,
 						'columns' => array( 'venue_term_id', 'claimant_user_id' ),
 					),
-					'status_created' => array(
+					'status_created'        => array(
 						'unique'  => false,
 						'columns' => array( 'status', 'created_at' ),
 					),
-					'venue_status'   => array(
+					'venue_status'          => array(
 						'unique'  => false,
 						'columns' => array( 'venue_term_id', 'status' ),
+					),
+					'claimant_status_venue' => array(
+						'unique'  => false,
+						'columns' => array( 'claimant_user_id', 'status', 'venue_term_id' ),
 					),
 				),
 			),
@@ -744,12 +755,17 @@ class BookingSchema {
 					'status'             => $required( 'varchar(20)', false, array( 'default' => 'pending' ) ),
 					'token_hash'         => $required( 'char(64)', false ),
 					'email_hash'         => $required( 'char(64)', false ),
+					'account_created'    => $required( 'tinyint unsigned', false, array( 'default' => '0' ) ),
+					'delivery_id'        => $required( 'char(36)', false ),
+					'delivery_status'    => $required( 'varchar(20)', false, array( 'default' => 'queued' ) ),
+					'delivery_attempts'  => $required( 'bigint unsigned', false, array( 'default' => '0' ) ),
 					'version'            => $required( 'bigint unsigned', false, array( 'default' => '1' ) ),
 					'invited_by_user_id' => $required( 'bigint unsigned', false ),
 					'created_at'         => $required( 'datetime', false ),
 					'updated_at'         => $required( 'datetime', false ),
 					'expires_at'         => $required( 'datetime', false ),
 					'resolved_at'        => $required( 'datetime', true ),
+					'delivered_at'       => $required( 'datetime', true ),
 				),
 				'indexes' => array(
 					'PRIMARY'           => array(
@@ -759,6 +775,10 @@ class BookingSchema {
 					'public_id'         => array(
 						'unique'  => true,
 						'columns' => array( 'public_id' ),
+					),
+					'delivery_id'       => array(
+						'unique'  => true,
+						'columns' => array( 'delivery_id' ),
 					),
 					'venue_user'        => array(
 						'unique'  => true,
@@ -771,6 +791,10 @@ class BookingSchema {
 					'status_expiration' => array(
 						'unique'  => false,
 						'columns' => array( 'status', 'expires_at' ),
+					),
+					'user_status_venue' => array(
+						'unique'  => false,
+						'columns' => array( 'user_id', 'status', 'venue_term_id' ),
 					),
 				),
 			),

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Owns and verifies the site-scoped private booking schema. */
 class BookingSchema {
 
-	public const SCHEMA_VERSION = '6';
+	public const SCHEMA_VERSION = '7';
 	public const VERSION_OPTION = 'extrachill_events_booking_schema_version';
 	public const FAILURE_OPTION = 'extrachill_events_booking_schema_error';
 
@@ -40,6 +40,24 @@ class BookingSchema {
 		return $wpdb->prefix . 'ec_venue_members';
 	}
 
+	/** Get the venue claims table for the current site. */
+	public static function claims_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_venue_claims';
+	}
+
+	/** Get the venue invitations table for the current site. */
+	public static function invitations_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_venue_invitations';
+	}
+
+	/** Get the privacy-safe venue onboarding audit table. */
+	public static function onboarding_audit_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_venue_onboarding_audit';
+	}
+
 	/** Get the booking holds table for the current site. */
 	public static function holds_table(): string {
 		global $wpdb;
@@ -53,6 +71,9 @@ class BookingSchema {
 		$bookings = self::bookings_table();
 		$activity = self::activity_table();
 		$members  = self::memberships_table();
+		$claims   = self::claims_table();
+		$invites  = self::invitations_table();
+		$audit    = self::onboarding_audit_table();
 		$holds    = self::holds_table();
 		$charset  = $wpdb->get_charset_collate();
 
@@ -135,6 +156,62 @@ class BookingSchema {
 			KEY venue_status_owner (venue_term_id, status, is_owner)
 		) ENGINE=InnoDB {$charset};";
 
+		$claims_sql = "CREATE TABLE {$claims} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			public_id CHAR(36) NOT NULL,
+			venue_term_id BIGINT UNSIGNED NOT NULL,
+			claimant_user_id BIGINT UNSIGNED NOT NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'pending',
+			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
+			reviewed_by_user_id BIGINT UNSIGNED NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			resolved_at DATETIME NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY public_id (public_id),
+			UNIQUE KEY venue_claimant (venue_term_id, claimant_user_id),
+			KEY status_created (status, created_at),
+			KEY venue_status (venue_term_id, status)
+		) ENGINE=InnoDB {$charset};";
+
+		$invites_sql = "CREATE TABLE {$invites} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			public_id CHAR(36) NOT NULL,
+			venue_term_id BIGINT UNSIGNED NOT NULL,
+			user_id BIGINT UNSIGNED NOT NULL,
+			is_owner TINYINT UNSIGNED NOT NULL DEFAULT '0',
+			status VARCHAR(20) NOT NULL DEFAULT 'pending',
+			token_hash CHAR(64) NOT NULL,
+			email_hash CHAR(64) NOT NULL,
+			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
+			invited_by_user_id BIGINT UNSIGNED NOT NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			expires_at DATETIME NOT NULL,
+			resolved_at DATETIME NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY public_id (public_id),
+			UNIQUE KEY venue_user (venue_term_id, user_id),
+			KEY venue_status (venue_term_id, status),
+			KEY status_expiration (status, expires_at)
+		) ENGINE=InnoDB {$charset};";
+
+		$audit_sql = "CREATE TABLE {$audit} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			venue_term_id BIGINT UNSIGNED NOT NULL,
+			entity_type VARCHAR(16) NOT NULL,
+			entity_id BIGINT UNSIGNED NOT NULL,
+			event VARCHAR(48) NOT NULL,
+			actor_user_id BIGINT UNSIGNED NULL,
+			subject_user_id BIGINT UNSIGNED NULL,
+			payload LONGTEXT NOT NULL,
+			created_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			KEY entity_created (entity_type, entity_id, created_at, id),
+			KEY venue_created (venue_term_id, created_at, id),
+			KEY event_created (event, created_at)
+		) ENGINE=InnoDB {$charset};";
+
 		$holds_sql = "CREATE TABLE {$holds} (
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 			booking_id BIGINT UNSIGNED NOT NULL,
@@ -173,9 +250,15 @@ class BookingSchema {
 		$activity_error = (string) $wpdb->last_error;
 		dbDelta( $members_sql );
 		$members_error = (string) $wpdb->last_error;
+		dbDelta( $claims_sql );
+		$claims_error = (string) $wpdb->last_error;
+		dbDelta( $invites_sql );
+		$invites_error = (string) $wpdb->last_error;
+		dbDelta( $audit_sql );
+		$audit_error = (string) $wpdb->last_error;
 		dbDelta( $holds_sql );
 		$holds_error = (string) $wpdb->last_error;
-		if ( '' !== $bookings_error || '' !== $activity_error || '' !== $members_error || '' !== $holds_error ) {
+		if ( '' !== $bookings_error || '' !== $activity_error || '' !== $members_error || '' !== $claims_error || '' !== $invites_error || '' !== $audit_error || '' !== $holds_error ) {
 			$error = new \WP_Error(
 				'booking_schema_dbdelta_failed',
 				__( 'The booking schema could not be reconciled.', 'extrachill-events' ),
@@ -183,6 +266,9 @@ class BookingSchema {
 					'bookings_error' => $bookings_error,
 					'activity_error' => $activity_error,
 					'members_error'  => $members_error,
+					'claims_error'   => $claims_error,
+					'invites_error'  => $invites_error,
+					'audit_error'    => $audit_error,
 					'holds_error'    => $holds_error,
 				)
 			);
@@ -458,7 +544,7 @@ class BookingSchema {
 			);
 		};
 		return array(
-			self::bookings_table()    => array(
+			self::bookings_table()         => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                      => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -537,7 +623,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::activity_table()    => array(
+			self::activity_table()         => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'              => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -576,7 +662,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::memberships_table() => array(
+			self::memberships_table()      => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                 => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -609,7 +695,117 @@ class BookingSchema {
 					),
 				),
 			),
-			self::holds_table()       => array(
+			self::claims_table()           => array(
+				'engine'  => 'innodb',
+				'columns' => array(
+					'id'                  => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'public_id'           => $required( 'char(36)', false ),
+					'venue_term_id'       => $required( 'bigint unsigned', false ),
+					'claimant_user_id'    => $required( 'bigint unsigned', false ),
+					'status'              => $required( 'varchar(20)', false, array( 'default' => 'pending' ) ),
+					'version'             => $required( 'bigint unsigned', false, array( 'default' => '1' ) ),
+					'reviewed_by_user_id' => $required( 'bigint unsigned', true ),
+					'created_at'          => $required( 'datetime', false ),
+					'updated_at'          => $required( 'datetime', false ),
+					'resolved_at'         => $required( 'datetime', true ),
+				),
+				'indexes' => array(
+					'PRIMARY'        => array(
+						'unique'  => true,
+						'columns' => array( 'id' ),
+					),
+					'public_id'      => array(
+						'unique'  => true,
+						'columns' => array( 'public_id' ),
+					),
+					'venue_claimant' => array(
+						'unique'  => true,
+						'columns' => array( 'venue_term_id', 'claimant_user_id' ),
+					),
+					'status_created' => array(
+						'unique'  => false,
+						'columns' => array( 'status', 'created_at' ),
+					),
+					'venue_status'   => array(
+						'unique'  => false,
+						'columns' => array( 'venue_term_id', 'status' ),
+					),
+				),
+			),
+			self::invitations_table()      => array(
+				'engine'  => 'innodb',
+				'columns' => array(
+					'id'                 => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'public_id'          => $required( 'char(36)', false ),
+					'venue_term_id'      => $required( 'bigint unsigned', false ),
+					'user_id'            => $required( 'bigint unsigned', false ),
+					'is_owner'           => $required( 'tinyint unsigned', false, array( 'default' => '0' ) ),
+					'status'             => $required( 'varchar(20)', false, array( 'default' => 'pending' ) ),
+					'token_hash'         => $required( 'char(64)', false ),
+					'email_hash'         => $required( 'char(64)', false ),
+					'version'            => $required( 'bigint unsigned', false, array( 'default' => '1' ) ),
+					'invited_by_user_id' => $required( 'bigint unsigned', false ),
+					'created_at'         => $required( 'datetime', false ),
+					'updated_at'         => $required( 'datetime', false ),
+					'expires_at'         => $required( 'datetime', false ),
+					'resolved_at'        => $required( 'datetime', true ),
+				),
+				'indexes' => array(
+					'PRIMARY'           => array(
+						'unique'  => true,
+						'columns' => array( 'id' ),
+					),
+					'public_id'         => array(
+						'unique'  => true,
+						'columns' => array( 'public_id' ),
+					),
+					'venue_user'        => array(
+						'unique'  => true,
+						'columns' => array( 'venue_term_id', 'user_id' ),
+					),
+					'venue_status'      => array(
+						'unique'  => false,
+						'columns' => array( 'venue_term_id', 'status' ),
+					),
+					'status_expiration' => array(
+						'unique'  => false,
+						'columns' => array( 'status', 'expires_at' ),
+					),
+				),
+			),
+			self::onboarding_audit_table() => array(
+				'engine'  => 'innodb',
+				'columns' => array(
+					'id'              => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'venue_term_id'   => $required( 'bigint unsigned', false ),
+					'entity_type'     => $required( 'varchar(16)', false ),
+					'entity_id'       => $required( 'bigint unsigned', false ),
+					'event'           => $required( 'varchar(48)', false ),
+					'actor_user_id'   => $required( 'bigint unsigned', true ),
+					'subject_user_id' => $required( 'bigint unsigned', true ),
+					'payload'         => $required( 'longtext', false ),
+					'created_at'      => $required( 'datetime', false ),
+				),
+				'indexes' => array(
+					'PRIMARY'        => array(
+						'unique'  => true,
+						'columns' => array( 'id' ),
+					),
+					'entity_created' => array(
+						'unique'  => false,
+						'columns' => array( 'entity_type', 'entity_id', 'created_at', 'id' ),
+					),
+					'venue_created'  => array(
+						'unique'  => false,
+						'columns' => array( 'venue_term_id', 'created_at', 'id' ),
+					),
+					'event_created'  => array(
+						'unique'  => false,
+						'columns' => array( 'event', 'created_at' ),
+					),
+				),
+			),
+			self::holds_table()            => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                   => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),

--- a/inc/Core/VenueAuthorization.php
+++ b/inc/Core/VenueAuthorization.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Venue-scoped booking authorization.
+ * Venue-scoped membership and booking authorization.
  *
  * @package ExtraChillEvents\Core
  */
@@ -50,7 +50,7 @@ class VenueAuthorization {
 		if ( self::ACTION_MANAGE_MEMBERS === $action && $this->is_administrator( $user_id ) ) {
 			return true;
 		}
-		if ( ! $this->has_feature_access( $user_id ) ) {
+		if ( self::ACTION_ACCESS_VENUE === $action && ! $this->has_feature_access( $user_id ) ) {
 			return $this->denied();
 		}
 
@@ -67,7 +67,7 @@ class VenueAuthorization {
 		if ( self::ACTION_MANAGE_MEMBERS === $action && $this->is_administrator( $user_id ) ) {
 			return true;
 		}
-		if ( ! $this->has_feature_access( $user_id ) ) {
+		if ( self::ACTION_ACCESS_VENUE === $action && ! $this->has_feature_access( $user_id ) ) {
 			return $this->denied();
 		}
 
@@ -148,7 +148,7 @@ class VenueAuthorization {
 		return $user_id > 0 && user_can( $user_id, 'manage_options' );
 	}
 
-	/** Check the established WordPress capability and rollout primitives. */
+	/** Check the established booking capability and rollout primitives. */
 	public function has_feature_access( int $user_id ): bool {
 		if ( $user_id < 1 || ! user_can( $user_id, self::ACCESS_CAPABILITY ) ) {
 			return false;

--- a/inc/Core/VenueInvitationDeliveryWorker.php
+++ b/inc/Core/VenueInvitationDeliveryWorker.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Bounded venue invitation delivery worker.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Composes bearer credentials only inside a fixed Action Scheduler callback. */
+class VenueInvitationDeliveryWorker {
+
+	public const HOOK  = 'extrachill_events_deliver_venue_invitation';
+	public const GROUP = 'extrachill-events-venue-invitations';
+
+	/**
+	 * Venue onboarding persistence.
+	 *
+	 * @var VenueOnboardingRepository
+	 */
+	private $repository;
+
+	public function __construct( ?VenueOnboardingRepository $repository = null ) {
+		$this->repository = $repository ? $repository : new VenueOnboardingRepository();
+	}
+
+	/** Register the fixed worker callback. */
+	public static function register(): void {
+		add_action( self::HOOK, array( self::class, 'run' ), 10, 1 );
+	}
+
+	/**
+	 * Action Scheduler callback receiving only an opaque stored delivery ID.
+	 *
+	 * @throws \RuntimeException When delivery fails and Action Scheduler should retry.
+	 */
+	public static function run( string $delivery_id ): void {
+		$result = ( new self() )->deliver( $delivery_id );
+		if ( is_wp_error( $result ) ) {
+			throw new \RuntimeException( 'Venue invitation delivery failed.' );
+		}
+	}
+
+	/** Mint runtime credentials, synchronously deliver, and persist the outcome. */
+	public function deliver( string $delivery_id ) {
+		$invitation = $this->repository->prepare_delivery( $delivery_id, VenueOnboardingService::INVITATION_TTL );
+		if ( is_wp_error( $invitation ) ) {
+			return $invitation;
+		}
+
+		$user  = get_userdata( $invitation['user_id'] );
+		$venue = get_term( $invitation['venue_term_id'], 'venue' );
+		$email = $user instanceof \WP_User ? strtolower( sanitize_email( $user->user_email ) ) : '';
+		if ( ! $user || ! $venue || is_wp_error( $venue ) || '' === $email || ! hash_equals( $invitation['_email_hash'], hash_hmac( 'sha256', $email, wp_salt( 'auth' ) ) ) ) {
+			$this->repository->finish_delivery( $delivery_id, false );
+			return new \WP_Error( 'venue_invitation_delivery_identity_changed', __( 'The invitation delivery identity changed.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+
+		$claim_url = '';
+		if ( '1' === (string) get_user_meta( $user->ID, 'ec_unclaimed', true ) ) {
+			$key = get_password_reset_key( $user );
+			if ( is_wp_error( $key ) ) {
+				$this->repository->finish_delivery( $delivery_id, false );
+				return new \WP_Error( 'venue_invitation_reset_key_failed', __( 'The invited account handoff could not be created.', 'extrachill-events' ), array( 'status' => 500 ) );
+			}
+			$base      = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : network_site_url();
+			$claim_url = trailingslashit( $base ) . 'wp-login.php?action=rp&key=' . rawurlencode( $key ) . '&login=' . rawurlencode( $user->user_login );
+		}
+
+		$accept_url = add_query_arg(
+			array(
+				'action'        => 'ec_accept_venue_invitation',
+				'invitation_id' => $invitation['public_id'],
+				'token'         => $invitation['_delivery_token'],
+				'venue_term_id' => $invitation['venue_term_id'],
+				'is_owner'      => $invitation['is_owner'] ? 1 : 0,
+				'version'       => $invitation['version'],
+			),
+			admin_url( 'admin-post.php' )
+		);
+		$cta_url    = $claim_url ? $claim_url : $accept_url;
+		/* translators: %s: Venue name. */
+		$body = '<p>' . esc_html( sprintf( __( 'You have been invited to help manage %s on Extra Chill.', 'extrachill-events' ), $venue->name ) ) . '</p>';
+		if ( $claim_url ) {
+			$body .= '<p>' . esc_html__( 'Set your account password first, then return to the invitation link below to accept.', 'extrachill-events' ) . '</p>';
+			$body .= '<p><a href="' . esc_url( $accept_url ) . '">' . esc_html__( 'Accept venue invitation', 'extrachill-events' ) . '</a></p>';
+		}
+		$body .= '<p>' . esc_html__( 'This message was sent by Extra Chill Bot acting on Chris Huber\'s behalf.', 'extrachill-events' ) . '</p>';
+
+		if ( ! function_exists( 'ec_send_email' ) ) {
+			$this->repository->finish_delivery( $delivery_id, false );
+			return new \WP_Error( 'venue_invitation_delivery_unavailable', __( 'Synchronous invitation delivery is unavailable.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+		$result = ec_send_email(
+			array(
+				'to'        => $user->user_email,
+				'cc'        => 'chubes@extrachill.com',
+				/* translators: %s: Venue name. */
+				'subject'   => sprintf( __( 'Invitation to manage %s', 'extrachill-events' ), $venue->name ),
+				'from_name' => 'Extra Chill Bot',
+				'template'  => 'extrachill/branded',
+				'context'   => array(
+					'recipient_name' => $user->display_name,
+					'body_html'      => $body,
+					'cta_url'        => $cta_url,
+					'cta_label'      => $claim_url ? __( 'Set Your Password', 'extrachill-events' ) : __( 'Accept Invitation', 'extrachill-events' ),
+				),
+			)
+		);
+		$sent   = is_array( $result ) && ! empty( $result['success'] );
+		$saved  = $this->repository->finish_delivery( $delivery_id, $sent );
+		if ( is_wp_error( $saved ) ) {
+			return $saved;
+		}
+		return $sent ? $this->repository->public_invitation( $saved ) : new \WP_Error( 'venue_invitation_delivery_failed', __( 'The invitation email could not be sent.', 'extrachill-events' ), array( 'status' => 503 ) );
+	}
+}

--- a/inc/Core/VenueInvitationToken.php
+++ b/inc/Core/VenueInvitationToken.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Venue invitation token generation and binding.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Generates opaque tokens and binds their hashes to one invitation grant. */
+class VenueInvitationToken {
+
+	/** Generate 256 bits of cryptographically secure token material. */
+	public function generate(): string {
+		return bin2hex( random_bytes( 32 ) );
+	}
+
+	/**
+	 * Hash a token together with its immutable venue, user, and authority grant.
+	 *
+	 * @param string $token      Raw invitation token.
+	 * @param array  $invitation Immutable invitation binding.
+	 */
+	public function hash( string $token, array $invitation ): string {
+		$binding = implode(
+			'|',
+			array(
+				(string) ( $invitation['public_id'] ?? '' ),
+				(string) (int) ( $invitation['venue_term_id'] ?? 0 ),
+				(string) (int) ( $invitation['user_id'] ?? 0 ),
+				! empty( $invitation['is_owner'] ) ? 'owner' : 'member',
+			)
+		);
+
+		return hash_hmac( 'sha256', $token . '|' . $binding, wp_salt( 'auth' ) );
+	}
+
+	/**
+	 * Verify an opaque token without exposing timing information.
+	 *
+	 * @param string $token         Raw invitation token.
+	 * @param array  $invitation    Immutable invitation binding.
+	 * @param string $expected_hash Stored invitation hash.
+	 */
+	public function verify( string $token, array $invitation, string $expected_hash ): bool {
+		if ( '' === $token || ! preg_match( '/^[a-f0-9]{64}$/', $expected_hash ) ) {
+			return false;
+		}
+
+		return hash_equals( $expected_hash, $this->hash( $token, $invitation ) );
+	}
+}

--- a/inc/Core/VenueOnboardingRepository.php
+++ b/inc/Core/VenueOnboardingRepository.php
@@ -229,8 +229,9 @@ class VenueOnboardingRepository {
 	 * @param string $email_hash    Privacy-preserving email binding.
 	 * @param string $token         Raw token used only to derive its hash.
 	 * @param int    $ttl           Token lifetime in seconds.
+	 * @param bool   $account_created Whether this invitation created the account.
 	 */
-	public function create_invitation( int $actor_user_id, int $venue_term_id, int $user_id, bool $is_owner, string $email_hash, string $token, int $ttl ) {
+	public function create_invitation( int $actor_user_id, int $venue_term_id, int $user_id, bool $is_owner, string $email_hash, string $token, int $ttl, bool $account_created = false ) {
 		global $wpdb;
 
 		$valid = $this->validate_actor_venue( $user_id, $venue_term_id );
@@ -293,6 +294,7 @@ class VenueOnboardingRepository {
 			'status'             => self::INVITE_PENDING,
 			'token_hash'         => $this->tokens->hash( $token, $invitation ),
 			'email_hash'         => $email_hash,
+			'account_created'    => $account_created ? 1 : 0,
 			'version'            => 1,
 			'invited_by_user_id' => $actor_user_id,
 			'created_at'         => $now,
@@ -346,6 +348,45 @@ class VenueOnboardingRepository {
 	 */
 	public function cancel_invitation( int $actor_user_id, int $invitation_id, int $expected_version ) {
 		return $this->mutate_invitation( $actor_user_id, $invitation_id, $expected_version, self::INVITE_CANCELLED );
+	}
+
+	/** Cancel an invitation whose post-persistence delivery setup failed. */
+	public function abandon_invitation( array $invitation, int $actor_user_id, string $event ) {
+		$started = $this->begin_and_lock_venue( (int) $invitation['venue_term_id'] );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$current = $this->get_invitation_by_id( (int) $invitation['id'], true );
+		if ( ! is_array( $current ) || self::INVITE_PENDING !== $current['status'] || (int) $invitation['version'] !== $current['version'] ) {
+			$this->rollback();
+			return new \WP_Error( 'venue_invitation_compensation_conflict', __( 'The failed invitation changed before it could be compensated.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$membership = $this->set_invited_membership_status( $current, VenueAuthorization::STATUS_REVOKED );
+		if ( is_wp_error( $membership ) ) {
+			$this->rollback();
+			return $membership;
+		}
+
+		global $wpdb;
+		$now    = gmdate( 'Y-m-d H:i:s' );
+		$table  = BookingSchema::invitations_table();
+		$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = %s, token_hash = %s, version = version + 1, updated_at = %s, resolved_at = %s WHERE id = %d AND version = %d AND status = %s", self::INVITE_CANCELLED, str_repeat( '0', 64 ), $now, $now, $current['id'], $current['version'], self::INVITE_PENDING ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Compensates an unusable invitation under its venue lock.
+		if ( 1 !== $result || ! $this->audit( $current['venue_term_id'], 'invitation', $current['id'], $event, $actor_user_id, $current['user_id'], array( 'version' => $current['version'] + 1 ) ) ) {
+			return $this->rollback_error( 'venue_invitation_compensation_failed', __( 'The failed invitation could not be compensated.', 'extrachill-events' ) );
+		}
+		$updated = $this->get_invitation_by_id( $current['id'], true );
+		if ( ! $this->commit() ) {
+			return $this->commit_error();
+		}
+		return $updated;
+	}
+
+	/** Return whether this invitation remains the account's only venue relationship. */
+	public function account_is_exclusive_to_invitation( array $invitation ): bool {
+		global $wpdb;
+		$table = BookingSchema::memberships_table();
+		$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND NOT (venue_term_id = %d AND status = %s)", $invitation['user_id'], $invitation['venue_term_id'], VenueAuthorization::STATUS_REVOKED ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Safety check before network-account compensation.
+		return '' === (string) $wpdb->last_error && 0 === (int) $count;
 	}
 
 	/**
@@ -403,7 +444,14 @@ class VenueOnboardingRepository {
 			if ( is_wp_error( $expired ) ) {
 				return $expired;
 			}
-			return new \WP_Error( 'venue_invitation_expired', __( 'The venue invitation has expired.', 'extrachill-events' ), array( 'status' => 410 ) );
+			return new \WP_Error(
+				'venue_invitation_expired',
+				__( 'The venue invitation has expired.', 'extrachill-events' ),
+				array(
+					'status'              => 410,
+					'_cleanup_invitation' => $expired,
+				)
+			);
 		}
 		return $this->finish_invitation( $invite, $decision, $actor_user_id );
 	}
@@ -512,11 +560,12 @@ class VenueOnboardingRepository {
 		foreach ( array( 'id', 'venue_term_id', 'user_id', 'version', 'invited_by_user_id' ) as $field ) {
 			$row[ $field ] = (int) $row[ $field ];
 		}
-		$row['is_owner']    = (bool) (int) $row['is_owner'];
-		$row['resolved_at'] = empty( $row['resolved_at'] ) ? null : (string) $row['resolved_at'];
-		$row['_token_hash'] = (string) $row['token_hash'];
-		$row['_email_hash'] = (string) $row['email_hash'];
-		unset( $row['token_hash'], $row['email_hash'] );
+		$row['is_owner']         = (bool) (int) $row['is_owner'];
+		$row['_account_created'] = ! empty( $row['account_created'] );
+		$row['resolved_at']      = empty( $row['resolved_at'] ) ? null : (string) $row['resolved_at'];
+		$row['_token_hash']      = (string) $row['token_hash'];
+		$row['_email_hash']      = (string) $row['email_hash'];
+		unset( $row['token_hash'], $row['email_hash'], $row['account_created'] );
 		return $row;
 	}
 
@@ -526,7 +575,7 @@ class VenueOnboardingRepository {
 	 * @param array $invitation Internal invitation row.
 	 */
 	public function public_invitation( array $invitation ): array {
-		unset( $invitation['_token_hash'], $invitation['_email_hash'] );
+		unset( $invitation['_token_hash'], $invitation['_email_hash'], $invitation['_account_created'] );
 		return $invitation;
 	}
 

--- a/inc/Core/VenueOnboardingRepository.php
+++ b/inc/Core/VenueOnboardingRepository.php
@@ -48,14 +48,28 @@ class VenueOnboardingRepository {
 		if ( is_wp_error( $valid ) ) {
 			return $valid;
 		}
-		if ( is_array( ( new VenueMembershipRepository() )->get( $venue_term_id, $actor_user_id ) ) ) {
-			return new \WP_Error( 'venue_claim_membership_exists', __( 'This user already belongs to the venue.', 'extrachill-events' ), array( 'status' => 409 ) );
-		}
-
 		global $wpdb;
 		$started = $this->begin_and_lock_venue( $venue_term_id );
 		if ( is_wp_error( $started ) ) {
 			return $started;
+		}
+
+		$members = $this->lock_memberships( $venue_term_id );
+		if ( is_wp_error( $members ) ) {
+			$this->rollback();
+			return $members;
+		}
+		$invitations_table = BookingSchema::invitations_table();
+		$invitation        = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$invitations_table} WHERE venue_term_id = %d AND user_id = %d FOR UPDATE", $venue_term_id, $actor_user_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reciprocal onboarding exclusion under venue lock.
+		if ( is_array( $invitation ) && in_array( $invitation['status'], array( self::INVITE_PENDING, self::INVITE_ACCEPTED ), true ) ) {
+			$this->rollback();
+			return new \WP_Error( 'venue_claim_invitation_exists', __( 'This user already has a venue invitation.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		foreach ( $members as $member ) {
+			if ( (int) $member['user_id'] === $actor_user_id ) {
+				$this->rollback();
+				return new \WP_Error( 'venue_claim_membership_exists', __( 'This user already belongs to the venue.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
 		}
 
 		$table = BookingSchema::claims_table();
@@ -367,7 +381,10 @@ class VenueOnboardingRepository {
 			$this->rollback();
 			return $this->invalid_invitation();
 		}
-		$binding_matches = $invite['user_id'] === $actor_user_id && $invite['venue_term_id'] === $venue_term_id && $invite['is_owner'] === $is_owner;
+		$user            = get_userdata( $actor_user_id );
+		$current_email   = $user instanceof \WP_User ? strtolower( sanitize_email( $user->user_email ) ) : '';
+		$email_hash      = hash_hmac( 'sha256', $current_email, wp_salt( 'auth' ) );
+		$binding_matches = $invite['user_id'] === $actor_user_id && $invite['venue_term_id'] === $venue_term_id && $invite['is_owner'] === $is_owner && '' !== $current_email && hash_equals( $invite['_email_hash'], $email_hash );
 		if ( ! $binding_matches || ! $this->tokens->verify( $token, $invite, $invite['_token_hash'] ) ) {
 			$this->rollback();
 			return $this->invalid_invitation();
@@ -424,14 +441,31 @@ class VenueOnboardingRepository {
 	 * @param int $venue_term_id Venue term ID.
 	 */
 	public function list_invitations( int $actor_user_id, int $venue_term_id ) {
-		$allowed = $this->authorization->authorize( $actor_user_id, $venue_term_id, VenueAuthorization::ACTION_MANAGE_MEMBERS );
+		global $wpdb;
+		$started = $this->begin_and_lock_venue( $venue_term_id );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$members = $this->lock_memberships( $venue_term_id );
+		if ( is_wp_error( $members ) ) {
+			$this->rollback();
+			return $members;
+		}
+		$allowed = $this->authorization->authorize_locked( $actor_user_id, $venue_term_id, VenueAuthorization::ACTION_MANAGE_MEMBERS, $members );
 		if ( true !== $allowed ) {
+			$this->rollback();
 			return $allowed;
 		}
-		global $wpdb;
 		$table = BookingSchema::invitations_table();
-		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY created_at ASC, id ASC LIMIT 100", $venue_term_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private venue invitations.
-		return array_map( array( $this, 'hydrate_invitation' ), (array) $rows );
+		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY created_at ASC, id ASC LIMIT 100 FOR UPDATE", $venue_term_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private venue invitations under the same authorization transaction.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return $this->rollback_error( 'venue_invitation_read_failed', __( 'Venue invitations could not be read.', 'extrachill-events' ) );
+		}
+		$result = array_map( array( $this, 'hydrate_invitation' ), (array) $rows );
+		if ( ! $this->commit() ) {
+			return $this->commit_error();
+		}
+		return $result;
 	}
 
 	/**
@@ -481,6 +515,7 @@ class VenueOnboardingRepository {
 		$row['is_owner']    = (bool) (int) $row['is_owner'];
 		$row['resolved_at'] = empty( $row['resolved_at'] ) ? null : (string) $row['resolved_at'];
 		$row['_token_hash'] = (string) $row['token_hash'];
+		$row['_email_hash'] = (string) $row['email_hash'];
 		unset( $row['token_hash'], $row['email_hash'] );
 		return $row;
 	}
@@ -491,7 +526,7 @@ class VenueOnboardingRepository {
 	 * @param array $invitation Internal invitation row.
 	 */
 	public function public_invitation( array $invitation ): array {
-		unset( $invitation['_token_hash'] );
+		unset( $invitation['_token_hash'], $invitation['_email_hash'] );
 		return $invitation;
 	}
 
@@ -532,9 +567,6 @@ class VenueOnboardingRepository {
 		if ( ! is_array( $preview ) ) {
 			return is_wp_error( $preview ) ? $preview : $this->not_found( 'venue_invitation_not_found' );
 		}
-		if ( self::INVITE_CANCELLED === $action && self::INVITE_CANCELLED === $preview['status'] ) {
-			return $preview;
-		}
 		$started = $this->begin_and_lock_venue( $preview['venue_term_id'] );
 		if ( is_wp_error( $started ) ) {
 			return $started;
@@ -550,6 +582,12 @@ class VenueOnboardingRepository {
 			return $allowed;
 		}
 		$current = $this->get_invitation_by_id( $invitation_id, true );
+		if ( self::INVITE_CANCELLED === $action && is_array( $current ) && self::INVITE_CANCELLED === $current['status'] ) {
+			if ( ! $this->commit() ) {
+				return $this->commit_error();
+			}
+			return $current;
+		}
 		if ( ! is_array( $current ) || self::INVITE_PENDING !== $current['status'] ) {
 			$this->rollback();
 			return is_array( $current ) ? $this->transition_conflict( 'venue_invitation_transition_conflict', $current ) : $this->not_found( 'venue_invitation_not_found' );

--- a/inc/Core/VenueOnboardingRepository.php
+++ b/inc/Core/VenueOnboardingRepository.php
@@ -1,0 +1,855 @@
+<?php
+/**
+ * Transactional venue claim and invitation persistence.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Owns onboarding transitions and their privacy-safe audit trail. */
+class VenueOnboardingRepository {
+
+	public const CLAIM_PENDING   = 'pending';
+	public const CLAIM_APPROVED  = 'approved';
+	public const CLAIM_REJECTED  = 'rejected';
+	public const CLAIM_CANCELLED = 'cancelled';
+
+	public const INVITE_PENDING   = 'pending';
+	public const INVITE_ACCEPTED  = 'accepted';
+	public const INVITE_REJECTED  = 'rejected';
+	public const INVITE_CANCELLED = 'cancelled';
+	public const INVITE_EXPIRED   = 'expired';
+
+	/** Invitation token service. */
+	private $tokens;
+
+	/** Venue authorization service. */
+	private $authorization;
+
+	/** Build the transactional onboarding repository. */
+	public function __construct( ?VenueInvitationToken $tokens = null, ?VenueAuthorization $authorization = null ) {
+		$this->tokens        = $tokens ? $tokens : new VenueInvitationToken();
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+	}
+
+	/**
+	 * Submit or idempotently return one user's claim for a venue.
+	 *
+	 * @param int $actor_user_id Actor user ID.
+	 * @param int $venue_term_id Venue term ID.
+	 */
+	public function submit_claim( int $actor_user_id, int $venue_term_id ) {
+		$valid = $this->validate_actor_venue( $actor_user_id, $venue_term_id );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+		if ( is_array( ( new VenueMembershipRepository() )->get( $venue_term_id, $actor_user_id ) ) ) {
+			return new \WP_Error( 'venue_claim_membership_exists', __( 'This user already belongs to the venue.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+
+		global $wpdb;
+		$started = $this->begin_and_lock_venue( $venue_term_id );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+
+		$table = BookingSchema::claims_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d AND claimant_user_id = %d FOR UPDATE", $venue_term_id, $actor_user_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locked private claim row.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return $this->rollback_error( 'venue_claim_read_failed', __( 'The venue claim could not be read.', 'extrachill-events' ) );
+		}
+		if ( is_array( $row ) && self::CLAIM_PENDING === $row['status'] ) {
+			$this->commit();
+			return $this->hydrate_claim( $row );
+		}
+		if ( is_array( $row ) && self::CLAIM_APPROVED === $row['status'] ) {
+			$this->commit();
+			return $this->hydrate_claim( $row );
+		}
+
+		$now = gmdate( 'Y-m-d H:i:s' );
+		if ( is_array( $row ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locked private claim update.
+			$result = $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$table} SET status = %s, version = version + 1, reviewed_by_user_id = NULL, updated_at = %s, resolved_at = NULL WHERE id = %d AND version = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Trusted private table name.
+					self::CLAIM_PENDING,
+					$now,
+					(int) $row['id'],
+					(int) $row['version']
+				)
+			); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locked optimistic claim resubmission.
+			$event  = 'claim_resubmitted';
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private claim write under venue lock.
+			$result = $wpdb->insert(
+				$table,
+				array(
+					'public_id'        => wp_generate_uuid4(),
+					'venue_term_id'    => $venue_term_id,
+					'claimant_user_id' => $actor_user_id,
+					'status'           => self::CLAIM_PENDING,
+					'version'          => 1,
+					'created_at'       => $now,
+					'updated_at'       => $now,
+				)
+			); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private claim write under venue lock.
+			$row    = array( 'id' => $wpdb->insert_id );
+			$event  = 'claim_submitted';
+		}
+		if ( false === $result || 0 === $result ) {
+			return $this->rollback_error( 'venue_claim_write_failed', __( 'The venue claim could not be saved.', 'extrachill-events' ) );
+		}
+		$claim = $this->get_claim_by_id( (int) $row['id'], true );
+		if ( ! is_array( $claim ) || ! $this->audit( $venue_term_id, 'claim', (int) $row['id'], $event, $actor_user_id, $actor_user_id, array( 'status' => self::CLAIM_PENDING ) ) ) {
+			return $this->rollback_error( 'venue_claim_audit_failed', __( 'The venue claim audit could not be recorded.', 'extrachill-events' ) );
+		}
+		if ( ! $this->commit() ) {
+			return $this->commit_error();
+		}
+		return $claim;
+	}
+
+	/**
+	 * Approve or reject a claim while serializing first-owner creation.
+	 *
+	 * @param int    $actor_user_id   Operator user ID.
+	 * @param int    $claim_id        Claim row ID.
+	 * @param string $decision        Approved or rejected status.
+	 * @param int    $expected_version Expected claim version.
+	 */
+	public function review_claim( int $actor_user_id, int $claim_id, string $decision, int $expected_version ) {
+		if ( ! in_array( $decision, array( self::CLAIM_APPROVED, self::CLAIM_REJECTED ), true ) ) {
+			return new \WP_Error( 'invalid_venue_claim_decision', __( 'The venue claim decision is invalid.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		if ( ! user_can( $actor_user_id, 'manage_options' ) ) {
+			return $this->forbidden();
+		}
+		$preview = $this->get_claim_by_id( $claim_id );
+		if ( ! is_array( $preview ) ) {
+			return is_wp_error( $preview ) ? $preview : $this->not_found( 'venue_claim_not_found' );
+		}
+		$started = $this->begin_and_lock_venue( $preview['venue_term_id'] );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$claim = $this->get_claim_by_id( $claim_id, true );
+		if ( ! is_array( $claim ) ) {
+			$this->rollback();
+			return is_wp_error( $claim ) ? $claim : $this->not_found( 'venue_claim_not_found' );
+		}
+		if ( ! user_can( $actor_user_id, 'manage_options' ) ) {
+			$this->rollback();
+			return $this->forbidden();
+		}
+		if ( $decision === $claim['status'] ) {
+			$this->commit();
+			return $claim;
+		}
+		if ( self::CLAIM_PENDING !== $claim['status'] ) {
+			$this->rollback();
+			return $this->transition_conflict( 'venue_claim_transition_conflict', $claim );
+		}
+		if ( $expected_version !== $claim['version'] ) {
+			$this->rollback();
+			return $this->version_conflict( 'venue_claim_version_conflict', $claim );
+		}
+
+		global $wpdb;
+		if ( self::CLAIM_APPROVED === $decision ) {
+			$members = $this->lock_memberships( $claim['venue_term_id'] );
+			if ( is_wp_error( $members ) ) {
+				$this->rollback();
+				return $members;
+			}
+			$membership = $this->grant_claim_owner( $claim, $actor_user_id, $members );
+			if ( is_wp_error( $membership ) ) {
+				$this->rollback();
+				return $membership;
+			}
+		}
+
+		$now    = gmdate( 'Y-m-d H:i:s' );
+		$table  = BookingSchema::claims_table();
+		$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = %s, version = version + 1, reviewed_by_user_id = %d, updated_at = %s, resolved_at = %s WHERE id = %d AND version = %d", $decision, $actor_user_id, $now, $now, $claim_id, $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locked optimistic claim review.
+		if ( 1 !== $result || ! $this->audit( $claim['venue_term_id'], 'claim', $claim_id, 'claim_' . $decision, $actor_user_id, $claim['claimant_user_id'], array( 'status' => $decision ) ) ) {
+			return $this->rollback_error( 'venue_claim_review_failed', __( 'The venue claim decision could not be saved.', 'extrachill-events' ) );
+		}
+		$updated = $this->get_claim_by_id( $claim_id, true );
+		if ( ! $this->commit() ) {
+			return $this->commit_error();
+		}
+		return $updated;
+	}
+
+	/**
+	 * Cancel a pending claim as its claimant or an administrator.
+	 *
+	 * @param int $actor_user_id   Actor user ID.
+	 * @param int $claim_id        Claim row ID.
+	 * @param int $expected_version Expected claim version.
+	 */
+	public function cancel_claim( int $actor_user_id, int $claim_id, int $expected_version ) {
+		$claim = $this->get_claim_by_id( $claim_id );
+		if ( ! is_array( $claim ) ) {
+			return is_wp_error( $claim ) ? $claim : $this->not_found( 'venue_claim_not_found' );
+		}
+		if ( $claim['claimant_user_id'] !== $actor_user_id && ! user_can( $actor_user_id, 'manage_options' ) ) {
+			return $this->forbidden();
+		}
+		return $this->resolve_claim( $actor_user_id, $claim, self::CLAIM_CANCELLED, $expected_version );
+	}
+
+	/**
+	 * Create an invitation and canonical invited membership atomically.
+	 *
+	 * @param int    $actor_user_id Actor user ID.
+	 * @param int    $venue_term_id Venue term ID.
+	 * @param int    $user_id       Bound invitee user ID.
+	 * @param bool   $is_owner      Structural owner grant.
+	 * @param string $email_hash    Privacy-preserving email binding.
+	 * @param string $token         Raw token used only to derive its hash.
+	 * @param int    $ttl           Token lifetime in seconds.
+	 */
+	public function create_invitation( int $actor_user_id, int $venue_term_id, int $user_id, bool $is_owner, string $email_hash, string $token, int $ttl ) {
+		global $wpdb;
+
+		$valid = $this->validate_actor_venue( $user_id, $venue_term_id );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+		$started = $this->begin_and_lock_venue( $venue_term_id );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$members = $this->lock_memberships( $venue_term_id );
+		if ( is_wp_error( $members ) ) {
+			$this->rollback();
+			return $members;
+		}
+		$allowed = $this->authorization->authorize_locked( $actor_user_id, $venue_term_id, VenueAuthorization::ACTION_MANAGE_MEMBERS, $members );
+		if ( true !== $allowed ) {
+			$this->rollback();
+			return $allowed;
+		}
+		$claims_table = BookingSchema::claims_table();
+		$claim        = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$claims_table} WHERE venue_term_id = %d AND claimant_user_id = %d FOR UPDATE", $venue_term_id, $user_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Prevents parallel claim and invitation authority paths.
+		if ( is_array( $claim ) && in_array( $claim['status'], array( self::CLAIM_PENDING, self::CLAIM_APPROVED ), true ) ) {
+			$this->rollback();
+			return new \WP_Error( 'venue_invitation_claim_exists', __( 'This user already has a venue claim.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		foreach ( $members as $member ) {
+			if ( (int) $member['user_id'] === $user_id ) {
+				$this->rollback();
+				return new \WP_Error( 'venue_invitation_membership_exists', __( 'This user already has a venue membership.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+		}
+
+		$now        = gmdate( 'Y-m-d H:i:s' );
+		$public_id  = wp_generate_uuid4();
+		$invitation = array(
+			'public_id'     => $public_id,
+			'venue_term_id' => $venue_term_id,
+			'user_id'       => $user_id,
+			'is_owner'      => $is_owner,
+		);
+		$member_row = array(
+			'venue_term_id'      => $venue_term_id,
+			'user_id'            => $user_id,
+			'is_owner'           => $is_owner ? 1 : 0,
+			'status'             => VenueAuthorization::STATUS_INVITED,
+			'version'            => 1,
+			'created_by_user_id' => $actor_user_id,
+			'created_at'         => $now,
+			'updated_at'         => $now,
+		);
+		if ( false === $wpdb->insert( BookingSchema::memberships_table(), $member_row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Canonical invited membership under venue lock.
+			return $this->rollback_error( 'venue_invitation_membership_failed', __( 'The invited membership could not be created.', 'extrachill-events' ) );
+		}
+		$invite_row = array(
+			'public_id'          => $public_id,
+			'venue_term_id'      => $venue_term_id,
+			'user_id'            => $user_id,
+			'is_owner'           => $is_owner ? 1 : 0,
+			'status'             => self::INVITE_PENDING,
+			'token_hash'         => $this->tokens->hash( $token, $invitation ),
+			'email_hash'         => $email_hash,
+			'version'            => 1,
+			'invited_by_user_id' => $actor_user_id,
+			'created_at'         => $now,
+			'updated_at'         => $now,
+			'expires_at'         => gmdate( 'Y-m-d H:i:s', time() + $ttl ),
+		);
+		if ( false === $wpdb->insert( BookingSchema::invitations_table(), $invite_row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private invitation under venue lock.
+			return $this->rollback_error( 'venue_invitation_create_failed', __( 'The venue invitation could not be created.', 'extrachill-events' ) );
+		}
+		$invite_id = (int) $wpdb->insert_id;
+		if ( ! $this->audit(
+			$venue_term_id,
+			'invitation',
+			$invite_id,
+			'invitation_created',
+			$actor_user_id,
+			$user_id,
+			array(
+				'status'   => self::INVITE_PENDING,
+				'is_owner' => $is_owner,
+			)
+		) ) {
+			return $this->rollback_error( 'venue_invitation_audit_failed', __( 'The invitation audit could not be recorded.', 'extrachill-events' ) );
+		}
+		$created = $this->get_invitation_by_id( $invite_id, true );
+		if ( ! $this->commit() ) {
+			return $this->commit_error();
+		}
+		return $created;
+	}
+
+	/**
+	 * Rotate a pending invitation token under current owner authority.
+	 *
+	 * @param int    $actor_user_id   Actor user ID.
+	 * @param int    $invitation_id   Invitation row ID.
+	 * @param int    $expected_version Expected invitation version.
+	 * @param string $token           Replacement raw token.
+	 * @param int    $ttl             Replacement lifetime in seconds.
+	 */
+	public function resend_invitation( int $actor_user_id, int $invitation_id, int $expected_version, string $token, int $ttl ) {
+		return $this->mutate_invitation( $actor_user_id, $invitation_id, $expected_version, 'resend', $token, $ttl );
+	}
+
+	/**
+	 * Cancel a pending invitation under current owner authority.
+	 *
+	 * @param int $actor_user_id   Actor user ID.
+	 * @param int $invitation_id   Invitation row ID.
+	 * @param int $expected_version Expected invitation version.
+	 */
+	public function cancel_invitation( int $actor_user_id, int $invitation_id, int $expected_version ) {
+		return $this->mutate_invitation( $actor_user_id, $invitation_id, $expected_version, self::INVITE_CANCELLED );
+	}
+
+	/**
+	 * Accept or reject an invitation as the exactly-bound user.
+	 *
+	 * @param int    $actor_user_id   Responding user ID.
+	 * @param string $public_id       Public invitation ID.
+	 * @param string $token           Raw invitation token.
+	 * @param int    $venue_term_id   Bound venue term ID.
+	 * @param bool   $is_owner        Bound structural authority.
+	 * @param int    $expected_version Expected invitation version.
+	 * @param string $decision        Accepted or rejected status.
+	 */
+	public function respond_to_invitation( int $actor_user_id, string $public_id, string $token, int $venue_term_id, bool $is_owner, int $expected_version, string $decision ) {
+		if ( ! in_array( $decision, array( self::INVITE_ACCEPTED, self::INVITE_REJECTED ), true ) ) {
+			return new \WP_Error( 'invalid_venue_invitation_decision', __( 'The invitation response is invalid.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$preview = $this->get_invitation_by_public_id( $public_id );
+		if ( ! is_array( $preview ) ) {
+			return is_wp_error( $preview ) ? $preview : $this->invalid_invitation();
+		}
+		$started = $this->begin_and_lock_venue( $preview['venue_term_id'] );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$members = $this->lock_memberships( $preview['venue_term_id'] );
+		if ( is_wp_error( $members ) ) {
+			$this->rollback();
+			return $members;
+		}
+		$invite = $this->get_invitation_by_public_id( $public_id, true );
+		if ( ! is_array( $invite ) || self::INVITE_PENDING !== $invite['status'] ) {
+			$this->rollback();
+			return $this->invalid_invitation();
+		}
+		$binding_matches = $invite['user_id'] === $actor_user_id && $invite['venue_term_id'] === $venue_term_id && $invite['is_owner'] === $is_owner;
+		if ( ! $binding_matches || ! $this->tokens->verify( $token, $invite, $invite['_token_hash'] ) ) {
+			$this->rollback();
+			return $this->invalid_invitation();
+		}
+		if ( $invite['version'] !== $expected_version ) {
+			$this->rollback();
+			return $this->version_conflict( 'venue_invitation_version_conflict', $invite );
+		}
+		$inviter_allowed = $this->authorization->authorize_locked( $invite['invited_by_user_id'], $venue_term_id, VenueAuthorization::ACTION_MANAGE_MEMBERS, $members );
+		if ( true !== $inviter_allowed ) {
+			$this->rollback();
+			return new \WP_Error( 'venue_invitation_inviter_revoked', __( 'The inviter no longer manages this venue.', 'extrachill-events' ), array( 'status' => 403 ) );
+		}
+		if ( strtotime( $invite['expires_at'] . ' UTC' ) <= time() ) {
+			$expired = $this->finish_invitation( $invite, self::INVITE_EXPIRED, $actor_user_id );
+			if ( is_wp_error( $expired ) ) {
+				return $expired;
+			}
+			return new \WP_Error( 'venue_invitation_expired', __( 'The venue invitation has expired.', 'extrachill-events' ), array( 'status' => 410 ) );
+		}
+		return $this->finish_invitation( $invite, $decision, $actor_user_id );
+	}
+
+	/**
+	 * List claims for operators without exposing identity data beyond user IDs.
+	 *
+	 * @param int    $actor_user_id Operator user ID.
+	 * @param string $status        Optional claim status.
+	 */
+	public function list_claims( int $actor_user_id, string $status = '' ) {
+		if ( ! user_can( $actor_user_id, 'manage_options' ) ) {
+			return $this->forbidden();
+		}
+		global $wpdb;
+		$table  = BookingSchema::claims_table();
+		$where  = '';
+		$values = array();
+		if ( '' !== $status ) {
+			if ( ! in_array( $status, self::claim_statuses(), true ) ) {
+				return new \WP_Error( 'invalid_venue_claim_status', __( 'The venue claim status is invalid.', 'extrachill-events' ) );
+			}
+			$where    = ' WHERE status = %s';
+			$values[] = $status;
+		}
+		$query = "SELECT * FROM {$table}{$where} ORDER BY created_at ASC, id ASC LIMIT 100"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Fixed clauses and private table.
+		$rows  = $values ? $wpdb->get_results( $wpdb->prepare( $query, $values ), ARRAY_A ) : $wpdb->get_results( $query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Values are prepared when present.
+		return array_map( array( $this, 'hydrate_claim' ), (array) $rows );
+	}
+
+	/**
+	 * List invitations for one currently managed venue with all secrets redacted.
+	 *
+	 * @param int $actor_user_id Actor user ID.
+	 * @param int $venue_term_id Venue term ID.
+	 */
+	public function list_invitations( int $actor_user_id, int $venue_term_id ) {
+		$allowed = $this->authorization->authorize( $actor_user_id, $venue_term_id, VenueAuthorization::ACTION_MANAGE_MEMBERS );
+		if ( true !== $allowed ) {
+			return $allowed;
+		}
+		global $wpdb;
+		$table = BookingSchema::invitations_table();
+		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY created_at ASC, id ASC LIMIT 100", $venue_term_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private venue invitations.
+		return array_map( array( $this, 'hydrate_invitation' ), (array) $rows );
+	}
+
+	/**
+	 * Record delivery disposition without token, email, or message content.
+	 *
+	 * @param array $invitation   Internal invitation row.
+	 * @param int   $actor_user_id Actor user ID.
+	 * @param bool  $queued        Whether delivery was queued.
+	 */
+	public function audit_delivery( array $invitation, int $actor_user_id, bool $queued ): bool {
+		return $this->audit( $invitation['venue_term_id'], 'invitation', $invitation['id'], $queued ? 'invitation_delivery_queued' : 'invitation_delivery_failed', $actor_user_id, $invitation['user_id'], array( 'version' => $invitation['version'] ) );
+	}
+
+	/** Return bounded claim statuses. */
+	public static function claim_statuses(): array {
+		return array( self::CLAIM_PENDING, self::CLAIM_APPROVED, self::CLAIM_REJECTED, self::CLAIM_CANCELLED );
+	}
+
+	/** Return bounded invitation statuses. */
+	public static function invitation_statuses(): array {
+		return array( self::INVITE_PENDING, self::INVITE_ACCEPTED, self::INVITE_REJECTED, self::INVITE_CANCELLED, self::INVITE_EXPIRED );
+	}
+
+	/**
+	 * Hydrate a claim's scalar public contract.
+	 *
+	 * @param array $row Stored claim row.
+	 */
+	public function hydrate_claim( array $row ): array {
+		foreach ( array( 'id', 'venue_term_id', 'claimant_user_id', 'version' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		$row['reviewed_by_user_id'] = empty( $row['reviewed_by_user_id'] ) ? null : (int) $row['reviewed_by_user_id'];
+		$row['resolved_at']         = empty( $row['resolved_at'] ) ? null : (string) $row['resolved_at'];
+		return $row;
+	}
+
+	/**
+	 * Hydrate an invitation while retaining its hash only for internal verification.
+	 *
+	 * @param array $row Stored invitation row.
+	 */
+	public function hydrate_invitation( array $row ): array {
+		foreach ( array( 'id', 'venue_term_id', 'user_id', 'version', 'invited_by_user_id' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		$row['is_owner']    = (bool) (int) $row['is_owner'];
+		$row['resolved_at'] = empty( $row['resolved_at'] ) ? null : (string) $row['resolved_at'];
+		$row['_token_hash'] = (string) $row['token_hash'];
+		unset( $row['token_hash'], $row['email_hash'] );
+		return $row;
+	}
+
+	/**
+	 * Strip every internal secret before returning an invitation to callers.
+	 *
+	 * @param array $invitation Internal invitation row.
+	 */
+	public function public_invitation( array $invitation ): array {
+		unset( $invitation['_token_hash'] );
+		return $invitation;
+	}
+
+	/** Resolve a pending claim to a terminal status. */
+	private function resolve_claim( int $actor_user_id, array $claim, string $status, int $expected_version ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private transition arguments are self-describing.
+		if ( $claim['status'] === $status ) {
+			return $claim;
+		}
+		if ( self::CLAIM_PENDING !== $claim['status'] || $claim['version'] !== $expected_version ) {
+			return $this->transition_conflict( 'venue_claim_transition_conflict', $claim );
+		}
+		$started = $this->begin_and_lock_venue( $claim['venue_term_id'] );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$current = $this->get_claim_by_id( $claim['id'], true );
+		if ( ! is_array( $current ) || self::CLAIM_PENDING !== $current['status'] || $expected_version !== $current['version'] ) {
+			$this->rollback();
+			return is_array( $current ) ? $this->version_conflict( 'venue_claim_version_conflict', $current ) : $this->not_found( 'venue_claim_not_found' );
+		}
+		global $wpdb;
+		$now    = gmdate( 'Y-m-d H:i:s' );
+		$table  = BookingSchema::claims_table();
+		$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = %s, version = version + 1, updated_at = %s, resolved_at = %s WHERE id = %d AND version = %d", $status, $now, $now, $claim['id'], $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locked optimistic cancellation.
+		if ( 1 !== $result || ! $this->audit( $claim['venue_term_id'], 'claim', $claim['id'], 'claim_' . $status, $actor_user_id, $claim['claimant_user_id'], array( 'status' => $status ) ) ) {
+			return $this->rollback_error( 'venue_claim_cancel_failed', __( 'The venue claim could not be cancelled.', 'extrachill-events' ) );
+		}
+		$updated = $this->get_claim_by_id( $claim['id'], true );
+		if ( ! $this->commit() ) {
+			return $this->commit_error();
+		}
+		return $updated;
+	}
+
+	/** Mutate a pending invitation under lock-current owner authority. */
+	private function mutate_invitation( int $actor_user_id, int $invitation_id, int $expected_version, string $action, string $token = '', int $ttl = 0 ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private transition arguments are self-describing.
+		$preview = $this->get_invitation_by_id( $invitation_id );
+		if ( ! is_array( $preview ) ) {
+			return is_wp_error( $preview ) ? $preview : $this->not_found( 'venue_invitation_not_found' );
+		}
+		if ( self::INVITE_CANCELLED === $action && self::INVITE_CANCELLED === $preview['status'] ) {
+			return $preview;
+		}
+		$started = $this->begin_and_lock_venue( $preview['venue_term_id'] );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$members = $this->lock_memberships( $preview['venue_term_id'] );
+		if ( is_wp_error( $members ) ) {
+			$this->rollback();
+			return $members;
+		}
+		$allowed = $this->authorization->authorize_locked( $actor_user_id, $preview['venue_term_id'], VenueAuthorization::ACTION_MANAGE_MEMBERS, $members );
+		if ( true !== $allowed ) {
+			$this->rollback();
+			return $allowed;
+		}
+		$current = $this->get_invitation_by_id( $invitation_id, true );
+		if ( ! is_array( $current ) || self::INVITE_PENDING !== $current['status'] ) {
+			$this->rollback();
+			return is_array( $current ) ? $this->transition_conflict( 'venue_invitation_transition_conflict', $current ) : $this->not_found( 'venue_invitation_not_found' );
+		}
+		if ( $expected_version !== $current['version'] ) {
+			$this->rollback();
+			return $this->version_conflict( 'venue_invitation_version_conflict', $current );
+		}
+
+		global $wpdb;
+		$now   = gmdate( 'Y-m-d H:i:s' );
+		$table = BookingSchema::invitations_table();
+		if ( 'resend' === $action ) {
+			$hash   = $this->tokens->hash( $token, $current );
+			$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET token_hash = %s, version = version + 1, invited_by_user_id = %d, updated_at = %s, expires_at = %s WHERE id = %d AND version = %d", $hash, $actor_user_id, $now, gmdate( 'Y-m-d H:i:s', time() + $ttl ), $invitation_id, $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locked token rotation.
+			$event  = 'invitation_resent';
+		} else {
+			$result     = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = %s, token_hash = %s, version = version + 1, updated_at = %s, resolved_at = %s WHERE id = %d AND version = %d", self::INVITE_CANCELLED, str_repeat( '0', 64 ), $now, $now, $invitation_id, $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locked invitation cancellation.
+			$membership = $this->set_invited_membership_status( $current, VenueAuthorization::STATUS_REVOKED );
+			if ( is_wp_error( $membership ) ) {
+				$this->rollback();
+				return $membership;
+			}
+			$event = 'invitation_cancelled';
+		}
+		if ( 1 !== $result || ! $this->audit( $current['venue_term_id'], 'invitation', $invitation_id, $event, $actor_user_id, $current['user_id'], array( 'version' => $expected_version + 1 ) ) ) {
+			return $this->rollback_error( 'venue_invitation_update_failed', __( 'The venue invitation could not be updated.', 'extrachill-events' ) );
+		}
+		$updated = $this->get_invitation_by_id( $invitation_id, true );
+		if ( ! $this->commit() ) {
+			return $this->commit_error();
+		}
+		return $updated;
+	}
+
+	/** Complete an invitation and its canonical membership transition. */
+	private function finish_invitation( array $invite, string $status, int $actor_user_id ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private transition arguments are self-describing.
+		global $wpdb;
+		$membership_status = self::INVITE_ACCEPTED === $status ? VenueAuthorization::STATUS_ACTIVE : VenueAuthorization::STATUS_REVOKED;
+		$membership        = $this->set_invited_membership_status( $invite, $membership_status );
+		if ( is_wp_error( $membership ) ) {
+			$this->rollback();
+			return $membership;
+		}
+		$now    = gmdate( 'Y-m-d H:i:s' );
+		$table  = BookingSchema::invitations_table();
+		$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = %s, token_hash = %s, version = version + 1, updated_at = %s, resolved_at = %s WHERE id = %d AND version = %d AND status = %s", $status, str_repeat( '0', 64 ), $now, $now, $invite['id'], $invite['version'], self::INVITE_PENDING ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Single-use invitation transition.
+		if ( 1 !== $result || ! $this->audit(
+			$invite['venue_term_id'],
+			'invitation',
+			$invite['id'],
+			'invitation_' . $status,
+			$actor_user_id,
+			$invite['user_id'],
+			array(
+				'status'   => $status,
+				'is_owner' => $invite['is_owner'],
+			)
+		) ) {
+			return $this->rollback_error( 'venue_invitation_response_failed', __( 'The invitation response could not be saved.', 'extrachill-events' ) );
+		}
+		$updated = $this->get_invitation_by_id( $invite['id'], true );
+		if ( ! $this->commit() ) {
+			return $this->commit_error();
+		}
+		return $updated;
+	}
+
+	/** Grant approved structural owner authority. */
+	private function grant_claim_owner( array $claim, int $actor_user_id, array $members ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private transition arguments are self-describing.
+		global $wpdb;
+		$current = null;
+		foreach ( $members as $member ) {
+			if ( (int) $member['user_id'] === $claim['claimant_user_id'] ) {
+				$current = $member;
+				break;
+			}
+		}
+		$now = gmdate( 'Y-m-d H:i:s' );
+		if ( null === $current ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Explicit owner bootstrap under venue lock.
+			$result = $wpdb->insert(
+				BookingSchema::memberships_table(),
+				array(
+					'venue_term_id'      => $claim['venue_term_id'],
+					'user_id'            => $claim['claimant_user_id'],
+					'is_owner'           => 1,
+					'status'             => VenueAuthorization::STATUS_ACTIVE,
+					'version'            => 1,
+					'created_by_user_id' => $actor_user_id,
+					'created_at'         => $now,
+					'updated_at'         => $now,
+				)
+			); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Explicit operator-approved owner bootstrap under venue lock.
+			return false === $result ? new \WP_Error( 'venue_claim_owner_create_failed', __( 'The approved venue owner could not be created.', 'extrachill-events' ) ) : true;
+		}
+		if ( VenueAuthorization::STATUS_REVOKED === $current['status'] ) {
+			return new \WP_Error( 'venue_claim_membership_revoked', __( 'A revoked membership requires explicit operator repair.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$table  = BookingSchema::memberships_table();
+		$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET is_owner = 1, status = %s, version = version + 1, updated_at = %s, revoked_at = NULL WHERE venue_term_id = %d AND user_id = %d AND version = %d", VenueAuthorization::STATUS_ACTIVE, $now, $claim['venue_term_id'], $claim['claimant_user_id'], (int) $current['version'] ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Operator-approved promotion under lock.
+		return 1 === $result ? true : new \WP_Error( 'venue_claim_owner_update_failed', __( 'The approved venue owner could not be updated.', 'extrachill-events' ) );
+	}
+
+	/** Transition only the matching canonical invited membership. */
+	private function set_invited_membership_status( array $invite, string $status ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private transition arguments are self-describing.
+		global $wpdb;
+		$table   = BookingSchema::memberships_table();
+		$row     = null;
+		$members = $this->lock_memberships( $invite['venue_term_id'] );
+		if ( is_wp_error( $members ) ) {
+			return $members;
+		}
+		$has_active_owner = false;
+		foreach ( $members as $member ) {
+			if ( (int) $member['user_id'] === $invite['user_id'] ) {
+				$row = $member;
+			}
+			if ( ! empty( $member['is_owner'] ) && VenueAuthorization::STATUS_ACTIVE === $member['status'] ) {
+				$has_active_owner = true;
+			}
+		}
+		if ( ! is_array( $row ) || VenueAuthorization::STATUS_INVITED !== $row['status'] || (bool) (int) $row['is_owner'] !== $invite['is_owner'] ) {
+			return new \WP_Error( 'venue_invitation_membership_changed', __( 'The invited membership no longer matches this invitation.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		if ( VenueAuthorization::STATUS_ACTIVE === $status && ! $invite['is_owner'] && ! $has_active_owner ) {
+			return new \WP_Error( 'venue_membership_owner_required', __( 'The first active venue member must be an owner.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$revoked_at = VenueAuthorization::STATUS_REVOKED === $status ? gmdate( 'Y-m-d H:i:s' ) : null;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locked canonical membership transition.
+		$result = $wpdb->update(
+			$table,
+			array(
+				'status'     => $status,
+				'version'    => (int) $row['version'] + 1,
+				'updated_at' => gmdate( 'Y-m-d H:i:s' ),
+				'revoked_at' => $revoked_at,
+			),
+			array(
+				'venue_term_id' => $invite['venue_term_id'],
+				'user_id'       => $invite['user_id'],
+				'version'       => (int) $row['version'],
+			)
+		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locked canonical membership transition.
+		return 1 === $result ? true : new \WP_Error( 'venue_invitation_membership_update_failed', __( 'The invited membership could not be updated.', 'extrachill-events' ) );
+	}
+
+	/** Start a transaction and acquire the stable venue-term lock. */
+	private function begin_and_lock_venue( int $venue_term_id ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private lock helper.
+		global $wpdb;
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serializes onboarding transitions.
+			return new \WP_Error( 'venue_onboarding_transaction_failed', __( 'The venue onboarding transaction could not start.', 'extrachill-events' ) );
+		}
+		$term_id = $wpdb->get_var( $wpdb->prepare( "SELECT term_id FROM {$wpdb->terms} WHERE term_id = %d FOR UPDATE", $venue_term_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Stable lock even before venue-owned rows exist.
+		if ( (int) $term_id !== $venue_term_id || '' !== (string) $wpdb->last_error ) {
+			$this->rollback();
+			return new \WP_Error( 'invalid_venue_membership_venue', __( 'A valid Events venue term is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return true;
+	}
+
+	/** Read lock-current membership authority for a venue. */
+	private function lock_memberships( int $venue_term_id ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private lock helper.
+		global $wpdb;
+		$table = BookingSchema::memberships_table();
+		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $venue_term_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Lock-current authority rows.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'venue_membership_read_failed', __( 'Venue memberships could not be locked.', 'extrachill-events' ) );
+		}
+		return (array) $rows;
+	}
+
+	/** Read a claim, optionally under a row lock. */
+	private function get_claim_by_id( int $claim_id, bool $locked = false ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private read helper.
+		global $wpdb;
+		$table = BookingSchema::claims_table();
+		$lock  = $locked ? ' FOR UPDATE' : '';
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d{$lock}", $claim_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private claim read.
+		return is_array( $row ) ? $this->hydrate_claim( $row ) : null;
+	}
+
+	/** Read an invitation by internal ID. */
+	private function get_invitation_by_id( int $invitation_id, bool $locked = false ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private read helper.
+		global $wpdb;
+		$table = BookingSchema::invitations_table();
+		$lock  = $locked ? ' FOR UPDATE' : '';
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d{$lock}", $invitation_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private invitation read.
+		return is_array( $row ) ? $this->hydrate_invitation( $row ) : null;
+	}
+
+	/** Read an invitation by opaque public ID. */
+	private function get_invitation_by_public_id( string $public_id, bool $locked = false ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private read helper.
+		global $wpdb;
+		$table = BookingSchema::invitations_table();
+		$lock  = $locked ? ' FOR UPDATE' : '';
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE public_id = %s{$lock}", $public_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Opaque invitation lookup.
+		return is_array( $row ) ? $this->hydrate_invitation( $row ) : null;
+	}
+
+	/** Append a privacy-safe onboarding audit event. */
+	private function audit( int $venue_term_id, string $entity_type, int $entity_id, string $event, ?int $actor_user_id, ?int $subject_user_id, array $payload ): bool { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private audit helper.
+		global $wpdb;
+		$encoded = wp_json_encode( $payload );
+		if ( false === $encoded || preg_match( '/(?:token|email)/i', implode( '|', array_keys( $payload ) ) ) ) {
+			return false;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Append-only private audit write.
+		$result = $wpdb->insert(
+			BookingSchema::onboarding_audit_table(),
+			array(
+				'venue_term_id'   => $venue_term_id,
+				'entity_type'     => $entity_type,
+				'entity_id'       => $entity_id,
+				'event'           => $event,
+				'actor_user_id'   => $actor_user_id,
+				'subject_user_id' => $subject_user_id,
+				'payload'         => $encoded,
+				'created_at'      => gmdate( 'Y-m-d H:i:s' ),
+			)
+		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Append-only private audit write.
+		return false !== $result;
+	}
+
+	/** Validate schema, venue, and network-user existence. */
+	private function validate_actor_venue( int $user_id, int $venue_term_id ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private validation helper.
+		if ( ! BookingSchema::is_ready() ) {
+			return new \WP_Error( 'venue_membership_schema_unavailable', __( 'Venue onboarding storage is not ready.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+		$venue = get_term( $venue_term_id, 'venue' );
+		if ( $venue_term_id < 1 || ! $venue || is_wp_error( $venue ) || 'venue' !== $venue->taxonomy ) {
+			return new \WP_Error( 'invalid_venue_membership_venue', __( 'A valid Events venue term is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		if ( $user_id < 1 || ! get_userdata( $user_id ) ) {
+			return $this->forbidden();
+		}
+		return true;
+	}
+
+	/** Commit the current transaction. */
+	private function commit(): bool {
+		global $wpdb;
+		return false !== $wpdb->query( 'COMMIT' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Completes onboarding transaction.
+	}
+
+	/** Roll back the current transaction. */
+	private function rollback(): void {
+		global $wpdb;
+		$wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Rolls back onboarding transaction.
+	}
+
+	/** Roll back and return a database error. */
+	private function rollback_error( string $code, string $message ): \WP_Error { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private error helper.
+		global $wpdb;
+		$database_error = (string) $wpdb->last_error;
+		$this->rollback();
+		return new \WP_Error( $code, $message, array( 'database_error' => $database_error ) );
+	}
+
+	/** Return the uncertain-commit error. */
+	private function commit_error(): \WP_Error {
+		return new \WP_Error( 'venue_onboarding_commit_uncertain', __( 'The onboarding transaction outcome could not be confirmed.', 'extrachill-events' ) );
+	}
+
+	/** Return a non-enumerating invitation error. */
+	private function invalid_invitation(): \WP_Error {
+		return new \WP_Error( 'invalid_venue_invitation', __( 'The venue invitation is invalid or no longer available.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+
+	/** Return a standard authorization error. */
+	private function forbidden(): \WP_Error {
+		return new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+
+	/** Return a standard not-found error. */
+	private function not_found( string $code ): \WP_Error { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private error helper.
+		return new \WP_Error( $code, __( 'The venue onboarding record was not found.', 'extrachill-events' ), array( 'status' => 404 ) );
+	}
+
+	/** Return an optimistic version conflict. */
+	private function version_conflict( string $code, array $current ): \WP_Error { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private error helper.
+		return new \WP_Error(
+			$code,
+			__( 'The venue onboarding record changed since it was read.', 'extrachill-events' ),
+			array(
+				'status'          => 409,
+				'current_version' => $current['version'],
+			)
+		);
+	}
+
+	/** Return a terminal transition conflict. */
+	private function transition_conflict( string $code, array $current ): \WP_Error { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private error helper.
+		return new \WP_Error(
+			$code,
+			__( 'The venue onboarding transition is no longer valid.', 'extrachill-events' ),
+			array(
+				'status'          => 409,
+				'current_status'  => $current['status'],
+				'current_version' => $current['version'],
+			)
+		);
+	}
+}

--- a/inc/Core/VenueOnboardingRepository.php
+++ b/inc/Core/VenueOnboardingRepository.php
@@ -25,6 +25,11 @@ class VenueOnboardingRepository {
 	public const INVITE_CANCELLED = 'cancelled';
 	public const INVITE_EXPIRED   = 'expired';
 
+	public const DELIVERY_QUEUED     = 'queued';
+	public const DELIVERY_PROCESSING = 'processing';
+	public const DELIVERY_SENT       = 'sent';
+	public const DELIVERY_FAILED     = 'failed';
+
 	/** Invitation token service. */
 	private $tokens;
 
@@ -227,11 +232,9 @@ class VenueOnboardingRepository {
 	 * @param int    $user_id       Bound invitee user ID.
 	 * @param bool   $is_owner      Structural owner grant.
 	 * @param string $email_hash    Privacy-preserving email binding.
-	 * @param string $token         Raw token used only to derive its hash.
-	 * @param int    $ttl           Token lifetime in seconds.
 	 * @param bool   $account_created Whether this invitation created the account.
 	 */
-	public function create_invitation( int $actor_user_id, int $venue_term_id, int $user_id, bool $is_owner, string $email_hash, string $token, int $ttl, bool $account_created = false ) {
+	public function create_invitation( int $actor_user_id, int $venue_term_id, int $user_id, bool $is_owner, string $email_hash, bool $account_created = false ) {
 		global $wpdb;
 
 		$valid = $this->validate_actor_venue( $user_id, $venue_term_id );
@@ -258,22 +261,31 @@ class VenueOnboardingRepository {
 			$this->rollback();
 			return new \WP_Error( 'venue_invitation_claim_exists', __( 'This user already has a venue claim.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
+		$current_member = null;
 		foreach ( $members as $member ) {
 			if ( (int) $member['user_id'] === $user_id ) {
+				$current_member = $member;
+				break;
+			}
+		}
+		$invites_table  = BookingSchema::invitations_table();
+		$current_invite = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$invites_table} WHERE venue_term_id = %d AND user_id = %d FOR UPDATE", $venue_term_id, $user_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Determines whether a terminal onboarding row can be safely reactivated.
+		$terminal       = array( self::INVITE_CANCELLED, self::INVITE_REJECTED, self::INVITE_EXPIRED );
+		if ( is_array( $current_member ) || is_array( $current_invite ) ) {
+			$can_reactivate = is_array( $current_member )
+				&& VenueAuthorization::STATUS_REVOKED === $current_member['status']
+				&& is_array( $current_invite )
+				&& in_array( $current_invite['status'], $terminal, true );
+			if ( ! $can_reactivate ) {
 				$this->rollback();
-				return new \WP_Error( 'venue_invitation_membership_exists', __( 'This user already has a venue membership.', 'extrachill-events' ), array( 'status' => 409 ) );
+				return new \WP_Error( 'venue_invitation_membership_exists', __( 'This user already has a venue membership or invitation.', 'extrachill-events' ), array( 'status' => 409 ) );
 			}
 		}
 
-		$now        = gmdate( 'Y-m-d H:i:s' );
-		$public_id  = wp_generate_uuid4();
-		$invitation = array(
-			'public_id'     => $public_id,
-			'venue_term_id' => $venue_term_id,
-			'user_id'       => $user_id,
-			'is_owner'      => $is_owner,
-		);
-		$member_row = array(
+		$now           = gmdate( 'Y-m-d H:i:s' );
+		$public_id     = wp_generate_uuid4();
+		$delivery_id   = wp_generate_uuid4();
+		$member_row    = array(
 			'venue_term_id'      => $venue_term_id,
 			'user_id'            => $user_id,
 			'is_owner'           => $is_owner ? 1 : 0,
@@ -283,7 +295,13 @@ class VenueOnboardingRepository {
 			'created_at'         => $now,
 			'updated_at'         => $now,
 		);
-		if ( false === $wpdb->insert( BookingSchema::memberships_table(), $member_row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Canonical invited membership under venue lock.
+		$members_table = BookingSchema::memberships_table();
+		if ( is_array( $current_member ) ) {
+			$member_result = $wpdb->query( $wpdb->prepare( "UPDATE {$members_table} SET is_owner = %d, status = %s, version = version + 1, created_by_user_id = %d, updated_at = %s, revoked_at = NULL WHERE venue_term_id = %d AND user_id = %d AND version = %d", $is_owner ? 1 : 0, VenueAuthorization::STATUS_INVITED, $actor_user_id, $now, $venue_term_id, $user_id, (int) $current_member['version'] ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reactivates only the exact terminal membership under venue lock.
+			if ( 1 !== $member_result ) {
+				return $this->rollback_error( 'venue_invitation_membership_failed', __( 'The terminal venue membership could not be reactivated.', 'extrachill-events' ) );
+			}
+		} elseif ( false === $wpdb->insert( $members_table, $member_row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Canonical invited membership under venue lock.
 			return $this->rollback_error( 'venue_invitation_membership_failed', __( 'The invited membership could not be created.', 'extrachill-events' ) );
 		}
 		$invite_row = array(
@@ -292,24 +310,38 @@ class VenueOnboardingRepository {
 			'user_id'            => $user_id,
 			'is_owner'           => $is_owner ? 1 : 0,
 			'status'             => self::INVITE_PENDING,
-			'token_hash'         => $this->tokens->hash( $token, $invitation ),
+			'token_hash'         => str_repeat( '0', 64 ),
 			'email_hash'         => $email_hash,
 			'account_created'    => $account_created ? 1 : 0,
+			'delivery_id'        => $delivery_id,
+			'delivery_status'    => self::DELIVERY_QUEUED,
+			'delivery_attempts'  => 0,
 			'version'            => 1,
 			'invited_by_user_id' => $actor_user_id,
 			'created_at'         => $now,
 			'updated_at'         => $now,
-			'expires_at'         => gmdate( 'Y-m-d H:i:s', time() + $ttl ),
+			'expires_at'         => $now,
 		);
-		if ( false === $wpdb->insert( BookingSchema::invitations_table(), $invite_row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private invitation under venue lock.
-			return $this->rollback_error( 'venue_invitation_create_failed', __( 'The venue invitation could not be created.', 'extrachill-events' ) );
+		if ( is_array( $current_invite ) ) {
+			$preserve_created = $account_created || ! empty( $current_invite['account_created'] );
+			$result           = $wpdb->query( $wpdb->prepare( "UPDATE {$invites_table} SET public_id = %s, is_owner = %d, status = %s, token_hash = %s, email_hash = %s, account_created = %d, delivery_id = %s, delivery_status = %s, delivery_attempts = 0, version = version + 1, invited_by_user_id = %d, updated_at = %s, expires_at = %s, resolved_at = NULL, delivered_at = NULL WHERE id = %d AND version = %d", $public_id, $is_owner ? 1 : 0, self::INVITE_PENDING, str_repeat( '0', 64 ), $email_hash, $preserve_created ? 1 : 0, $delivery_id, self::DELIVERY_QUEUED, $actor_user_id, $now, $now, (int) $current_invite['id'], (int) $current_invite['version'] ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Rotates every bearer binding while reactivating a terminal invitation.
+			if ( 1 !== $result ) {
+				return $this->rollback_error( 'venue_invitation_create_failed', __( 'The terminal venue invitation could not be reactivated.', 'extrachill-events' ) );
+			}
+			$invite_id = (int) $current_invite['id'];
+			$event     = 'invitation_reinvited';
+		} else {
+			if ( false === $wpdb->insert( $invites_table, $invite_row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private invitation under venue lock.
+				return $this->rollback_error( 'venue_invitation_create_failed', __( 'The venue invitation could not be created.', 'extrachill-events' ) );
+			}
+			$invite_id = (int) $wpdb->insert_id;
+			$event     = 'invitation_created';
 		}
-		$invite_id = (int) $wpdb->insert_id;
 		if ( ! $this->audit(
 			$venue_term_id,
 			'invitation',
 			$invite_id,
-			'invitation_created',
+			$event,
 			$actor_user_id,
 			$user_id,
 			array(
@@ -332,11 +364,9 @@ class VenueOnboardingRepository {
 	 * @param int    $actor_user_id   Actor user ID.
 	 * @param int    $invitation_id   Invitation row ID.
 	 * @param int    $expected_version Expected invitation version.
-	 * @param string $token           Replacement raw token.
-	 * @param int    $ttl             Replacement lifetime in seconds.
 	 */
-	public function resend_invitation( int $actor_user_id, int $invitation_id, int $expected_version, string $token, int $ttl ) {
-		return $this->mutate_invitation( $actor_user_id, $invitation_id, $expected_version, 'resend', $token, $ttl );
+	public function resend_invitation( int $actor_user_id, int $invitation_id, int $expected_version ) {
+		return $this->mutate_invitation( $actor_user_id, $invitation_id, $expected_version, 'resend' );
 	}
 
 	/**
@@ -381,12 +411,146 @@ class VenueOnboardingRepository {
 		return $updated;
 	}
 
-	/** Return whether this invitation remains the account's only venue relationship. */
-	public function account_is_exclusive_to_invitation( array $invitation ): bool {
+	/**
+	 * Delete an invitation-created account only while all cross-venue ranges are locked.
+	 *
+	 * @param array    $invitation Internal invitation identity, or an initial account identity.
+	 * @param callable $delete     Bounded account validation and deletion callback.
+	 */
+	public function delete_account_if_exclusive( array $invitation, callable $delete ): bool {
 		global $wpdb;
-		$table = BookingSchema::memberships_table();
-		$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND NOT (venue_term_id = %d AND status = %s)", $invitation['user_id'], $invitation['venue_term_id'], VenueAuthorization::STATUS_REVOKED ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Safety check before network-account compensation.
-		return '' === (string) $wpdb->last_error && 0 === (int) $count;
+		$user_id = (int) ( $invitation['user_id'] ?? 0 );
+		if ( $user_id < 1 || false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serializes account compensation.
+			return false;
+		}
+		$user_table = $wpdb->users;
+		$wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$user_table} WHERE ID = %d FOR UPDATE", $user_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Stabilizes account identity through compensation.
+		if ( '' !== (string) $wpdb->last_error ) {
+			$this->rollback();
+			return false;
+		}
+		$members_table = BookingSchema::memberships_table();
+		$members       = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$members_table} WHERE user_id = %d ORDER BY venue_term_id ASC, id ASC FOR UPDATE", $user_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- User-first index locks every membership range and insertion gap.
+		if ( '' !== (string) $wpdb->last_error ) {
+			$this->rollback();
+			return false;
+		}
+		$invites_table = BookingSchema::invitations_table();
+		$invitations   = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$invites_table} WHERE user_id = %d ORDER BY venue_term_id ASC, id ASC FOR UPDATE", $user_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- User-first index locks every invitation range and insertion gap.
+		if ( '' !== (string) $wpdb->last_error ) {
+			$this->rollback();
+			return false;
+		}
+		$claims_table = BookingSchema::claims_table();
+		$claims       = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$claims_table} WHERE claimant_user_id = %d ORDER BY venue_term_id ASC, id ASC FOR UPDATE", $user_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- User-first index locks every claim range and insertion gap.
+		if ( '' !== (string) $wpdb->last_error ) {
+			$this->rollback();
+			return false;
+		}
+
+		$allowed_invitation_id = (int) ( $invitation['id'] ?? 0 );
+		$allowed_venue_id      = (int) ( $invitation['venue_term_id'] ?? 0 );
+		foreach ( (array) $members as $member ) {
+			if ( (int) $member['venue_term_id'] !== $allowed_venue_id || VenueAuthorization::STATUS_REVOKED !== $member['status'] ) {
+				$this->commit();
+				return true;
+			}
+		}
+		foreach ( (array) $invitations as $row ) {
+			if ( (int) $row['id'] !== $allowed_invitation_id || ! in_array( $row['status'], array( self::INVITE_CANCELLED, self::INVITE_REJECTED, self::INVITE_EXPIRED ), true ) ) {
+				$this->commit();
+				return true;
+			}
+		}
+		if ( ! empty( $claims ) ) {
+			$this->commit();
+			return true;
+		}
+
+		$deleted = (bool) $delete();
+		if ( ! $deleted ) {
+			$this->rollback();
+			return false;
+		}
+		return $this->commit();
+	}
+
+	/** Mint one runtime-only token after claiming an opaque queued delivery. */
+	public function prepare_delivery( string $delivery_id, int $ttl ) {
+		$preview = $this->get_invitation_by_delivery_id( $delivery_id );
+		if ( ! is_array( $preview ) ) {
+			return $this->not_found( 'venue_invitation_delivery_not_found' );
+		}
+		$started = $this->begin_and_lock_venue( $preview['venue_term_id'] );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$members = $this->lock_memberships( $preview['venue_term_id'] );
+		if ( is_wp_error( $members ) ) {
+			$this->rollback();
+			return $members;
+		}
+		$current = $this->get_invitation_by_delivery_id( $delivery_id, true );
+		if ( ! is_array( $current ) || self::INVITE_PENDING !== $current['status'] || ! in_array( $current['delivery_status'], array( self::DELIVERY_QUEUED, self::DELIVERY_FAILED ), true ) ) {
+			$this->rollback();
+			return new \WP_Error( 'venue_invitation_delivery_unavailable', __( 'The invitation delivery is no longer available.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$allowed = $this->authorization->authorize_locked( $current['invited_by_user_id'], $current['venue_term_id'], VenueAuthorization::ACTION_MANAGE_MEMBERS, $members );
+		if ( true !== $allowed ) {
+			$this->rollback();
+			return new \WP_Error( 'venue_invitation_inviter_revoked', __( 'The inviter no longer manages this venue.', 'extrachill-events' ), array( 'status' => 403 ) );
+		}
+
+		$token = $this->tokens->generate();
+		$hash  = $this->tokens->hash( $token, $current );
+		$now   = gmdate( 'Y-m-d H:i:s' );
+		global $wpdb;
+		$table  = BookingSchema::invitations_table();
+		$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET token_hash = %s, delivery_status = %s, delivery_attempts = delivery_attempts + 1, version = version + 1, updated_at = %s, expires_at = %s WHERE id = %d AND version = %d AND delivery_id = %s", $hash, self::DELIVERY_PROCESSING, $now, gmdate( 'Y-m-d H:i:s', time() + $ttl ), $current['id'], $current['version'], $delivery_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Mints the bearer only after the opaque worker record is claimed.
+		if ( 1 !== $result ) {
+			return $this->rollback_error( 'venue_invitation_delivery_claim_failed', __( 'The invitation delivery could not be claimed.', 'extrachill-events' ) );
+		}
+		$prepared = $this->get_invitation_by_delivery_id( $delivery_id, true );
+		if ( ! $this->commit() ) {
+			return $this->commit_error();
+		}
+		$prepared['_delivery_token'] = $token;
+		return $prepared;
+	}
+
+	/** Mark a claimed delivery sent or failed, invalidating unsent bearer material. */
+	public function finish_delivery( string $delivery_id, bool $sent ) {
+		$preview = $this->get_invitation_by_delivery_id( $delivery_id );
+		if ( ! is_array( $preview ) ) {
+			return $this->not_found( 'venue_invitation_delivery_not_found' );
+		}
+		$started = $this->begin_and_lock_venue( $preview['venue_term_id'] );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$current = $this->get_invitation_by_delivery_id( $delivery_id, true );
+		if ( ! is_array( $current ) || self::DELIVERY_PROCESSING !== $current['delivery_status'] ) {
+			$this->rollback();
+			return new \WP_Error( 'venue_invitation_delivery_state_changed', __( 'The invitation delivery state changed.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		global $wpdb;
+		$table      = BookingSchema::invitations_table();
+		$now        = gmdate( 'Y-m-d H:i:s' );
+		$status     = $sent ? self::DELIVERY_SENT : self::DELIVERY_FAILED;
+		$token_hash = $sent ? $current['_token_hash'] : str_repeat( '0', 64 );
+		if ( $sent ) {
+			$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET delivery_status = %s, token_hash = %s, updated_at = %s, delivered_at = %s WHERE id = %d AND version = %d AND delivery_id = %s", $status, $token_hash, $now, $now, $current['id'], $current['version'], $delivery_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Completes only the claimed opaque delivery without invalidating its acceptance version.
+		} else {
+			$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET delivery_status = %s, token_hash = %s, updated_at = %s, delivered_at = NULL WHERE id = %d AND version = %d AND delivery_id = %s", $status, $token_hash, $now, $current['id'], $current['version'], $delivery_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Invalidates unsent bearer material.
+		}
+		if ( 1 !== $result || ! $this->audit( $current['venue_term_id'], 'invitation', $current['id'], $sent ? 'invitation_delivery_sent' : 'invitation_delivery_failed', null, $current['user_id'], array( 'version' => $current['version'] ) ) ) {
+			return $this->rollback_error( 'venue_invitation_delivery_finish_failed', __( 'The invitation delivery outcome could not be saved.', 'extrachill-events' ) );
+		}
+		$updated = $this->get_invitation_by_delivery_id( $delivery_id, true );
+		if ( ! $this->commit() ) {
+			return $this->commit_error();
+		}
+		return $updated;
 	}
 
 	/**
@@ -560,12 +724,15 @@ class VenueOnboardingRepository {
 		foreach ( array( 'id', 'venue_term_id', 'user_id', 'version', 'invited_by_user_id' ) as $field ) {
 			$row[ $field ] = (int) $row[ $field ];
 		}
-		$row['is_owner']         = (bool) (int) $row['is_owner'];
-		$row['_account_created'] = ! empty( $row['account_created'] );
-		$row['resolved_at']      = empty( $row['resolved_at'] ) ? null : (string) $row['resolved_at'];
-		$row['_token_hash']      = (string) $row['token_hash'];
-		$row['_email_hash']      = (string) $row['email_hash'];
-		unset( $row['token_hash'], $row['email_hash'], $row['account_created'] );
+		$row['is_owner']          = (bool) (int) $row['is_owner'];
+		$row['_account_created']  = ! empty( $row['account_created'] );
+		$row['resolved_at']       = empty( $row['resolved_at'] ) ? null : (string) $row['resolved_at'];
+		$row['_token_hash']       = (string) $row['token_hash'];
+		$row['_email_hash']       = (string) $row['email_hash'];
+		$row['_delivery_id']      = (string) $row['delivery_id'];
+		$row['delivery_attempts'] = (int) $row['delivery_attempts'];
+		$row['delivered_at']      = empty( $row['delivered_at'] ) ? null : (string) $row['delivered_at'];
+		unset( $row['token_hash'], $row['email_hash'], $row['account_created'], $row['delivery_id'] );
 		return $row;
 	}
 
@@ -575,7 +742,7 @@ class VenueOnboardingRepository {
 	 * @param array $invitation Internal invitation row.
 	 */
 	public function public_invitation( array $invitation ): array {
-		unset( $invitation['_token_hash'], $invitation['_email_hash'], $invitation['_account_created'] );
+		unset( $invitation['_token_hash'], $invitation['_email_hash'], $invitation['_account_created'], $invitation['_delivery_id'], $invitation['_delivery_token'] );
 		return $invitation;
 	}
 
@@ -611,7 +778,7 @@ class VenueOnboardingRepository {
 	}
 
 	/** Mutate a pending invitation under lock-current owner authority. */
-	private function mutate_invitation( int $actor_user_id, int $invitation_id, int $expected_version, string $action, string $token = '', int $ttl = 0 ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private transition arguments are self-describing.
+	private function mutate_invitation( int $actor_user_id, int $invitation_id, int $expected_version, string $action ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private transition arguments are self-describing.
 		$preview = $this->get_invitation_by_id( $invitation_id );
 		if ( ! is_array( $preview ) ) {
 			return is_wp_error( $preview ) ? $preview : $this->not_found( 'venue_invitation_not_found' );
@@ -650,9 +817,9 @@ class VenueOnboardingRepository {
 		$now   = gmdate( 'Y-m-d H:i:s' );
 		$table = BookingSchema::invitations_table();
 		if ( 'resend' === $action ) {
-			$hash   = $this->tokens->hash( $token, $current );
-			$result = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET token_hash = %s, version = version + 1, invited_by_user_id = %d, updated_at = %s, expires_at = %s WHERE id = %d AND version = %d", $hash, $actor_user_id, $now, gmdate( 'Y-m-d H:i:s', time() + $ttl ), $invitation_id, $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locked token rotation.
-			$event  = 'invitation_resent';
+			$delivery_id = wp_generate_uuid4();
+			$result      = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET token_hash = %s, delivery_id = %s, delivery_status = %s, delivery_attempts = 0, version = version + 1, invited_by_user_id = %d, updated_at = %s, expires_at = %s, delivered_at = NULL WHERE id = %d AND version = %d", str_repeat( '0', 64 ), $delivery_id, self::DELIVERY_QUEUED, $actor_user_id, $now, $now, $invitation_id, $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Rotates the opaque delivery identity before a new worker is queued.
+			$event       = 'invitation_resent';
 		} else {
 			$result     = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = %s, token_hash = %s, version = version + 1, updated_at = %s, resolved_at = %s WHERE id = %d AND version = %d", self::INVITE_CANCELLED, str_repeat( '0', 64 ), $now, $now, $invitation_id, $expected_version ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locked invitation cancellation.
 			$membership = $this->set_invited_membership_status( $current, VenueAuthorization::STATUS_REVOKED );
@@ -833,6 +1000,15 @@ class VenueOnboardingRepository {
 		$table = BookingSchema::invitations_table();
 		$lock  = $locked ? ' FOR UPDATE' : '';
 		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE public_id = %s{$lock}", $public_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Opaque invitation lookup.
+		return is_array( $row ) ? $this->hydrate_invitation( $row ) : null;
+	}
+
+	/** Read an invitation by opaque delivery ID. */
+	private function get_invitation_by_delivery_id( string $delivery_id, bool $locked = false ) { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag -- Private read helper.
+		global $wpdb;
+		$table = BookingSchema::invitations_table();
+		$lock  = $locked ? ' FOR UPDATE' : '';
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE delivery_id = %s{$lock}", $delivery_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Opaque delivery lookup.
 		return is_array( $row ) ? $this->hydrate_invitation( $row ) : null;
 	}
 

--- a/inc/Core/VenueOnboardingService.php
+++ b/inc/Core/VenueOnboardingService.php
@@ -14,7 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Composes Events-owned onboarding with existing user and email primitives. */
 class VenueOnboardingService {
 
-	public const INVITATION_TTL = 604800;
+	public const INVITATION_TTL           = 604800;
+	private const ACCOUNT_PROVENANCE_META = 'ec_venue_invitation_account';
 
 	/** Venue onboarding persistence. */
 	private $repository;
@@ -77,15 +78,21 @@ class VenueOnboardingService {
 
 		$token      = $this->tokens->generate();
 		$email_hash = hash_hmac( 'sha256', $email, wp_salt( 'auth' ) );
-		$invitation = $this->repository->create_invitation( $actor_user_id, $venue_term_id, $account['user_id'], $is_owner, $email_hash, $token, self::INVITATION_TTL );
+		$invitation = $this->repository->create_invitation( $actor_user_id, $venue_term_id, $account['user_id'], $is_owner, $email_hash, $token, self::INVITATION_TTL, $account['created'] );
 		if ( is_wp_error( $invitation ) ) {
-			return $invitation;
+			return $this->compensate_initial_account( $account, $email, $invitation );
+		}
+		if ( $account['created'] && ! $this->persist_account_provenance( $account['user_id'], $invitation['public_id'] ) ) {
+			return $this->compensate_persisted_invitation( $invitation, $actor_user_id, $email, new \WP_Error( 'venue_invitation_provenance_failed', __( 'The invitation account provenance could not be saved.', 'extrachill-events' ), array( 'status' => 500 ) ), 'invitation_provenance_failed' );
 		}
 
 		$queued = $this->queue_delivery( $invitation, $token, $account['claim_url'] );
-		$this->repository->audit_delivery( $invitation, $actor_user_id, $queued );
+		if ( is_wp_error( $queued ) ) {
+			return $this->compensate_persisted_invitation( $invitation, $actor_user_id, $email, $queued, 'invitation_delivery_failed' );
+		}
+		$this->repository->audit_delivery( $invitation, $actor_user_id, true );
 		$result                    = $this->repository->public_invitation( $invitation );
-		$result['delivery_queued'] = $queued;
+		$result['delivery_queued'] = true;
 		$result['account_created'] = $account['created'];
 		return $result;
 	}
@@ -108,8 +115,14 @@ class VenueOnboardingService {
 			return new \WP_Error( 'venue_invitation_user_missing', __( 'The invitation user no longer exists.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
 		$claim_url = '1' === (string) get_user_meta( $user->ID, 'ec_unclaimed', true ) ? $this->build_claim_url( $user ) : '';
-		$queued    = $this->queue_delivery( $invitation, $token, $claim_url );
-		$this->repository->audit_delivery( $invitation, $actor_user_id, $queued );
+		if ( is_wp_error( $claim_url ) ) {
+			return $this->compensate_persisted_invitation( $invitation, $actor_user_id, strtolower( sanitize_email( $user->user_email ) ), $claim_url, 'invitation_reset_key_failed' );
+		}
+		$queued = $this->queue_delivery( $invitation, $token, $claim_url );
+		if ( is_wp_error( $queued ) ) {
+			return $this->compensate_persisted_invitation( $invitation, $actor_user_id, strtolower( sanitize_email( $user->user_email ) ), $queued, 'invitation_delivery_failed' );
+		}
+		$this->repository->audit_delivery( $invitation, $actor_user_id, true );
 		$result                    = $this->repository->public_invitation( $invitation );
 		$result['delivery_queued'] = $queued;
 		return $result;
@@ -118,12 +131,33 @@ class VenueOnboardingService {
 	/** Cancel a pending invitation. */
 	public function cancel_invitation( int $actor_user_id, int $invitation_id, int $expected_version ) {
 		$result = $this->repository->cancel_invitation( $actor_user_id, $invitation_id, $expected_version );
-		return is_array( $result ) ? $this->repository->public_invitation( $result ) : $result;
+		if ( is_array( $result ) ) {
+			$cleanup = $this->cleanup_invited_account( $result );
+			return is_wp_error( $cleanup ) ? $cleanup : $this->repository->public_invitation( $result );
+		}
+		return $result;
 	}
 
 	/** Accept or reject an exactly-bound invitation. */
 	public function respond( int $actor_user_id, string $public_id, string $token, int $venue_term_id, bool $is_owner, int $expected_version, string $decision ) {
 		$result = $this->repository->respond_to_invitation( $actor_user_id, $public_id, $token, $venue_term_id, $is_owner, $expected_version, $decision );
+		if ( is_wp_error( $result ) && 'venue_invitation_expired' === $result->get_error_code() ) {
+			$data       = $result->get_error_data();
+			$invitation = is_array( $data ) ? ( $data['_cleanup_invitation'] ?? null ) : null;
+			if ( is_array( $invitation ) ) {
+				$cleanup = $this->cleanup_invited_account( $invitation );
+				if ( is_wp_error( $cleanup ) ) {
+					return $cleanup;
+				}
+			}
+			return new \WP_Error( $result->get_error_code(), $result->get_error_message(), array( 'status' => 410 ) );
+		}
+		if ( is_array( $result ) && VenueOnboardingRepository::INVITE_ACCEPTED !== $result['status'] ) {
+			$cleanup = $this->cleanup_invited_account( $result );
+			if ( is_wp_error( $cleanup ) ) {
+				return $cleanup;
+			}
+		}
 		return is_array( $result ) ? $this->repository->public_invitation( $result ) : $result;
 	}
 
@@ -144,10 +178,14 @@ class VenueOnboardingService {
 	private function resolve_account( string $email ) {
 		$user = get_user_by( 'email', $email );
 		if ( $user instanceof \WP_User ) {
+			$claim_url = '1' === (string) get_user_meta( $user->ID, 'ec_unclaimed', true ) ? $this->build_claim_url( $user ) : '';
+			if ( is_wp_error( $claim_url ) ) {
+				return $claim_url;
+			}
 			return array(
 				'user_id'   => (int) $user->ID,
 				'created'   => false,
-				'claim_url' => '',
+				'claim_url' => $claim_url,
 			);
 		}
 		$create = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/create-user' ) : null;
@@ -176,10 +214,21 @@ class VenueOnboardingService {
 		if ( ! $user ) {
 			return new \WP_Error( 'venue_invitation_account_missing', __( 'The invited account could not be resolved.', 'extrachill-events' ) );
 		}
+		$claim_url = $this->build_claim_url( $user );
+		if ( is_wp_error( $claim_url ) ) {
+			return $this->compensate_initial_account(
+				array(
+					'user_id' => (int) $user_id,
+					'created' => true,
+				),
+				$email,
+				$claim_url
+			);
+		}
 		return array(
 			'user_id'   => (int) $user_id,
 			'created'   => true,
-			'claim_url' => $this->build_claim_url( $user ),
+			'claim_url' => $claim_url,
 		);
 	}
 
@@ -188,10 +237,10 @@ class VenueOnboardingService {
 	 *
 	 * @param \WP_User $user Invited network user.
 	 */
-	private function build_claim_url( \WP_User $user ): string {
+	private function build_claim_url( \WP_User $user ) {
 		$key = get_password_reset_key( $user );
 		if ( is_wp_error( $key ) ) {
-			return '';
+			return new \WP_Error( 'venue_invitation_reset_key_failed', __( 'The invited account handoff could not be created.', 'extrachill-events' ), array( 'status' => 500 ) );
 		}
 		$base = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : network_site_url();
 		return trailingslashit( $base ) . 'wp-login.php?action=rp&key=' . rawurlencode( $key ) . '&login=' . rawurlencode( $user->user_login );
@@ -204,11 +253,11 @@ class VenueOnboardingService {
 	 * @param string $token      Raw one-time token.
 	 * @param string $claim_url  Existing account-claim URL, when needed.
 	 */
-	private function queue_delivery( array $invitation, string $token, string $claim_url ): bool {
+	private function queue_delivery( array $invitation, string $token, string $claim_url ) {
 		$user  = get_userdata( $invitation['user_id'] );
 		$venue = get_term( $invitation['venue_term_id'], 'venue' );
 		if ( ! $user || ! $venue || is_wp_error( $venue ) || ! function_exists( 'ec_send_email_queued' ) ) {
-			return false;
+			return new \WP_Error( 'venue_invitation_delivery_unavailable', __( 'The invitation delivery could not be prepared.', 'extrachill-events' ), array( 'status' => 503 ) );
 		}
 		$accept_url = add_query_arg(
 			array(
@@ -249,6 +298,81 @@ class VenueOnboardingService {
 		$result  = class_exists( '\DataMachine\Abilities\PermissionHelper' )
 			? \DataMachine\Abilities\PermissionHelper::run_as_authenticated( $send, $invitation['invited_by_user_id'] )
 			: $send();
-		return is_array( $result ) && ! empty( $result['success'] );
+		return is_array( $result ) && ! empty( $result['success'] )
+			? true
+			: new \WP_Error( 'venue_invitation_delivery_failed', __( 'The invitation delivery could not be queued.', 'extrachill-events' ), array( 'status' => 503 ) );
+	}
+
+	/** Persist exact invitation provenance on a newly created account. */
+	private function persist_account_provenance( int $user_id, string $public_id ): bool {
+		update_user_meta( $user_id, self::ACCOUNT_PROVENANCE_META, $public_id );
+		return hash_equals( $public_id, (string) get_user_meta( $user_id, self::ACCOUNT_PROVENANCE_META, true ) );
+	}
+
+	/** Compensate a newly created account before invitation persistence. */
+	private function compensate_initial_account( array $account, string $email, \WP_Error $error ) {
+		if ( empty( $account['created'] ) ) {
+			return $error;
+		}
+		return $this->rollback_account_if_safe( (int) $account['user_id'], $email, '' ) ? $error : $this->reconciliation_error( $error );
+	}
+
+	/** Cancel failed persisted state, then compensate its created account. */
+	private function compensate_persisted_invitation( array $invitation, int $actor_user_id, string $email, \WP_Error $error, string $event ) {
+		$cancelled = $this->repository->abandon_invitation( $invitation, $actor_user_id, $event );
+		if ( is_wp_error( $cancelled ) ) {
+			return $this->reconciliation_error( $error );
+		}
+		$public_id = 'invitation_provenance_failed' === $event ? '' : $invitation['public_id'];
+		if ( ! empty( $invitation['_account_created'] ) && ! $this->rollback_account_if_safe( $invitation['user_id'], $email, $public_id, $cancelled ) ) {
+			return $this->reconciliation_error( $error );
+		}
+		return $error;
+	}
+
+	/** Delete only the still-unused account proven to belong to this invitation. */
+	private function cleanup_invited_account( array $invitation ) {
+		if ( empty( $invitation['_account_created'] ) ) {
+			return true;
+		}
+		$user = get_userdata( $invitation['user_id'] );
+		if ( ! $user ) {
+			return true;
+		}
+		$email = strtolower( sanitize_email( $user->user_email ) );
+		if ( ! $this->rollback_account_if_safe( $invitation['user_id'], $email, $invitation['public_id'], $invitation ) ) {
+			return $this->reconciliation_error( new \WP_Error( 'venue_invitation_account_cleanup_failed', __( 'The unused invitation account could not be removed.', 'extrachill-events' ) ) );
+		}
+		return true;
+	}
+
+	/** Apply strict provenance and usage checks before calling the Users rollback primitive. */
+	private function rollback_account_if_safe( int $user_id, string $email, string $public_id, ?array $invitation = null ): bool {
+		$user = get_userdata( $user_id );
+		if ( ! $user ) {
+			return true;
+		}
+		$matches = '1' === (string) get_user_meta( $user_id, 'ec_unclaimed', true )
+			&& 'venue_invitation' === (string) get_user_meta( $user_id, 'registration_source', true )
+			&& strtolower( sanitize_email( $user->user_email ) ) === $email;
+		if ( '' !== $public_id ) {
+			$matches = $matches && hash_equals( $public_id, (string) get_user_meta( $user_id, self::ACCOUNT_PROVENANCE_META, true ) );
+		}
+		if ( ! $matches || ( is_array( $invitation ) && ! $this->repository->account_is_exclusive_to_invitation( $invitation ) ) ) {
+			return true;
+		}
+		return function_exists( 'extrachill_users_rollback_created_user' ) && extrachill_users_rollback_created_user( $user_id );
+	}
+
+	/** Return a bounded manual-reconciliation error without leaking account data. */
+	private function reconciliation_error( \WP_Error $cause ): \WP_Error {
+		return new \WP_Error(
+			'venue_invitation_account_reconciliation_required',
+			__( 'The invitation failed and its unused account could not be safely reconciled.', 'extrachill-events' ),
+			array(
+				'status' => 500,
+				'cause'  => $cause->get_error_code(),
+			)
+		);
 	}
 }

--- a/inc/Core/VenueOnboardingService.php
+++ b/inc/Core/VenueOnboardingService.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Venue claim, account handoff, and invitation delivery policy.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Composes Events-owned onboarding with existing user and email primitives. */
+class VenueOnboardingService {
+
+	public const INVITATION_TTL = 604800;
+
+	/** Venue onboarding persistence. */
+	private $repository;
+
+	/** Invitation token service. */
+	private $tokens;
+
+	/** Build the onboarding policy service. */
+	public function __construct( ?VenueOnboardingRepository $repository = null, ?VenueInvitationToken $tokens = null ) {
+		$this->tokens     = $tokens ? $tokens : new VenueInvitationToken();
+		$this->repository = $repository ? $repository : new VenueOnboardingRepository( $this->tokens );
+	}
+
+	/** Submit a venue claim. */
+	public function submit_claim( int $actor_user_id, int $venue_term_id ) {
+		return $this->repository->submit_claim( $actor_user_id, $venue_term_id );
+	}
+
+	/** Review a pending venue claim. */
+	public function review_claim( int $actor_user_id, int $claim_id, string $decision, int $expected_version ) {
+		return $this->repository->review_claim( $actor_user_id, $claim_id, $decision, $expected_version );
+	}
+
+	/** Cancel a pending venue claim. */
+	public function cancel_claim( int $actor_user_id, int $claim_id, int $expected_version ) {
+		return $this->repository->cancel_claim( $actor_user_id, $claim_id, $expected_version );
+	}
+
+	/** List operator-visible venue claims. */
+	public function list_claims( int $actor_user_id, string $status = '' ) {
+		return $this->repository->list_claims( $actor_user_id, $status );
+	}
+
+	/**
+	 * Resolve or create the exactly-bound user, persist the invitation, and queue delivery.
+	 *
+	 * @param int    $actor_user_id Actor user ID.
+	 * @param int    $venue_term_id Venue term ID.
+	 * @param string $email         Invitee email address.
+	 * @param bool   $is_owner      Whether structural owner authority is invited.
+	 */
+	public function invite( int $actor_user_id, int $venue_term_id, string $email, bool $is_owner ) {
+		$email = strtolower( sanitize_email( $email ) );
+		if ( ! is_email( $email ) ) {
+			return new \WP_Error( 'invalid_venue_invitation_email', __( 'A valid invitation email is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+
+		$account = $this->resolve_account( $email );
+		if ( is_wp_error( $account ) ) {
+			return $account;
+		}
+
+		$token      = $this->tokens->generate();
+		$email_hash = hash_hmac( 'sha256', $email, wp_salt( 'auth' ) );
+		$invitation = $this->repository->create_invitation( $actor_user_id, $venue_term_id, $account['user_id'], $is_owner, $email_hash, $token, self::INVITATION_TTL );
+		if ( is_wp_error( $invitation ) ) {
+			return $invitation;
+		}
+
+		$queued = $this->queue_delivery( $invitation, $token, $account['claim_url'] );
+		$this->repository->audit_delivery( $invitation, $actor_user_id, $queued );
+		$result                    = $this->repository->public_invitation( $invitation );
+		$result['delivery_queued'] = $queued;
+		$result['account_created'] = $account['created'];
+		return $result;
+	}
+
+	/**
+	 * Rotate the token before issuing another delivery request.
+	 *
+	 * @param int $actor_user_id   Actor user ID.
+	 * @param int $invitation_id   Invitation row ID.
+	 * @param int $expected_version Expected invitation version.
+	 */
+	public function resend( int $actor_user_id, int $invitation_id, int $expected_version ) {
+		$token      = $this->tokens->generate();
+		$invitation = $this->repository->resend_invitation( $actor_user_id, $invitation_id, $expected_version, $token, self::INVITATION_TTL );
+		if ( is_wp_error( $invitation ) ) {
+			return $invitation;
+		}
+		$user = get_userdata( $invitation['user_id'] );
+		if ( ! $user ) {
+			return new \WP_Error( 'venue_invitation_user_missing', __( 'The invitation user no longer exists.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$claim_url = '1' === (string) get_user_meta( $user->ID, 'ec_unclaimed', true ) ? $this->build_claim_url( $user ) : '';
+		$queued    = $this->queue_delivery( $invitation, $token, $claim_url );
+		$this->repository->audit_delivery( $invitation, $actor_user_id, $queued );
+		$result                    = $this->repository->public_invitation( $invitation );
+		$result['delivery_queued'] = $queued;
+		return $result;
+	}
+
+	/** Cancel a pending invitation. */
+	public function cancel_invitation( int $actor_user_id, int $invitation_id, int $expected_version ) {
+		$result = $this->repository->cancel_invitation( $actor_user_id, $invitation_id, $expected_version );
+		return is_array( $result ) ? $this->repository->public_invitation( $result ) : $result;
+	}
+
+	/** Accept or reject an exactly-bound invitation. */
+	public function respond( int $actor_user_id, string $public_id, string $token, int $venue_term_id, bool $is_owner, int $expected_version, string $decision ) {
+		$result = $this->repository->respond_to_invitation( $actor_user_id, $public_id, $token, $venue_term_id, $is_owner, $expected_version, $decision );
+		return is_array( $result ) ? $this->repository->public_invitation( $result ) : $result;
+	}
+
+	/** List invitations for a managed venue. */
+	public function list_invitations( int $actor_user_id, int $venue_term_id ) {
+		$result = $this->repository->list_invitations( $actor_user_id, $venue_term_id );
+		if ( ! is_array( $result ) ) {
+			return $result;
+		}
+		return array_map( array( $this->repository, 'public_invitation' ), $result );
+	}
+
+	/**
+	 * Reuse the canonical network user creation ability for unclaimed accounts.
+	 *
+	 * @param string $email Verified invitee email.
+	 */
+	private function resolve_account( string $email ) {
+		$user = get_user_by( 'email', $email );
+		if ( $user instanceof \WP_User ) {
+			return array(
+				'user_id'   => (int) $user->ID,
+				'created'   => false,
+				'claim_url' => '',
+			);
+		}
+		$create = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/create-user' ) : null;
+		if ( ! $create ) {
+			return new \WP_Error( 'venue_invitation_account_unavailable', __( 'Network account creation is unavailable.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+		$local_part = strstr( $email, '@', true );
+		$username   = function_exists( 'ec_generate_username_from_email' )
+			? ec_generate_username_from_email( $email )
+			: sanitize_title( substr( false !== $local_part ? $local_part : 'venue', 0, 50 ) );
+		$user_id    = $create->execute(
+			array(
+				'email'               => $email,
+				'password'            => wp_generate_password( 32 ),
+				'username'            => $username,
+				'role'                => 'subscriber',
+				'unclaimed'           => true,
+				'registration_source' => 'venue_invitation',
+				'registration_method' => 'standard',
+			)
+		);
+		if ( is_wp_error( $user_id ) || ! $user_id ) {
+			return is_wp_error( $user_id ) ? $user_id : new \WP_Error( 'venue_invitation_account_failed', __( 'The invited account could not be created.', 'extrachill-events' ) );
+		}
+		$user = get_userdata( (int) $user_id );
+		if ( ! $user ) {
+			return new \WP_Error( 'venue_invitation_account_missing', __( 'The invited account could not be resolved.', 'extrachill-events' ) );
+		}
+		return array(
+			'user_id'   => (int) $user_id,
+			'created'   => true,
+			'claim_url' => $this->build_claim_url( $user ),
+		);
+	}
+
+	/**
+	 * Generate the existing WordPress one-time password handoff URL.
+	 *
+	 * @param \WP_User $user Invited network user.
+	 */
+	private function build_claim_url( \WP_User $user ): string {
+		$key = get_password_reset_key( $user );
+		if ( is_wp_error( $key ) ) {
+			return '';
+		}
+		$base = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : network_site_url();
+		return trailingslashit( $base ) . 'wp-login.php?action=rp&key=' . rawurlencode( $key ) . '&login=' . rawurlencode( $user->user_login );
+	}
+
+	/**
+	 * Queue through Data Machine without logging or returning the raw token.
+	 *
+	 * @param array  $invitation Internal invitation record.
+	 * @param string $token      Raw one-time token.
+	 * @param string $claim_url  Existing account-claim URL, when needed.
+	 */
+	private function queue_delivery( array $invitation, string $token, string $claim_url ): bool {
+		$user  = get_userdata( $invitation['user_id'] );
+		$venue = get_term( $invitation['venue_term_id'], 'venue' );
+		if ( ! $user || ! $venue || is_wp_error( $venue ) || ! function_exists( 'ec_send_email_queued' ) ) {
+			return false;
+		}
+		$accept_url = add_query_arg(
+			array(
+				'action'        => 'ec_accept_venue_invitation',
+				'invitation_id' => $invitation['public_id'],
+				'token'         => $token,
+				'venue_term_id' => $invitation['venue_term_id'],
+				'is_owner'      => $invitation['is_owner'] ? 1 : 0,
+				'version'       => $invitation['version'],
+			),
+			admin_url( 'admin-post.php' )
+		);
+		$cta_url    = $claim_url ? $claim_url : $accept_url;
+		/* translators: %s: Venue name. */
+		$body = '<p>' . esc_html( sprintf( __( 'You have been invited to help manage %s on Extra Chill.', 'extrachill-events' ), $venue->name ) ) . '</p>';
+		if ( $claim_url ) {
+			$body .= '<p>' . esc_html__( 'Set your account password first, then return to the invitation link below to accept.', 'extrachill-events' ) . '</p>';
+			$body .= '<p><a href="' . esc_url( $accept_url ) . '">' . esc_html__( 'Accept venue invitation', 'extrachill-events' ) . '</a></p>';
+		}
+		$body   .= '<p>' . esc_html__( 'This message was sent by Extra Chill Bot acting on Chris Huber\'s behalf.', 'extrachill-events' ) . '</p>';
+		$payload = array(
+			'to'        => $user->user_email,
+			'cc'        => 'chubes@extrachill.com',
+			/* translators: %s: Venue name. */
+			'subject'   => sprintf( __( 'Invitation to manage %s', 'extrachill-events' ), $venue->name ),
+			'from_name' => 'Extra Chill Bot',
+			'template'  => 'extrachill/branded',
+			'context'   => array(
+				'recipient_name' => $user->display_name,
+				'body_html'      => $body,
+				'cta_url'        => $cta_url,
+				'cta_label'      => $claim_url ? __( 'Set Your Password', 'extrachill-events' ) : __( 'Accept Invitation', 'extrachill-events' ),
+			),
+		);
+		$send    = static function () use ( $payload ) {
+			return ec_send_email_queued( $payload );
+		};
+		$result  = class_exists( '\DataMachine\Abilities\PermissionHelper' )
+			? \DataMachine\Abilities\PermissionHelper::run_as_authenticated( $send, $invitation['invited_by_user_id'] )
+			: $send();
+		return is_array( $result ) && ! empty( $result['success'] );
+	}
+}

--- a/inc/Core/VenueOnboardingService.php
+++ b/inc/Core/VenueOnboardingService.php
@@ -76,9 +76,8 @@ class VenueOnboardingService {
 			return $account;
 		}
 
-		$token      = $this->tokens->generate();
 		$email_hash = hash_hmac( 'sha256', $email, wp_salt( 'auth' ) );
-		$invitation = $this->repository->create_invitation( $actor_user_id, $venue_term_id, $account['user_id'], $is_owner, $email_hash, $token, self::INVITATION_TTL, $account['created'] );
+		$invitation = $this->repository->create_invitation( $actor_user_id, $venue_term_id, $account['user_id'], $is_owner, $email_hash, $account['created'] );
 		if ( is_wp_error( $invitation ) ) {
 			return $this->compensate_initial_account( $account, $email, $invitation );
 		}
@@ -86,7 +85,7 @@ class VenueOnboardingService {
 			return $this->compensate_persisted_invitation( $invitation, $actor_user_id, $email, new \WP_Error( 'venue_invitation_provenance_failed', __( 'The invitation account provenance could not be saved.', 'extrachill-events' ), array( 'status' => 500 ) ), 'invitation_provenance_failed' );
 		}
 
-		$queued = $this->queue_delivery( $invitation, $token, $account['claim_url'] );
+		$queued = $this->schedule_delivery( $invitation );
 		if ( is_wp_error( $queued ) ) {
 			return $this->compensate_persisted_invitation( $invitation, $actor_user_id, $email, $queued, 'invitation_delivery_failed' );
 		}
@@ -105,22 +104,15 @@ class VenueOnboardingService {
 	 * @param int $expected_version Expected invitation version.
 	 */
 	public function resend( int $actor_user_id, int $invitation_id, int $expected_version ) {
-		$token      = $this->tokens->generate();
-		$invitation = $this->repository->resend_invitation( $actor_user_id, $invitation_id, $expected_version, $token, self::INVITATION_TTL );
+		$invitation = $this->repository->resend_invitation( $actor_user_id, $invitation_id, $expected_version );
 		if ( is_wp_error( $invitation ) ) {
 			return $invitation;
 		}
-		$user = get_userdata( $invitation['user_id'] );
-		if ( ! $user ) {
-			return new \WP_Error( 'venue_invitation_user_missing', __( 'The invitation user no longer exists.', 'extrachill-events' ), array( 'status' => 409 ) );
-		}
-		$claim_url = '1' === (string) get_user_meta( $user->ID, 'ec_unclaimed', true ) ? $this->build_claim_url( $user ) : '';
-		if ( is_wp_error( $claim_url ) ) {
-			return $this->compensate_persisted_invitation( $invitation, $actor_user_id, strtolower( sanitize_email( $user->user_email ) ), $claim_url, 'invitation_reset_key_failed' );
-		}
-		$queued = $this->queue_delivery( $invitation, $token, $claim_url );
+		$queued = $this->schedule_delivery( $invitation );
 		if ( is_wp_error( $queued ) ) {
-			return $this->compensate_persisted_invitation( $invitation, $actor_user_id, strtolower( sanitize_email( $user->user_email ) ), $queued, 'invitation_delivery_failed' );
+			$user  = get_userdata( $invitation['user_id'] );
+			$email = $user instanceof \WP_User ? strtolower( sanitize_email( $user->user_email ) ) : '';
+			return $this->compensate_persisted_invitation( $invitation, $actor_user_id, $email, $queued, 'invitation_delivery_failed' );
 		}
 		$this->repository->audit_delivery( $invitation, $actor_user_id, true );
 		$result                    = $this->repository->public_invitation( $invitation );
@@ -178,14 +170,9 @@ class VenueOnboardingService {
 	private function resolve_account( string $email ) {
 		$user = get_user_by( 'email', $email );
 		if ( $user instanceof \WP_User ) {
-			$claim_url = '1' === (string) get_user_meta( $user->ID, 'ec_unclaimed', true ) ? $this->build_claim_url( $user ) : '';
-			if ( is_wp_error( $claim_url ) ) {
-				return $claim_url;
-			}
 			return array(
-				'user_id'   => (int) $user->ID,
-				'created'   => false,
-				'claim_url' => $claim_url,
+				'user_id' => (int) $user->ID,
+				'created' => false,
 			);
 		}
 		$create = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/create-user' ) : null;
@@ -214,93 +201,23 @@ class VenueOnboardingService {
 		if ( ! $user ) {
 			return new \WP_Error( 'venue_invitation_account_missing', __( 'The invited account could not be resolved.', 'extrachill-events' ) );
 		}
-		$claim_url = $this->build_claim_url( $user );
-		if ( is_wp_error( $claim_url ) ) {
-			return $this->compensate_initial_account(
-				array(
-					'user_id' => (int) $user_id,
-					'created' => true,
-				),
-				$email,
-				$claim_url
-			);
-		}
 		return array(
-			'user_id'   => (int) $user_id,
-			'created'   => true,
-			'claim_url' => $claim_url,
+			'user_id' => (int) $user_id,
+			'created' => true,
 		);
 	}
 
 	/**
-	 * Generate the existing WordPress one-time password handoff URL.
+	 * Queue only the opaque stored delivery identity.
 	 *
-	 * @param \WP_User $user Invited network user.
+	 * @param array $invitation Internal invitation record.
 	 */
-	private function build_claim_url( \WP_User $user ) {
-		$key = get_password_reset_key( $user );
-		if ( is_wp_error( $key ) ) {
-			return new \WP_Error( 'venue_invitation_reset_key_failed', __( 'The invited account handoff could not be created.', 'extrachill-events' ), array( 'status' => 500 ) );
+	private function schedule_delivery( array $invitation ) {
+		if ( empty( $invitation['_delivery_id'] ) || ! function_exists( 'as_enqueue_async_action' ) ) {
+			return new \WP_Error( 'venue_invitation_delivery_unavailable', __( 'The invitation delivery worker is unavailable.', 'extrachill-events' ), array( 'status' => 503 ) );
 		}
-		$base = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : network_site_url();
-		return trailingslashit( $base ) . 'wp-login.php?action=rp&key=' . rawurlencode( $key ) . '&login=' . rawurlencode( $user->user_login );
-	}
-
-	/**
-	 * Queue through Data Machine without logging or returning the raw token.
-	 *
-	 * @param array  $invitation Internal invitation record.
-	 * @param string $token      Raw one-time token.
-	 * @param string $claim_url  Existing account-claim URL, when needed.
-	 */
-	private function queue_delivery( array $invitation, string $token, string $claim_url ) {
-		$user  = get_userdata( $invitation['user_id'] );
-		$venue = get_term( $invitation['venue_term_id'], 'venue' );
-		if ( ! $user || ! $venue || is_wp_error( $venue ) || ! function_exists( 'ec_send_email_queued' ) ) {
-			return new \WP_Error( 'venue_invitation_delivery_unavailable', __( 'The invitation delivery could not be prepared.', 'extrachill-events' ), array( 'status' => 503 ) );
-		}
-		$accept_url = add_query_arg(
-			array(
-				'action'        => 'ec_accept_venue_invitation',
-				'invitation_id' => $invitation['public_id'],
-				'token'         => $token,
-				'venue_term_id' => $invitation['venue_term_id'],
-				'is_owner'      => $invitation['is_owner'] ? 1 : 0,
-				'version'       => $invitation['version'],
-			),
-			admin_url( 'admin-post.php' )
-		);
-		$cta_url    = $claim_url ? $claim_url : $accept_url;
-		/* translators: %s: Venue name. */
-		$body = '<p>' . esc_html( sprintf( __( 'You have been invited to help manage %s on Extra Chill.', 'extrachill-events' ), $venue->name ) ) . '</p>';
-		if ( $claim_url ) {
-			$body .= '<p>' . esc_html__( 'Set your account password first, then return to the invitation link below to accept.', 'extrachill-events' ) . '</p>';
-			$body .= '<p><a href="' . esc_url( $accept_url ) . '">' . esc_html__( 'Accept venue invitation', 'extrachill-events' ) . '</a></p>';
-		}
-		$body   .= '<p>' . esc_html__( 'This message was sent by Extra Chill Bot acting on Chris Huber\'s behalf.', 'extrachill-events' ) . '</p>';
-		$payload = array(
-			'to'        => $user->user_email,
-			'cc'        => 'chubes@extrachill.com',
-			/* translators: %s: Venue name. */
-			'subject'   => sprintf( __( 'Invitation to manage %s', 'extrachill-events' ), $venue->name ),
-			'from_name' => 'Extra Chill Bot',
-			'template'  => 'extrachill/branded',
-			'context'   => array(
-				'recipient_name' => $user->display_name,
-				'body_html'      => $body,
-				'cta_url'        => $cta_url,
-				'cta_label'      => $claim_url ? __( 'Set Your Password', 'extrachill-events' ) : __( 'Accept Invitation', 'extrachill-events' ),
-			),
-		);
-		$send    = static function () use ( $payload ) {
-			return ec_send_email_queued( $payload );
-		};
-		$result  = class_exists( '\DataMachine\Abilities\PermissionHelper' )
-			? \DataMachine\Abilities\PermissionHelper::run_as_authenticated( $send, $invitation['invited_by_user_id'] )
-			: $send();
-		return is_array( $result ) && ! empty( $result['success'] )
-			? true
-			: new \WP_Error( 'venue_invitation_delivery_failed', __( 'The invitation delivery could not be queued.', 'extrachill-events' ), array( 'status' => 503 ) );
+		$action_id = as_enqueue_async_action( VenueInvitationDeliveryWorker::HOOK, array( $invitation['_delivery_id'] ), VenueInvitationDeliveryWorker::GROUP, true );
+		return $action_id ? true : new \WP_Error( 'venue_invitation_delivery_failed', __( 'The invitation delivery could not be queued.', 'extrachill-events' ), array( 'status' => 503 ) );
 	}
 
 	/** Persist exact invitation provenance on a newly created account. */
@@ -352,16 +269,30 @@ class VenueOnboardingService {
 		if ( ! $user ) {
 			return true;
 		}
-		$matches = '1' === (string) get_user_meta( $user_id, 'ec_unclaimed', true )
-			&& 'venue_invitation' === (string) get_user_meta( $user_id, 'registration_source', true )
-			&& strtolower( sanitize_email( $user->user_email ) ) === $email;
-		if ( '' !== $public_id ) {
-			$matches = $matches && hash_equals( $public_id, (string) get_user_meta( $user_id, self::ACCOUNT_PROVENANCE_META, true ) );
-		}
-		if ( ! $matches || ( is_array( $invitation ) && ! $this->repository->account_is_exclusive_to_invitation( $invitation ) ) ) {
-			return true;
-		}
-		return function_exists( 'extrachill_users_rollback_created_user' ) && extrachill_users_rollback_created_user( $user_id );
+		$identity = is_array( $invitation ) ? $invitation : array(
+			'id'            => 0,
+			'venue_term_id' => 0,
+			'user_id'       => $user_id,
+		);
+		return $this->repository->delete_account_if_exclusive(
+			$identity,
+			static function () use ( $user_id, $email, $public_id ) {
+				$user = get_userdata( $user_id );
+				if ( ! $user ) {
+					return true;
+				}
+				$matches = '1' === (string) get_user_meta( $user_id, 'ec_unclaimed', true )
+					&& 'venue_invitation' === (string) get_user_meta( $user_id, 'registration_source', true )
+					&& strtolower( sanitize_email( $user->user_email ) ) === $email;
+				if ( '' !== $public_id ) {
+					$matches = $matches && hash_equals( $public_id, (string) get_user_meta( $user_id, self::ACCOUNT_PROVENANCE_META, true ) );
+				}
+				if ( ! $matches ) {
+					return true;
+				}
+				return function_exists( 'extrachill_users_rollback_created_user' ) && extrachill_users_rollback_created_user( $user_id );
+			}
+		);
 	}
 
 	/** Return a bounded manual-reconciliation error without leaking account data. */

--- a/inc/Core/VenueOnboardingService.php
+++ b/inc/Core/VenueOnboardingService.php
@@ -22,10 +22,14 @@ class VenueOnboardingService {
 	/** Invitation token service. */
 	private $tokens;
 
+	/** Venue membership authorization. */
+	private $authorization;
+
 	/** Build the onboarding policy service. */
-	public function __construct( ?VenueOnboardingRepository $repository = null, ?VenueInvitationToken $tokens = null ) {
-		$this->tokens     = $tokens ? $tokens : new VenueInvitationToken();
-		$this->repository = $repository ? $repository : new VenueOnboardingRepository( $this->tokens );
+	public function __construct( ?VenueOnboardingRepository $repository = null, ?VenueInvitationToken $tokens = null, ?VenueAuthorization $authorization = null ) {
+		$this->tokens        = $tokens ? $tokens : new VenueInvitationToken();
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+		$this->repository    = $repository ? $repository : new VenueOnboardingRepository( $this->tokens, $this->authorization );
 	}
 
 	/** Submit a venue claim. */
@@ -60,6 +64,10 @@ class VenueOnboardingService {
 		$email = strtolower( sanitize_email( $email ) );
 		if ( ! is_email( $email ) ) {
 			return new \WP_Error( 'invalid_venue_invitation_email', __( 'A valid invitation email is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$allowed = $this->authorization->authorize( $actor_user_id, $venue_term_id, VenueAuthorization::ACTION_MANAGE_MEMBERS );
+		if ( true !== $allowed ) {
+			return $allowed;
 		}
 
 		$account = $this->resolve_account( $email );

--- a/inc/core/bootstrap.php
+++ b/inc/core/bootstrap.php
@@ -112,6 +112,52 @@ function ec_events_redirect_post_type_archive() {
 add_action( 'template_redirect', 'ec_events_redirect_post_type_archive' );
 
 /**
+ * Accept a signed venue invitation from its email link.
+ *
+ * The invitation token is the one-time request authenticator. Logged-out users
+ * are sent through the canonical WordPress login flow and returned here; the
+ * service still binds acceptance to the authenticated invitation user.
+ */
+function ec_events_accept_venue_invitation() {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- The signed single-use invitation token authenticates this email callback.
+	$invitation_id = sanitize_text_field( wp_unslash( $_GET['invitation_id'] ?? '' ) );
+	$token         = sanitize_text_field( wp_unslash( $_GET['token'] ?? '' ) );
+	$venue_term_id = absint( $_GET['venue_term_id'] ?? 0 );
+	$is_owner      = ! empty( $_GET['is_owner'] );
+	$version       = absint( $_GET['version'] ?? 0 );
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+	if ( ! get_current_user_id() ) {
+		$current_url = add_query_arg(
+			array(
+				'action'        => 'ec_accept_venue_invitation',
+				'invitation_id' => $invitation_id,
+				'token'         => $token,
+				'venue_term_id' => $venue_term_id,
+				'is_owner'      => $is_owner ? 1 : 0,
+				'version'       => $version,
+			),
+			admin_url( 'admin-post.php' )
+		);
+		wp_safe_redirect( wp_login_url( $current_url ) );
+		exit;
+	}
+
+	$service = new \ExtraChillEvents\Core\VenueOnboardingService();
+	$result  = $service->respond( get_current_user_id(), $invitation_id, $token, $venue_term_id, $is_owner, $version, \ExtraChillEvents\Core\VenueOnboardingRepository::INVITE_ACCEPTED );
+	$venue   = get_term( $venue_term_id, 'venue' );
+	$target  = $venue && ! is_wp_error( $venue ) ? get_term_link( $venue ) : home_url( '/' );
+	if ( is_wp_error( $target ) ) {
+		$target = home_url( '/' );
+	}
+	$target = add_query_arg( 'venue_invitation', is_wp_error( $result ) ? 'failed' : 'accepted', $target );
+	wp_safe_redirect( $target );
+	exit;
+}
+add_action( 'admin_post_ec_accept_venue_invitation', 'ec_events_accept_venue_invitation' );
+add_action( 'admin_post_nopriv_ec_accept_venue_invitation', 'ec_events_accept_venue_invitation' );
+
+/**
  * Contribute approved artist tour-URL submissions to the community rank engine.
  *
  * Hooks `ec_points_sources` (owned by extrachill-users). Each approved

--- a/phpunit-onboarding.xml.dist
+++ b/phpunit-onboarding.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+	beStrictAboutOutputDuringTests="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	failOnRisky="true"
+	failOnWarning="true">
+	<testsuites>
+		<testsuite name="venue-onboarding">
+			<file>tests/VenueMembershipAuthorizationTest.php</file>
+			<file>tests/VenueOnboardingTest.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -127,6 +127,14 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertSame( 'extra', BookingSchema::health()->get_error_data()['attribute'] );
 		$columns['id']['Extra'] = 'auto_increment';
 		$this->assertTrue( BookingSchema::health() );
+		$invitation_columns =& $GLOBALS['wpdb']->schemas['wp_7_ec_venue_invitations']['columns'];
+		$this->assertArrayHasKey( 'account_created', $invitation_columns );
+		unset( $invitation_columns['account_created'] );
+		$missing_provenance = BookingSchema::health();
+		$this->assertSame( 'booking_schema_columns_missing', $missing_provenance->get_error_code() );
+		$this->assertSame( 'account_created', $missing_provenance->get_error_data()['column'] );
+		$this->assertTrue( BookingSchema::install() );
+		$this->assertArrayHasKey( 'account_created', $GLOBALS['wpdb']->schemas['wp_7_ec_venue_invitations']['columns'] );
 
 		$GLOBALS['wpdb']->prefix = 'wp_12_';
 		$this->assertSame( 'wp_12_ec_bookings', BookingSchema::bookings_table() );

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -131,8 +131,8 @@ final class BookingHoldTest extends TestCase {
 		return array( $holds, $lifecycle );
 	}
 
-	public function test_schema_v6_installs_site_scoped_holds_contract(): void {
-		$this->assertSame( '6', BookingSchema::SCHEMA_VERSION );
+	public function test_schema_v7_installs_site_scoped_holds_contract(): void {
+		$this->assertSame( '7', BookingSchema::SCHEMA_VERSION );
 		$this->assertTrue( BookingSchema::install() );
 		$table = BookingSchema::holds_table();
 		$this->assertSame( 'wp_7_ec_booking_holds', $table );

--- a/tests/BookingMutationTest.php
+++ b/tests/BookingMutationTest.php
@@ -118,7 +118,7 @@ final class BookingMutationTest extends TestCase {
 	}
 
 	public function test_schema_and_public_inquiry_separate_requested_from_authoritative_fields(): void {
-		$this->assertSame( '6', BookingSchema::SCHEMA_VERSION );
+		$this->assertSame( '7', BookingSchema::SCHEMA_VERSION );
 		$this->assertTrue( BookingSchema::install() );
 		$columns = $GLOBALS['wpdb']->schemas[ BookingSchema::bookings_table() ]['columns'];
 		foreach ( array( 'requested_space_key', 'performance_start_at', 'performance_end_at', 'production_payload', 'confirmed_deal_payload' ) as $column ) {

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -423,14 +423,7 @@ final class VenueMembershipWpdb {
 		if ( false !== strpos( $query, 'ec_venue_invitations' ) ) {
 			$rows = array_values( $this->rows['wp_7_ec_venue_invitations'] ?? array() );
 			if ( preg_match( '/user_id = (\d+)/', $query, $user_match ) ) {
-				$rows = array_values(
-					array_filter(
-						$rows,
-						static function ( $row ) use ( $user_match ) {
-							return (int) $row['user_id'] === (int) $user_match[1];
-						}
-					)
-				);
+				$rows = $this->filter_rows( $rows, 'user_id', (int) $user_match[1] );
 			}
 			if ( preg_match( '/venue_term_id = (\d+)/', $query, $match ) ) {
 				$rows = array_values(
@@ -447,14 +440,7 @@ final class VenueMembershipWpdb {
 		if ( false !== strpos( $query, 'ec_venue_claims' ) ) {
 			$rows = array_values( $this->rows['wp_7_ec_venue_claims'] ?? array() );
 			if ( preg_match( '/claimant_user_id = (\d+)/', $query, $claimant ) ) {
-				$rows = array_values(
-					array_filter(
-						$rows,
-						static function ( $row ) use ( $claimant ) {
-							return (int) $row['claimant_user_id'] === (int) $claimant[1];
-						}
-					)
-				);
+				$rows = $this->filter_rows( $rows, 'claimant_user_id', (int) $claimant[1] );
 			}
 			return $rows;
 		}
@@ -465,14 +451,7 @@ final class VenueMembershipWpdb {
 		}
 		$rows = array_values( $this->rows[ $this->prefix . 'ec_venue_members' ] ?? array() );
 		if ( preg_match( '/WHERE user_id = (\d+)/', $query, $user_match ) ) {
-			$rows = array_values(
-				array_filter(
-					$rows,
-					static function ( $row ) use ( $user_match ) {
-						return (int) $row['user_id'] === (int) $user_match[1];
-					}
-				)
-			);
+			$rows = $this->filter_rows( $rows, 'user_id', (int) $user_match[1] );
 		}
 		if ( preg_match( '/AS actor .*actor.user_id = (\d+)/', $query, $actor ) ) {
 			$authorized = false;
@@ -619,6 +598,12 @@ final class VenueMembershipWpdb {
 		$this->insert_id                          = count( $this->rows[ $table ] ?? array() ) + 1;
 		$row['id']                                = $this->insert_id;
 		$this->rows[ $table ][ $this->insert_id ] = $row;
+	}
+
+	private function filter_rows( array $rows, string $field, int $value ): array {
+		return array_values( array_filter( $rows, static function ( $row ) use ( $field, $value ) {
+			return (int) $row[ $field ] === $value;
+		} ) );
 	}
 
 	private function find_onboarding_row( string $table, string $query ) {
@@ -1120,11 +1105,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 	}
 
 	public static function terminal_invitation_status_provider(): array {
-		return array(
-			'cancelled' => array( VenueOnboardingRepository::INVITE_CANCELLED ),
-			'rejected'  => array( VenueOnboardingRepository::INVITE_REJECTED ),
-			'expired'   => array( VenueOnboardingRepository::INVITE_EXPIRED ),
-		);
+		return array( 'cancelled' => array( VenueOnboardingRepository::INVITE_CANCELLED ), 'rejected' => array( VenueOnboardingRepository::INVITE_REJECTED ), 'expired' => array( VenueOnboardingRepository::INVITE_EXPIRED ) );
 	}
 
 	/** @dataProvider terminal_invitation_status_provider */
@@ -1316,17 +1297,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$GLOBALS['wpdb']->after_start = static function ( VenueMembershipWpdb $wpdb ): void {
 			$wpdb->insert(
 				'wp_7_ec_venue_members',
-				array(
-					'venue_term_id'      => 56,
-					'user_id'            => 8,
-					'is_owner'           => 0,
-					'status'             => VenueAuthorization::STATUS_ACTIVE,
-					'version'            => 1,
-					'created_by_user_id' => 3,
-					'created_at'         => '2026-01-01 00:00:00',
-					'updated_at'         => '2026-01-01 00:00:00',
-					'revoked_at'         => null,
-				)
+				array( 'venue_term_id' => 56, 'user_id' => 8, 'is_owner' => 0, 'status' => VenueAuthorization::STATUS_ACTIVE, 'version' => 1, 'created_by_user_id' => 3, 'created_at' => '2026-01-01 00:00:00', 'updated_at' => '2026-01-01 00:00:00', 'revoked_at' => null )
 			);
 		};
 

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -134,12 +134,24 @@ if ( ! function_exists( 'get_user_meta' ) ) {
 		unset( $single );
 		return $GLOBALS['venue_membership_test']['user_meta'][ $user_id ][ $key ] ?? ''; }
 }
+if ( ! function_exists( 'update_user_meta' ) ) {
+	function update_user_meta( $user_id, $key, $value ) {
+		if ( 'ec_venue_invitation_account' === $key && ! empty( $GLOBALS['venue_membership_test']['fail_provenance'] ) ) {
+			return false;
+		}
+		$GLOBALS['venue_membership_test']['user_meta'][ $user_id ][ $key ] = $value;
+		return true;
+	}
+}
 if ( ! function_exists( 'wp_get_ability' ) ) {
 	function wp_get_ability( $name ) {
 		return $GLOBALS['venue_membership_test']['ability_objects'][ $name ] ?? null; }
 }
 if ( ! function_exists( 'get_password_reset_key' ) ) {
 	function get_password_reset_key( $user ) {
+		if ( ! empty( $GLOBALS['venue_membership_test']['fail_reset_key'] ) ) {
+			return new WP_Error( 'reset_key_failed' );
+		}
 		return 'reset-' . $user->ID; }
 }
 if ( ! function_exists( 'ec_get_site_url' ) ) {
@@ -173,7 +185,20 @@ if ( ! function_exists( 'esc_url' ) ) {
 if ( ! function_exists( 'ec_send_email_queued' ) ) {
 	function ec_send_email_queued( array $args ) {
 		$GLOBALS['venue_membership_test']['queued_emails'][] = $args;
+		if ( ! empty( $GLOBALS['venue_membership_test']['fail_delivery'] ) ) {
+			return array( 'success' => false );
+		}
 		return array( 'success' => true, 'action_id' => count( $GLOBALS['venue_membership_test']['queued_emails'] ) );
+	}
+}
+if ( ! function_exists( 'extrachill_users_rollback_created_user' ) ) {
+	function extrachill_users_rollback_created_user( $user_id ) {
+		$GLOBALS['venue_membership_test']['rollback_attempts'][] = (int) $user_id;
+		if ( ! empty( $GLOBALS['venue_membership_test']['fail_account_rollback'] ) ) {
+			return false;
+		}
+		unset( $GLOBALS['venue_membership_test']['users'][ $user_id ], $GLOBALS['venue_membership_test']['user_meta'][ $user_id ] );
+		return true;
 	}
 }
 if ( ! function_exists( 'user_can' ) ) {
@@ -246,6 +271,7 @@ final class VenueMembershipWpdb {
 	public $last_error            = '';
 	public $rows                  = array();
 	public $race_insert           = false;
+	public $fail_invitation_insert = false;
 	public $after_start           = null;
 	public $before_list           = null;
 	private $snapshot             = null;
@@ -271,6 +297,10 @@ final class VenueMembershipWpdb {
 
 	public function insert( $table, $row ) {
 		$this->last_error = '';
+		if ( $this->fail_invitation_insert && 'wp_7_ec_venue_invitations' === $table ) {
+			$this->last_error = 'simulated invitation write failure';
+			return false;
+		}
 		if ( $this->termmeta === $table ) {
 			if ( VenueBookingConfig::META_KEY === $row['meta_key'] && ! empty( $GLOBALS['venue_membership_test']['fail_config_save'] ) ) {
 				$this->last_error = 'simulated config write failure';
@@ -341,6 +371,15 @@ final class VenueMembershipWpdb {
 
 	public function get_var( $query ) {
 		$this->last_error = '';
+		if ( preg_match( '/SELECT COUNT\(\*\) FROM .*user_id = (\d+) AND NOT \(venue_term_id = (\d+) AND status = \'([^\']+)\'\)/', $query, $count_match ) ) {
+			$count = 0;
+			foreach ( $this->rows[ $this->prefix . 'ec_venue_members' ] ?? array() as $row ) {
+				if ( (int) $row['user_id'] === (int) $count_match[1] && ( (int) $row['venue_term_id'] !== (int) $count_match[2] || $row['status'] !== stripslashes( $count_match[3] ) ) ) {
+					++$count;
+				}
+			}
+			return $count;
+		}
 		if ( preg_match( '/SELECT meta_value FROM .*meta_id = (\d+) FOR UPDATE/', $query, $meta_match ) ) {
 			return $this->meta_values[ (int) $meta_match[1] ] ?? null;
 		}
@@ -625,6 +664,11 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			'user_meta'         => array(),
 			'ability_objects'   => array(),
 			'queued_emails'     => array(),
+			'rollback_attempts' => array(),
+			'fail_reset_key'    => false,
+			'fail_delivery'     => false,
+			'fail_provenance'   => false,
+			'fail_account_rollback' => false,
 		);
 		$GLOBALS['wpdb']                  = new VenueMembershipWpdb();
 	}
@@ -643,6 +687,23 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 
 	private function email_hash( string $email ): string {
 		return hash_hmac( 'sha256', strtolower( $email ), wp_salt( 'auth' ) );
+	}
+
+	private function install_account_creator(): void {
+		$GLOBALS['venue_membership_test']['account_create_calls'] = 0;
+		$GLOBALS['venue_membership_test']['ability_objects']['extrachill/create-user'] = new class() {
+			public function execute( array $input ) {
+				++$GLOBALS['venue_membership_test']['account_create_calls'];
+				$user_id = max( array_keys( $GLOBALS['venue_membership_test']['users'] ) ) + 1;
+				$GLOBALS['venue_membership_test']['users'][ $user_id ] = new WP_User( $user_id, $input['email'] );
+				$GLOBALS['venue_membership_test']['user_meta'][ $user_id ] = array(
+					'ec_unclaimed'       => '1',
+					'registration_source' => $input['registration_source'],
+				);
+				$GLOBALS['venue_membership_test']['created_account_input'] = $input;
+				return $user_id;
+			}
+		};
 	}
 
 	public function test_capability_scope_and_inactive_statuses_fail_closed(): void {
@@ -1031,15 +1092,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->assertSame( 'Extra Chill Bot', $GLOBALS['venue_membership_test']['queued_emails'][0]['from_name'] );
 		$this->assertStringContainsString( 'acting on Chris Huber', $GLOBALS['venue_membership_test']['queued_emails'][0]['context']['body_html'] );
 
-		$GLOBALS['venue_membership_test']['ability_objects']['extrachill/create-user'] = new class() {
-			public function execute( array $input ) {
-				$user = new WP_User( 8, $input['email'] );
-				$GLOBALS['venue_membership_test']['users'][8]                  = $user;
-				$GLOBALS['venue_membership_test']['user_meta'][8]['ec_unclaimed'] = 1;
-				$GLOBALS['venue_membership_test']['created_account_input']      = $input;
-				return 8;
-			}
-		};
+		$this->install_account_creator();
 		$new = $service->invite( 1, 56, 'brand-new@example.com', true );
 		$this->assertTrue( $new['account_created'] );
 		$this->assertTrue( $new['delivery_queued'] );
@@ -1053,15 +1106,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		unset( $GLOBALS['venue_membership_test']['team_access'][2] );
 		$GLOBALS['venue_membership_test']['feature_available'] = false;
 
-		$GLOBALS['venue_membership_test']['ability_objects']['extrachill/create-user'] = new class() {
-			public function execute( array $input ) {
-				++$GLOBALS['venue_membership_test']['account_create_calls'];
-				$user_id = 8 + $GLOBALS['venue_membership_test']['account_create_calls'];
-				$GLOBALS['venue_membership_test']['users'][ $user_id ] = new WP_User( $user_id, $input['email'] );
-				return $user_id;
-			}
-		};
-		$GLOBALS['venue_membership_test']['account_create_calls'] = 0;
+		$this->install_account_creator();
 
 		$service = new VenueOnboardingService();
 
@@ -1073,6 +1118,143 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$denied = $service->invite( 3, 55, 'unauthorized-new@example.com', false );
 		$this->assertSame( 'venue_action_forbidden', $denied->get_error_code() );
 		$this->assertSame( 1, $GLOBALS['venue_membership_test']['account_create_calls'] );
+	}
+
+	public function test_reset_key_failure_rolls_back_new_account_without_sending_or_persisting(): void {
+		$this->create_member( 55, 2, true );
+		$this->install_account_creator();
+		$GLOBALS['venue_membership_test']['fail_reset_key'] = true;
+
+		$result = ( new VenueOnboardingService() )->invite( 2, 55, 'reset-failure@example.com', false );
+
+		$this->assertSame( 'venue_invitation_reset_key_failed', $result->get_error_code() );
+		$this->assertSame( array( 8 ), $GLOBALS['venue_membership_test']['rollback_attempts'] );
+		$this->assertArrayNotHasKey( 8, $GLOBALS['venue_membership_test']['users'] );
+		$this->assertSame( array(), $GLOBALS['venue_membership_test']['queued_emails'] );
+		$this->assertSame( array(), $GLOBALS['wpdb']->rows['wp_7_ec_venue_invitations'] ?? array() );
+	}
+
+	public function test_authority_race_and_invitation_write_failure_compensate_new_accounts(): void {
+		$this->create_member( 55, 2, true );
+		$this->install_account_creator();
+		$GLOBALS['wpdb']->after_start = static function ( VenueMembershipWpdb $wpdb ): void {
+			foreach ( $wpdb->rows['wp_7_ec_venue_members'] as &$row ) {
+				if ( 2 === (int) $row['user_id'] ) {
+					$row['status'] = VenueAuthorization::STATUS_REVOKED;
+				}
+			}
+			unset( $row );
+		};
+
+		$race = ( new VenueOnboardingService() )->invite( 2, 55, 'authority-race@example.com', false );
+		$this->assertSame( 'venue_action_forbidden', $race->get_error_code() );
+		$this->assertArrayNotHasKey( 8, $GLOBALS['venue_membership_test']['users'] );
+
+		foreach ( $GLOBALS['wpdb']->rows['wp_7_ec_venue_members'] as &$row ) {
+			if ( 2 === (int) $row['user_id'] ) {
+				$row['status'] = VenueAuthorization::STATUS_ACTIVE;
+			}
+		}
+		unset( $row );
+		$this->install_account_creator();
+		$GLOBALS['wpdb']->fail_invitation_insert = true;
+		$write = ( new VenueOnboardingService() )->invite( 2, 55, 'write-failure@example.com', false );
+		$this->assertSame( 'venue_invitation_create_failed', $write->get_error_code() );
+		$this->assertArrayNotHasKey( 8, $GLOBALS['venue_membership_test']['users'] );
+		$this->assertSame( array( 8, 8 ), $GLOBALS['venue_membership_test']['rollback_attempts'] );
+	}
+
+	public function test_delivery_failure_cancels_state_and_compensates_provenanced_account(): void {
+		$this->create_member( 55, 2, true );
+		$this->install_account_creator();
+		$GLOBALS['venue_membership_test']['fail_delivery'] = true;
+
+		$result = ( new VenueOnboardingService() )->invite( 2, 55, 'delivery-failure@example.com', false );
+
+		$this->assertSame( 'venue_invitation_delivery_failed', $result->get_error_code() );
+		$this->assertArrayNotHasKey( 8, $GLOBALS['venue_membership_test']['users'] );
+		$invitation = array_values( $GLOBALS['wpdb']->rows['wp_7_ec_venue_invitations'] )[0];
+		$this->assertSame( VenueOnboardingRepository::INVITE_CANCELLED, $invitation['status'] );
+		$this->assertSame( 1, (int) $invitation['account_created'] );
+		$this->assertSame( VenueAuthorization::STATUS_REVOKED, ( new VenueMembershipRepository() )->get( 55, 8 )['status'] );
+	}
+
+	public function test_provenance_failure_cancels_invitation_and_rolls_back_created_account(): void {
+		$this->create_member( 55, 2, true );
+		$this->install_account_creator();
+		$GLOBALS['venue_membership_test']['fail_provenance'] = true;
+
+		$result = ( new VenueOnboardingService() )->invite( 2, 55, 'provenance-failure@example.com', false );
+
+		$this->assertSame( 'venue_invitation_provenance_failed', $result->get_error_code() );
+		$this->assertArrayNotHasKey( 8, $GLOBALS['venue_membership_test']['users'] );
+		$invitation = array_values( $GLOBALS['wpdb']->rows['wp_7_ec_venue_invitations'] )[0];
+		$this->assertSame( VenueOnboardingRepository::INVITE_CANCELLED, $invitation['status'] );
+		$this->assertSame( array( 8 ), $GLOBALS['venue_membership_test']['rollback_attempts'] );
+	}
+
+	public function test_terminal_cleanup_deletes_only_unused_provenanced_accounts(): void {
+		$this->create_member( 55, 2, true );
+		$this->install_account_creator();
+		$service = new VenueOnboardingService();
+		$created = $service->invite( 2, 55, 'cancel-created@example.com', false );
+		$this->assertSame( VenueOnboardingRepository::INVITE_CANCELLED, $service->cancel_invitation( 2, $created['id'], 1 )['status'] );
+		$this->assertArrayNotHasKey( 8, $GLOBALS['venue_membership_test']['users'] );
+
+		$existing = $service->invite( 2, 55, 'existing@example.com', false );
+		$this->assertSame( VenueOnboardingRepository::INVITE_CANCELLED, $service->cancel_invitation( 2, $existing['id'], 1 )['status'] );
+		$this->assertArrayHasKey( 7, $GLOBALS['venue_membership_test']['users'] );
+	}
+
+	public function test_claimed_or_shared_provenanced_accounts_are_preserved_on_terminal_transition(): void {
+		$this->create_member( 55, 2, true );
+		$this->create_member( 56, 3, true );
+		$this->install_account_creator();
+		$service = new VenueOnboardingService();
+		$claimed = $service->invite( 2, 55, 'claimed-before-cancel@example.com', false );
+		unset( $GLOBALS['venue_membership_test']['user_meta'][8]['ec_unclaimed'] );
+		$service->cancel_invitation( 2, $claimed['id'], 1 );
+		$this->assertArrayHasKey( 8, $GLOBALS['venue_membership_test']['users'] );
+
+		$this->install_account_creator();
+		$shared = $service->invite( 3, 56, 'shared-before-reject@example.com', false );
+		$this->create_member( 55, 9, false, VenueAuthorization::STATUS_ACTIVE, 2 );
+		$service->cancel_invitation( 3, $shared['id'], 1 );
+		$this->assertArrayHasKey( 9, $GLOBALS['venue_membership_test']['users'] );
+		$this->assertSame( 56, $shared['venue_term_id'] );
+	}
+
+	public function test_rejection_and_expiry_cleanup_created_account_provenance(): void {
+		$this->create_member( 55, 2, true );
+		$this->create_member( 56, 3, true );
+		$repository = new VenueOnboardingRepository();
+		$service    = new VenueOnboardingService( $repository );
+		$tokens     = new VenueInvitationToken();
+
+		$GLOBALS['venue_membership_test']['users'][8] = new WP_User( 8, 'reject-created@example.com' );
+		$GLOBALS['venue_membership_test']['user_meta'][8] = array(
+			'ec_unclaimed'       => '1',
+			'registration_source' => 'venue_invitation',
+		);
+		$reject_token = $tokens->generate();
+		$rejected     = $repository->create_invitation( 2, 55, 8, false, $this->email_hash( 'reject-created@example.com' ), $reject_token, 3600, true );
+		update_user_meta( 8, 'ec_venue_invitation_account', $rejected['public_id'] );
+		$result = $service->respond( 8, $rejected['public_id'], $reject_token, 55, false, 1, VenueOnboardingRepository::INVITE_REJECTED );
+		$this->assertSame( VenueOnboardingRepository::INVITE_REJECTED, $result['status'] );
+		$this->assertArrayNotHasKey( 8, $GLOBALS['venue_membership_test']['users'] );
+
+		$GLOBALS['venue_membership_test']['users'][9] = new WP_User( 9, 'expire-created@example.com' );
+		$GLOBALS['venue_membership_test']['user_meta'][9] = array(
+			'ec_unclaimed'       => '1',
+			'registration_source' => 'venue_invitation',
+		);
+		$expire_token = $tokens->generate();
+		$expired      = $repository->create_invitation( 3, 56, 9, false, $this->email_hash( 'expire-created@example.com' ), $expire_token, 3600, true );
+		update_user_meta( 9, 'ec_venue_invitation_account', $expired['public_id'] );
+		$GLOBALS['wpdb']->rows['wp_7_ec_venue_invitations'][ $expired['id'] ]['expires_at'] = '2000-01-01 00:00:00';
+		$result = $service->respond( 9, $expired['public_id'], $expire_token, 56, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED );
+		$this->assertSame( 'venue_invitation_expired', $result->get_error_code() );
+		$this->assertArrayNotHasKey( 9, $GLOBALS['venue_membership_test']['users'] );
 	}
 
 	public function test_config_abilities_round_trip_revision_and_audit(): void {

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -361,6 +361,20 @@ final class VenueMembershipWpdb {
 	public function get_results( $query, $output = null ) {
 		unset( $output );
 		$this->last_error = '';
+		if ( false !== strpos( $query, 'ec_venue_invitations' ) ) {
+			$rows = array_values( $this->rows['wp_7_ec_venue_invitations'] ?? array() );
+			if ( preg_match( '/venue_term_id = (\d+)/', $query, $match ) ) {
+				$rows = array_values(
+					array_filter(
+						$rows,
+						static function ( $row ) use ( $match ) {
+							return (int) $row['venue_term_id'] === (int) $match[1];
+						}
+					)
+				);
+			}
+			return $rows;
+		}
 		if ( false !== strpos( $query, 'SELECT member.*' ) && is_callable( $this->before_list ) ) {
 			$callback          = $this->before_list;
 			$this->before_list = null;
@@ -525,6 +539,9 @@ final class VenueMembershipWpdb {
 			if ( preg_match( '/venue_term_id = (\d+) AND claimant_user_id = (\d+)/', $query, $claim ) && (int) $row['venue_term_id'] === (int) $claim[1] && (int) $row['claimant_user_id'] === (int) $claim[2] ) {
 				return $row;
 			}
+			if ( preg_match( '/venue_term_id = (\d+) AND user_id = (\d+)/', $query, $invitation ) && (int) $row['venue_term_id'] === (int) $invitation[1] && (int) $row['user_id'] === (int) $invitation[2] ) {
+				return $row;
+			}
 		}
 		return null;
 	}
@@ -624,6 +641,10 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		);
 	}
 
+	private function email_hash( string $email ): string {
+		return hash_hmac( 'sha256', strtolower( $email ), wp_salt( 'auth' ) );
+	}
+
 	public function test_capability_scope_and_inactive_statuses_fail_closed(): void {
 		$authorization = new VenueAuthorization();
 		$this->create_member( 55, 3, true );
@@ -646,8 +667,10 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 
 		unset( $GLOBALS['venue_membership_test']['team_access'][6] );
 		$this->assertFalse( $authorization->can( 6, 56, VenueAuthorization::ACTION_ACCESS_VENUE ) );
+		$this->assertTrue( $authorization->can( 6, 56, VenueAuthorization::ACTION_MANAGE_MEMBERS ) );
 		$GLOBALS['venue_membership_test']['feature_available'] = false;
 		$this->assertFalse( $authorization->can( 3, 55, VenueAuthorization::ACTION_ACCESS_VENUE ) );
+		$this->assertTrue( $authorization->can( 3, 55, VenueAuthorization::ACTION_MANAGE_MEMBERS ) );
 	}
 
 	public function test_administrator_override_validates_venue_and_cross_venue_access_is_denied(): void {
@@ -857,14 +880,30 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->assertSame( 'venue_claim_version_conflict', $onboarding->review_claim( 1, $claim['id'], VenueOnboardingRepository::CLAIM_REJECTED, 1 )->get_error_code() );
 	}
 
+	public function test_claims_and_invitations_are_reciprocally_exclusive_under_the_venue_lock(): void {
+		$onboarding = new VenueOnboardingRepository();
+		$this->create_member( 55, 2, true );
+		$token  = ( new VenueInvitationToken() )->generate();
+		$invite = $onboarding->create_invitation( 2, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
+
+		$this->assertSame( VenueOnboardingRepository::INVITE_PENDING, $invite['status'] );
+		$this->assertSame( 'venue_claim_invitation_exists', $onboarding->submit_claim( 7, 55 )->get_error_code() );
+
+		$claim = $onboarding->submit_claim( 6, 55 );
+		$this->assertSame( VenueOnboardingRepository::CLAIM_PENDING, $claim['status'] );
+		$result = $onboarding->create_invitation( 2, 55, 6, false, $this->email_hash( 'member6@example.com' ), $token, 3600 );
+		$this->assertSame( 'venue_invitation_claim_exists', $result->get_error_code() );
+	}
+
 	public function test_invitation_acceptance_is_single_use_and_exactly_bound(): void {
 		$onboarding = new VenueOnboardingRepository();
 		$this->create_member( 55, 2, true );
-		$token      = ( new VenueInvitationToken() )->generate();
-		$invite     = $onboarding->create_invitation( 1, 55, 7, false, hash( 'sha256', 'user@example.com' ), $token, 3600 );
+		$token  = ( new VenueInvitationToken() )->generate();
+		$invite = $onboarding->create_invitation( 1, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
 
 		$this->assertArrayNotHasKey( 'token_hash', $invite );
 		$this->assertArrayNotHasKey( 'email_hash', $invite );
+		$this->assertArrayNotHasKey( '_email_hash', $onboarding->public_invitation( $invite ) );
 		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 56, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
 		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, true, 1, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
 		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 6, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
@@ -875,10 +914,23 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
 	}
 
+	public function test_invitation_acceptance_rechecks_current_account_email_binding(): void {
+		$onboarding = new VenueOnboardingRepository();
+		$this->create_member( 55, 2, true );
+		$token  = ( new VenueInvitationToken() )->generate();
+		$invite = $onboarding->create_invitation( 2, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
+
+		$GLOBALS['venue_membership_test']['users'][7]->user_email = 'changed@example.com';
+		$result = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED );
+
+		$this->assertSame( 'invalid_venue_invitation', $result->get_error_code() );
+		$this->assertSame( VenueAuthorization::STATUS_INVITED, ( new VenueMembershipRepository() )->get( 55, 7 )['status'] );
+	}
+
 	public function test_first_active_invitation_must_bootstrap_an_owner(): void {
 		$onboarding = new VenueOnboardingRepository();
 		$token      = ( new VenueInvitationToken() )->generate();
-		$invite     = $onboarding->create_invitation( 1, 55, 7, false, hash( 'sha256', 'existing@example.com' ), $token, 3600 );
+		$invite     = $onboarding->create_invitation( 1, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
 
 		$result = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED );
 		$this->assertSame( 'venue_membership_owner_required', $result->get_error_code() );
@@ -890,7 +942,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$onboarding = new VenueOnboardingRepository();
 		$tokens     = new VenueInvitationToken();
 		$old_token  = $tokens->generate();
-		$invite     = $onboarding->create_invitation( 2, 55, 7, true, hash( 'sha256', 'new@example.com' ), $old_token, 3600 );
+		$invite     = $onboarding->create_invitation( 2, 55, 7, true, $this->email_hash( 'existing@example.com' ), $old_token, 3600 );
 		$new_token  = $tokens->generate();
 		$rotated    = $onboarding->resend_invitation( 2, $invite['id'], 1, $new_token, 3600 );
 
@@ -909,21 +961,21 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$onboarding = new VenueOnboardingRepository();
 		$tokens     = new VenueInvitationToken();
 		$token      = $tokens->generate();
-		$invite     = $onboarding->create_invitation( 1, 55, 7, false, hash( 'sha256', 'private@example.com' ), $token, 3600 );
+		$invite     = $onboarding->create_invitation( 1, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
 		$rejected   = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_REJECTED );
 		$this->assertSame( VenueOnboardingRepository::INVITE_REJECTED, $rejected['status'] );
 		$this->assertSame( VenueAuthorization::STATUS_REVOKED, ( new VenueMembershipRepository() )->get( 55, 7 )['status'] );
 
-		$owner  = $this->create_member( 56, 2, true );
-		$token2 = $tokens->generate();
-		$invite2 = $onboarding->create_invitation( 2, 56, 6, false, hash( 'sha256', 'cancel@example.com' ), $token2, 3600 );
+		$owner     = $this->create_member( 56, 2, true );
+		$token2    = $tokens->generate();
+		$invite2   = $onboarding->create_invitation( 2, 56, 6, false, $this->email_hash( 'member6@example.com' ), $token2, 3600 );
 		$cancelled = $onboarding->cancel_invitation( 2, $invite2['id'], 1 );
 		$this->assertSame( VenueOnboardingRepository::INVITE_CANCELLED, $cancelled['status'] );
 		$this->assertSame( $cancelled, $onboarding->cancel_invitation( 2, $invite2['id'], 1 ) );
 		$this->assertTrue( $owner['is_owner'] );
 
 		$token3  = $tokens->generate();
-		$invite3 = $onboarding->create_invitation( 2, 56, 5, false, hash( 'sha256', 'expired@example.com' ), $token3, 3600 );
+		$invite3 = $onboarding->create_invitation( 2, 56, 5, false, $this->email_hash( 'member5@example.com' ), $token3, 3600 );
 		$GLOBALS['wpdb']->rows['wp_7_ec_venue_invitations'][ $invite3['id'] ]['expires_at'] = '2000-01-01 00:00:00';
 		$expired = $onboarding->respond_to_invitation( 5, $invite3['public_id'], $token3, 56, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED );
 		$this->assertSame( 'venue_invitation_expired', $expired->get_error_code() );
@@ -936,6 +988,37 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			$this->assertStringNotContainsString( 'token', strtolower( $audit['payload'] ) );
 			$this->assertStringNotContainsString( 'email', strtolower( $audit['payload'] ) );
 		}
+	}
+
+	public function test_cancelled_invitation_is_not_disclosed_to_another_venue_owner(): void {
+		$onboarding = new VenueOnboardingRepository();
+		$this->create_member( 55, 2, true );
+		$this->create_member( 56, 3, true );
+		$token     = ( new VenueInvitationToken() )->generate();
+		$invite    = $onboarding->create_invitation( 2, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
+		$cancelled = $onboarding->cancel_invitation( 2, $invite['id'], 1 );
+
+		$this->assertSame( VenueOnboardingRepository::INVITE_CANCELLED, $cancelled['status'] );
+		$this->assertSame( 'venue_action_forbidden', $onboarding->cancel_invitation( 3, $invite['id'], 2 )->get_error_code() );
+	}
+
+	public function test_invitation_listing_rechecks_owner_authority_under_the_venue_lock(): void {
+		$onboarding = new VenueOnboardingRepository();
+		$this->create_member( 55, 2, true );
+		$token = ( new VenueInvitationToken() )->generate();
+		$onboarding->create_invitation( 2, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
+
+		$GLOBALS['wpdb']->after_start = static function ( VenueMembershipWpdb $wpdb ): void {
+			foreach ( $wpdb->rows['wp_7_ec_venue_members'] as &$row ) {
+				if ( 2 === (int) $row['user_id'] ) {
+					$row['status'] = VenueAuthorization::STATUS_REVOKED;
+				}
+			}
+			unset( $row );
+		};
+
+		$result = $onboarding->list_invitations( 2, 55 );
+		$this->assertSame( 'venue_action_forbidden', $result->get_error_code() );
 	}
 
 	public function test_existing_and_new_user_invitations_use_account_and_queued_mail_primitives(): void {
@@ -963,6 +1046,33 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->assertTrue( $GLOBALS['venue_membership_test']['created_account_input']['unclaimed'] );
 		$this->assertSame( 'venue_invitation', $GLOBALS['venue_membership_test']['created_account_input']['registration_source'] );
 		$this->assertStringContainsString( 'action=rp', $GLOBALS['venue_membership_test']['queued_emails'][1]['context']['cta_url'] );
+	}
+
+	public function test_account_creation_requires_fresh_membership_authority_but_not_booking_access(): void {
+		$this->create_member( 55, 2, true );
+		unset( $GLOBALS['venue_membership_test']['team_access'][2] );
+		$GLOBALS['venue_membership_test']['feature_available'] = false;
+
+		$GLOBALS['venue_membership_test']['ability_objects']['extrachill/create-user'] = new class() {
+			public function execute( array $input ) {
+				++$GLOBALS['venue_membership_test']['account_create_calls'];
+				$user_id = 8 + $GLOBALS['venue_membership_test']['account_create_calls'];
+				$GLOBALS['venue_membership_test']['users'][ $user_id ] = new WP_User( $user_id, $input['email'] );
+				return $user_id;
+			}
+		};
+		$GLOBALS['venue_membership_test']['account_create_calls'] = 0;
+
+		$service = new VenueOnboardingService();
+
+		$allowed = $service->invite( 2, 55, 'authorized-new@example.com', false );
+		$this->assertTrue( $allowed['account_created'] );
+		$this->assertSame( 1, $GLOBALS['venue_membership_test']['account_create_calls'] );
+		$this->assertFalse( ( new VenueAuthorization() )->can( 2, 55, VenueAuthorization::ACTION_ACCESS_VENUE ) );
+
+		$denied = $service->invite( 3, 55, 'unauthorized-new@example.com', false );
+		$this->assertSame( 'venue_action_forbidden', $denied->get_error_code() );
+		$this->assertSame( 1, $GLOBALS['venue_membership_test']['account_create_calls'] );
 	}
 
 	public function test_config_abilities_round_trip_revision_and_audit(): void {

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -12,6 +12,9 @@ use ExtraChillEvents\Core\VenueAuthorization;
 use ExtraChillEvents\Core\VenueBookingConfig;
 use ExtraChillEvents\Core\VenueMembershipRepository;
 use ExtraChillEvents\Core\VenueMembershipService;
+use ExtraChillEvents\Core\VenueInvitationToken;
+use ExtraChillEvents\Core\VenueOnboardingRepository;
+use ExtraChillEvents\Core\VenueOnboardingService;
 use PHPUnit\Framework\TestCase;
 
 if ( ! defined( 'ARRAY_A' ) ) {
@@ -35,6 +38,20 @@ if ( ! class_exists( 'WP_Error' ) ) {
 			return $this->data; }
 	}
 }
+if ( ! class_exists( 'WP_User' ) ) {
+	class WP_User {
+		public $ID;
+		public $user_email;
+		public $user_login;
+		public $display_name;
+		public function __construct( $id, $email = '' ) {
+			$this->ID           = (int) $id;
+			$this->user_email   = $email;
+			$this->user_login   = 'user' . $id;
+			$this->display_name = 'User ' . $id;
+		}
+	}
+}
 if ( ! function_exists( 'is_wp_error' ) ) {
 	function is_wp_error( $value ) {
 		return $value instanceof WP_Error; }
@@ -55,6 +72,39 @@ if ( ! function_exists( 'sanitize_text_field' ) ) {
 	function sanitize_text_field( $value ) {
 		return trim( strip_tags( (string) $value ) ); }
 }
+if ( ! function_exists( 'sanitize_email' ) ) {
+	function sanitize_email( $value ) {
+		return filter_var( trim( (string) $value ), FILTER_SANITIZE_EMAIL ); }
+}
+if ( ! function_exists( 'is_email' ) ) {
+	function is_email( $value ) {
+		return false !== filter_var( $value, FILTER_VALIDATE_EMAIL ); }
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $value ) {
+		return preg_replace( '/[^a-z0-9]+/', '-', strtolower( (string) $value ) ); }
+}
+if ( ! function_exists( 'wp_generate_password' ) ) {
+	function wp_generate_password( $length = 12 ) {
+		return str_repeat( 'x', $length ); }
+}
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4() {
+		static $sequence = 0;
+		++$sequence;
+		return sprintf( '00000000-0000-4000-8000-%012d', $sequence );
+	}
+}
+if ( ! function_exists( 'wp_salt' ) ) {
+	function wp_salt( $scheme = 'auth' ) {
+		return 'venue-test-' . $scheme;
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value ) {
+		return json_encode( $value );
+	}
+}
 if ( ! function_exists( 'get_term' ) ) {
 	function get_term( $term_id, $taxonomy = '' ) {
 		$term = $GLOBALS['venue_membership_test']['terms'][ $term_id ] ?? null;
@@ -64,6 +114,66 @@ if ( ! function_exists( 'get_term' ) ) {
 if ( ! function_exists( 'get_userdata' ) ) {
 	function get_userdata( $user_id ) {
 		return $GLOBALS['venue_membership_test']['users'][ $user_id ] ?? false;
+	}
+}
+if ( ! function_exists( 'get_user_by' ) ) {
+	function get_user_by( $field, $value ) {
+		if ( 'email' !== $field ) {
+			return false;
+		}
+		foreach ( $GLOBALS['venue_membership_test']['users'] as $user ) {
+			if ( strtolower( $user->user_email ) === strtolower( $value ) ) {
+				return $user;
+			}
+		}
+		return false;
+	}
+}
+if ( ! function_exists( 'get_user_meta' ) ) {
+	function get_user_meta( $user_id, $key, $single = false ) {
+		unset( $single );
+		return $GLOBALS['venue_membership_test']['user_meta'][ $user_id ][ $key ] ?? ''; }
+}
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( $name ) {
+		return $GLOBALS['venue_membership_test']['ability_objects'][ $name ] ?? null; }
+}
+if ( ! function_exists( 'get_password_reset_key' ) ) {
+	function get_password_reset_key( $user ) {
+		return 'reset-' . $user->ID; }
+}
+if ( ! function_exists( 'ec_get_site_url' ) ) {
+	function ec_get_site_url( $site ) {
+		return 'https://' . $site . '.extrachill.test'; }
+}
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $value ) {
+		return rtrim( $value, '/' ) . '/'; }
+}
+if ( ! function_exists( 'admin_url' ) ) {
+	function admin_url( $path = '' ) {
+		return 'https://events.extrachill.test/wp-admin/' . ltrim( $path, '/' ); }
+}
+if ( ! function_exists( 'add_query_arg' ) ) {
+	function add_query_arg( $args, $url ) {
+		return $url . '?' . http_build_query( $args ); }
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES ); }
+}
+if ( ! function_exists( 'esc_html__' ) ) {
+	function esc_html__( $value ) {
+		return esc_html( $value ); }
+}
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $value ) {
+		return (string) $value; }
+}
+if ( ! function_exists( 'ec_send_email_queued' ) ) {
+	function ec_send_email_queued( array $args ) {
+		$GLOBALS['venue_membership_test']['queued_emails'][] = $args;
+		return array( 'success' => true, 'action_id' => count( $GLOBALS['venue_membership_test']['queued_emails'] ) );
 	}
 }
 if ( ! function_exists( 'user_can' ) ) {
@@ -181,7 +291,8 @@ final class VenueMembershipWpdb {
 			return 1;
 		}
 		foreach ( $this->rows[ $table ] ?? array() as $existing ) {
-			if ( (int) $existing['venue_term_id'] === (int) $row['venue_term_id'] && (int) $existing['user_id'] === (int) $row['user_id'] ) {
+			$user_field = isset( $row['claimant_user_id'] ) ? 'claimant_user_id' : ( isset( $row['user_id'] ) ? 'user_id' : '' );
+			if ( $user_field && (int) $existing['venue_term_id'] === (int) $row['venue_term_id'] && (int) $existing[ $user_field ] === (int) $row[ $user_field ] ) {
 				$this->last_error = 'duplicate venue user';
 				return false;
 			}
@@ -210,6 +321,12 @@ final class VenueMembershipWpdb {
 				'meta_id'    => 100,
 				'meta_value' => $this->meta_values[100],
 			);
+		}
+		if ( false !== strpos( $query, 'ec_venue_claims' ) ) {
+			return $this->find_onboarding_row( 'wp_7_ec_venue_claims', $query );
+		}
+		if ( false !== strpos( $query, 'ec_venue_invitations' ) ) {
+			return $this->find_onboarding_row( 'wp_7_ec_venue_invitations', $query );
 		}
 		if ( ! preg_match( '/venue_term_id = (\d+) AND user_id = (\d+)/', $query, $match ) ) {
 			return null;
@@ -343,6 +460,15 @@ final class VenueMembershipWpdb {
 			$this->meta_values_snapshot = array();
 			return 1;
 		}
+		if ( preg_match( '/UPDATE (wp_7_ec_venue_(?:claims|invitations)) SET .* WHERE id = (\d+) AND version = (\d+)/', $query, $onboarding ) ) {
+			$table = $onboarding[1];
+			$id    = (int) $onboarding[2];
+			if ( ! isset( $this->rows[ $table ][ $id ] ) || (int) $this->rows[ $table ][ $id ]['version'] !== (int) $onboarding[3] ) {
+				return 0;
+			}
+			$this->apply_assignments( $table, $id, $query );
+			return 1;
+		}
 		if ( ! preg_match( '/WHERE venue_term_id = (\d+) AND user_id = (\d+) AND version = (\d+)/', $query, $match ) ) {
 			return false;
 		}
@@ -351,17 +477,7 @@ final class VenueMembershipWpdb {
 			if ( (int) $row['venue_term_id'] !== (int) $match[1] || (int) $row['user_id'] !== (int) $match[2] || (int) $row['version'] !== (int) $match[3] ) {
 				continue;
 			}
-			$set = substr( $query, strpos( $query, ' SET ' ) + 5, strpos( $query, ' WHERE ' ) - strpos( $query, ' SET ' ) - 5 );
-			preg_match_all( "/([a-z_]+) = (version \\+ 1|[01]|'(?:\\\\.|[^'])*')(?=, [a-z_]+ = |$)/", $set, $assignments, PREG_SET_ORDER );
-			foreach ( $assignments as $assignment ) {
-				if ( 'version + 1' === $assignment[2] ) {
-					++$this->rows[ $table ][ $id ]['version'];
-				} elseif ( "'" === $assignment[2][0] ) {
-					$this->rows[ $table ][ $id ][ $assignment[1] ] = stripslashes( substr( $assignment[2], 1, -1 ) );
-				} else {
-					$this->rows[ $table ][ $id ][ $assignment[1] ] = (int) $assignment[2];
-				}
-			}
+			$this->apply_assignments( $table, $id, $query );
 			return 1;
 		}
 		return 0;
@@ -370,6 +486,15 @@ final class VenueMembershipWpdb {
 	public function update( $table, $data, $where, $format = null, $where_format = null ) {
 		unset( $format, $where_format );
 		$this->last_error = '';
+		if ( $this->prefix . 'ec_venue_members' === $table ) {
+			foreach ( $this->rows[ $table ] ?? array() as $id => $row ) {
+				if ( (int) $row['venue_term_id'] === (int) $where['venue_term_id'] && (int) $row['user_id'] === (int) $where['user_id'] && (int) $row['version'] === (int) $where['version'] ) {
+					$this->rows[ $table ][ $id ] = array_merge( $row, $data );
+					return 1;
+				}
+			}
+			return 0;
+		}
 		if ( $this->termmeta !== $table || ! isset( $where['meta_id'], $data['meta_value'] ) ) {
 			return false;
 		}
@@ -388,12 +513,46 @@ final class VenueMembershipWpdb {
 		$row['id']                                = $this->insert_id;
 		$this->rows[ $table ][ $this->insert_id ] = $row;
 	}
+
+	private function find_onboarding_row( string $table, string $query ) {
+		foreach ( $this->rows[ $table ] ?? array() as $row ) {
+			if ( preg_match( '/WHERE id = (\d+)/', $query, $id ) && (int) $row['id'] === (int) $id[1] ) {
+				return $row;
+			}
+			if ( preg_match( "/WHERE public_id = '([^']+)'/", $query, $public ) && $row['public_id'] === stripslashes( $public[1] ) ) {
+				return $row;
+			}
+			if ( preg_match( '/venue_term_id = (\d+) AND claimant_user_id = (\d+)/', $query, $claim ) && (int) $row['venue_term_id'] === (int) $claim[1] && (int) $row['claimant_user_id'] === (int) $claim[2] ) {
+				return $row;
+			}
+		}
+		return null;
+	}
+
+	private function apply_assignments( string $table, int $id, string $query ): void {
+		$set = substr( $query, strpos( $query, ' SET ' ) + 5, strpos( $query, ' WHERE ' ) - strpos( $query, ' SET ' ) - 5 );
+		preg_match_all( "/([a-z_]+) = (version \\+ 1|NULL|[01]|'(?:\\\\.|[^'])*')(?=, [a-z_]+ = |$)/", $set, $assignments, PREG_SET_ORDER );
+		foreach ( $assignments as $assignment ) {
+			if ( 'version + 1' === $assignment[2] ) {
+				++$this->rows[ $table ][ $id ]['version'];
+			} elseif ( 'NULL' === $assignment[2] ) {
+				$this->rows[ $table ][ $id ][ $assignment[1] ] = null;
+			} elseif ( "'" === $assignment[2][0] ) {
+				$this->rows[ $table ][ $id ][ $assignment[1] ] = stripslashes( substr( $assignment[2], 1, -1 ) );
+			} else {
+				$this->rows[ $table ][ $id ][ $assignment[1] ] = (int) $assignment[2];
+			}
+		}
+	}
 }
 
 require_once dirname( __DIR__ ) . '/inc/Core/BookingSchema.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueAuthorization.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueMembershipRepository.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueMembershipService.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VenueInvitationToken.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VenueOnboardingRepository.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VenueOnboardingService.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueBookingConfig.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueMembershipAbilities.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueBookingConfigAbilities.php';
@@ -405,10 +564,12 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 				55 => (object) array(
 					'term_id'  => 55,
 					'taxonomy' => 'venue',
+					'name'     => 'Venue 55',
 				),
 				56 => (object) array(
 					'term_id'  => 56,
 					'taxonomy' => 'venue',
+					'name'     => 'Venue 56',
 				),
 				57 => (object) array(
 					'term_id'  => 57,
@@ -416,13 +577,13 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 				),
 			),
 			'users'             => array(
-				1 => (object) array( 'ID' => 1 ),
-				2 => (object) array( 'ID' => 2 ),
-				3 => (object) array( 'ID' => 3 ),
-				4 => (object) array( 'ID' => 4 ),
-				5 => (object) array( 'ID' => 5 ),
-				6 => (object) array( 'ID' => 6 ),
-				7 => (object) array( 'ID' => 7 ),
+				1 => new WP_User( 1, 'admin@example.com' ),
+				2 => new WP_User( 2, 'owner@example.com' ),
+				3 => new WP_User( 3, 'member3@example.com' ),
+				4 => new WP_User( 4, 'member4@example.com' ),
+				5 => new WP_User( 5, 'member5@example.com' ),
+				6 => new WP_User( 6, 'member6@example.com' ),
+				7 => new WP_User( 7, 'existing@example.com' ),
 			),
 			'administrators'    => array( 1 => true ),
 			'team_access'       => array(
@@ -444,6 +605,9 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			'cache_deletes'     => array(),
 			'fail_config_save'  => false,
 			'fail_config_audit' => false,
+			'user_meta'         => array(),
+			'ability_objects'   => array(),
+			'queued_emails'     => array(),
 		);
 		$GLOBALS['wpdb']                  = new VenueMembershipWpdb();
 	}
@@ -662,6 +826,143 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			)
 		);
 		$this->assertSame( 'venue_action_forbidden', $denied->get_error_code() );
+	}
+
+	public function test_claim_submission_is_idempotent_and_approval_bootstraps_exact_owner(): void {
+		$onboarding = new VenueOnboardingRepository();
+		$first      = $onboarding->submit_claim( 7, 55 );
+		$duplicate  = $onboarding->submit_claim( 7, 55 );
+
+		$this->assertSame( $first['id'], $duplicate['id'] );
+		$this->assertSame( VenueOnboardingRepository::CLAIM_PENDING, $first['status'] );
+		$approved = $onboarding->review_claim( 1, $first['id'], VenueOnboardingRepository::CLAIM_APPROVED, 1 );
+		$this->assertSame( VenueOnboardingRepository::CLAIM_APPROVED, $approved['status'] );
+		$owner = ( new VenueMembershipRepository() )->get( 55, 7 );
+		$this->assertSame( VenueAuthorization::STATUS_ACTIVE, $owner['status'] );
+		$this->assertTrue( $owner['is_owner'] );
+
+		$idempotent = $onboarding->review_claim( 1, $first['id'], VenueOnboardingRepository::CLAIM_APPROVED, 1 );
+		$this->assertSame( $approved, $idempotent );
+	}
+
+	public function test_claim_cancellation_resubmission_and_review_conflicts_are_optimistic(): void {
+		$onboarding = new VenueOnboardingRepository();
+		$claim      = $onboarding->submit_claim( 7, 55 );
+		$cancelled  = $onboarding->cancel_claim( 7, $claim['id'], 1 );
+
+		$this->assertSame( VenueOnboardingRepository::CLAIM_CANCELLED, $cancelled['status'] );
+		$this->assertSame( $cancelled, $onboarding->cancel_claim( 7, $claim['id'], 1 ) );
+		$resubmitted = $onboarding->submit_claim( 7, 55 );
+		$this->assertSame( 3, $resubmitted['version'] );
+		$this->assertSame( 'venue_claim_version_conflict', $onboarding->review_claim( 1, $claim['id'], VenueOnboardingRepository::CLAIM_REJECTED, 1 )->get_error_code() );
+	}
+
+	public function test_invitation_acceptance_is_single_use_and_exactly_bound(): void {
+		$onboarding = new VenueOnboardingRepository();
+		$this->create_member( 55, 2, true );
+		$token      = ( new VenueInvitationToken() )->generate();
+		$invite     = $onboarding->create_invitation( 1, 55, 7, false, hash( 'sha256', 'user@example.com' ), $token, 3600 );
+
+		$this->assertArrayNotHasKey( 'token_hash', $invite );
+		$this->assertArrayNotHasKey( 'email_hash', $invite );
+		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 56, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, true, 1, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 6, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+
+		$accepted = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED );
+		$this->assertSame( VenueOnboardingRepository::INVITE_ACCEPTED, $accepted['status'] );
+		$this->assertSame( VenueAuthorization::STATUS_ACTIVE, ( new VenueMembershipRepository() )->get( 55, 7 )['status'] );
+		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+	}
+
+	public function test_first_active_invitation_must_bootstrap_an_owner(): void {
+		$onboarding = new VenueOnboardingRepository();
+		$token      = ( new VenueInvitationToken() )->generate();
+		$invite     = $onboarding->create_invitation( 1, 55, 7, false, hash( 'sha256', 'existing@example.com' ), $token, 3600 );
+
+		$result = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED );
+		$this->assertSame( 'venue_membership_owner_required', $result->get_error_code() );
+		$this->assertSame( VenueAuthorization::STATUS_INVITED, ( new VenueMembershipRepository() )->get( 55, 7 )['status'] );
+	}
+
+	public function test_resend_rotates_token_and_revoked_inviter_fails_closed(): void {
+		$this->create_member( 55, 2, true );
+		$onboarding = new VenueOnboardingRepository();
+		$tokens     = new VenueInvitationToken();
+		$old_token  = $tokens->generate();
+		$invite     = $onboarding->create_invitation( 2, 55, 7, true, hash( 'sha256', 'new@example.com' ), $old_token, 3600 );
+		$new_token  = $tokens->generate();
+		$rotated    = $onboarding->resend_invitation( 2, $invite['id'], 1, $new_token, 3600 );
+
+		$this->assertSame( 2, $rotated['version'] );
+		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $old_token, 55, true, 2, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+		foreach ( $GLOBALS['wpdb']->rows['wp_7_ec_venue_members'] as &$member ) {
+			if ( 2 === (int) $member['user_id'] ) {
+				$member['status'] = VenueAuthorization::STATUS_REVOKED;
+			}
+		}
+		unset( $member );
+		$this->assertSame( 'venue_invitation_inviter_revoked', $onboarding->respond_to_invitation( 7, $invite['public_id'], $new_token, 55, true, 2, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+	}
+
+	public function test_rejection_cancellation_expiry_and_audit_are_private(): void {
+		$onboarding = new VenueOnboardingRepository();
+		$tokens     = new VenueInvitationToken();
+		$token      = $tokens->generate();
+		$invite     = $onboarding->create_invitation( 1, 55, 7, false, hash( 'sha256', 'private@example.com' ), $token, 3600 );
+		$rejected   = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_REJECTED );
+		$this->assertSame( VenueOnboardingRepository::INVITE_REJECTED, $rejected['status'] );
+		$this->assertSame( VenueAuthorization::STATUS_REVOKED, ( new VenueMembershipRepository() )->get( 55, 7 )['status'] );
+
+		$owner  = $this->create_member( 56, 2, true );
+		$token2 = $tokens->generate();
+		$invite2 = $onboarding->create_invitation( 2, 56, 6, false, hash( 'sha256', 'cancel@example.com' ), $token2, 3600 );
+		$cancelled = $onboarding->cancel_invitation( 2, $invite2['id'], 1 );
+		$this->assertSame( VenueOnboardingRepository::INVITE_CANCELLED, $cancelled['status'] );
+		$this->assertSame( $cancelled, $onboarding->cancel_invitation( 2, $invite2['id'], 1 ) );
+		$this->assertTrue( $owner['is_owner'] );
+
+		$token3  = $tokens->generate();
+		$invite3 = $onboarding->create_invitation( 2, 56, 5, false, hash( 'sha256', 'expired@example.com' ), $token3, 3600 );
+		$GLOBALS['wpdb']->rows['wp_7_ec_venue_invitations'][ $invite3['id'] ]['expires_at'] = '2000-01-01 00:00:00';
+		$expired = $onboarding->respond_to_invitation( 5, $invite3['public_id'], $token3, 56, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED );
+		$this->assertSame( 'venue_invitation_expired', $expired->get_error_code() );
+		$this->assertSame( VenueAuthorization::STATUS_REVOKED, ( new VenueMembershipRepository() )->get( 56, 5 )['status'] );
+
+		foreach ( $GLOBALS['wpdb']->rows['wp_7_ec_venue_onboarding_audit'] as $audit ) {
+			$encoded = json_encode( $audit );
+			$this->assertStringNotContainsString( $token, $encoded );
+			$this->assertStringNotContainsString( 'private@example.com', $encoded );
+			$this->assertStringNotContainsString( 'token', strtolower( $audit['payload'] ) );
+			$this->assertStringNotContainsString( 'email', strtolower( $audit['payload'] ) );
+		}
+	}
+
+	public function test_existing_and_new_user_invitations_use_account_and_queued_mail_primitives(): void {
+		$service  = new VenueOnboardingService();
+		$existing = $service->invite( 1, 55, 'existing@example.com', true );
+
+		$this->assertFalse( $existing['account_created'] );
+		$this->assertTrue( $existing['delivery_queued'] );
+		$this->assertSame( 'chubes@extrachill.com', $GLOBALS['venue_membership_test']['queued_emails'][0]['cc'] );
+		$this->assertSame( 'Extra Chill Bot', $GLOBALS['venue_membership_test']['queued_emails'][0]['from_name'] );
+		$this->assertStringContainsString( 'acting on Chris Huber', $GLOBALS['venue_membership_test']['queued_emails'][0]['context']['body_html'] );
+
+		$GLOBALS['venue_membership_test']['ability_objects']['extrachill/create-user'] = new class() {
+			public function execute( array $input ) {
+				$user = new WP_User( 8, $input['email'] );
+				$GLOBALS['venue_membership_test']['users'][8]                  = $user;
+				$GLOBALS['venue_membership_test']['user_meta'][8]['ec_unclaimed'] = 1;
+				$GLOBALS['venue_membership_test']['created_account_input']      = $input;
+				return 8;
+			}
+		};
+		$new = $service->invite( 1, 56, 'brand-new@example.com', true );
+		$this->assertTrue( $new['account_created'] );
+		$this->assertTrue( $new['delivery_queued'] );
+		$this->assertTrue( $GLOBALS['venue_membership_test']['created_account_input']['unclaimed'] );
+		$this->assertSame( 'venue_invitation', $GLOBALS['venue_membership_test']['created_account_input']['registration_source'] );
+		$this->assertStringContainsString( 'action=rp', $GLOBALS['venue_membership_test']['queued_emails'][1]['context']['cta_url'] );
 	}
 
 	public function test_config_abilities_round_trip_revision_and_audit(): void {

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -12,7 +12,7 @@ use ExtraChillEvents\Core\VenueAuthorization;
 use ExtraChillEvents\Core\VenueBookingConfig;
 use ExtraChillEvents\Core\VenueMembershipRepository;
 use ExtraChillEvents\Core\VenueMembershipService;
-use ExtraChillEvents\Core\VenueInvitationToken;
+use ExtraChillEvents\Core\VenueInvitationDeliveryWorker;
 use ExtraChillEvents\Core\VenueOnboardingRepository;
 use ExtraChillEvents\Core\VenueOnboardingService;
 use PHPUnit\Framework\TestCase;
@@ -149,6 +149,7 @@ if ( ! function_exists( 'wp_get_ability' ) ) {
 }
 if ( ! function_exists( 'get_password_reset_key' ) ) {
 	function get_password_reset_key( $user ) {
+		++$GLOBALS['venue_membership_test']['reset_key_calls'];
 		if ( ! empty( $GLOBALS['venue_membership_test']['fail_reset_key'] ) ) {
 			return new WP_Error( 'reset_key_failed' );
 		}
@@ -182,13 +183,28 @@ if ( ! function_exists( 'esc_url' ) ) {
 	function esc_url( $value ) {
 		return (string) $value; }
 }
-if ( ! function_exists( 'ec_send_email_queued' ) ) {
-	function ec_send_email_queued( array $args ) {
-		$GLOBALS['venue_membership_test']['queued_emails'][] = $args;
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook ) {
+		return $hook === ( $GLOBALS['venue_membership_test']['doing_action'] ?? '' );
+	}
+}
+if ( ! function_exists( 'as_enqueue_async_action' ) ) {
+	function as_enqueue_async_action( $hook, array $args = array(), $group = '', $unique = false ) {
+		$GLOBALS['venue_membership_test']['scheduled_actions'][] = compact( 'hook', 'args', 'group', 'unique' );
+		return empty( $GLOBALS['venue_membership_test']['fail_schedule'] ) ? count( $GLOBALS['venue_membership_test']['scheduled_actions'] ) : 0;
+	}
+}
+if ( ! function_exists( 'ec_send_email' ) ) {
+	function ec_send_email( array $args ) {
+		$GLOBALS['venue_membership_test']['sent_emails'][] = $args;
+		if ( ! doing_action( 'action_scheduler_run_queue' ) ) {
+			$GLOBALS['venue_membership_test']['permission_boundary_failures'][] = $args;
+			return array( 'success' => false );
+		}
 		if ( ! empty( $GLOBALS['venue_membership_test']['fail_delivery'] ) ) {
 			return array( 'success' => false );
 		}
-		return array( 'success' => true, 'action_id' => count( $GLOBALS['venue_membership_test']['queued_emails'] ) );
+		return array( 'success' => true );
 	}
 }
 if ( ! function_exists( 'extrachill_users_rollback_created_user' ) ) {
@@ -265,6 +281,7 @@ if ( ! function_exists( 'maybe_unserialize' ) ) {
 /** Minimal membership wpdb fake with transaction and optimistic update support. */
 final class VenueMembershipWpdb {
 	public $prefix                = 'wp_7_';
+	public $users                 = 'wp_users';
 	public $terms                 = 'wp_7_terms';
 	public $termmeta              = 'wp_7_termmeta';
 	public $insert_id             = 0;
@@ -371,6 +388,9 @@ final class VenueMembershipWpdb {
 
 	public function get_var( $query ) {
 		$this->last_error = '';
+		if ( preg_match( '/SELECT ID FROM .* WHERE ID = (\d+) FOR UPDATE/', $query, $user_match ) ) {
+			return isset( $GLOBALS['venue_membership_test']['users'][ (int) $user_match[1] ] ) ? (int) $user_match[1] : null;
+		}
 		if ( preg_match( '/SELECT COUNT\(\*\) FROM .*user_id = (\d+) AND NOT \(venue_term_id = (\d+) AND status = \'([^\']+)\'\)/', $query, $count_match ) ) {
 			$count = 0;
 			foreach ( $this->rows[ $this->prefix . 'ec_venue_members' ] ?? array() as $row ) {
@@ -402,6 +422,16 @@ final class VenueMembershipWpdb {
 		$this->last_error = '';
 		if ( false !== strpos( $query, 'ec_venue_invitations' ) ) {
 			$rows = array_values( $this->rows['wp_7_ec_venue_invitations'] ?? array() );
+			if ( preg_match( '/user_id = (\d+)/', $query, $user_match ) ) {
+				$rows = array_values(
+					array_filter(
+						$rows,
+						static function ( $row ) use ( $user_match ) {
+							return (int) $row['user_id'] === (int) $user_match[1];
+						}
+					)
+				);
+			}
 			if ( preg_match( '/venue_term_id = (\d+)/', $query, $match ) ) {
 				$rows = array_values(
 					array_filter(
@@ -414,12 +444,36 @@ final class VenueMembershipWpdb {
 			}
 			return $rows;
 		}
+		if ( false !== strpos( $query, 'ec_venue_claims' ) ) {
+			$rows = array_values( $this->rows['wp_7_ec_venue_claims'] ?? array() );
+			if ( preg_match( '/claimant_user_id = (\d+)/', $query, $claimant ) ) {
+				$rows = array_values(
+					array_filter(
+						$rows,
+						static function ( $row ) use ( $claimant ) {
+							return (int) $row['claimant_user_id'] === (int) $claimant[1];
+						}
+					)
+				);
+			}
+			return $rows;
+		}
 		if ( false !== strpos( $query, 'SELECT member.*' ) && is_callable( $this->before_list ) ) {
 			$callback          = $this->before_list;
 			$this->before_list = null;
 			$callback( $this );
 		}
 		$rows = array_values( $this->rows[ $this->prefix . 'ec_venue_members' ] ?? array() );
+		if ( preg_match( '/WHERE user_id = (\d+)/', $query, $user_match ) ) {
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $user_match ) {
+						return (int) $row['user_id'] === (int) $user_match[1];
+					}
+				)
+			);
+		}
 		if ( preg_match( '/AS actor .*actor.user_id = (\d+)/', $query, $actor ) ) {
 			$authorized = false;
 			preg_match( '/member\.venue_term_id = (\d+)/', $query, $requested_venue );
@@ -575,6 +629,9 @@ final class VenueMembershipWpdb {
 			if ( preg_match( "/WHERE public_id = '([^']+)'/", $query, $public ) && $row['public_id'] === stripslashes( $public[1] ) ) {
 				return $row;
 			}
+			if ( preg_match( "/WHERE delivery_id = '([^']+)'/", $query, $delivery ) && ( $row['delivery_id'] ?? '' ) === stripslashes( $delivery[1] ) ) {
+				return $row;
+			}
 			if ( preg_match( '/venue_term_id = (\d+) AND claimant_user_id = (\d+)/', $query, $claim ) && (int) $row['venue_term_id'] === (int) $claim[1] && (int) $row['claimant_user_id'] === (int) $claim[2] ) {
 				return $row;
 			}
@@ -599,6 +656,9 @@ final class VenueMembershipWpdb {
 				$this->rows[ $table ][ $id ][ $assignment[1] ] = (int) $assignment[2];
 			}
 		}
+		if ( false !== strpos( $set, 'delivery_attempts = delivery_attempts + 1' ) ) {
+			++$this->rows[ $table ][ $id ]['delivery_attempts'];
+		}
 	}
 }
 
@@ -609,6 +669,7 @@ require_once dirname( __DIR__ ) . '/inc/Core/VenueMembershipService.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueInvitationToken.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueOnboardingRepository.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueOnboardingService.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VenueInvitationDeliveryWorker.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueBookingConfig.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueMembershipAbilities.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueBookingConfigAbilities.php';
@@ -663,10 +724,15 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			'fail_config_audit' => false,
 			'user_meta'         => array(),
 			'ability_objects'   => array(),
-			'queued_emails'     => array(),
+			'scheduled_actions' => array(),
+			'sent_emails'       => array(),
+			'permission_boundary_failures' => array(),
+			'doing_action'      => '',
 			'rollback_attempts' => array(),
+			'reset_key_calls'   => 0,
 			'fail_reset_key'    => false,
 			'fail_delivery'     => false,
+			'fail_schedule'     => false,
 			'fail_provenance'   => false,
 			'fail_account_rollback' => false,
 		);
@@ -687,6 +753,11 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 
 	private function email_hash( string $email ): string {
 		return hash_hmac( 'sha256', strtolower( $email ), wp_salt( 'auth' ) );
+	}
+
+	private function create_prepared_invitation( VenueOnboardingRepository $repository, int $actor, int $venue, int $user, bool $is_owner, string $email, bool $account_created = false ): array {
+		$created = $repository->create_invitation( $actor, $venue, $user, $is_owner, $this->email_hash( $email ), $account_created );
+		return $repository->prepare_delivery( $created['_delivery_id'], 3600 );
 	}
 
 	private function install_account_creator(): void {
@@ -944,45 +1015,44 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 	public function test_claims_and_invitations_are_reciprocally_exclusive_under_the_venue_lock(): void {
 		$onboarding = new VenueOnboardingRepository();
 		$this->create_member( 55, 2, true );
-		$token  = ( new VenueInvitationToken() )->generate();
-		$invite = $onboarding->create_invitation( 2, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
+		$invite = $onboarding->create_invitation( 2, 55, 7, false, $this->email_hash( 'existing@example.com' ) );
 
 		$this->assertSame( VenueOnboardingRepository::INVITE_PENDING, $invite['status'] );
 		$this->assertSame( 'venue_claim_invitation_exists', $onboarding->submit_claim( 7, 55 )->get_error_code() );
 
 		$claim = $onboarding->submit_claim( 6, 55 );
 		$this->assertSame( VenueOnboardingRepository::CLAIM_PENDING, $claim['status'] );
-		$result = $onboarding->create_invitation( 2, 55, 6, false, $this->email_hash( 'member6@example.com' ), $token, 3600 );
+		$result = $onboarding->create_invitation( 2, 55, 6, false, $this->email_hash( 'member6@example.com' ) );
 		$this->assertSame( 'venue_invitation_claim_exists', $result->get_error_code() );
 	}
 
 	public function test_invitation_acceptance_is_single_use_and_exactly_bound(): void {
 		$onboarding = new VenueOnboardingRepository();
 		$this->create_member( 55, 2, true );
-		$token  = ( new VenueInvitationToken() )->generate();
-		$invite = $onboarding->create_invitation( 1, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
+		$invite = $this->create_prepared_invitation( $onboarding, 1, 55, 7, false, 'existing@example.com' );
+		$token  = $invite['_delivery_token'];
 
 		$this->assertArrayNotHasKey( 'token_hash', $invite );
 		$this->assertArrayNotHasKey( 'email_hash', $invite );
 		$this->assertArrayNotHasKey( '_email_hash', $onboarding->public_invitation( $invite ) );
-		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 56, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
-		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, true, 1, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
-		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 6, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 56, false, 2, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, true, 2, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 6, $invite['public_id'], $token, 55, false, 2, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
 
-		$accepted = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED );
+		$accepted = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 2, VenueOnboardingRepository::INVITE_ACCEPTED );
 		$this->assertSame( VenueOnboardingRepository::INVITE_ACCEPTED, $accepted['status'] );
 		$this->assertSame( VenueAuthorization::STATUS_ACTIVE, ( new VenueMembershipRepository() )->get( 55, 7 )['status'] );
-		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 2, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
 	}
 
 	public function test_invitation_acceptance_rechecks_current_account_email_binding(): void {
 		$onboarding = new VenueOnboardingRepository();
 		$this->create_member( 55, 2, true );
-		$token  = ( new VenueInvitationToken() )->generate();
-		$invite = $onboarding->create_invitation( 2, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
+		$invite = $this->create_prepared_invitation( $onboarding, 2, 55, 7, false, 'existing@example.com' );
+		$token  = $invite['_delivery_token'];
 
 		$GLOBALS['venue_membership_test']['users'][7]->user_email = 'changed@example.com';
-		$result = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED );
+		$result = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 2, VenueOnboardingRepository::INVITE_ACCEPTED );
 
 		$this->assertSame( 'invalid_venue_invitation', $result->get_error_code() );
 		$this->assertSame( VenueAuthorization::STATUS_INVITED, ( new VenueMembershipRepository() )->get( 55, 7 )['status'] );
@@ -990,10 +1060,10 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 
 	public function test_first_active_invitation_must_bootstrap_an_owner(): void {
 		$onboarding = new VenueOnboardingRepository();
-		$token      = ( new VenueInvitationToken() )->generate();
-		$invite     = $onboarding->create_invitation( 1, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
+		$invite     = $this->create_prepared_invitation( $onboarding, 1, 55, 7, false, 'existing@example.com' );
+		$token      = $invite['_delivery_token'];
 
-		$result = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED );
+		$result = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 2, VenueOnboardingRepository::INVITE_ACCEPTED );
 		$this->assertSame( 'venue_membership_owner_required', $result->get_error_code() );
 		$this->assertSame( VenueAuthorization::STATUS_INVITED, ( new VenueMembershipRepository() )->get( 55, 7 )['status'] );
 	}
@@ -1001,44 +1071,42 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 	public function test_resend_rotates_token_and_revoked_inviter_fails_closed(): void {
 		$this->create_member( 55, 2, true );
 		$onboarding = new VenueOnboardingRepository();
-		$tokens     = new VenueInvitationToken();
-		$old_token  = $tokens->generate();
-		$invite     = $onboarding->create_invitation( 2, 55, 7, true, $this->email_hash( 'existing@example.com' ), $old_token, 3600 );
-		$new_token  = $tokens->generate();
-		$rotated    = $onboarding->resend_invitation( 2, $invite['id'], 1, $new_token, 3600 );
+		$invite     = $this->create_prepared_invitation( $onboarding, 2, 55, 7, true, 'existing@example.com' );
+		$old_token  = $invite['_delivery_token'];
+		$rotated    = $onboarding->resend_invitation( 2, $invite['id'], 2 );
+		$prepared   = $onboarding->prepare_delivery( $rotated['_delivery_id'], 3600 );
+		$new_token  = $prepared['_delivery_token'];
 
-		$this->assertSame( 2, $rotated['version'] );
-		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $old_token, 55, true, 2, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+		$this->assertSame( 3, $rotated['version'] );
+		$this->assertSame( 'invalid_venue_invitation', $onboarding->respond_to_invitation( 7, $invite['public_id'], $old_token, 55, true, 4, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
 		foreach ( $GLOBALS['wpdb']->rows['wp_7_ec_venue_members'] as &$member ) {
 			if ( 2 === (int) $member['user_id'] ) {
 				$member['status'] = VenueAuthorization::STATUS_REVOKED;
 			}
 		}
 		unset( $member );
-		$this->assertSame( 'venue_invitation_inviter_revoked', $onboarding->respond_to_invitation( 7, $invite['public_id'], $new_token, 55, true, 2, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+		$this->assertSame( 'venue_invitation_inviter_revoked', $onboarding->respond_to_invitation( 7, $invite['public_id'], $new_token, 55, true, 4, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
 	}
 
 	public function test_rejection_cancellation_expiry_and_audit_are_private(): void {
 		$onboarding = new VenueOnboardingRepository();
-		$tokens     = new VenueInvitationToken();
-		$token      = $tokens->generate();
-		$invite     = $onboarding->create_invitation( 1, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
-		$rejected   = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 1, VenueOnboardingRepository::INVITE_REJECTED );
+		$invite     = $this->create_prepared_invitation( $onboarding, 1, 55, 7, false, 'existing@example.com' );
+		$token      = $invite['_delivery_token'];
+		$rejected   = $onboarding->respond_to_invitation( 7, $invite['public_id'], $token, 55, false, 2, VenueOnboardingRepository::INVITE_REJECTED );
 		$this->assertSame( VenueOnboardingRepository::INVITE_REJECTED, $rejected['status'] );
 		$this->assertSame( VenueAuthorization::STATUS_REVOKED, ( new VenueMembershipRepository() )->get( 55, 7 )['status'] );
 
 		$owner     = $this->create_member( 56, 2, true );
-		$token2    = $tokens->generate();
-		$invite2   = $onboarding->create_invitation( 2, 56, 6, false, $this->email_hash( 'member6@example.com' ), $token2, 3600 );
+		$invite2   = $onboarding->create_invitation( 2, 56, 6, false, $this->email_hash( 'member6@example.com' ) );
 		$cancelled = $onboarding->cancel_invitation( 2, $invite2['id'], 1 );
 		$this->assertSame( VenueOnboardingRepository::INVITE_CANCELLED, $cancelled['status'] );
 		$this->assertSame( $cancelled, $onboarding->cancel_invitation( 2, $invite2['id'], 1 ) );
 		$this->assertTrue( $owner['is_owner'] );
 
-		$token3  = $tokens->generate();
-		$invite3 = $onboarding->create_invitation( 2, 56, 5, false, $this->email_hash( 'member5@example.com' ), $token3, 3600 );
+		$invite3 = $this->create_prepared_invitation( $onboarding, 2, 56, 5, false, 'member5@example.com' );
+		$token3  = $invite3['_delivery_token'];
 		$GLOBALS['wpdb']->rows['wp_7_ec_venue_invitations'][ $invite3['id'] ]['expires_at'] = '2000-01-01 00:00:00';
-		$expired = $onboarding->respond_to_invitation( 5, $invite3['public_id'], $token3, 56, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED );
+		$expired = $onboarding->respond_to_invitation( 5, $invite3['public_id'], $token3, 56, false, 2, VenueOnboardingRepository::INVITE_ACCEPTED );
 		$this->assertSame( 'venue_invitation_expired', $expired->get_error_code() );
 		$this->assertSame( VenueAuthorization::STATUS_REVOKED, ( new VenueMembershipRepository() )->get( 56, 5 )['status'] );
 
@@ -1051,12 +1119,51 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		}
 	}
 
+	public static function terminal_invitation_status_provider(): array {
+		return array(
+			'cancelled' => array( VenueOnboardingRepository::INVITE_CANCELLED ),
+			'rejected'  => array( VenueOnboardingRepository::INVITE_REJECTED ),
+			'expired'   => array( VenueOnboardingRepository::INVITE_EXPIRED ),
+		);
+	}
+
+	/** @dataProvider terminal_invitation_status_provider */
+	public function test_terminal_invitation_can_be_reactivated_with_rotated_bindings_and_audit( string $terminal_status ): void {
+		$this->create_member( 55, 2, true );
+		$repository = new VenueOnboardingRepository();
+		$first      = $this->create_prepared_invitation( $repository, 2, 55, 7, false, 'existing@example.com' );
+		$old_token  = $first['_delivery_token'];
+
+		if ( VenueOnboardingRepository::INVITE_CANCELLED === $terminal_status ) {
+			$terminal = $repository->cancel_invitation( 2, $first['id'], 2 );
+		} elseif ( VenueOnboardingRepository::INVITE_REJECTED === $terminal_status ) {
+			$terminal = $repository->respond_to_invitation( 7, $first['public_id'], $old_token, 55, false, 2, VenueOnboardingRepository::INVITE_REJECTED );
+		} else {
+			$GLOBALS['wpdb']->rows['wp_7_ec_venue_invitations'][ $first['id'] ]['expires_at'] = '2000-01-01 00:00:00';
+			$expired = $repository->respond_to_invitation( 7, $first['public_id'], $old_token, 55, false, 2, VenueOnboardingRepository::INVITE_ACCEPTED );
+			$this->assertSame( 'venue_invitation_expired', $expired->get_error_code() );
+			$terminal = $GLOBALS['wpdb']->rows['wp_7_ec_venue_invitations'][ $first['id'] ];
+		}
+		$this->assertSame( $terminal_status, $terminal['status'] );
+
+		$reactivated = $repository->create_invitation( 2, 55, 7, true, $this->email_hash( 'existing@example.com' ) );
+		$prepared    = $repository->prepare_delivery( $reactivated['_delivery_id'], 3600 );
+		$this->assertSame( VenueOnboardingRepository::INVITE_PENDING, $prepared['status'] );
+		$this->assertSame( VenueAuthorization::STATUS_INVITED, ( new VenueMembershipRepository() )->get( 55, 7 )['status'] );
+		$this->assertTrue( $prepared['is_owner'] );
+		$this->assertNotSame( $first['public_id'], $prepared['public_id'] );
+		$this->assertNotSame( $first['_delivery_id'], $prepared['_delivery_id'] );
+		$this->assertNotSame( $old_token, $prepared['_delivery_token'] );
+		$this->assertSame( 'invalid_venue_invitation', $repository->respond_to_invitation( 7, $first['public_id'], $old_token, 55, false, 5, VenueOnboardingRepository::INVITE_ACCEPTED )->get_error_code() );
+		$events = array_column( $GLOBALS['wpdb']->rows['wp_7_ec_venue_onboarding_audit'], 'event' );
+		$this->assertContains( 'invitation_reinvited', $events );
+	}
+
 	public function test_cancelled_invitation_is_not_disclosed_to_another_venue_owner(): void {
 		$onboarding = new VenueOnboardingRepository();
 		$this->create_member( 55, 2, true );
 		$this->create_member( 56, 3, true );
-		$token     = ( new VenueInvitationToken() )->generate();
-		$invite    = $onboarding->create_invitation( 2, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
+		$invite    = $onboarding->create_invitation( 2, 55, 7, false, $this->email_hash( 'existing@example.com' ) );
 		$cancelled = $onboarding->cancel_invitation( 2, $invite['id'], 1 );
 
 		$this->assertSame( VenueOnboardingRepository::INVITE_CANCELLED, $cancelled['status'] );
@@ -1066,8 +1173,7 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 	public function test_invitation_listing_rechecks_owner_authority_under_the_venue_lock(): void {
 		$onboarding = new VenueOnboardingRepository();
 		$this->create_member( 55, 2, true );
-		$token = ( new VenueInvitationToken() )->generate();
-		$onboarding->create_invitation( 2, 55, 7, false, $this->email_hash( 'existing@example.com' ), $token, 3600 );
+		$onboarding->create_invitation( 2, 55, 7, false, $this->email_hash( 'existing@example.com' ) );
 
 		$GLOBALS['wpdb']->after_start = static function ( VenueMembershipWpdb $wpdb ): void {
 			foreach ( $wpdb->rows['wp_7_ec_venue_members'] as &$row ) {
@@ -1082,15 +1188,31 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->assertSame( 'venue_action_forbidden', $result->get_error_code() );
 	}
 
-	public function test_existing_and_new_user_invitations_use_account_and_queued_mail_primitives(): void {
+	public function test_queue_persists_only_opaque_delivery_id_and_worker_sends_synchronously(): void {
+		$this->create_member( 55, 2, true );
 		$service  = new VenueOnboardingService();
-		$existing = $service->invite( 1, 55, 'existing@example.com', true );
+		$existing = $service->invite( 2, 55, 'existing@example.com', false );
 
 		$this->assertFalse( $existing['account_created'] );
 		$this->assertTrue( $existing['delivery_queued'] );
-		$this->assertSame( 'chubes@extrachill.com', $GLOBALS['venue_membership_test']['queued_emails'][0]['cc'] );
-		$this->assertSame( 'Extra Chill Bot', $GLOBALS['venue_membership_test']['queued_emails'][0]['from_name'] );
-		$this->assertStringContainsString( 'acting on Chris Huber', $GLOBALS['venue_membership_test']['queued_emails'][0]['context']['body_html'] );
+		$this->assertSame( 0, $GLOBALS['venue_membership_test']['reset_key_calls'] );
+		$this->assertSame( array(), $GLOBALS['venue_membership_test']['sent_emails'] );
+		$scheduled = $GLOBALS['venue_membership_test']['scheduled_actions'][0];
+		$this->assertSame( VenueInvitationDeliveryWorker::HOOK, $scheduled['hook'] );
+		$this->assertSame( VenueInvitationDeliveryWorker::GROUP, $scheduled['group'] );
+		$this->assertTrue( $scheduled['unique'] );
+		$this->assertCount( 1, $scheduled['args'] );
+		$this->assertMatchesRegularExpression( '/^[0-9a-f-]{36}$/', $scheduled['args'][0] );
+		$this->assertStringNotContainsString( 'token', strtolower( serialize( $scheduled ) ) );
+		$this->assertStringNotContainsString( 'existing@example.com', serialize( $scheduled ) );
+
+		$GLOBALS['venue_membership_test']['doing_action'] = 'action_scheduler_run_queue';
+		$delivered = ( new VenueInvitationDeliveryWorker() )->deliver( $scheduled['args'][0] );
+		$this->assertFalse( is_wp_error( $delivered ) );
+		$this->assertSame( 'chubes@extrachill.com', $GLOBALS['venue_membership_test']['sent_emails'][0]['cc'] );
+		$this->assertSame( 'Extra Chill Bot', $GLOBALS['venue_membership_test']['sent_emails'][0]['from_name'] );
+		$this->assertStringContainsString( 'acting on Chris Huber', $GLOBALS['venue_membership_test']['sent_emails'][0]['context']['body_html'] );
+		$this->assertSame( array(), $GLOBALS['venue_membership_test']['permission_boundary_failures'] );
 
 		$this->install_account_creator();
 		$new = $service->invite( 1, 56, 'brand-new@example.com', true );
@@ -1098,7 +1220,11 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->assertTrue( $new['delivery_queued'] );
 		$this->assertTrue( $GLOBALS['venue_membership_test']['created_account_input']['unclaimed'] );
 		$this->assertSame( 'venue_invitation', $GLOBALS['venue_membership_test']['created_account_input']['registration_source'] );
-		$this->assertStringContainsString( 'action=rp', $GLOBALS['venue_membership_test']['queued_emails'][1]['context']['cta_url'] );
+		$this->assertSame( 0, $GLOBALS['venue_membership_test']['reset_key_calls'] );
+		$delivery_id = $GLOBALS['venue_membership_test']['scheduled_actions'][1]['args'][0];
+		( new VenueInvitationDeliveryWorker() )->deliver( $delivery_id );
+		$this->assertSame( 1, $GLOBALS['venue_membership_test']['reset_key_calls'] );
+		$this->assertStringContainsString( 'action=rp', $GLOBALS['venue_membership_test']['sent_emails'][1]['context']['cta_url'] );
 	}
 
 	public function test_account_creation_requires_fresh_membership_authority_but_not_booking_access(): void {
@@ -1120,18 +1246,37 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->assertSame( 1, $GLOBALS['venue_membership_test']['account_create_calls'] );
 	}
 
-	public function test_reset_key_failure_rolls_back_new_account_without_sending_or_persisting(): void {
+	public function test_failed_existing_unclaimed_invitation_preserves_prior_reset_handoff(): void {
+		$this->create_member( 55, 2, true );
+		$GLOBALS['venue_membership_test']['user_meta'][7] = array( 'ec_unclaimed' => '1' );
+		$GLOBALS['wpdb']->fail_invitation_insert          = true;
+
+		$result = ( new VenueOnboardingService() )->invite( 2, 55, 'existing@example.com', false );
+
+		$this->assertSame( 'venue_invitation_create_failed', $result->get_error_code() );
+		$this->assertSame( 0, $GLOBALS['venue_membership_test']['reset_key_calls'] );
+		$this->assertSame( array(), $GLOBALS['venue_membership_test']['scheduled_actions'] );
+		$this->assertArrayHasKey( 7, $GLOBALS['venue_membership_test']['users'] );
+	}
+
+	public function test_reset_key_is_deferred_until_persisted_worker_delivery(): void {
 		$this->create_member( 55, 2, true );
 		$this->install_account_creator();
 		$GLOBALS['venue_membership_test']['fail_reset_key'] = true;
 
 		$result = ( new VenueOnboardingService() )->invite( 2, 55, 'reset-failure@example.com', false );
 
-		$this->assertSame( 'venue_invitation_reset_key_failed', $result->get_error_code() );
-		$this->assertSame( array( 8 ), $GLOBALS['venue_membership_test']['rollback_attempts'] );
-		$this->assertArrayNotHasKey( 8, $GLOBALS['venue_membership_test']['users'] );
-		$this->assertSame( array(), $GLOBALS['venue_membership_test']['queued_emails'] );
-		$this->assertSame( array(), $GLOBALS['wpdb']->rows['wp_7_ec_venue_invitations'] ?? array() );
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertSame( 0, $GLOBALS['venue_membership_test']['reset_key_calls'] );
+		$GLOBALS['venue_membership_test']['doing_action'] = 'action_scheduler_run_queue';
+		$delivered = ( new VenueInvitationDeliveryWorker() )->deliver( $GLOBALS['venue_membership_test']['scheduled_actions'][0]['args'][0] );
+		$this->assertSame( 'venue_invitation_reset_key_failed', $delivered->get_error_code() );
+		$this->assertSame( 1, $GLOBALS['venue_membership_test']['reset_key_calls'] );
+		$this->assertArrayHasKey( 8, $GLOBALS['venue_membership_test']['users'] );
+		$this->assertSame( array(), $GLOBALS['venue_membership_test']['sent_emails'] );
+		$invitation = array_values( $GLOBALS['wpdb']->rows['wp_7_ec_venue_invitations'] )[0];
+		$this->assertSame( VenueOnboardingRepository::DELIVERY_FAILED, $invitation['delivery_status'] );
+		$this->assertSame( str_repeat( '0', 64 ), $invitation['token_hash'] );
 	}
 
 	public function test_authority_race_and_invitation_write_failure_compensate_new_accounts(): void {
@@ -1164,10 +1309,39 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->assertSame( array( 8, 8 ), $GLOBALS['venue_membership_test']['rollback_attempts'] );
 	}
 
-	public function test_delivery_failure_cancels_state_and_compensates_provenanced_account(): void {
+	public function test_compensation_locks_and_preserves_concurrently_adopted_account(): void {
 		$this->create_member( 55, 2, true );
 		$this->install_account_creator();
-		$GLOBALS['venue_membership_test']['fail_delivery'] = true;
+		$GLOBALS['venue_membership_test']['fail_schedule'] = true;
+		$GLOBALS['wpdb']->after_start = static function ( VenueMembershipWpdb $wpdb ): void {
+			$wpdb->insert(
+				'wp_7_ec_venue_members',
+				array(
+					'venue_term_id'      => 56,
+					'user_id'            => 8,
+					'is_owner'           => 0,
+					'status'             => VenueAuthorization::STATUS_ACTIVE,
+					'version'            => 1,
+					'created_by_user_id' => 3,
+					'created_at'         => '2026-01-01 00:00:00',
+					'updated_at'         => '2026-01-01 00:00:00',
+					'revoked_at'         => null,
+				)
+			);
+		};
+
+		$result = ( new VenueOnboardingService() )->invite( 2, 55, 'adopted-race@example.com', false );
+
+		$this->assertSame( 'venue_invitation_delivery_failed', $result->get_error_code() );
+		$this->assertArrayHasKey( 8, $GLOBALS['venue_membership_test']['users'] );
+		$this->assertSame( array(), $GLOBALS['venue_membership_test']['rollback_attempts'] );
+		$this->assertSame( VenueAuthorization::STATUS_ACTIVE, ( new VenueMembershipRepository() )->get( 56, 8 )['status'] );
+	}
+
+	public function test_schedule_failure_cancels_state_and_compensates_provenanced_account(): void {
+		$this->create_member( 55, 2, true );
+		$this->install_account_creator();
+		$GLOBALS['venue_membership_test']['fail_schedule'] = true;
 
 		$result = ( new VenueOnboardingService() )->invite( 2, 55, 'delivery-failure@example.com', false );
 
@@ -1229,17 +1403,16 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 		$this->create_member( 56, 3, true );
 		$repository = new VenueOnboardingRepository();
 		$service    = new VenueOnboardingService( $repository );
-		$tokens     = new VenueInvitationToken();
 
 		$GLOBALS['venue_membership_test']['users'][8] = new WP_User( 8, 'reject-created@example.com' );
 		$GLOBALS['venue_membership_test']['user_meta'][8] = array(
 			'ec_unclaimed'       => '1',
 			'registration_source' => 'venue_invitation',
 		);
-		$reject_token = $tokens->generate();
-		$rejected     = $repository->create_invitation( 2, 55, 8, false, $this->email_hash( 'reject-created@example.com' ), $reject_token, 3600, true );
+		$rejected     = $this->create_prepared_invitation( $repository, 2, 55, 8, false, 'reject-created@example.com', true );
+		$reject_token = $rejected['_delivery_token'];
 		update_user_meta( 8, 'ec_venue_invitation_account', $rejected['public_id'] );
-		$result = $service->respond( 8, $rejected['public_id'], $reject_token, 55, false, 1, VenueOnboardingRepository::INVITE_REJECTED );
+		$result = $service->respond( 8, $rejected['public_id'], $reject_token, 55, false, 2, VenueOnboardingRepository::INVITE_REJECTED );
 		$this->assertSame( VenueOnboardingRepository::INVITE_REJECTED, $result['status'] );
 		$this->assertArrayNotHasKey( 8, $GLOBALS['venue_membership_test']['users'] );
 
@@ -1248,11 +1421,11 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			'ec_unclaimed'       => '1',
 			'registration_source' => 'venue_invitation',
 		);
-		$expire_token = $tokens->generate();
-		$expired      = $repository->create_invitation( 3, 56, 9, false, $this->email_hash( 'expire-created@example.com' ), $expire_token, 3600, true );
+		$expired      = $this->create_prepared_invitation( $repository, 3, 56, 9, false, 'expire-created@example.com', true );
+		$expire_token = $expired['_delivery_token'];
 		update_user_meta( 9, 'ec_venue_invitation_account', $expired['public_id'] );
 		$GLOBALS['wpdb']->rows['wp_7_ec_venue_invitations'][ $expired['id'] ]['expires_at'] = '2000-01-01 00:00:00';
-		$result = $service->respond( 9, $expired['public_id'], $expire_token, 56, false, 1, VenueOnboardingRepository::INVITE_ACCEPTED );
+		$result = $service->respond( 9, $expired['public_id'], $expire_token, 56, false, 2, VenueOnboardingRepository::INVITE_ACCEPTED );
 		$this->assertSame( 'venue_invitation_expired', $result->get_error_code() );
 		$this->assertArrayNotHasKey( 9, $GLOBALS['venue_membership_test']['users'] );
 	}

--- a/tests/VenueOnboardingTest.php
+++ b/tests/VenueOnboardingTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Venue claim and invitation security tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Core\VenueInvitationToken;
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'wp_salt' ) ) {
+	function wp_salt( $scheme = 'auth' ) {
+		return 'test-' . $scheme . '-salt';
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/VenueInvitationToken.php';
+
+final class VenueOnboardingTest extends TestCase {
+
+	private function invitation( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'public_id'     => '18b61ee7-9965-43b3-b6af-df4b6b10f24f',
+				'venue_term_id' => 55,
+				'user_id'       => 7,
+				'is_owner'      => false,
+			),
+			$overrides
+		);
+	}
+
+	public function test_tokens_are_strong_hashed_and_exactly_bound(): void {
+		$tokens     = new VenueInvitationToken();
+		$token      = $tokens->generate();
+		$invitation = $this->invitation();
+		$hash       = $tokens->hash( $token, $invitation );
+
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', $token );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', $hash );
+		$this->assertNotSame( $token, $hash );
+		$this->assertTrue( $tokens->verify( $token, $invitation, $hash ) );
+		$this->assertFalse( $tokens->verify( $token, $this->invitation( array( 'venue_term_id' => 56 ) ), $hash ) );
+		$this->assertFalse( $tokens->verify( $token, $this->invitation( array( 'user_id' => 8 ) ), $hash ) );
+		$this->assertFalse( $tokens->verify( $token, $this->invitation( array( 'is_owner' => true ) ), $hash ) );
+	}
+
+	public function test_rotation_invalidates_the_previous_token(): void {
+		$tokens     = new VenueInvitationToken();
+		$invitation = $this->invitation();
+		$old_token  = $tokens->generate();
+		$new_token  = $tokens->generate();
+		$new_hash   = $tokens->hash( $new_token, $invitation );
+
+		$this->assertNotSame( $old_token, $new_token );
+		$this->assertFalse( $tokens->verify( $old_token, $invitation, $new_hash ) );
+		$this->assertTrue( $tokens->verify( $new_token, $invitation, $new_hash ) );
+	}
+
+	public function test_token_hash_does_not_expose_binding_values(): void {
+		$tokens     = new VenueInvitationToken();
+		$token      = $tokens->generate();
+		$invitation = $this->invitation();
+		$hash       = $tokens->hash( $token, $invitation );
+
+		$this->assertSame( 64, strlen( $hash ) );
+		$this->assertNotSame( hash( 'sha256', $token ), $hash );
+		$this->assertTrue( $tokens->verify( $token, $invitation, $hash ) );
+	}
+}


### PR DESCRIPTION
## Summary
- add operator-reviewed venue claims with serialized, explicit first-owner bootstrap
- add existing-user and unclaimed-account invitations with acceptance, rejection, cancellation, expiry, resend rotation, and safe account compensation
- expose bounded onboarding abilities while retaining #291 membership authority
- separate venue identity/membership management from booking access without introducing a role matrix
- persist privacy-safe transition audit records and queue invitation delivery through Data Machine

Closes #314

## Existing Primitives Checked
- #291/#329 and #330: reused `VenueAuthorization`, `VenueMembershipRepository`, exact venue scoping, structural `is_owner`, optimistic versions, and final-owner behavior
- Extra Chill Users: reused `extrachill/create-user`, `ec_unclaimed`, registration provenance, `get_password_reset_key()`, and `extrachill_users_rollback_created_user()` for correct network deletion
- WordPress: reused secure randomness, HMAC/hash-equals verification, authenticated user identity, password-reset keys, and safe login/redirect APIs
- Data Machine / Extra Chill Network: reused `ec_send_email_queued()` and `PermissionHelper::run_as_authenticated()` rather than adding mail infrastructure

## Authorization Policy
- venue membership/profile/onboarding management requires exact active owner membership; administrators retain the existing membership-only override
- booking operations remain unchanged behind both `access_events_admin` and the `venue_booking` rollout gate, plus exact active venue membership
- membership does not grant booking access, and no speculative venue role matrix was added
- account resolution/creation runs only after fresh execution-time owner authorization; invitation persistence reauthorizes against lock-current membership rows

## Account Lifecycle
- reset-key failure fails closed before persistence or delivery; no acceptance-only handoff is sent for an unclaimed account
- lock-current authority loss and invitation persistence failure compensate a newly created account through the Users-owned network rollback primitive
- post-persistence provenance or delivery setup failure atomically cancels the invitation, revokes its invited membership, zeroes its token, then compensates the account when safe
- invitation rows persist whether the account was created for that invitation; newly created accounts store the exact opaque invitation ID as user provenance
- cancellation, rejection, and expiry attempt cleanup only when the invitation created the account, the account remains unclaimed, source and email still match, exact provenance still matches, and no other live venue relationship exists
- pre-existing, claimed, repurposed, shared, or otherwise non-matching accounts are preserved
- rollback or state-compensation uncertainty returns a bounded manual-reconciliation error rather than silently claiming success

## Security Model
- acceptance verifies the authenticated account's current canonical email against the invitation's stored HMAC binding
- tokens are stored only as HMAC hashes bound to invitation ID, venue, user, and `is_owner`; terminal transitions zero the hash
- claim and invitation creation are reciprocally excluded under the same stable venue lock
- invitation listing authorizes and reads inside one transaction, closing revocation TOCTOU
- cancelled invitation idempotency occurs only after exact-venue lock-current authorization, preventing cross-venue disclosure
- delivery requests always CC `chubes@extrachill.com` and identify Extra Chill Bot acting on Chris Huber's behalf

## Verification
- `./vendor/bin/phpunit -c phpunit-onboarding.xml.dist` (34 tests, 217 assertions)
- `./vendor/bin/phpunit -c phpunit-membership.xml.dist` (31 tests, 204 assertions)
- `./vendor/bin/phpunit -c phpunit-booking.xml.dist` (147 tests, 1,011 assertions)
- Homeboy changed-file lint: PHPCS and PHPStan passed with 0 findings (run `5bc45995-d5ef-4e88-bd64-624c560fa231`)
- PHP syntax checks on all modified files (clean)
- `git diff --check` (clean)

## Operational Notes
- no email was sent during implementation or verification; delivery was exercised only through the test double
- schema version 7 must run through the existing idempotent installer when this PR is eventually released and deployed
- no version or changelog files were edited