### PR TITLE
fix: serialize event publication with bookings

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -253,7 +253,9 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingEventConversionService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingLifecycle.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingConfig.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/CanonicalEventPublicationGuard.php';
 		\ExtraChillEvents\Core\BookingHoldRepository::register();
+		new \ExtraChillEvents\Core\CanonicalEventPublicationGuard();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/ArtistUrlImport.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/ArtistUrlImportRoutes.php';
 

--- a/inc/Abilities/VenueBookingEventAbilities.php
+++ b/inc/Abilities/VenueBookingEventAbilities.php
@@ -32,6 +32,7 @@ class VenueBookingEventAbilities {
 		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
 		$this->conversion    = $conversion ? $conversion : new BookingEventConversionService( $this->bookings, null, null, $this->authorization );
 		add_filter( 'datamachine_events_upsert_event_permission', array( $this, 'can_upsert_booking_event' ), 10, 2 );
+		add_filter( 'extrachill_events_canonical_event_excluded_booking_id', array( $this, 'excluded_booking_id_for_active_conversion' ), 10, 3 );
 		if ( ! self::$registered ) {
 			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
 			self::$registered = true;
@@ -87,6 +88,34 @@ class VenueBookingEventAbilities {
 			(int) $this->active_conversion['venue_term_id'],
 			VenueAuthorization::ACTION_ACCESS_VENUE
 		);
+	}
+
+	/** Exempt only the exact booking in the active authorized conversion wrapper. */
+	public function excluded_booking_id_for_active_conversion( int $booking_id, array $input, array $publication ): int {
+		unset( $booking_id );
+		if ( ! is_array( $this->active_conversion ) ) {
+			return 0;
+		}
+		$candidate_match = false;
+		$candidate_intervals = (array) ( $publication['_candidate_intervals'] ?? array() );
+		if ( empty( $candidate_intervals ) && isset( $publication['start_at'], $publication['end_at'] ) ) {
+			$candidate_intervals[] = array( 'start_at' => $publication['start_at'], 'end_at' => $publication['end_at'] );
+		}
+		foreach ( $candidate_intervals as $interval ) {
+			if ( $this->active_conversion['performance_start_at'] === ( $interval['start_at'] ?? '' )
+				&& $this->active_conversion['performance_end_at'] === ( $interval['end_at'] ?? '' ) ) {
+				$candidate_match = true;
+				break;
+			}
+		}
+		if ( BookingEventConversionService::SOURCE !== ( $input['source'] ?? '' )
+			|| $this->active_conversion['public_id'] !== ( $input['source_id'] ?? '' )
+			|| (int) $this->active_conversion['venue_term_id'] !== (int) ( $publication['venue_id'] ?? 0 )
+			|| ! $candidate_match ) {
+			return 0;
+		}
+
+		return (int) $this->active_conversion['id'];
 	}
 
 	/** Missing records deliberately use the same denial as inaccessible records. */

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -217,8 +217,9 @@ class BookingHoldRepository {
 			return new \WP_Error( 'invalid_booking_performance', __( 'A configured space and strict UTC performance range are required.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
 		$venue_id = (int) $booking['venue_term_id'];
-		return $this->with_lock(
-			$this->lock_name( $booking['venue_term_id'], $space_key ),
+		return $this->with_booking_locks(
+			(int) $booking['venue_term_id'],
+			$space_key,
 			function () use ( $booking_id, $expected_version, $space_key, $start_at, $end_at, $actor_id, $venue_id ) {
 				$started = $this->begin_authorized( $venue_id, $actor_id );
 				if ( is_wp_error( $started ) ) {
@@ -321,10 +322,10 @@ class BookingHoldRepository {
 		if ( is_wp_error( $selection ) ) {
 			return $selection;
 		}
-		$lock     = $this->lock_name( $booking['venue_term_id'], $booking['space_key'] );
 		$venue_id = (int) $booking['venue_term_id'];
-		$result   = $this->with_lock(
-			$lock,
+		$result   = $this->with_booking_locks(
+			$venue_id,
+			(string) $booking['space_key'],
 			function () use ( $booking_id, $expected_booking_version, $actor_id, $venue_id ) {
 				$started = $this->begin_authorized( $venue_id, $actor_id );
 				if ( is_wp_error( $started ) ) {
@@ -475,8 +476,9 @@ class BookingHoldRepository {
 			return is_wp_error( $reconciled ) ? $reconciled : $this->hold_not_active_error();
 		}
 		$venue_id = (int) $hold['venue_term_id'];
-		$result   = $this->with_lock(
-			$this->lock_name( $hold['venue_term_id'], $hold['space_key'] ),
+		$result   = $this->with_booking_locks(
+			$venue_id,
+			(string) $hold['space_key'],
 			function () use ( $hold_id, $expected_version, $actor_id, $reason, $venue_id ) {
 				$started = $this->begin_authorized( $venue_id, $actor_id );
 				if ( is_wp_error( $started ) ) {
@@ -677,8 +679,9 @@ class BookingHoldRepository {
 		if ( is_wp_error( $elapsed ) || ! $elapsed ) {
 			return is_wp_error( $elapsed ) ? $elapsed : $this->hydrate( $hold );
 		}
-		return $this->with_lock(
-			$this->lock_name( $hold['venue_term_id'], $hold['space_key'] ),
+		return $this->with_booking_locks(
+			(int) $hold['venue_term_id'],
+			(string) $hold['space_key'],
 			function () use ( $hold_id ) {
 				$hold = $this->raw_get( $hold_id );
 				if ( ! is_array( $hold ) || 'active' !== $hold['status'] ) {
@@ -785,9 +788,10 @@ class BookingHoldRepository {
 		if ( in_array( $to_status, array( 'held', 'confirmed' ), true ) && ! is_array( $hold ) ) {
 			return new \WP_Error( 'booking_matching_hold_required', __( 'This transition requires an exact active unexpired hold.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
-		$lock = is_array( $hold ) ? $this->lock_name( $hold['venue_term_id'], $hold['space_key'] ) : $this->lock_name( $booking['venue_term_id'], (string) $booking['space_key'] );
-		return $this->with_lock(
-			$lock,
+		$space_key = is_array( $hold ) ? (string) $hold['space_key'] : (string) $booking['space_key'];
+		return $this->with_booking_locks(
+			(int) $booking['venue_term_id'],
+			$space_key,
 			function () use ( $booking, $to_status, $expected_version, $actor_id, $note ) {
 				$started = $this->begin_authorized( $booking['venue_term_id'], $actor_id );
 				if ( is_wp_error( $started ) ) {
@@ -1078,7 +1082,23 @@ class BookingHoldRepository {
 		return $result;
 	}
 
-	private function lock_name( int $venue_id, string $space_key ): string {
+	/** Acquire the stable venue domain before its narrower venue-space lock. */
+	private function with_booking_locks( int $venue_id, string $space_key, callable $callback ) {
+		return $this->with_lock(
+			self::venue_lock_name( $venue_id ),
+			function () use ( $venue_id, $space_key, $callback ) {
+				return $this->with_lock( self::venue_space_lock_name( $venue_id, $space_key ), $callback );
+			}
+		);
+	}
+
+	/** Return the shared advisory-lock name for all booking writes at one venue. */
+	public static function venue_lock_name( int $venue_id ): string {
+		return 'ecbv:' . sha1( BookingSchema::holds_table() . ':' . $venue_id );
+	}
+
+	/** Return the shared advisory-lock name for one venue space. */
+	public static function venue_space_lock_name( int $venue_id, string $space_key ): string {
 		return 'ecbh:' . sha1( BookingSchema::holds_table() . ':' . $venue_id . ':' . $space_key );
 	}
 

--- a/inc/Core/CanonicalEventPublicationGuard.php
+++ b/inc/Core/CanonicalEventPublicationGuard.php
@@ -1,0 +1,591 @@
+<?php
+/**
+ * Serializes canonical event publication with venue booking writers.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Prevents venue-wide canonical events from racing booking holds or confirmations. */
+class CanonicalEventPublicationGuard {
+
+	private const DEFAULT_DURATION_SECONDS = 3 * HOUR_IN_SECONDS;
+
+	/** @var array<int,string> */
+	private $acquired_locks = array();
+	/** @var string|null */
+	private $active_context;
+	/** @var int */
+	private $active_post_id = 0;
+	/** @var array|null */
+	private $active_publication;
+	/** @var string */
+	private $active_lifecycle_key = '';
+	/** @var bool */
+	private $active_poisoned = false;
+	/** @var bool */
+	private $active_boundary_consumed = false;
+	/** @var object|null Exact REST request which acquired the active lock. */
+	private $active_rest_request;
+
+	public function __construct() {
+		add_filter( 'datamachine_events_before_event_upsert_persistence', array( $this, 'preflight_dme_persistence' ), 10, 2 );
+		add_action( 'datamachine_events_after_event_upsert_persistence', array( $this, 'complete_dme_persistence' ), 10, 3 );
+		add_action( 'datamachine_upsert_post_identity_before_population', array( $this, 'bind_dme_post_id' ), PHP_INT_MAX );
+		add_filter( 'rest_pre_insert_data_machine_events', array( $this, 'preflight_rest_insert' ), PHP_INT_MAX, 2 );
+		add_action( 'rest_after_insert_data_machine_events', array( $this, 'complete_rest_insert' ), 10, 3 );
+		add_filter( 'rest_request_after_callbacks', array( $this, 'complete_rest_request' ), 10, 3 );
+		add_filter( 'wp_insert_post_empty_content', array( $this, 'preflight_direct_post_insert' ), PHP_INT_MAX, 2 );
+		add_action( 'wp_after_insert_post', array( $this, 'complete_post_insert' ), 10, 4 );
+		add_filter( 'datamachine_events_before_event_update_persistence', array( $this, 'preflight_event_update_persistence' ), 10, 2 );
+		add_action( 'datamachine_events_after_event_update_persistence', array( $this, 'complete_event_update_persistence' ), 10, 2 );
+		add_action( 'shutdown', array( $this, 'release' ) );
+	}
+
+	/** Preflight the generic DME persistence lifecycle after exact venue resolution. */
+	public function preflight_dme_persistence( $preflight, array $context ) {
+		if ( is_wp_error( $preflight ) || false === $preflight || 'publish' !== ( $context['post_status'] ?? '' ) ) {
+			return $preflight;
+		}
+		if ( null !== $this->active_context ) {
+			$error = new \WP_Error( 'canonical_event_publication_reentrant', __( 'Another canonical event publication is already active in this request.', 'extrachill-events' ), array( 'status' => 409 ) );
+			$this->audit_denial( 'dme', $error );
+			return $error;
+		}
+
+		$venue_id    = absint( $context['venue_term_id'] ?? 0 );
+		$event       = is_array( $context['event'] ?? null ) ? $context['event'] : array();
+		$publication = $venue_id > 0 ? $this->publication_window( $venue_id, $event ) : null;
+		if ( null === $publication ) {
+			return $preflight;
+		}
+		if ( is_wp_error( $publication ) ) {
+			$this->audit_denial( 'dme', $publication );
+			return $publication;
+		}
+
+		$result = $this->acquire_for_publication(
+			$publication['venue_id'],
+			$publication['start_at'],
+			$publication['end_at'],
+			(int) ( $context['existing_post_id'] ?? 0 ),
+			(int) apply_filters( 'extrachill_events_canonical_event_excluded_booking_id', 0, $context, $publication ),
+			$publication['_candidate_intervals']
+		);
+		if ( is_wp_error( $result ) ) {
+			$this->audit_denial( 'dme', $result );
+			return $result;
+		}
+
+		$this->active_context       = 'dme';
+		$this->active_post_id       = (int) ( $context['existing_post_id'] ?? 0 );
+		$this->active_publication   = $publication;
+		$this->active_lifecycle_key = $this->lifecycle_key( $context );
+		$this->active_poisoned      = false;
+		$this->active_boundary_consumed = false;
+		return $preflight;
+	}
+
+	/** Release only the DME lifecycle which acquired the active lock. */
+	public function complete_dme_persistence( array $context, int $post_id, $result = null ): void {
+		unset( $result );
+		if ( 'dme' === $this->active_context && $this->lifecycle_key( $context ) === $this->active_lifecycle_key && ( 0 === $this->active_post_id || 0 === $post_id || $post_id === $this->active_post_id ) ) {
+			$this->release();
+		}
+	}
+
+	/** Bind the DME permission preflight to Data Machine's reserved identity post. */
+	public function bind_dme_post_id( int $post_id ): void {
+		if ( 'dme' !== $this->active_context ) {
+			return;
+		}
+		if ( $post_id < 1 || ( $this->active_post_id > 0 && $post_id !== $this->active_post_id ) ) {
+			$error = new \WP_Error( 'canonical_event_publication_identity_mismatch', __( 'Canonical event publication could not bind its reserved post identity.', 'extrachill-events' ), array( 'status' => 409, 'post_id' => $post_id ) );
+			$this->active_poisoned = true;
+			$this->audit_denial( 'dme', $error );
+			return;
+		}
+		$this->active_post_id = $post_id;
+	}
+
+	/** Reject a conflicting REST/editor publication before WordPress persists it. */
+	public function preflight_rest_insert( $prepared_post, $request ) {
+		$post_id          = absint( $prepared_post->ID ?? 0 );
+		$existing         = $post_id > 0 ? get_post( $post_id ) : null;
+		$effective_status = (string) ( $prepared_post->post_status ?? ( $existing->post_status ?? '' ) );
+		if ( 'publish' !== $effective_status ) {
+			return $prepared_post;
+		}
+		if ( null !== $this->active_context ) {
+			return new \WP_Error( 'canonical_event_publication_reentrant', __( 'Another canonical event publication is already active in this request.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+
+		$publication_post = $prepared_post;
+		if ( $existing && ! isset( $publication_post->post_content ) ) {
+			$publication_post               = clone $prepared_post;
+			$publication_post->post_content = $existing->post_content;
+		}
+		$publication = $this->publication_from_post( $publication_post, $request, $post_id );
+		if ( is_wp_error( $publication ) ) {
+			$this->audit_denial( 'rest', $publication );
+			return $publication;
+		}
+		if ( null === $publication ) {
+			return $prepared_post;
+		}
+
+		$result = $this->acquire_for_publication( $publication['venue_id'], $publication['start_at'], $publication['end_at'], $post_id, 0, $publication['_candidate_intervals'] );
+		if ( is_wp_error( $result ) ) {
+			$this->audit_denial( 'rest', $result );
+			return $result;
+		}
+
+		$this->active_context     = 'rest';
+		$this->active_post_id     = $post_id;
+		$this->active_publication = $publication;
+		$this->active_boundary_consumed = false;
+		$this->active_rest_request = is_object( $request ) ? $request : null;
+		return $prepared_post;
+	}
+
+	/** Keep the REST locks through all controller persistence. */
+	public function complete_rest_insert( $post, $request = null, $creating = null ): void {
+		unset( $creating );
+		if ( 'rest' === $this->active_context && $this->owns_rest_request( $request ) && ( 0 === $this->active_post_id || (int) ( $post->ID ?? 0 ) === $this->active_post_id ) ) {
+			$this->release();
+		}
+	}
+
+	/** Release a REST lock when the controller returns before rest_after_insert. */
+	public function complete_rest_request( $response, $handler = null, $request = null ) {
+		unset( $handler );
+		if ( 'rest' === $this->active_context && $this->owns_rest_request( $request ) ) {
+			$this->release();
+		}
+		return $response;
+	}
+
+	/** Abort an entire direct insert/update before post or taxonomy persistence. */
+	public function preflight_direct_post_insert( bool $maybe_empty, array $postarr ): bool {
+		$post_type = defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events';
+		if ( $maybe_empty ) {
+			return true;
+		}
+		if ( $post_type !== ( $postarr['post_type'] ?? '' ) || 'publish' !== ( $postarr['post_status'] ?? '' ) ) {
+			return $maybe_empty;
+		}
+
+		$post_id = absint( $postarr['ID'] ?? 0 );
+		if ( 'dme' === $this->active_context ) {
+			$matches_reserved = $post_id > 0 && $post_id === $this->active_post_id;
+			$matches_sourceless_new = 0 === $post_id && 0 === $this->active_post_id;
+			if ( ! $this->active_poisoned && ! $this->active_boundary_consumed && ( $matches_reserved || $matches_sourceless_new ) ) {
+				$this->active_boundary_consumed = true;
+				return false;
+			}
+			$error = new \WP_Error( 'canonical_event_publication_post_mismatch', __( 'This event write does not match the active canonical publication.', 'extrachill-events' ), array( 'status' => 409, 'post_id' => $post_id ) );
+			$this->active_poisoned = true;
+			$this->audit_denial( 'wp_insert_post_empty_content', $error );
+			return true;
+		}
+		if ( 'event_update' === $this->active_context ) {
+			if ( ! $this->active_poisoned && ! $this->active_boundary_consumed && $post_id > 0 && $post_id === $this->active_post_id ) {
+				$this->active_boundary_consumed = true;
+				return false;
+			}
+			$error = new \WP_Error( 'canonical_event_publication_post_mismatch', __( 'This event write does not match the active canonical publication.', 'extrachill-events' ), array( 'status' => 409, 'post_id' => $post_id ) );
+			$this->active_poisoned = true;
+			$this->audit_denial( 'wp_insert_post_empty_content', $error );
+			return true;
+		}
+		if ( null !== $this->active_context ) {
+			if ( 'rest' === $this->active_context && ! $this->active_boundary_consumed && ( 0 === $this->active_post_id || $post_id === $this->active_post_id ) ) {
+				$this->active_boundary_consumed = true;
+				return false;
+			}
+			return true;
+		}
+
+		$publication = $this->publication_from_post( (object) $postarr, $postarr, $post_id );
+		$result      = null === $publication || is_wp_error( $publication )
+			? $publication
+			: $this->acquire_for_publication( $publication['venue_id'], $publication['start_at'], $publication['end_at'], $post_id, 0, $publication['_candidate_intervals'] );
+
+		if ( is_wp_error( $result ) ) {
+			$this->audit_denial( 'wp_insert_post_empty_content', $result );
+			return true;
+		}
+		if ( true === $result ) {
+			$this->active_context     = 'post';
+			$this->active_post_id     = $post_id;
+			$this->active_publication = $publication;
+			$this->active_boundary_consumed = true;
+		}
+		return false;
+	}
+
+	/** Release direct-write locks after save_post/date synchronization. */
+	public function complete_post_insert( int $post_id, $post = null, bool $update = false, $post_before = null ): void {
+		unset( $update, $post_before );
+		$post      = is_object( $post ) ? $post : get_post( $post_id );
+		$post_type = defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events';
+		if ( 'post' === $this->active_context && $post && $post_type === ( $post->post_type ?? '' ) && ( 0 === $this->active_post_id || $post_id === $this->active_post_id ) ) {
+			$this->active_post_id = $post_id;
+			$this->release();
+		}
+	}
+
+	/** Preflight one complete DME event update after all proposed values are known. */
+	public function preflight_event_update_persistence( $preflight, array $context ) {
+		if ( is_wp_error( $preflight ) || false === $preflight || 'publish' !== ( $context['post_status'] ?? '' ) ) {
+			return $preflight;
+		}
+		$post_id  = absint( $context['post_id'] ?? 0 );
+		$venue_id = absint( $context['next_venue_id'] ?? 0 );
+		$previous_venue_ids = array_values( array_unique( array_filter( array_map( 'absint', (array) ( $context['previous_venue_ids'] ?? array() ) ) ) ) );
+		if ( $post_id < 1 ) {
+			return $preflight;
+		}
+		if ( $venue_id < 1 ) {
+			if ( count( $previous_venue_ids ) > 1 ) {
+				$error = new \WP_Error( 'canonical_event_venue_ambiguous', __( 'The published event has multiple retained venue assignments and cannot be updated safely.', 'extrachill-events' ), array( 'status' => 409, 'venue_ids' => $previous_venue_ids ) );
+				$this->audit_denial( 'event_update', $error );
+				return $error;
+			}
+			return $preflight;
+		}
+		if ( null !== $this->active_context ) {
+			return new \WP_Error( 'canonical_event_publication_reentrant', __( 'Another canonical event publication is already active in this request.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+
+		$event       = is_array( $context['event'] ?? null ) ? $context['event'] : array();
+		$publication = $this->publication_window( $venue_id, $event );
+		if ( is_wp_error( $publication ) ) {
+			$this->audit_denial( 'event_update', $publication );
+			return $publication;
+		}
+		$result = $this->acquire_for_publication( $publication['venue_id'], $publication['start_at'], $publication['end_at'], $post_id, 0, $publication['_candidate_intervals'] );
+		if ( is_wp_error( $result ) ) {
+			$this->audit_denial( 'event_update', $result );
+			return $result;
+		}
+		$this->active_context       = 'event_update';
+		$this->active_post_id       = $post_id;
+		$this->active_publication   = $publication;
+		$this->active_lifecycle_key = $this->lifecycle_key( $context );
+		$this->active_poisoned      = false;
+		$this->active_boundary_consumed = false;
+		return $preflight;
+	}
+
+	/** Release only the complete event update invocation which acquired the lock. */
+	public function complete_event_update_persistence( array $context, $result = null ): void {
+		unset( $result );
+		if ( 'event_update' === $this->active_context && (int) ( $context['post_id'] ?? 0 ) === $this->active_post_id && $this->lifecycle_key( $context ) === $this->active_lifecycle_key ) {
+			$this->release();
+		}
+	}
+
+	/** Acquire the stable venue lock and reject booking overlaps. */
+	public function acquire_for_publication( int $venue_id, string $start_at, string $end_at, int $post_id = 0, int $excluded_booking_id = 0, array $candidate_intervals = array() ) {
+		global $wpdb;
+		$name     = BookingHoldRepository::venue_lock_name( $venue_id );
+		$acquired = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $name, 5 ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Cross-connection venue booking serialization.
+		if ( 1 !== (int) $acquired || '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'canonical_event_booking_lock_not_acquired', __( 'Venue booking availability is busy; retry publication.', 'extrachill-events' ), array( 'status' => 503, 'database_error' => $wpdb->last_error ) );
+		}
+		$this->acquired_locks[] = $name;
+
+		$candidate_intervals = empty( $candidate_intervals ) ? array( array( 'start_at' => $start_at, 'end_at' => $end_at ) ) : $candidate_intervals;
+		$conflict = $this->find_booking_conflict( $venue_id, $start_at, $end_at, $post_id, $excluded_booking_id, $candidate_intervals );
+		if ( is_wp_error( $conflict ) ) {
+			$this->release();
+			return $conflict;
+		}
+		if ( $conflict ) {
+			$this->release();
+			return new \WP_Error(
+				'canonical_event_booking_conflict',
+				__( 'This venue already has an overlapping booking hold or confirmed booking.', 'extrachill-events' ),
+				array(
+					'status'                       => 409,
+					'conflict'                     => $conflict,
+					'canonical_event_space_policy' => 'venue_wide',
+					'post_id'                      => $post_id,
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/** Release all acquired locks in reverse global acquisition order. */
+	public function release(): void {
+		global $wpdb;
+		foreach ( array_reverse( $this->acquired_locks ) as $name ) {
+			$released       = $wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Releases only locks acquired by this request.
+			$database_error = (string) $wpdb->last_error;
+			if ( 1 === (int) $released && '' === $database_error ) {
+				continue;
+			}
+			do_action( 'extrachill_events_canonical_event_booking_lock_release_failed', $name, $database_error );
+			do_action(
+				'datamachine_log',
+				'error',
+				'Canonical event booking lock release could not be confirmed',
+				array(
+					'lock_name'      => $name,
+					'database_error' => $database_error,
+				)
+			);
+		}
+		$this->acquired_locks = array();
+		$this->active_context = null;
+		$this->active_post_id = 0;
+		$this->active_publication = null;
+		$this->active_lifecycle_key = '';
+		$this->active_poisoned = false;
+		$this->active_boundary_consumed = false;
+		$this->active_rest_request = null;
+	}
+
+	/** Match only the REST request object which acquired the active lock. */
+	private function owns_rest_request( $request ): bool {
+		return is_object( $request ) && is_object( $this->active_rest_request ) && $request === $this->active_rest_request;
+	}
+
+	private function find_booking_conflict( int $venue_id, string $start_at, string $end_at, int $post_id, int $excluded_booking_id, array $candidate_intervals ) {
+		global $wpdb;
+		$hold_exact       = array();
+		$booking_exact    = array();
+		$exact_values     = array();
+		foreach ( $candidate_intervals as $interval ) {
+			$hold_exact[]    = '(start_at = %s AND end_at = %s)';
+			$booking_exact[] = '(performance_start_at = %s AND performance_end_at = %s)';
+			$exact_values[]  = (string) $interval['start_at'];
+			$exact_values[]  = (string) $interval['end_at'];
+		}
+		$hold_exact_sql    = implode( ' OR ', $hold_exact );
+		$booking_exact_sql = implode( ' OR ', $booking_exact );
+		$bookings          = BookingSchema::bookings_table();
+		if ( $post_id > 0 ) {
+			$linked = $wpdb->get_row( $wpdb->prepare( "SELECT id, venue_term_id, space_key, performance_start_at, performance_end_at, 'confirmed_booking' AS conflict_type FROM {$bookings} WHERE event_id = %d AND status = 'confirmed' LIMIT 1", $post_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- A linked booking may not be silently detached by moving its event.
+			if ( '' !== (string) $wpdb->last_error ) {
+				return new \WP_Error( 'canonical_event_booking_conflict_check_failed', __( 'The event-linked booking could not be checked safely.', 'extrachill-events' ), array( 'status' => 503, 'database_error' => $wpdb->last_error ) );
+			}
+			if ( is_array( $linked ) ) {
+				$exact = (int) $linked['venue_term_id'] === $venue_id;
+				foreach ( $candidate_intervals as $interval ) {
+					if ( $exact && $linked['performance_start_at'] === $interval['start_at'] && $linked['performance_end_at'] === $interval['end_at'] ) {
+						$linked = null;
+						break;
+					}
+				}
+				if ( is_array( $linked ) ) {
+					return $linked;
+				}
+			}
+		}
+		$holds = BookingSchema::holds_table();
+		$hold_values = array_merge( array( $venue_id, $end_at, $start_at, $excluded_booking_id ), $exact_values );
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT id, booking_id, space_key, 'hold' AS conflict_type FROM {$holds} WHERE venue_term_id = %d AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND start_at < %s AND end_at > %s AND NOT (booking_id = %d AND ({$hold_exact_sql})) LIMIT 1", $hold_values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Checked while the stable venue-wide lock is held.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'canonical_event_booking_conflict_check_failed', __( 'Venue booking holds could not be checked safely.', 'extrachill-events' ), array( 'status' => 503, 'database_error' => $wpdb->last_error ) );
+		}
+		if ( is_array( $row ) ) {
+			return $row;
+		}
+
+		$booking_values = array_merge( array( $venue_id, $end_at, $start_at, $excluded_booking_id, $post_id ), $exact_values );
+		$row      = $wpdb->get_row( $wpdb->prepare( "SELECT id, space_key, 'confirmed_booking' AS conflict_type FROM {$bookings} WHERE venue_term_id = %d AND status = 'confirmed' AND performance_start_at < %s AND performance_end_at > %s AND NOT ((id = %d OR event_id = %d) AND ({$booking_exact_sql})) LIMIT 1", $booking_values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Only an exact originating booking is exempt from the venue-wide policy.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'canonical_event_booking_conflict_check_failed', __( 'Confirmed venue bookings could not be checked safely.', 'extrachill-events' ), array( 'status' => 503, 'database_error' => $wpdb->last_error ) );
+		}
+		return is_array( $row ) ? $row : null;
+	}
+
+	private function publication_from_post( $post, $request, int $post_id ) {
+		$venue_id = $this->venue_id_from_request( $request );
+		if ( $venue_id < 1 && $post_id > 0 ) {
+			$venues   = wp_get_object_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
+			if ( is_wp_error( $venues ) ) {
+				return new \WP_Error(
+					'canonical_event_venue_read_failed',
+					__( 'The published event venue could not be read safely.', 'extrachill-events' ),
+					array(
+						'status'         => 503,
+						'database_error' => $venues->get_error_message(),
+						'cause'          => $venues->get_error_code(),
+					)
+				);
+			}
+			$venue_id = 1 === count( (array) $venues ) ? (int) reset( $venues ) : 0;
+		}
+		if ( $venue_id < 1 ) {
+			return null;
+		}
+
+		$content = (string) ( $post->post_content ?? '' );
+		$event   = $this->event_details_from_content( $content );
+		if ( empty( $event['startDate'] ) && $post_id > 0 && class_exists( '\\DataMachineEvents\\Core\\EventDatesTable' ) ) {
+			$dates = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+			if ( $dates && ! empty( $dates->start_datetime ) ) {
+				$event['startDate'] = substr( (string) $dates->start_datetime, 0, 10 );
+				$event['startTime'] = substr( (string) $dates->start_datetime, 11 );
+				if ( ! empty( $dates->end_datetime ) ) {
+					$event['endDate'] = substr( (string) $dates->end_datetime, 0, 10 );
+					$event['endTime'] = substr( (string) $dates->end_datetime, 11 );
+				}
+			}
+		}
+		return $this->publication_window( $venue_id, $event );
+	}
+
+	private function venue_id_from_request( $request ): int {
+		if ( is_object( $request ) && method_exists( $request, 'get_param' ) ) {
+			$value = $request->get_param( 'venue' );
+		} elseif ( is_array( $request ) ) {
+			$value = $request['venue'] ?? ( $request['tax_input']['venue'] ?? null );
+		} else {
+			$value = null;
+		}
+		$ids   = array_values( array_filter( array_map( 'absint', (array) $value ) ) );
+		return 1 === count( $ids ) ? $ids[0] : 0;
+	}
+
+	private function event_details_from_content( string $content ): array {
+		if ( '' === $content || ! function_exists( 'parse_blocks' ) ) {
+			return array();
+		}
+		foreach ( parse_blocks( $content ) as $block ) {
+			if ( 'data-machine-events/event-details' === ( $block['blockName'] ?? '' ) ) {
+				return is_array( $block['attrs'] ?? null ) ? $block['attrs'] : array();
+			}
+		}
+		return array();
+	}
+
+	private function publication_window( int $venue_id, array $event ) {
+		$timezone_name = (string) get_term_meta( $venue_id, '_venue_timezone', true );
+		try {
+			$timezone = new \DateTimeZone( $timezone_name );
+		} catch ( \Exception $exception ) {
+			return new \WP_Error( 'canonical_event_venue_timezone_invalid', __( 'The venue timezone is missing or invalid, so publication cannot be checked safely.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+
+		$start_date       = (string) ( $event['startDate'] ?? '' );
+		$start_time       = (string) ( $event['startTime'] ?? '00:00:00' );
+		$start_candidates = $this->strict_local_datetime_candidates( $start_date, $start_time, $timezone );
+		if ( is_wp_error( $start_candidates ) ) {
+			return $start_candidates;
+		}
+
+		$end_candidates = array();
+		if ( ! empty( $event['endDate'] ) ) {
+			$end_candidates = $this->strict_local_datetime_candidates( (string) $event['endDate'], (string) ( $event['endTime'] ?? '23:59:59' ), $timezone );
+		} elseif ( ! empty( $event['endTime'] ) ) {
+			$end_date = $start_date;
+			$end_time = (string) $event['endTime'];
+			if ( $this->normalized_time( $end_time ) <= $this->normalized_time( $start_time ) ) {
+				$end_date = ( new \DateTimeImmutable( $start_date, $timezone ) )->modify( '+1 day' )->format( 'Y-m-d' );
+			}
+			$end_candidates = $this->strict_local_datetime_candidates( $end_date, $end_time, $timezone );
+		} else {
+			foreach ( $start_candidates as $candidate ) {
+				$end_candidates[] = $candidate->modify( '+' . self::DEFAULT_DURATION_SECONDS . ' seconds' );
+			}
+		}
+		if ( is_wp_error( $end_candidates ) ) {
+			return $end_candidates;
+		}
+
+		$start_timestamps = array_map( static function ( \DateTimeImmutable $date ): int { return $date->getTimestamp(); }, $start_candidates );
+		$end_timestamps   = array_map( static function ( \DateTimeImmutable $date ): int { return $date->getTimestamp(); }, $end_candidates );
+		$start_timestamp  = min( $start_timestamps );
+		$end_timestamp    = max( $end_timestamps );
+		if ( $end_timestamp <= $start_timestamp ) {
+			return new \WP_Error( 'canonical_event_datetime_invalid', __( 'The event end must be later than its start.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$utc = new \DateTimeZone( 'UTC' );
+		$candidate_intervals = array();
+		foreach ( $start_timestamps as $candidate_start ) {
+			foreach ( $end_timestamps as $candidate_end ) {
+				if ( $candidate_end <= $candidate_start ) {
+					continue;
+				}
+				$key = $candidate_start . ':' . $candidate_end;
+				$candidate_intervals[ $key ] = array(
+					'start_at' => ( new \DateTimeImmutable( '@' . $candidate_start ) )->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
+					'end_at'   => ( new \DateTimeImmutable( '@' . $candidate_end ) )->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
+				);
+			}
+		}
+		return array(
+			'venue_id' => $venue_id,
+			'start_at' => ( new \DateTimeImmutable( '@' . $start_timestamp ) )->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
+			'end_at'   => ( new \DateTimeImmutable( '@' . $end_timestamp ) )->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
+			'_candidate_intervals' => array_values( $candidate_intervals ),
+		);
+	}
+
+	/** Return every UTC instant represented by one strict local wall time. */
+	private function strict_local_datetime_candidates( string $date, string $time, \DateTimeZone $timezone ) {
+		$time  = $this->normalized_time( $time );
+		$value = $date . ' ' . $time;
+		$wall  = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $value, new \DateTimeZone( 'UTC' ) );
+		if ( false === $wall || $wall->format( 'Y-m-d H:i:s' ) !== $value ) {
+			return new \WP_Error( 'canonical_event_datetime_invalid', __( 'Event dates must be valid local venue wall times.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$offsets = array();
+		foreach ( (array) $timezone->getTransitions( $wall->getTimestamp() - DAY_IN_SECONDS, $wall->getTimestamp() + DAY_IN_SECONDS ) as $transition ) {
+			$offsets[] = (int) $transition['offset'];
+		}
+		$candidates = array();
+		foreach ( array_unique( $offsets ) as $offset ) {
+			$candidate = ( new \DateTimeImmutable( '@' . ( $wall->getTimestamp() - $offset ) ) )->setTimezone( $timezone );
+			if ( $candidate->format( 'Y-m-d H:i:s' ) === $value ) {
+				$candidates[ $candidate->getTimestamp() ] = $candidate;
+			}
+		}
+		if ( empty( $candidates ) ) {
+			return new \WP_Error( 'canonical_event_datetime_invalid', __( 'Event dates must be valid local venue wall times.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		ksort( $candidates, SORT_NUMERIC );
+		return array_values( $candidates );
+	}
+
+	private function normalized_time( string $time ): string {
+		return preg_match( '/^\d{2}:\d{2}$/', $time ) ? $time . ':00' : $time;
+	}
+
+	private function lifecycle_key( array $context ): string {
+		return hash( 'sha256', wp_json_encode( array(
+			'invocation_id'    => (string) ( $context['invocation_id'] ?? '' ),
+			'venue_term_id'   => (int) ( $context['venue_term_id'] ?? $context['next_venue_id'] ?? 0 ),
+			'existing_post_id' => (int) ( $context['existing_post_id'] ?? $context['post_id'] ?? 0 ),
+			'source'          => (string) ( $context['source'] ?? '' ),
+			'source_id'       => (string) ( $context['source_id'] ?? '' ),
+			'source_identity' => (string) ( $context['source_identity'] ?? '' ),
+			'event'           => $context['event'] ?? array(),
+		) ) );
+	}
+
+	private function audit_denial( string $context, \WP_Error $error ): void {
+		do_action( 'extrachill_events_canonical_event_publication_denied', $context, $error );
+		do_action(
+			'datamachine_log',
+			'warning',
+			'Canonical event publication denied by venue booking policy',
+			array(
+				'context'    => $context,
+				'error_code' => $error->get_error_code(),
+				'error_data' => $error->get_error_data(),
+			)
+		);
+	}
+}

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -12,6 +12,7 @@
 			<file>tests/BookingHoldTest.php</file>
 			<file>tests/BookingMutationTest.php</file>
 			<file>tests/BookingEventConversionTest.php</file>
+			<file>tests/CanonicalEventPublicationGuardTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/BookingEventConversionTest.php
+++ b/tests/BookingEventConversionTest.php
@@ -29,6 +29,7 @@ final class BookingConversionAbilityFake {
 
 final class BookingEventConversionTest extends TestCase {
 	protected function setUp(): void {
+		$GLOBALS['ec_test_filters'] = array();
 		$GLOBALS['ec_artist_test'] = array(
 			'blog_id'         => 7,
 			'stack'           => array(),
@@ -238,9 +239,19 @@ final class BookingEventConversionTest extends TestCase {
 		$authorization = new BookingTestAuthorization();
 		$wrapper       = null;
 		$this->install_ability(
-			function ( array $input ) use ( &$wrapper ): array {
+			function ( array $input ) use ( &$wrapper, $booking ): array {
+				$publication = array(
+					'venue_id' => $booking['venue_term_id'],
+					'start_at' => $booking['performance_start_at'],
+					'end_at'   => $booking['performance_end_at'],
+				);
 				$this->assertTrue( $wrapper->can_upsert_booking_event( false, $input ) );
 				$this->assertFalse( $wrapper->can_upsert_booking_event( false, array_merge( $input, array( 'source_id' => 'another-booking' ) ) ) );
+				$this->assertSame( $booking['id'], apply_filters( 'extrachill_events_canonical_event_excluded_booking_id', 0, $input, $publication ) );
+				$this->assertSame( 0, apply_filters( 'extrachill_events_canonical_event_excluded_booking_id', 0, array_merge( $input, array( 'source_id' => 'another-booking' ) ), $publication ) );
+				$this->assertSame( 0, apply_filters( 'extrachill_events_canonical_event_excluded_booking_id', 0, $input, array_merge( $publication, array( 'venue_id' => 999 ) ) ) );
+				$this->assertSame( 0, apply_filters( 'extrachill_events_canonical_event_excluded_booking_id', 0, $input, array_merge( $publication, array( 'start_at' => '2030-01-01 00:00:00' ) ) ) );
+				$this->assertSame( 0, apply_filters( 'extrachill_events_canonical_event_excluded_booking_id', 0, $input, array_merge( $publication, array( 'end_at' => '2030-01-01 01:00:00' ) ) ) );
 				$this->add_event( 901 );
 				$this->add_event_source_proof( 901, $input );
 				return $this->upstream_result( $input );
@@ -255,6 +266,15 @@ final class BookingEventConversionTest extends TestCase {
 			$wrapper->can_upsert_booking_event(
 				false,
 				array( 'source' => BookingEventConversionService::SOURCE, 'source_id' => $booking['public_id'] )
+			)
+		);
+		$this->assertSame(
+			0,
+			apply_filters(
+				'extrachill_events_canonical_event_excluded_booking_id',
+				0,
+				array( 'source' => BookingEventConversionService::SOURCE, 'source_id' => $booking['public_id'] ),
+				array( 'venue_id' => $booking['venue_term_id'], 'start_at' => $booking['performance_start_at'], 'end_at' => $booking['performance_end_at'] )
 			)
 		);
 	}

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -150,14 +150,16 @@ final class BookingHoldTest extends TestCase {
 		$this->assertSame( 'active', $holds->create( $adjacent['id'], 1, 12 )['hold']['status'] );
 		$patio = $this->booking( '2030-08-01 23:00:00', '2030-08-02 01:00:00', 'patio' );
 		$this->assertSame( 'active', $holds->create( $patio['id'], 1, 12 )['hold']['status'] );
-		$this->assertSame( $GLOBALS['wpdb']->lock_names[0][1], $GLOBALS['wpdb']->lock_names[2][1], 'The same venue-space must produce the same lock name.' );
-		$this->assertNotSame( $GLOBALS['wpdb']->lock_names[0][1], $GLOBALS['wpdb']->lock_names[4][1], 'Different spaces must not share a lock.' );
+		$this->assertSame( BookingHoldRepository::venue_lock_name( 55 ), $GLOBALS['wpdb']->lock_names[0][1], 'Booking writers must acquire the venue lock first.' );
+		$this->assertSame( $GLOBALS['wpdb']->lock_names[0][1], $GLOBALS['wpdb']->lock_names[4][1], 'The same venue must produce the same outer lock name.' );
+		$this->assertSame( $GLOBALS['wpdb']->lock_names[1][1], $GLOBALS['wpdb']->lock_names[5][1], 'The same venue-space must produce the same inner lock name.' );
+		$this->assertNotSame( $GLOBALS['wpdb']->lock_names[1][1], $GLOBALS['wpdb']->lock_names[9][1], 'Different spaces must not share an inner lock.' );
 		$this->assertLessThanOrEqual( 64, strlen( $GLOBALS['wpdb']->lock_names[0][1] ) );
 		$first_lock = $GLOBALS['wpdb']->lock_names[0][1];
 		$GLOBALS['wpdb']->prefix = 'wp_8_';
 		$other_site = $this->booking( '2030-10-01 20:00:00', '2030-10-01 23:00:00' );
 		$holds->create( $other_site['id'], 1, 12 );
-		$this->assertNotSame( $first_lock, $GLOBALS['wpdb']->lock_names[6][1], 'Different site tables must not share advisory locks.' );
+		$this->assertNotSame( $first_lock, $GLOBALS['wpdb']->lock_names[12][1], 'Different site tables must not share advisory locks.' );
 	}
 
 	public function test_same_space_conflicts_different_space_succeeds_and_elapsed_never_blocks(): void {

--- a/tests/CanonicalEventPublicationGuardTest.php
+++ b/tests/CanonicalEventPublicationGuardTest.php
@@ -1,0 +1,587 @@
+<?php
+/**
+ * Canonical publication/booking serialization tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Core\BookingEventConversionService;
+use ExtraChillEvents\Core\BookingHoldRepository;
+use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\CanonicalEventPublicationGuard;
+use ExtraChillEvents\Core\VenueBookingConfig;
+use ExtraChillEvents\Abilities\VenueBookingEventAbilities;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
+final class CanonicalEventPublicationGuardTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['ec_test_filters'] = array();
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id'       => 7,
+			'stack'         => array(),
+			'uuid'          => 0,
+			'options'       => array(),
+			'abilities'     => array(),
+			'actions'       => array(),
+			'fired_actions' => array(),
+			'scheduled'     => array(),
+			'cache_deletes' => array(),
+			'posts'         => array(),
+			'post_meta'     => array(),
+			'event_venues'  => array( 7 => array() ),
+			'parsed_blocks' => array(),
+			'tms'           => array(),
+			'terms'         => array(
+				7 => array(
+					55 => (object) array(
+						'term_id'  => 55,
+						'taxonomy' => 'venue',
+						'name'     => 'The Room',
+					),
+				),
+			),
+			'meta'          => array(
+				7 => array(
+					55 => array(
+						'_venue_timezone'            => 'America/New_York',
+						VenueBookingConfig::META_KEY => array(
+							'enabled' => true,
+							'spaces'  => array(
+								array( 'key' => 'patio', 'name' => 'Patio' ),
+								array( 'key' => 'main-room', 'name' => 'Main Room', 'is_default' => true ),
+							),
+						),
+					),
+				),
+			),
+		);
+		$GLOBALS['wpdb'] = new BookingWpdb();
+	}
+
+	public function test_acquires_and_releases_one_stable_venue_lock(): void {
+		$guard = new CanonicalEventPublicationGuard();
+
+		$this->assertTrue( $guard->acquire_for_publication( 55, '2030-08-01 20:00:00', '2030-08-01 23:00:00' ) );
+		$guard->release();
+
+		$venue = BookingHoldRepository::venue_lock_name( 55 );
+		$this->assertSame(
+			array(
+				array( 'get', $venue ),
+				array( 'release', $venue ),
+			),
+			$GLOBALS['wpdb']->lock_names
+		);
+	}
+
+	public function test_active_hold_conflict_releases_immediately(): void {
+		$this->seed_hold( 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00' );
+		$guard  = new CanonicalEventPublicationGuard();
+		$result = $guard->acquire_for_publication( 55, '2030-08-01 21:00:00', '2030-08-02 00:00:00' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'canonical_event_booking_conflict', $result->get_error_code() );
+		$this->assertSame( 'hold', $result->get_error_data()['conflict']['conflict_type'] );
+		$this->assertSame( 1, $this->release_count() );
+	}
+
+	public function test_confirmed_booking_conflict_is_venue_wide(): void {
+		$this->seed_booking( 'patio', '2030-08-01 20:00:00', '2030-08-01 23:00:00', 'confirmed' );
+		$result = ( new CanonicalEventPublicationGuard() )->acquire_for_publication( 55, '2030-08-01 20:30:00', '2030-08-01 21:30:00' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'confirmed_booking', $result->get_error_data()['conflict']['conflict_type'] );
+		$this->assertSame( 'venue_wide', $result->get_error_data()['canonical_event_space_policy'] );
+	}
+
+	public function test_disabled_empty_booking_config_does_not_skip_durable_conflicts(): void {
+		$GLOBALS['ec_artist_test']['meta'][7][55][ VenueBookingConfig::META_KEY ] = array( 'enabled' => false, 'spaces' => array() );
+		$this->seed_booking( 'retired-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00', 'confirmed' );
+
+		$result = ( new CanonicalEventPublicationGuard() )->acquire_for_publication( 55, '2030-08-01 20:30:00', '2030-08-01 21:30:00' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'canonical_event_booking_conflict', $result->get_error_code() );
+	}
+
+	public function test_non_overlapping_publication_retains_locks_until_completion(): void {
+		$this->seed_hold( 'main-room', '2030-08-02 20:00:00', '2030-08-02 23:00:00' );
+		$guard = new CanonicalEventPublicationGuard();
+
+		$this->assertTrue( $guard->acquire_for_publication( 55, '2030-08-01 20:00:00', '2030-08-01 23:00:00' ) );
+		$this->assertSame( 0, $this->release_count() );
+		$guard->release();
+		$this->assertSame( 1, $this->release_count() );
+	}
+
+	public function test_dme_conflict_denies_before_write_and_is_audited(): void {
+		$this->seed_hold( 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00' );
+		$guard = new CanonicalEventPublicationGuard();
+
+		$this->assertInstanceOf( WP_Error::class, $this->preflight_dme( $guard, $this->dme_input() ) );
+		$this->assertArrayHasKey( 'extrachill_events_canonical_event_publication_denied', $GLOBALS['ec_artist_test']['fired_actions'] );
+		$this->assertSame( 1, $this->release_count() );
+	}
+
+	public function test_dme_missing_end_uses_conservative_three_hour_window(): void {
+		$this->seed_hold( 'main-room', '2030-08-01 22:00:00', '2030-08-01 23:00:00' );
+		$input = $this->dme_input();
+		unset( $input['event']['endTime'] );
+
+		$this->assertInstanceOf( WP_Error::class, $this->preflight_dme( new CanonicalEventPublicationGuard(), $input ) );
+	}
+
+	public function test_dme_locks_remain_until_taxonomy_completion(): void {
+		$guard = new CanonicalEventPublicationGuard();
+
+		$context = $this->dme_context( $this->dme_input() );
+		$this->assertTrue( $guard->preflight_dme_persistence( true, $context ) );
+		$this->assertSame( 0, $this->release_count() );
+		$guard->bind_dme_post_id( 901 );
+		$guard->complete_dme_persistence( $context, 901, true );
+		$this->assertSame( 1, $this->release_count() );
+	}
+
+	public function test_second_dme_preflight_rejects_without_releasing_outer_context(): void {
+		$guard = new CanonicalEventPublicationGuard();
+		$context = $this->dme_context( $this->dme_input() );
+		$this->assertTrue( $guard->preflight_dme_persistence( true, $context ) );
+
+		$nested = $context;
+		$nested['invocation_id'] = 'nested-invocation';
+		$this->assertInstanceOf( WP_Error::class, $guard->preflight_dme_persistence( true, $nested ) );
+		$this->assertSame( 0, $this->release_count() );
+		$this->assertSame( 'canonical_event_publication_reentrant', $GLOBALS['ec_artist_test']['fired_actions']['extrachill_events_canonical_event_publication_denied'][0][1]->get_error_code() );
+		$guard->complete_dme_persistence( $nested, 0, new WP_Error( 'nested_denied' ) );
+		$this->assertSame( 0, $this->release_count(), 'Nested completion must not release the outer invocation.' );
+		$guard->complete_dme_persistence( $context, 0, new WP_Error( 'outer_complete' ) );
+		$this->assertSame( 1, $this->release_count() );
+	}
+
+	public function test_sourceless_new_dme_write_consumes_only_first_zero_id_boundary(): void {
+		$guard   = new CanonicalEventPublicationGuard();
+		$context = $this->dme_context( $this->dme_input() );
+		$this->assertTrue( $guard->preflight_dme_persistence( true, $context ) );
+		$postarr = array( 'post_type' => 'data_machine_events', 'post_status' => 'publish' );
+
+		$this->assertFalse( $guard->preflight_direct_post_insert( false, $postarr ) );
+		$this->assertTrue( $guard->preflight_direct_post_insert( false, $postarr ) );
+		$this->assertSame( 0, $this->release_count() );
+		$guard->complete_dme_persistence( $context, 901, true );
+		$this->assertSame( 1, $this->release_count() );
+	}
+
+	public function test_dme_fence_and_completion_require_bound_post_identity(): void {
+		$guard = new CanonicalEventPublicationGuard();
+		$context = $this->dme_context( $this->dme_input() );
+		$this->assertTrue( $guard->preflight_dme_persistence( true, $context ) );
+		$guard->bind_dme_post_id( 901 );
+		$postarr = array(
+			'ID'           => 902,
+			'post_type'    => 'data_machine_events',
+			'post_status'  => 'publish',
+			'post_title'   => 'Wrong Event',
+			'post_content' => '',
+			'post_excerpt' => '',
+		);
+
+		$this->assertTrue( $guard->preflight_direct_post_insert( false, $postarr ) );
+		$this->assertSame( 0, $this->release_count() );
+		$this->assertTrue( $guard->preflight_direct_post_insert( false, array_merge( $postarr, array( 'ID' => 901 ) ) ), 'A poisoned identity must fail closed.' );
+		$guard->complete_dme_persistence( $context, 0, new WP_Error( 'identity_mismatch' ) );
+		$this->assertSame( 1, $this->release_count() );
+	}
+
+	public function test_dme_guard_does_not_widen_existing_authorization(): void {
+		$guard = new CanonicalEventPublicationGuard();
+
+		$this->assertFalse( $guard->preflight_dme_persistence( false, $this->dme_context( $this->dme_input() ) ) );
+		$this->assertSame( array(), $GLOBALS['wpdb']->lock_names );
+	}
+
+	public function test_spoofed_booking_conversion_source_does_not_exempt_confirmed_booking(): void {
+		$booking_id = $this->seed_booking( 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00', 'confirmed' );
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking_id ]['public_id'] = 'booking-source';
+		$input              = $this->dme_input();
+		$input['source']    = BookingEventConversionService::SOURCE;
+		$input['source_id'] = 'booking-source';
+		$guard              = new CanonicalEventPublicationGuard();
+
+		$this->assertInstanceOf( WP_Error::class, $this->preflight_dme( $guard, $input ) );
+		$this->assertSame( 'canonical_event_booking_conflict', $GLOBALS['ec_artist_test']['fired_actions']['extrachill_events_canonical_event_publication_denied'][0][1]->get_error_code() );
+	}
+
+	public function test_dst_fallback_window_covers_both_repeated_wall_time_occurrences(): void {
+		$this->seed_hold( 'main-room', '2030-11-03 06:10:00', '2030-11-03 06:20:00' );
+		$input                       = $this->dme_input();
+		$input['event']['startDate'] = '2030-11-03';
+		$input['event']['startTime'] = '01:30';
+		$input['event']['endTime']   = '01:45';
+
+		$this->assertInstanceOf( WP_Error::class, $this->preflight_dme( new CanonicalEventPublicationGuard(), $input ) );
+	}
+
+	public function test_dst_spring_forward_gap_is_rejected(): void {
+		$input                       = $this->dme_input();
+		$input['event']['startDate'] = '2030-03-10';
+		$input['event']['startTime'] = '02:30';
+		$input['event']['endTime']   = '03:30';
+
+		$this->assertInstanceOf( WP_Error::class, $this->preflight_dme( new CanonicalEventPublicationGuard(), $input ) );
+		$this->assertSame( array(), $GLOBALS['wpdb']->lock_names );
+	}
+
+	public function test_release_failure_is_audited_while_every_lock_is_attempted(): void {
+		$guard = new CanonicalEventPublicationGuard();
+		$this->assertTrue( $guard->acquire_for_publication( 55, '2030-08-01 20:00:00', '2030-08-01 23:00:00' ) );
+		$GLOBALS['wpdb']->release_lock_results = array( 0 );
+		$GLOBALS['wpdb']->release_lock_errors  = array( 'simulated release uncertainty' );
+
+		$guard->release();
+
+		$this->assertSame( 1, $this->release_count() );
+		$this->assertCount( 1, $GLOBALS['ec_artist_test']['fired_actions']['extrachill_events_canonical_event_booking_lock_release_failed'] );
+		$audit = $GLOBALS['ec_artist_test']['fired_actions']['extrachill_events_canonical_event_booking_lock_release_failed'][0];
+		$this->assertSame( BookingHoldRepository::venue_lock_name( 55 ), $audit[0] );
+		$this->assertSame( 'simulated release uncertainty', $audit[1] );
+		$logs = $GLOBALS['ec_artist_test']['fired_actions']['datamachine_log'];
+		$this->assertSame( 'error', $logs[0][0] );
+		$this->assertSame( array( 'lock_name', 'database_error' ), array_keys( $logs[0][2] ) );
+	}
+
+	public function test_rest_conflict_returns_error_before_persistence(): void {
+		$this->seed_booking( 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00', 'confirmed' );
+		$GLOBALS['ec_artist_test']['parsed_blocks']['event-content'] = array(
+			array(
+				'blockName' => 'data-machine-events/event-details',
+				'attrs'     => array( 'startDate' => '2030-08-01', 'startTime' => '16:00', 'endTime' => '19:00' ),
+			),
+		);
+		$post = (object) array( 'ID' => 0, 'post_status' => 'publish', 'post_content' => 'event-content' );
+
+		$result = ( new CanonicalEventPublicationGuard() )->preflight_rest_insert( $post, new BookingTestRestRequest( array( 'venue' => array( 55 ) ) ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'canonical_event_booking_conflict', $result->get_error_code() );
+		$this->assertSame( array(), $GLOBALS['ec_artist_test']['posts'] );
+	}
+
+	public function test_rest_venue_only_update_of_published_event_is_preflighted(): void {
+		$this->seed_booking( 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00', 'confirmed' );
+		$GLOBALS['ec_artist_test']['posts'][7][901] = (object) array(
+			'ID'           => 901,
+			'post_type'    => 'data_machine_events',
+			'post_status'  => 'publish',
+			'post_title'   => 'Published Event',
+			'post_content' => 'event-content',
+			'post_excerpt' => '',
+		);
+		$GLOBALS['ec_artist_test']['parsed_blocks']['event-content'] = array(
+			array(
+				'blockName' => 'data-machine-events/event-details',
+				'attrs'     => array( 'startDate' => '2030-08-01', 'startTime' => '16:00', 'endTime' => '19:00' ),
+			),
+		);
+		$prepared = (object) array( 'ID' => 901 );
+
+		$result = ( new CanonicalEventPublicationGuard() )->preflight_rest_insert( $prepared, new BookingTestRestRequest( array( 'venue' => array( 55 ) ) ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'canonical_event_booking_conflict', $result->get_error_code() );
+	}
+
+	public function test_rest_retained_venue_read_failure_fails_closed(): void {
+		$GLOBALS['ec_artist_test']['posts'][7][901] = (object) array(
+			'ID'           => 901,
+			'post_type'    => 'data_machine_events',
+			'post_status'  => 'publish',
+			'post_title'   => 'Published Event',
+			'post_content' => 'event-content',
+			'post_excerpt' => '',
+		);
+		$GLOBALS['ec_artist_test']['venue_terms_error'] = true;
+
+		$result = ( new CanonicalEventPublicationGuard() )->preflight_rest_insert( (object) array( 'ID' => 901 ), new BookingTestRestRequest( array() ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'canonical_event_venue_read_failed', $result->get_error_code() );
+		$this->assertSame( 503, $result->get_error_data()['status'] );
+		$this->assertSame( 'venue_terms_read_failed', $result->get_error_data()['cause'] );
+		$this->assertSame( 'simulated venue taxonomy read failure', $result->get_error_data()['database_error'] );
+		$this->assertSame( array(), $GLOBALS['wpdb']->lock_names );
+	}
+
+	public function test_rest_locks_remain_until_after_insert(): void {
+		$GLOBALS['ec_artist_test']['parsed_blocks']['event-content'] = array(
+			array(
+				'blockName' => 'data-machine-events/event-details',
+				'attrs'     => array( 'startDate' => '2030-08-01', 'startTime' => '16:00', 'endTime' => '19:00' ),
+			),
+		);
+		$post    = (object) array( 'ID' => 0, 'post_status' => 'publish', 'post_content' => 'event-content' );
+		$guard   = new CanonicalEventPublicationGuard();
+		$request = new BookingTestRestRequest( array( 'venue' => array( 55 ) ) );
+
+		$this->assertSame( $post, $guard->preflight_rest_insert( $post, $request ) );
+		$this->assertSame( 0, $this->release_count() );
+		$guard->complete_rest_insert( (object) array( 'ID' => 901 ), $request );
+		$this->assertSame( 1, $this->release_count() );
+	}
+
+	public function test_rest_callback_error_fallback_releases_exactly_once(): void {
+		$GLOBALS['ec_artist_test']['parsed_blocks']['event-content'] = array(
+			array( 'blockName' => 'data-machine-events/event-details', 'attrs' => array( 'startDate' => '2030-08-01', 'startTime' => '16:00', 'endTime' => '19:00' ) ),
+		);
+		$guard   = new CanonicalEventPublicationGuard();
+		$post    = (object) array( 'ID' => 0, 'post_status' => 'publish', 'post_content' => 'event-content' );
+		$request = new BookingTestRestRequest( array( 'venue' => array( 55 ) ) );
+		$this->assertSame( $post, $guard->preflight_rest_insert( $post, $request ) );
+
+		$error = new WP_Error( 'rest_persistence_failed', 'REST callback failed.' );
+		$this->assertSame( $error, $guard->complete_rest_request( $error, null, $request ) );
+		$this->assertSame( 1, $this->release_count() );
+		$guard->complete_rest_insert( (object) array( 'ID' => 901 ), $request );
+		$this->assertSame( 1, $this->release_count() );
+	}
+
+	public function test_nested_rest_request_cannot_release_owning_request_lock(): void {
+		$GLOBALS['ec_artist_test']['parsed_blocks']['event-content'] = array(
+			array( 'blockName' => 'data-machine-events/event-details', 'attrs' => array( 'startDate' => '2030-08-01', 'startTime' => '16:00', 'endTime' => '19:00' ) ),
+		);
+		$guard   = new CanonicalEventPublicationGuard();
+		$post    = (object) array( 'ID' => 0, 'post_status' => 'publish', 'post_content' => 'event-content' );
+		$owner   = new BookingTestRestRequest( array( 'venue' => array( 55 ) ) );
+		$nested  = new BookingTestRestRequest( array() );
+		$this->assertSame( $post, $guard->preflight_rest_insert( $post, $owner ) );
+
+		$response = new WP_Error( 'nested_complete', 'Nested request completed.' );
+		$this->assertSame( $response, $guard->complete_rest_request( $response, null, $nested ) );
+		$this->assertSame( 0, $this->release_count() );
+		$guard->complete_rest_insert( (object) array( 'ID' => 901 ), $nested );
+		$this->assertSame( 0, $this->release_count() );
+		$guard->complete_rest_insert( (object) array( 'ID' => 901 ), $owner );
+		$this->assertSame( 1, $this->release_count() );
+	}
+
+	public function test_rest_update_excludes_the_events_own_confirmed_booking(): void {
+		$booking_id = $this->seed_booking( 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00', 'confirmed' );
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking_id ]['event_id'] = 901;
+		$GLOBALS['ec_artist_test']['event_venues'][7][901]                                  = array( 55 );
+		$GLOBALS['ec_artist_test']['parsed_blocks']['event-content']                        = array(
+			array(
+				'blockName' => 'data-machine-events/event-details',
+				'attrs'     => array( 'startDate' => '2030-08-01', 'startTime' => '16:00', 'endTime' => '19:00' ),
+			),
+		);
+		$post    = (object) array( 'ID' => 901, 'post_status' => 'publish', 'post_content' => 'event-content' );
+		$guard   = new CanonicalEventPublicationGuard();
+		$request = new BookingTestRestRequest( array() );
+
+		$this->assertSame( $post, $guard->preflight_rest_insert( $post, $request ) );
+		$guard->complete_rest_insert( $post, $request );
+	}
+
+	public function test_direct_tax_input_locks_remain_through_wp_after_insert_post(): void {
+		$GLOBALS['ec_artist_test']['parsed_blocks']['event-content'] = array(
+			array(
+				'blockName' => 'data-machine-events/event-details',
+				'attrs'     => array( 'startDate' => '2030-08-01', 'startTime' => '16:00', 'endTime' => '19:00' ),
+			),
+		);
+		$data = array(
+			'post_type'    => 'data_machine_events',
+			'post_status'  => 'publish',
+			'post_title'   => 'Direct Event',
+			'post_content' => 'event-content',
+			'post_excerpt' => '',
+		);
+		$guard = new CanonicalEventPublicationGuard();
+
+		$this->assertFalse( $guard->preflight_direct_post_insert( false, array_merge( $data, array( 'tax_input' => array( 'venue' => array( 55 ) ) ) ) ) );
+		$this->assertSame( 0, $this->release_count() );
+		$guard->complete_post_insert( 901, (object) array( 'ID' => 901, 'post_type' => 'data_machine_events' ) );
+		$this->assertSame( 1, $this->release_count() );
+	}
+
+	public function test_direct_source_less_insert_ignores_nested_non_event_completion(): void {
+		$GLOBALS['ec_artist_test']['parsed_blocks']['event-content'] = array(
+			array( 'blockName' => 'data-machine-events/event-details', 'attrs' => array( 'startDate' => '2030-08-01', 'startTime' => '16:00', 'endTime' => '19:00' ) ),
+		);
+		$data = array(
+			'post_type'    => 'data_machine_events',
+			'post_status'  => 'publish',
+			'post_title'   => 'Direct Event',
+			'post_content' => 'event-content',
+			'post_excerpt' => '',
+			'tax_input'    => array( 'venue' => array( 55 ) ),
+		);
+		$guard = new CanonicalEventPublicationGuard();
+		$this->assertFalse( $guard->preflight_direct_post_insert( false, $data ) );
+
+		$guard->complete_post_insert( 700, (object) array( 'ID' => 700, 'post_type' => 'post' ) );
+		$this->assertSame( 0, $this->release_count() );
+		$guard->complete_post_insert( 901, (object) array( 'ID' => 901, 'post_type' => 'data_machine_events' ) );
+		$this->assertSame( 1, $this->release_count() );
+	}
+
+	public function test_direct_tax_input_conflict_aborts_before_seeded_state_changes(): void {
+		$this->seed_booking( 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00', 'confirmed' );
+		$GLOBALS['ec_artist_test']['posts'][7][901] = (object) array( 'ID' => 901, 'post_type' => 'data_machine_events', 'post_status' => 'publish', 'post_title' => 'Original', 'post_content' => 'original-content', 'post_excerpt' => '' );
+		$GLOBALS['ec_artist_test']['event_venues'][7][901] = array( 77 );
+		$GLOBALS['ec_artist_test']['parsed_blocks']['changed-content'] = array(
+			array( 'blockName' => 'data-machine-events/event-details', 'attrs' => array( 'startDate' => '2030-08-01', 'startTime' => '16:00', 'endTime' => '19:00' ) ),
+		);
+		$before_post  = clone $GLOBALS['ec_artist_test']['posts'][7][901];
+		$before_terms = $GLOBALS['ec_artist_test']['event_venues'][7][901];
+
+		$aborted = ( new CanonicalEventPublicationGuard() )->preflight_direct_post_insert( false, array( 'ID' => 901, 'post_type' => 'data_machine_events', 'post_status' => 'publish', 'post_title' => 'Changed', 'post_content' => 'changed-content', 'tax_input' => array( 'venue' => array( 55 ) ) ) );
+
+		$this->assertTrue( $aborted );
+		$this->assertEquals( $before_post, $GLOBALS['ec_artist_test']['posts'][7][901] );
+		$this->assertSame( $before_terms, $GLOBALS['ec_artist_test']['event_venues'][7][901] );
+	}
+
+	public function test_only_exact_originating_hold_is_exempt(): void {
+		$this->seed_hold( 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00' );
+		$guard = new CanonicalEventPublicationGuard();
+		$this->assertTrue( $guard->acquire_for_publication( 55, '2030-08-01 20:00:00', '2030-08-01 23:00:00', 0, 10 ) );
+		$guard->release();
+
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][2] = array( 'id' => 2, 'booking_id' => 10, 'venue_term_id' => 55, 'space_key' => 'patio', 'start_at' => '2030-08-01 21:00:00', 'end_at' => '2030-08-01 22:30:00', 'expires_at' => '2035-01-01 00:00:00', 'status' => 'active' );
+		$result = ( new CanonicalEventPublicationGuard() )->acquire_for_publication( 55, '2030-08-01 20:00:00', '2030-08-01 23:00:00', 0, 10 );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 2, $result->get_error_data()['conflict']['id'] );
+	}
+
+	public function test_event_linked_booking_requires_exact_venue_and_candidate_interval(): void {
+		$id = $this->seed_booking( 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00', 'confirmed' );
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $id ]['event_id'] = 901;
+		$guard = new CanonicalEventPublicationGuard();
+		$this->assertTrue( $guard->acquire_for_publication( 55, '2030-08-01 20:00:00', '2030-08-01 23:00:00', 901 ) );
+		$guard->release();
+		$this->assertInstanceOf( WP_Error::class, ( new CanonicalEventPublicationGuard() )->acquire_for_publication( 55, '2030-08-01 20:30:00', '2030-08-01 23:30:00', 901 ) );
+		$this->assertInstanceOf( WP_Error::class, ( new CanonicalEventPublicationGuard() )->acquire_for_publication( 56, '2030-08-01 20:00:00', '2030-08-01 23:00:00', 901 ) );
+	}
+
+	public function test_fold_conversion_exemption_accepts_each_occurrence_but_not_altered_interval(): void {
+		$reflection = new ReflectionClass( VenueBookingEventAbilities::class );
+		$wrapper    = $reflection->newInstanceWithoutConstructor();
+		$property   = $reflection->getProperty( 'active_conversion' );
+		$property->setAccessible( true );
+		$publication = array(
+			'venue_id' => 55,
+			'start_at' => '2030-11-03 05:30:00',
+			'end_at'   => '2030-11-03 06:45:00',
+			'_candidate_intervals' => array(
+				array( 'start_at' => '2030-11-03 05:30:00', 'end_at' => '2030-11-03 05:45:00' ),
+				array( 'start_at' => '2030-11-03 06:30:00', 'end_at' => '2030-11-03 06:45:00' ),
+			),
+		);
+		$input = array( 'source' => BookingEventConversionService::SOURCE, 'source_id' => 'fold-booking' );
+		foreach ( $publication['_candidate_intervals'] as $index => $interval ) {
+			$property->setValue( $wrapper, array( 'id' => 40 + $index, 'public_id' => 'fold-booking', 'venue_term_id' => 55, 'performance_start_at' => $interval['start_at'], 'performance_end_at' => $interval['end_at'] ) );
+			$this->assertSame( 40 + $index, $wrapper->excluded_booking_id_for_active_conversion( 0, $input, $publication ) );
+		}
+		$property->setValue( $wrapper, array( 'id' => 42, 'public_id' => 'fold-booking', 'venue_term_id' => 55, 'performance_start_at' => '2030-11-03 05:30:00', 'performance_end_at' => '2030-11-03 06:00:00' ) );
+		$this->assertSame( 0, $wrapper->excluded_booking_id_for_active_conversion( 0, $input, $publication ) );
+	}
+
+	public function test_complete_event_update_uses_proposed_values_and_exact_invocation_owner(): void {
+		$context = array(
+			'invocation_id'      => 'owning-update',
+			'post_id'            => 901,
+			'post_status'        => 'publish',
+			'event'              => array( 'startDate' => '2030-08-01', 'startTime' => '16:00', 'endTime' => '19:00' ),
+			'next_venue_id'      => 55,
+			'previous_venue_ids' => array( 77 ),
+		);
+		$guard = new CanonicalEventPublicationGuard();
+
+		$this->assertTrue( $guard->preflight_event_update_persistence( true, $context ) );
+		$this->assertFalse( $guard->preflight_direct_post_insert( false, array( 'ID' => 901, 'post_type' => 'data_machine_events', 'post_status' => 'publish' ) ) );
+		$other = array_merge( $context, array( 'invocation_id' => 'nested-update' ) );
+		$guard->complete_event_update_persistence( $other, array() );
+		$this->assertSame( 0, $this->release_count() );
+		$guard->complete_event_update_persistence( $context, array() );
+		$this->assertSame( 1, $this->release_count() );
+
+		$this->seed_hold( 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00' );
+		$result = ( new CanonicalEventPublicationGuard() )->preflight_event_update_persistence( true, $context );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'canonical_event_booking_conflict', $result->get_error_code() );
+	}
+
+	private function dme_input(): array {
+		return array(
+			'source'      => 'test-source',
+			'source_id'   => 'test-event',
+			'post_status' => 'publish',
+			'event'       => array(
+				'venue'     => 'The Room',
+				'startDate' => '2030-08-01',
+				'startTime' => '16:00',
+				'endTime'   => '19:00',
+			),
+		);
+	}
+
+	private function dme_context( array $input ): array {
+		return array(
+			'invocation_id'     => 'outer-invocation',
+			'venue_term_id'   => 55,
+			'event'           => $input['event'],
+			'post_status'     => $input['post_status'] ?? 'publish',
+			'existing_post_id' => 0,
+			'source'          => $input['source'] ?? '',
+			'source_id'       => $input['source_id'] ?? '',
+			'source_identity' => hash( 'sha256', ( $input['source'] ?? '' ) . "\0" . ( $input['source_id'] ?? '' ) ),
+		);
+	}
+
+	private function preflight_dme( CanonicalEventPublicationGuard $guard, array $input ) {
+		return $guard->preflight_dme_persistence( true, $this->dme_context( $input ) );
+	}
+
+	private function seed_hold( string $space, string $start, string $end ): void {
+		$table = BookingSchema::holds_table();
+		$GLOBALS['wpdb']->rows[ $table ][1] = array(
+			'id'            => 1,
+			'booking_id'    => 10,
+			'venue_term_id' => 55,
+			'space_key'     => $space,
+			'start_at'      => $start,
+			'end_at'        => $end,
+			'expires_at'    => '2035-01-01 00:00:00',
+			'status'        => 'active',
+		);
+	}
+
+	private function seed_booking( string $space, string $start, string $end, string $status ): int {
+		$table = BookingSchema::bookings_table();
+		$id    = count( $GLOBALS['wpdb']->rows[ $table ] ?? array() ) + 1;
+		$GLOBALS['wpdb']->rows[ $table ][ $id ] = array(
+			'id'                   => $id,
+			'public_id'            => 'booking-' . $id,
+			'venue_term_id'        => 55,
+			'space_key'            => $space,
+			'performance_start_at' => $start,
+			'performance_end_at'   => $end,
+			'status'               => $status,
+		);
+		return $id;
+	}
+
+	private function release_count(): int {
+		return count(
+			array_filter(
+				$GLOBALS['wpdb']->lock_names,
+				static function ( array $entry ): bool {
+					return 'release' === $entry[0];
+				}
+			)
+		);
+	}
+}

--- a/tests/Integration/canonical-event-booking-lock-mysql.php
+++ b/tests/Integration/canonical-event-booking-lock-mysql.php
@@ -1,0 +1,172 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Two-session canonical-event/booking advisory-lock regression.
+ *
+ * Environment:
+ * - EC_EVENTS_MYSQL_TEST_DSN=mysql:host=127.0.0.1;port=3306;dbname=events_test
+ * - EC_EVENTS_MYSQL_TEST_USER
+ * - EC_EVENTS_MYSQL_TEST_PASSWORD
+ *
+ * @package ExtraChillEvents\Tests\Integration
+ */
+
+$dsn = trim( (string) getenv( 'EC_EVENTS_MYSQL_TEST_DSN' ) );
+if ( '' === $dsn ) {
+	fwrite( STDOUT, "SKIP: EC_EVENTS_MYSQL_TEST_DSN is unavailable; no MySQL test endpoint was contacted.\n" );
+	exit( 0 );
+}
+if ( ! extension_loaded( 'mysqli' ) ) {
+	fwrite( STDERR, "FAIL: EC_EVENTS_MYSQL_TEST_DSN is configured but mysqli is unavailable.\n" );
+	exit( 1 );
+}
+
+$settings = array();
+foreach ( explode( ';', preg_replace( '/^mysql:/i', '', $dsn ) ) as $part ) {
+	if ( false === strpos( $part, '=' ) ) {
+		continue;
+	}
+	list( $key, $value ) = explode( '=', $part, 2 );
+	$settings[ strtolower( trim( $key ) ) ] = trim( $value );
+}
+$database = $settings['dbname'] ?? '';
+if ( '' === $database || false === strpos( strtolower( $database ), 'test' ) ) {
+	fwrite( STDERR, "FAIL: EC_EVENTS_MYSQL_TEST_DSN must name an explicit database containing 'test'; refusing a possible production endpoint.\n" );
+	exit( 1 );
+}
+
+$user       = (string) getenv( 'EC_EVENTS_MYSQL_TEST_USER' );
+$password   = (string) getenv( 'EC_EVENTS_MYSQL_TEST_PASSWORD' );
+$host       = $settings['host'] ?? '127.0.0.1';
+$port       = (int) ( $settings['port'] ?? 3306 );
+$socket     = $settings['unix_socket'] ?? null;
+$suffix     = bin2hex( random_bytes( 6 ) );
+$wpdb       = (object) array( 'prefix' => 'ec_events_lock_' . $suffix . '_' );
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingSchema.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingHoldRepository.php';
+
+$holds      = \ExtraChillEvents\Core\BookingSchema::holds_table();
+$bookings   = \ExtraChillEvents\Core\BookingSchema::bookings_table();
+$events     = 'ec_events_lock_events_' . $suffix;
+$venue_id   = 55;
+$space_keys = array( 'main-room', 'patio' );
+$event      = null;
+$booking    = null;
+$exit_code  = 0;
+
+$connect = static function () use ( $host, $user, $password, $database, $port, $socket ): mysqli {
+	$connection = mysqli_init();
+	$connection->real_connect( $host, $user, $password, $database, $port, $socket );
+	$connection->set_charset( 'utf8mb4' );
+	return $connection;
+};
+$assert = static function ( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+};
+$lock = static function ( mysqli $connection, string $name, int $timeout ): int {
+	$statement = $connection->prepare( 'SELECT GET_LOCK(?, ?)' );
+	$statement->bind_param( 'si', $name, $timeout );
+	$statement->execute();
+	return (int) $statement->get_result()->fetch_row()[0];
+};
+$lock_async = static function ( mysqli $connection, string $name, int $timeout ): void {
+	$name = $connection->real_escape_string( $name );
+	$connection->query( "SELECT GET_LOCK('{$name}', {$timeout})", MYSQLI_ASYNC );
+};
+$reap_lock = static function ( mysqli $connection ): int {
+	$result = $connection->reap_async_query();
+	if ( ! $result instanceof mysqli_result ) {
+		throw new RuntimeException( 'Asynchronous GET_LOCK query failed: ' . $connection->error );
+	}
+	return (int) $result->fetch_row()[0];
+};
+$release = static function ( mysqli $connection, string $name ): int {
+	$statement = $connection->prepare( 'SELECT RELEASE_LOCK(?)' );
+	$statement->bind_param( 's', $name );
+	$statement->execute();
+	return (int) $statement->get_result()->fetch_row()[0];
+};
+$venue_lock = \ExtraChillEvents\Core\BookingHoldRepository::venue_lock_name( $venue_id );
+$space_locks = array_map(
+	static function ( string $space_key ) use ( $venue_id ): string {
+		return \ExtraChillEvents\Core\BookingHoldRepository::venue_space_lock_name( $venue_id, $space_key );
+	},
+	$space_keys
+);
+$all_locks = array_merge( array( $venue_lock ), $space_locks );
+
+try {
+	$event   = $connect();
+	$booking = $connect();
+	foreach ( array( $event, $booking ) as $connection ) {
+		$connection->query( "SET SESSION sql_mode = 'STRICT_ALL_TABLES'" );
+	}
+	$event->query( "CREATE TABLE `{$holds}` (id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, booking_id BIGINT UNSIGNED NOT NULL, venue_term_id BIGINT UNSIGNED NOT NULL, space_key VARCHAR(64) NOT NULL, status VARCHAR(32) NOT NULL, expires_at DATETIME NOT NULL, start_at DATETIME NOT NULL, end_at DATETIME NOT NULL) ENGINE=InnoDB" );
+	$event->query( "CREATE TABLE `{$bookings}` (id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, venue_term_id BIGINT UNSIGNED NOT NULL, space_key VARCHAR(64) NOT NULL, status VARCHAR(32) NOT NULL, performance_start_at DATETIME NOT NULL, performance_end_at DATETIME NOT NULL) ENGINE=InnoDB" );
+	$event->query( "CREATE TABLE `{$events}` (id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, venue_term_id BIGINT UNSIGNED NOT NULL, post_status VARCHAR(20) NOT NULL, start_at DATETIME NOT NULL, end_at DATETIME NOT NULL) ENGINE=InnoDB" );
+
+	// Ordering one: publication owns the venue domain, then booking waits before taking its narrower space lock.
+	$assert( 1 === $lock( $event, $venue_lock, 0 ), 'Publication session did not acquire the venue lock.' );
+	$started = microtime( true );
+	$lock_async( $booking, $venue_lock, 3 );
+	usleep( 250000 );
+	$event->query( "INSERT INTO `{$events}` (venue_term_id, post_status, start_at, end_at) VALUES (55, 'publish', '2030-08-01 20:00:00', '2030-08-01 23:00:00')" );
+	$assert( 1 === $release( $event, $venue_lock ), 'Publication session did not release the venue lock.' );
+	$assert( 1 === $reap_lock( $booking ), 'Booking writer did not acquire the contended venue lock after publication completed.' );
+	$assert( microtime( true ) - $started >= 0.2, 'Booking writer did not actually wait behind publication.' );
+	$assert( 1 === $lock( $booking, $space_locks[0], 0 ), 'Booking writer did not acquire its space lock after the venue lock.' );
+	$result = $booking->query( "SELECT id FROM `{$events}` WHERE venue_term_id = 55 AND post_status = 'publish' AND start_at < '2030-08-01 22:00:00' AND end_at > '2030-08-01 21:00:00' LIMIT 1" );
+	$assert( 1 === $result->num_rows, 'Booking writer did not see the event committed while it waited.' );
+	$assert( 1 === $release( $booking, $space_locks[0] ), 'Booking writer did not release its space lock.' );
+	$assert( 1 === $release( $booking, $venue_lock ), 'Booking writer did not release its venue lock.' );
+
+	// Ordering two: booking owns venue then space, and publication waits on the venue domain before checking holds.
+	$assert( 1 === $lock( $booking, $venue_lock, 0 ), 'Booking session did not acquire the venue lock first.' );
+	$assert( 1 === $lock( $booking, $space_locks[0], 0 ), 'Booking session did not acquire its space lock second.' );
+	$started = microtime( true );
+	$lock_async( $event, $venue_lock, 3 );
+	usleep( 250000 );
+	$booking->query( "INSERT INTO `{$holds}` (booking_id, venue_term_id, space_key, status, expires_at, start_at, end_at) VALUES (99, 55, 'main-room', 'active', DATE_ADD(UTC_TIMESTAMP(), INTERVAL 1 HOUR), '2030-08-01 20:00:00', '2030-08-01 23:00:00')" );
+	$assert( 1 === $release( $booking, $space_locks[0] ), 'Booking session did not release its space lock first.' );
+	$assert( 1 === $release( $booking, $venue_lock ), 'Booking session did not release its venue lock second.' );
+	$assert( 1 === $reap_lock( $event ), 'Publication did not acquire the contended venue lock after booking completed.' );
+	$assert( microtime( true ) - $started >= 0.2, 'Publication did not actually wait behind the booking writer.' );
+	$result = $event->query( "SELECT id FROM `{$holds}` WHERE venue_term_id = 55 AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND start_at < '2030-08-01 22:00:00' AND end_at > '2030-08-01 21:00:00' LIMIT 1" );
+	$assert( 1 === $result->num_rows, 'Publication did not see the booking hold committed while it waited.' );
+	$assert( 1 === $release( $event, $venue_lock ), 'Publication did not release the second-order venue lock.' );
+
+	fwrite( STDOUT, "PASS: two MySQL sessions proved canonical publication and booking writers serialize and recheck conflicts in both orderings.\n" );
+} catch ( Throwable $throwable ) {
+	fwrite( STDERR, 'FAIL: ' . $throwable->getMessage() . "\n" );
+	$exit_code = 1;
+} finally {
+	foreach ( array( $event, $booking ) as $connection ) {
+		if ( ! $connection instanceof mysqli ) {
+			continue;
+		}
+		foreach ( $all_locks as $name ) {
+			try {
+				$release( $connection, $name );
+			} catch ( Throwable $throwable ) {
+				unset( $throwable );
+			}
+		}
+	}
+	if ( $event instanceof mysqli ) {
+		foreach ( array( $events, $bookings, $holds ) as $table ) {
+			$event->query( "DROP TABLE IF EXISTS `{$table}`" );
+		}
+	}
+	foreach ( array( $event, $booking ) as $connection ) {
+		if ( $connection instanceof mysqli ) {
+			$connection->close();
+		}
+	}
+}
+
+exit( $exit_code );

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -10,6 +10,7 @@ use ExtraChillEvents\Core\BookingLifecycle;
 use ExtraChillEvents\Core\BookingHoldRepository;
 use ExtraChillEvents\Core\BookingMutationService;
 use ExtraChillEvents\Core\BookingEventConversionService;
+use ExtraChillEvents\Core\CanonicalEventPublicationGuard;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\VenueBookingConfig;
@@ -142,11 +143,19 @@ if ( ! function_exists( 'get_post_meta' ) ) {
 }
 if ( ! function_exists( 'wp_get_object_terms' ) ) {
 	function wp_get_object_terms( $post_id, $taxonomy, $args = array() ) {
+		if ( ! empty( $GLOBALS['ec_artist_test']['venue_terms_error'] ) ) {
+			return new WP_Error( 'venue_terms_read_failed', 'simulated venue taxonomy read failure' );
+		}
 		if ( 'venue' !== $taxonomy ) {
 			return array();
 		}
 		$ids = $GLOBALS['ec_artist_test']['event_venues'][ get_current_blog_id() ][ $post_id ] ?? array();
 		return ( $args['fields'] ?? '' ) === 'ids' ? $ids : array();
+	}
+}
+if ( ! function_exists( 'parse_blocks' ) ) {
+	function parse_blocks( $content ) {
+		return $GLOBALS['ec_artist_test']['parsed_blocks'][ $content ] ?? array();
 	}
 }
 if ( ! function_exists( 'get_option' ) ) {
@@ -264,6 +273,8 @@ final class BookingWpdb {
 	public $natural_key_reads_in_transaction  = 0;
 	public $get_lock_result                   = 1;
 	public $release_lock_result               = 1;
+	public $release_lock_results              = array();
+	public $release_lock_errors               = array();
 	public $lock_names                        = array();
 	public $event_dates                       = array();
 	public $booking_lock_queries              = 0;
@@ -412,11 +423,23 @@ final class BookingWpdb {
 		}
 		if ( preg_match( "/SELECT RELEASE_LOCK\('([^']+)'\)/", $query, $match ) ) {
 			$this->lock_names[] = array( 'release', stripslashes( $match[1] ) );
-			return $this->release_lock_result;
+			$result = empty( $this->release_lock_results ) ? $this->release_lock_result : array_shift( $this->release_lock_results );
+			if ( ! empty( $this->release_lock_errors ) ) {
+				$this->last_error = (string) array_shift( $this->release_lock_errors );
+			}
+			return $result;
 		}
 		if ( preg_match( "/SELECT id FROM .*ec_booking_holds WHERE id = (\d+) AND status = 'active' AND expires_at <= UTC_TIMESTAMP\(\)/", $query, $match ) ) {
 			$row = $this->rows[ $this->prefix . 'ec_booking_holds' ][ (int) $match[1] ] ?? null;
 			return is_array( $row ) && 'active' === $row['status'] && $row['expires_at'] <= $database_now ? $row['id'] : null;
+		}
+		if ( preg_match( "/SELECT id FROM .*ec_bookings WHERE public_id = '([^']+)' AND status = 'confirmed'/", $query, $match ) ) {
+			foreach ( $this->rows[ $this->prefix . 'ec_bookings' ] ?? array() as $row ) {
+				if ( $row['public_id'] === stripslashes( $match[1] ) && 'confirmed' === $row['status'] ) {
+					return $row['id'];
+				}
+			}
+			return null;
 		}
 		if ( preg_match( "/SELECT id FROM .*ec_booking_holds WHERE booking_id = (\d+) AND venue_term_id = (\d+) AND space_key = '([^']+)' AND start_at = '([^']+)' AND end_at = '([^']+)'.*expires_at > UTC_TIMESTAMP\(\).*id <> (\d+)/", $query, $match ) ) {
 			foreach ( $this->rows[ $this->prefix . 'ec_booking_holds' ] ?? array() as $row ) {
@@ -513,6 +536,47 @@ final class BookingWpdb {
 				$row['database_now'] = $this->current_database_time();
 			}
 			return $row; }
+		if ( ! $is_hold && false !== strpos( $query, "performance_end_at, 'confirmed_booking' AS conflict_type" ) && preg_match( '/event_id = (\d+)/', $query, $match ) ) {
+			foreach ( $this->rows[ $table ] ?? array() as $row ) {
+				if ( (int) ( $row['event_id'] ?? 0 ) === (int) $match[1] && 'confirmed' === $row['status'] ) {
+					return array_merge( $row, array( 'conflict_type' => 'confirmed_booking' ) );
+				}
+			}
+			return null;
+		}
+		if ( $is_hold && false !== strpos( $query, "space_key, 'hold' AS conflict_type" ) ) {
+			preg_match( "/venue_term_id = (\d+).*start_at < '([^']+)'.*end_at > '([^']+)'.*booking_id = (\d+)/", $query, $match );
+			preg_match_all( "/\(start_at = '([^']+)' AND end_at = '([^']+)'\)/", $query, $exact_matches, PREG_SET_ORDER );
+			foreach ( $this->rows[ $table ] ?? array() as $row ) {
+				$exact_exempt = (int) $row['booking_id'] === (int) $match[4] && array_filter( $exact_matches, static fn( array $exact ): bool => $row['start_at'] === $exact[1] && $row['end_at'] === $exact[2] );
+				if ( (int) $row['venue_term_id'] === (int) $match[1] && 'active' === $row['status'] && $row['expires_at'] > $database_now && $row['start_at'] < $match[2] && $row['end_at'] > $match[3] && ! $exact_exempt ) {
+					return array(
+						'id'            => $row['id'],
+						'booking_id'    => $row['booking_id'],
+						'space_key'     => $row['space_key'],
+						'conflict_type' => 'hold',
+					);
+				}
+			}
+			return null;
+		}
+		if ( ! $is_hold && false !== strpos( $query, "space_key, 'confirmed_booking' AS conflict_type" ) ) {
+			preg_match( "/venue_term_id = (\d+).*performance_start_at < '([^']+)'.*performance_end_at > '([^']+)'.*id = (\d+) OR event_id = (\d+)/", $query, $match );
+			preg_match_all( "/\(performance_start_at = '([^']+)' AND performance_end_at = '([^']+)'\)/", $query, $exact_matches, PREG_SET_ORDER );
+			foreach ( $this->rows[ $table ] ?? array() as $row ) {
+				$origin = ( (int) $match[4] > 0 && (int) $row['id'] === (int) $match[4] )
+					|| ( (int) $match[5] > 0 && (int) ( $row['event_id'] ?? 0 ) === (int) $match[5] );
+				$exact_exempt = $origin && array_filter( $exact_matches, static fn( array $exact ): bool => $row['performance_start_at'] === $exact[1] && $row['performance_end_at'] === $exact[2] );
+				if ( (int) $row['venue_term_id'] === (int) $match[1] && 'confirmed' === $row['status'] && $row['performance_start_at'] < $match[2] && $row['performance_end_at'] > $match[3] && ! $exact_exempt ) {
+					return array(
+						'id'            => $row['id'],
+						'space_key'     => $row['space_key'],
+						'conflict_type' => 'confirmed_booking',
+					);
+				}
+			}
+			return null;
+		}
 		if ( $is_hold && false !== strpos( $query, 'booking_id =' ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
 				if ( preg_match( '/booking_id = (\d+)/', $query, $match ) && (int) $row['booking_id'] !== (int) $match[1] ) {
@@ -981,6 +1045,7 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingMutationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingEventConversionService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingLifecycle.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueBookingConfig.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/CanonicalEventPublicationGuard.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingHoldAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingMutationAbilities.php';
@@ -1011,5 +1076,31 @@ final class BookingTestConfig extends VenueBookingConfig {
 		unset( $venue_term_id );
 		$GLOBALS['wpdb']->last_error = 'simulated config read failure';
 		return array( 'enabled' => true );
+	}
+}
+
+final class BookingTestVenueTaxonomy {
+	public static function resolve_venue_identity( string $venue_name, array $venue_data = array() ): array {
+		unset( $venue_data );
+		foreach ( $GLOBALS['ec_artist_test']['terms'][ get_current_blog_id() ] ?? array() as $term ) {
+			if ( 'venue' === $term->taxonomy && 0 === strcasecmp( $term->name, $venue_name ) ) {
+				return array( 'term_id' => (int) $term->term_id, 'match_status' => 'matched' );
+			}
+		}
+		return array( 'term_id' => null, 'match_status' => 'no_match' );
+	}
+}
+
+if ( ! class_exists( '\\DataMachineEvents\\Core\\Venue_Taxonomy' ) ) {
+	class_alias( BookingTestVenueTaxonomy::class, '\\DataMachineEvents\\Core\\Venue_Taxonomy' );
+}
+
+final class BookingTestRestRequest {
+	private $params;
+	public function __construct( array $params ) {
+		$this->params = $params;
+	}
+	public function get_param( string $key ) {
+		return $this->params[ $key ] ?? null;
 	}
 }


### PR DESCRIPTION
## Summary
- add a stable site-and-venue advisory lock shared by canonical publication and every hold/confirmation writer
- reject overlapping DME, REST/editor, direct `wp_insert_post`, and DME venue/update writes before their authoritative persistence boundary
- preserve exact originating-booking conversion exemptions, including both valid DST-fold occurrences
- audit uncertain lock release and add deterministic unit plus optional two-session MySQL protocol coverage

## Protocol
Booking writers acquire the stable venue lock before their existing venue-space lock. Canonical publication acquires the same venue lock and checks all durable active holds and confirmed bookings venue-wide. Invocation tokens and exact REST/post ownership prevent nested operations from releasing another writer's lock.

## Dependency
- Requires Extra-Chill/data-machine-events#533 for the generic upsert/update persistence lifecycle.

## Testing
- `phpunit -c phpunit-booking.xml.dist`: 147 tests, 1011 assertions, passed
- PHP syntax passed for all changed production and test files
- `git diff --check` passed
- Homeboy changed-file lint passed with no findings
- Optional two-session MySQL protocol script safely skipped because `EC_EVENTS_MYSQL_TEST_DSN` is not configured

## Accepted boundaries
- venue resolution may create or update a venue term before publication preflight so consumers receive the exact term ID
- arbitrary standalone `wp_set_post_terms()` calls outside supported REST and DME lifecycles are not serialized

Closes #334