### PR TITLE
feat: add durable booking notification outbox

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -253,6 +253,7 @@ class ExtraChillEvents {
 		\ExtraChillEvents\Core\VenueInvitationDeliveryWorker::register();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingNotificationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingCommunicationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingHoldRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingMutationService.php';
@@ -269,6 +270,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/CanonicalEventPublicationGuard.php';
 		\ExtraChillEvents\Core\BookingHoldRepository::register();
 		\ExtraChillEvents\Core\BookingCommunicationService::register();
+		\ExtraChillEvents\Core\BookingNotificationService::register();
 		new \ExtraChillEvents\Core\CanonicalEventPublicationGuard();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/ArtistUrlImport.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/ArtistUrlImportRoutes.php';

--- a/inc/Core/BookingActivityRepository.php
+++ b/inc/Core/BookingActivityRepository.php
@@ -386,6 +386,62 @@ class BookingActivityRepository {
 		return is_array( $row ) ? $this->hydrate( $row ) : null;
 	}
 
+	/** List landed source activities that do not yet have outbox requests. */
+	public function notification_sources_without_requests( int $limit ) {
+		global $wpdb;
+		$table = BookingSchema::activity_table();
+		$limit = max( 1, min( 100, $limit ) );
+		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT source.* FROM {$table} source WHERE source.kind IN ('inquiry_submitted', 'assignment_changed', 'status_changed', 'hold_expired', 'event_conversion_failed') AND NOT EXISTS (SELECT 1 FROM {$table} request WHERE request.kind IN ('notification_requested', 'notification_source_ignored') AND request.external_id = CAST(source.id AS CHAR)) ORDER BY source.id ASC LIMIT %d", $limit ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded recovery scan over the append-only outbox ledger.
+		return $this->hydrate_rows( $rows, 'booking_notification_source_scan_failed' );
+	}
+
+	/** List pending outbox requests without terminal delivery/suppression records. */
+	public function pending_notification_requests( int $limit ) {
+		global $wpdb;
+		$table = BookingSchema::activity_table();
+		$limit = max( 1, min( 100, $limit ) );
+		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT request.* FROM {$table} request WHERE request.kind = 'notification_requested' AND NOT EXISTS (SELECT 1 FROM {$table} terminal WHERE terminal.kind IN ('notification_delivered', 'notification_suppressed') AND terminal.external_id = CAST(request.id AS CHAR)) ORDER BY request.id ASC LIMIT %d", $limit ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded pending outbox scan.
+		return $this->hydrate_rows( $rows, 'booking_notification_request_scan_failed' );
+	}
+
+	/** Read a terminal notification record for one request. */
+	public function notification_terminal( int $request_activity_id ) {
+		global $wpdb;
+		$table = BookingSchema::activity_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE external_id = %s AND kind IN ('notification_delivered', 'notification_suppressed') ORDER BY id DESC LIMIT 1", (string) $request_activity_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact request terminal lookup.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_notification_terminal_read_failed', __( 'Booking notification terminal state could not be read.', 'extrachill-events' ) );
+		}
+		return is_array( $row ) ? $this->hydrate( $row ) : null;
+	}
+
+	/** Count persisted delivery attempts for one request. */
+	public function notification_attempt_count( int $request_activity_id ) {
+		global $wpdb;
+		$table = BookingSchema::activity_table();
+		$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE external_id = %s AND kind = 'notification_delivery_attempted'", (string) $request_activity_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact request attempt count.
+		return '' !== (string) $wpdb->last_error || ! is_numeric( $count )
+			? new \WP_Error( 'booking_notification_attempt_read_failed', __( 'Booking notification attempts could not be read.', 'extrachill-events' ) )
+			: (int) $count;
+	}
+
+	/** Hydrate a query result set or return its database failure. */
+	private function hydrate_rows( $rows, string $error_code ) {
+		global $wpdb;
+		if ( '' !== (string) $wpdb->last_error || ! is_array( $rows ) ) {
+			return new \WP_Error( $error_code, __( 'Booking notification activity could not be read.', 'extrachill-events' ) );
+		}
+		$output = array();
+		foreach ( $rows as $row ) {
+			$item = $this->hydrate( $row );
+			if ( is_wp_error( $item ) ) {
+				return $item;
+			}
+			$output[] = $item;
+		}
+		return $output;
+	}
+
 	/** Hydrate one validated activity row. */
 	public function hydrate( array $row ) {
 		$decoded = json_decode( (string) ( $row['payload'] ?? '' ), true );

--- a/inc/Core/BookingEventConversionService.php
+++ b/inc/Core/BookingEventConversionService.php
@@ -305,6 +305,7 @@ class BookingEventConversionService {
 		if ( is_wp_error( $committed ) ) {
 			return $this->failure_finalize_error( $upstream, $attempt, $committed );
 		}
+		BookingNotificationService::emit( BookingNotificationService::TYPE_EVENT_HANDOFF_FAILED, (int) $failed['id'] );
 		return $this->upstream_error( $upstream, $attempt, $booking['version'] );
 	}
 

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -774,6 +774,7 @@ class BookingHoldRepository {
 				if ( is_wp_error( $committed ) ) {
 					return $committed;
 				}
+				BookingNotificationService::emit( BookingNotificationService::TYPE_HOLD_EXPIRED, (int) $event['id'] );
 				return $output;
 			}
 		);

--- a/inc/Core/BookingLifecycle.php
+++ b/inc/Core/BookingLifecycle.php
@@ -166,7 +166,11 @@ class BookingLifecycle {
 			return $this->rollback( $event );
 		}
 		$committed = $this->commit();
-		return is_wp_error( $committed ) ? $committed : $this->bookings->get( $booking['id'] );
+		if ( is_wp_error( $committed ) ) {
+			return $committed;
+		}
+		BookingNotificationService::emit( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, (int) $event['id'] );
+		return $this->bookings->get( $booking['id'] );
 	}
 
 	/**
@@ -454,7 +458,15 @@ class BookingLifecycle {
 			return $this->rollback( $event );
 		}
 		$committed = $this->commit();
-		return is_wp_error( $committed ) ? $committed : $this->bookings->get( $current['id'] );
+		if ( is_wp_error( $committed ) ) {
+			return $committed;
+		}
+		if ( 'assignment_changed' === $kind ) {
+			BookingNotificationService::emit( BookingNotificationService::TYPE_ASSIGNMENT_CHANGED, (int) $event['id'] );
+		} elseif ( 'status_changed' === $kind && 'needs_info' === ( $payload['from_status'] ?? '' ) && 'submitted' === ( $payload['to_status'] ?? '' ) ) {
+			BookingNotificationService::emit( BookingNotificationService::TYPE_INFORMATION_RECEIVED, (int) $event['id'] );
+		}
+		return $this->bookings->get( $current['id'] );
 	}
 
 	/** Fail closed before any lifecycle-owned version change while conversion runs. */

--- a/inc/Core/BookingNotificationService.php
+++ b/inc/Core/BookingNotificationService.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Venue operator notifications for durable booking activity.
+ * Durable venue operator notification outbox.
  *
  * @package ExtraChillEvents\Core
  */
@@ -11,10 +11,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/** Selects booking events and delegates network notification delivery to Users. */
+/** Selects source events and reconciles idempotent Users delivery receipts. */
 class BookingNotificationService {
 
-	public const EMIT_HOOK = 'extrachill_events_emit_booking_notification';
+	public const EMIT_HOOK       = 'extrachill_events_emit_booking_notification';
+	public const RECONCILE_HOOK  = 'extrachill_events_reconcile_booking_notifications';
+	public const SCHEDULER_GROUP = 'extrachill-events-booking-notifications';
 
 	public const TYPE_INQUIRY_SUBMITTED    = 'booking_inquiry_submitted';
 	public const TYPE_ASSIGNMENT_CHANGED   = 'booking_assignment_changed';
@@ -22,236 +24,343 @@ class BookingNotificationService {
 	public const TYPE_HOLD_EXPIRED         = 'booking_hold_expired';
 	public const TYPE_EVENT_HANDOFF_FAILED = 'booking_event_handoff_failed';
 
-	// Reserved extension types whose domain producers have not landed yet.
+	// Future producer seams. No source activity is synthesized here.
 	public const TYPE_ARTIST_REPLIED          = 'booking_artist_replied';
 	public const TYPE_HOLD_EXPIRING           = 'booking_hold_expiring';
 	public const TYPE_MARKETING_FAILED        = 'booking_marketing_failed';
 	public const TYPE_SETTLEMENT_READY        = 'booking_settlement_ready';
 	public const TYPE_OPERATOR_ACTION_OVERDUE = 'booking_operator_action_overdue';
 
-	/**
-	 * Booking persistence.
-	 *
-	 * @var BookingRepository
-	 */
+	/** @var bool Whether plugin runtime registration completed. */
+	private static $registered = false;
+	/** @var BookingRepository */
 	private $bookings;
-	/**
-	 * Activity persistence.
-	 *
-	 * @var BookingActivityRepository
-	 */
+	/** @var BookingActivityRepository */
 	private $activity;
-	/**
-	 * Optional delivery test double.
-	 *
-	 * @var callable|null
-	 */
-	private $notify;
-	/**
-	 * Optional actor resolver test double.
-	 *
-	 * @var callable|null
-	 */
+	/** @var callable|null Structured Users receipt adapter. */
+	private $delivery;
+	/** @var callable|null Authorized destination resolver. */
+	private $destination;
+	/** @var callable|null Actor resolver test seam. */
 	private $actor_resolver;
-	/**
-	 * Optional management-link test double.
-	 *
-	 * @var callable|null
-	 */
-	private $link_resolver;
-	/**
-	 * Whether this instance owns an open transaction.
-	 *
-	 * @var bool
-	 */
+	/** @var bool Whether this instance owns a transaction. */
 	private $transaction_active = false;
 
 	/**
-	 * Build the notification coordinator.
+	 * Build the outbox coordinator.
 	 *
-	 * @param BookingRepository|null         $bookings Booking persistence.
-	 * @param BookingActivityRepository|null $activity Activity persistence.
-	 * @param callable|null                  $notify   Optional delivery callback.
-	 * @param callable|null                  $actor_resolver Optional actor resolver.
-	 * @param callable|null                  $link_resolver  Optional link resolver.
+	 * @param BookingRepository|null         $bookings      Booking persistence.
+	 * @param BookingActivityRepository|null $activity      Activity persistence.
+	 * @param callable|null                  $delivery      Structured receipt adapter.
+	 * @param callable|null                  $destination   Authorized route resolver.
+	 * @param callable|null                  $actor_resolver Actor resolver.
 	 */
-	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, $notify = null, $actor_resolver = null, $link_resolver = null ) {
+	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, $delivery = null, $destination = null, $actor_resolver = null ) {
 		$this->bookings       = $bookings ? $bookings : new BookingRepository();
 		$this->activity       = $activity ? $activity : new BookingActivityRepository();
-		$this->notify         = $notify;
+		$this->delivery       = $delivery;
+		$this->destination    = $destination;
 		$this->actor_resolver = $actor_resolver;
-		$this->link_resolver  = $link_resolver;
 	}
 
-	/** Register the explicit producer seam used by later booking domains. */
+	/** Register producer and recovery hooks. */
 	public static function register(): void {
+		self::$registered = true;
 		add_action( self::EMIT_HOOK, array( self::class, 'emit' ), 10, 2 );
+		add_action( self::RECONCILE_HOOK, array( self::class, 'reconcile_scheduled' ) );
+		add_action( 'init', array( self::class, 'ensure_reconciliation_schedule' ) );
 	}
 
-	/**
-	 * Dispatch without changing the owning domain result.
-	 *
-	 * @param string $type               Notification type.
-	 * @param int    $source_activity_id Owning activity ID.
-	 */
-	public static function emit( string $type, int $source_activity_id ): void {
-		if ( ! function_exists( 'ec_users_notify' ) ) {
+	/** Ensure source recovery runs even if a request crashes after domain commit. */
+	public static function ensure_reconciliation_schedule(): void {
+		if ( ! function_exists( 'as_schedule_recurring_action' ) || ! function_exists( 'as_next_scheduled_action' ) || as_next_scheduled_action( self::RECONCILE_HOOK, array(), self::SCHEDULER_GROUP ) ) {
 			return;
 		}
-		( new self() )->deliver( $type, $source_activity_id );
+		as_schedule_recurring_action( time() + MINUTE_IN_SECONDS, 5 * MINUTE_IN_SECONDS, self::RECONCILE_HOOK, array(), self::SCHEDULER_GROUP, true );
 	}
 
 	/**
-	 * Deliver one activity-backed event exactly once.
+	 * Persist one source-backed outbox request after its domain commit.
 	 *
 	 * @param string $type               Notification type.
-	 * @param int    $source_activity_id Owning activity ID.
-	 * @return array|\WP_Error Delivery evidence or an error.
+	 * @param int    $source_activity_id Source activity ID.
 	 */
-	public function deliver( string $type, int $source_activity_id ) {
-		$definition = $this->definition( $type );
-		if ( null === $definition || $source_activity_id < 1 ) {
-			return new \WP_Error( 'booking_notification_event_invalid', __( 'The booking notification event is invalid.', 'extrachill-events' ) );
+	public static function emit( string $type, int $source_activity_id ): void {
+		if ( ! self::$registered ) {
+			return;
 		}
-		$source = $this->activity->get( $source_activity_id );
-		if ( ! is_array( $source ) || ! $this->source_matches( $definition, $source ) ) {
-			return new \WP_Error( 'booking_notification_source_invalid', __( 'The booking notification source activity is invalid.', 'extrachill-events' ) );
+		$service = new self();
+		$service->schedule_reconciliation();
+		$service->request( $type, $source_activity_id );
+	}
+
+	/** Run the bounded recovery and reconciliation pass. */
+	public static function reconcile_scheduled(): void {
+		$result = ( new self() )->reconcile_pending();
+		if ( is_wp_error( $result ) ) {
+			throw new \RuntimeException( $result->get_error_message() ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Scheduler-only diagnostic.
 		}
-		$booking = $this->bookings->get( $source['booking_id'] );
+	}
+
+	/**
+	 * Append an idempotent outbox request for a valid source event.
+	 *
+	 * @param string $type               Notification type.
+	 * @param int    $source_activity_id Source activity ID.
+	 * @return array|\WP_Error Request activity or error.
+	 */
+	public function request( string $type, int $source_activity_id ) {
+		$source = $this->validated_source( $type, $source_activity_id );
+		if ( is_wp_error( $source ) ) {
+			return $source;
+		}
+		return $this->activity->append(
+			array(
+				'booking_id'      => $source['booking_id'],
+				'kind'            => 'notification_requested',
+				'actor_type'      => 'system',
+				'external_id'     => (string) $source_activity_id,
+				'idempotency_key' => $this->request_key( $type, $source_activity_id ),
+				'payload'         => array(
+					'notification_type'  => $type,
+					'source_activity_id' => $source_activity_id,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Recover missing requests, then reconcile a bounded pending page.
+	 *
+	 * @param int $limit Maximum source and request rows per pass.
+	 * @return array|\WP_Error Pass summary or error.
+	 */
+	public function reconcile_pending( int $limit = 50 ) {
+		$limit   = max( 1, min( 100, $limit ) );
+		$sources = $this->activity->notification_sources_without_requests( $limit );
+		if ( is_wp_error( $sources ) ) {
+			return $sources;
+		}
+		$recovered = 0;
+		foreach ( $sources as $source ) {
+			$type = $this->source_type( $source );
+			if ( null === $type ) {
+				$ignored = $this->ignore_source( $source );
+				if ( is_wp_error( $ignored ) ) {
+					return $ignored;
+				}
+				continue;
+			}
+			$request = $this->request( $type, (int) $source['id'] );
+			if ( is_wp_error( $request ) ) {
+				return $request;
+			}
+			++$recovered;
+		}
+		$requests = $this->activity->pending_notification_requests( $limit );
+		if ( is_wp_error( $requests ) ) {
+			return $requests;
+		}
+		$completed = 0;
+		$retry     = false;
+		foreach ( $requests as $request ) {
+			$result = $this->reconcile( (int) $request['id'] );
+			if ( is_wp_error( $result ) ) {
+				$retry = true;
+				continue;
+			}
+			if ( in_array( $result['kind'] ?? '', array( 'notification_delivered', 'notification_suppressed' ), true ) ) {
+				++$completed;
+			}
+		}
+		if ( $retry || count( $sources ) === $limit || count( $requests ) === $limit ) {
+			$this->schedule_reconciliation();
+		}
+		return compact( 'recovered', 'completed' );
+	}
+
+	/**
+	 * Reconcile one outbox request using structured idempotent receipts.
+	 *
+	 * @param int $request_activity_id Outbox request activity ID.
+	 * @return array|\WP_Error Terminal/attempt activity or dependency error.
+	 */
+	public function reconcile( int $request_activity_id ) {
+		$request = $this->activity->get( $request_activity_id );
+		$data    = is_array( $request ) ? ( $request['payload']['data'] ?? array() ) : array();
+		if ( ! is_array( $request ) || 'notification_requested' !== $request['kind'] || empty( $data['notification_type'] ) || empty( $data['source_activity_id'] ) ) {
+			return new \WP_Error( 'booking_notification_request_invalid', __( 'The booking notification request is invalid.', 'extrachill-events' ) );
+		}
+		$terminal = $this->activity->notification_terminal( $request_activity_id );
+		if ( is_wp_error( $terminal ) || is_array( $terminal ) ) {
+			return $terminal;
+		}
+		$source = $this->validated_source( (string) $data['notification_type'], (int) $data['source_activity_id'] );
+		if ( is_wp_error( $source ) || (int) $source['booking_id'] !== (int) $request['booking_id'] ) {
+			return is_wp_error( $source ) ? $source : new \WP_Error( 'booking_notification_source_invalid', __( 'The booking notification source activity is invalid.', 'extrachill-events' ) );
+		}
+		$booking = $this->bookings->get( $request['booking_id'] );
 		if ( ! is_array( $booking ) ) {
 			return is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
 		}
-		if ( ! $this->notify && ! function_exists( 'ec_users_notify' ) ) {
-			return new \WP_Error( 'booking_notification_service_unavailable', __( 'Operator notifications are temporarily unavailable.', 'extrachill-events' ) );
-		}
-
 		$started = $this->begin();
 		if ( is_wp_error( $started ) ) {
 			return $started;
 		}
 		global $wpdb;
-		$members_table = BookingSchema::memberships_table();
-		$members       = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$members_table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $booking['venue_term_id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serializes recipient selection with membership changes.
+		$table   = BookingSchema::memberships_table();
+		$members = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $booking['venue_term_id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serializes recipients with membership changes.
 		if ( '' !== (string) $wpdb->last_error ) {
-			return $this->rollback( new \WP_Error( 'booking_notification_membership_read_failed', __( 'Venue notification recipients could not be locked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
+			return $this->rollback( new \WP_Error( 'booking_notification_membership_read_failed', __( 'Venue notification recipients could not be locked.', 'extrachill-events' ) ) );
 		}
 		$locked = $this->bookings->get_for_update( $booking['id'] );
 		if ( ! is_array( $locked ) || (int) $locked['venue_term_id'] !== (int) $booking['venue_term_id'] ) {
-			return $this->rollback( is_wp_error( $locked ) ? $locked : new \WP_Error( 'booking_notification_booking_changed', __( 'The booking notification target changed.', 'extrachill-events' ) ) );
+			return $this->rollback( new \WP_Error( 'booking_notification_booking_changed', __( 'The booking notification target changed.', 'extrachill-events' ) ) );
 		}
-		$source = $this->activity->get( $source_activity_id );
-		if ( ! is_array( $source ) || (int) $source['booking_id'] !== (int) $locked['id'] || ! $this->source_matches( $definition, $source ) ) {
-			return $this->rollback( new \WP_Error( 'booking_notification_source_invalid', __( 'The booking notification source activity is invalid.', 'extrachill-events' ) ) );
-		}
-
-		$key      = sprintf( 'notification:%s:%d', $type, $source_activity_id );
-		$existing = $this->activity->find_by_idempotency( $locked['id'], $key . ':receipt' );
-		if ( is_wp_error( $existing ) ) {
-			return $this->rollback( $existing );
-		}
-		if ( is_array( $existing ) ) {
-			$committed = $this->commit();
-			return is_wp_error( $committed ) ? $committed : $existing;
-		}
-		$claim = $this->activity->append(
-			array(
-				'booking_id'      => $locked['id'],
-				'kind'            => 'notification_claimed',
-				'actor_type'      => 'system',
-				'idempotency_key' => $key . ':claim',
-				'payload'         => array(
-					'notification_type'  => $type,
-					'source_activity_id' => $source_activity_id,
-				),
-			)
-		);
-		if ( is_wp_error( $claim ) ) {
-			return $this->rollback( $claim );
-		}
-
 		$recipient_ids = $this->active_recipient_ids( (array) $members, (int) $locked['venue_term_id'] );
-		$actor_id      = $this->actor_id( $source );
-		$link          = $this->management_link( $locked );
-		$inserted      = null;
-		$status        = 'skipped';
 		if ( empty( $recipient_ids ) ) {
-			$status = 'no_recipients';
-		} elseif ( $actor_id < 1 || '' === $link ) {
-			$status = 'unavailable';
-		} else {
-			try {
-				$payload = array(
+			$record = $this->terminal_record( $request, 'notification_suppressed', 'no_active_recipients', array() );
+			return is_wp_error( $record ) ? $this->rollback( $record ) : $this->finish( $record );
+		}
+		try {
+			$destination = $this->resolve_destination( $locked, $recipient_ids, (array) $members );
+		} catch ( \Throwable $throwable ) {
+			$this->schedule_reconciliation();
+			return $this->rollback( new \WP_Error( 'booking_notification_destination_uncertain', __( 'The booking management destination could not be resolved.', 'extrachill-events' ) ) );
+		}
+		if ( is_wp_error( $destination ) ) {
+			return $this->rollback( $destination );
+		}
+		if ( ! is_string( $destination ) || ! preg_match( '#^https?://#i', $destination ) ) {
+			return $this->rollback( new \WP_Error( 'booking_notification_destination_invalid', __( 'The booking management destination is invalid.', 'extrachill-events' ) ) );
+		}
+		$actor_id = $this->actor_id( $source );
+		if ( $actor_id < 1 ) {
+			return $this->rollback( new \WP_Error( 'booking_notification_actor_unavailable', __( 'A bounded notification actor is unavailable.', 'extrachill-events' ) ) );
+		}
+		$definition    = $this->definition( (string) $data['notification_type'] );
+		$attempt_count = $this->activity->notification_attempt_count( $request_activity_id );
+		if ( is_wp_error( $attempt_count ) ) {
+			return $this->rollback( $attempt_count );
+		}
+		$attempt = $attempt_count + 1;
+		try {
+			$receipt = $this->deliver_structured(
+				$recipient_ids,
+				array(
 					'actor_id' => $actor_id,
-					'type'     => $type,
-					'link'     => $link,
+					'type'     => (string) $data['notification_type'],
+					'link'     => $destination,
 					'title'    => $definition['title'],
 					'item_id'  => (int) $locked['id'],
-				);
-				$result  = $this->notify ? call_user_func( $this->notify, $recipient_ids, $payload ) : ec_users_notify( $recipient_ids, $payload );
-				if ( is_int( $result ) && 0 <= $result ) {
-					$inserted = $result;
-					$status   = count( $recipient_ids ) === $result ? 'delivered' : ( 0 === $result ? 'failed' : 'partial' );
-				} else {
-					$status = 'unknown';
-				}
-			} catch ( \Throwable $throwable ) {
-				$status = 'unknown';
-			}
-		}
-
-		$receipt = $this->activity->append(
-			array(
-				'booking_id'      => $locked['id'],
-				'kind'            => 'notification_delivery_recorded',
-				'actor_type'      => 'system',
-				'idempotency_key' => $key . ':receipt',
-				'payload'         => array(
-					'notification_type'  => $type,
-					'source_activity_id' => $source_activity_id,
-					'claim_activity_id'  => (int) $claim['id'],
-					'recipient_user_ids' => $recipient_ids,
-					'expected_count'     => count( $recipient_ids ),
-					'inserted_count'     => $inserted,
-					'status'             => $status,
 				),
-			)
-		);
+				$this->request_key( (string) $data['notification_type'], (int) $data['source_activity_id'] )
+			);
+		} catch ( \Throwable $throwable ) {
+			$this->schedule_reconciliation();
+			return $this->rollback( new \WP_Error( 'booking_notification_delivery_uncertain', __( 'The idempotent notification delivery outcome is uncertain.', 'extrachill-events' ) ) );
+		}
 		if ( is_wp_error( $receipt ) ) {
 			return $this->rollback( $receipt );
 		}
-		$committed = $this->commit();
-		return is_wp_error( $committed ) ? $committed : $receipt;
+		$summary = $this->receipt_summary( $recipient_ids, $receipt );
+		$record  = $this->activity->append(
+			array(
+				'booking_id'      => $request['booking_id'],
+				'kind'            => $summary['complete'] ? 'notification_delivered' : 'notification_delivery_attempted',
+				'actor_type'      => 'system',
+				'external_id'     => (string) $request_activity_id,
+				'idempotency_key' => $summary['complete'] ? 'notification-terminal:' . $request_activity_id : sprintf( 'notification-attempt:%d:%d', $request_activity_id, $attempt ),
+				'payload'         => array(
+					'request_activity_id' => $request_activity_id,
+					'notification_type'   => $data['notification_type'],
+					'attempt'             => $attempt,
+					'complete'            => $summary['complete'],
+					'inserted_count'      => $summary['inserted'],
+					'existing_count'      => $summary['existing'],
+					'failed_count'        => $summary['failed'],
+					'recipient_count'     => count( $recipient_ids ),
+				),
+			)
+		);
+		if ( is_wp_error( $record ) ) {
+			return $this->rollback( $record );
+		}
+		$finished = $this->finish( $record );
+		if ( ! $summary['complete'] ) {
+			$this->schedule_reconciliation();
+		}
+		return $finished;
 	}
 
-	/**
-	 * Return landed definitions and explicit future producer seams.
-	 *
-	 * @param string $type Notification type.
-	 * @return array|null Event definition.
-	 */
+	/** Resolve the type represented by one landed source activity. */
+	private function source_type( array $source ): ?string {
+		foreach ( $this->definitions() as $type => $definition ) {
+			if ( ! empty( $definition['landed'] ) && $this->source_matches( $definition, $source ) ) {
+				return $type;
+			}
+		}
+		return null;
+	}
+
+	/** Mark an irrelevant landed-kind activity so recovery can advance. */
+	private function ignore_source( array $source ) {
+		return $this->activity->append(
+			array(
+				'booking_id'      => $source['booking_id'],
+				'kind'            => 'notification_source_ignored',
+				'actor_type'      => 'system',
+				'external_id'     => (string) $source['id'],
+				'idempotency_key' => 'notification-source-ignored:' . $source['id'],
+				'payload'         => array( 'source_activity_id' => $source['id'] ),
+			)
+		);
+	}
+
+	/** Validate a type/source pair. */
+	private function validated_source( string $type, int $source_activity_id ) {
+		$definition = $this->definition( $type );
+		$source     = $source_activity_id > 0 ? $this->activity->get( $source_activity_id ) : null;
+		return null !== $definition && is_array( $source ) && $this->source_matches( $definition, $source )
+			? $source
+			: new \WP_Error( 'booking_notification_source_invalid', __( 'The booking notification source activity is invalid.', 'extrachill-events' ) );
+	}
+
+	/** Return one notification definition. */
 	private function definition( string $type ): ?array {
-		$definitions = array(
+		$definitions = $this->definitions();
+		return $definitions[ $type ] ?? null;
+	}
+
+	/** Return landed mappings and future source seams. */
+	private function definitions(): array {
+		return array(
 			self::TYPE_INQUIRY_SUBMITTED       => array(
-				'kind'  => 'inquiry_submitted',
-				'title' => __( 'New booking inquiry', 'extrachill-events' ),
+				'kind'   => 'inquiry_submitted',
+				'title'  => __( 'New booking inquiry', 'extrachill-events' ),
+				'landed' => true,
 			),
 			self::TYPE_ASSIGNMENT_CHANGED      => array(
-				'kind'  => 'assignment_changed',
-				'title' => __( 'Booking assignment changed', 'extrachill-events' ),
+				'kind'   => 'assignment_changed',
+				'title'  => __( 'Booking assignment changed', 'extrachill-events' ),
+				'landed' => true,
 			),
 			self::TYPE_INFORMATION_RECEIVED    => array(
-				'kind'  => 'status_changed',
-				'title' => __( 'Booking information received', 'extrachill-events' ),
-				'from'  => 'needs_info',
-				'to'    => 'submitted',
+				'kind'   => 'status_changed',
+				'title'  => __( 'Booking information received', 'extrachill-events' ),
+				'from'   => 'needs_info',
+				'to'     => 'submitted',
+				'landed' => true,
 			),
 			self::TYPE_HOLD_EXPIRED            => array(
-				'kind'  => 'hold_expired',
-				'title' => __( 'Booking hold expired', 'extrachill-events' ),
+				'kind'   => 'hold_expired',
+				'title'  => __( 'Booking hold expired', 'extrachill-events' ),
+				'landed' => true,
 			),
 			self::TYPE_EVENT_HANDOFF_FAILED    => array(
-				'kind'  => 'event_conversion_failed',
-				'title' => __( 'Booking event handoff failed', 'extrachill-events' ),
+				'kind'   => 'event_conversion_failed',
+				'title'  => __( 'Booking event handoff failed', 'extrachill-events' ),
+				'landed' => true,
 			),
 			self::TYPE_ARTIST_REPLIED          => array(
 				'kind'  => 'artist_replied',
@@ -274,117 +383,141 @@ class BookingNotificationService {
 				'title' => __( 'Booking action overdue', 'extrachill-events' ),
 			),
 		);
-		return $definitions[ $type ] ?? null;
 	}
 
-	/**
-	 * Validate that an activity owns the requested event.
-	 *
-	 * @param array $definition Event definition.
-	 * @param array $source     Source activity.
-	 * @return bool Whether the activity matches.
-	 */
+	/** Match the complete source contract. */
 	private function source_matches( array $definition, array $source ): bool {
-		if ( ( $source['kind'] ?? '' ) !== $definition['kind'] ) {
-			return false;
-		}
 		$data = $source['payload']['data'] ?? array();
-		return ! isset( $definition['from'] ) || ( ( $data['from_status'] ?? null ) === $definition['from'] && ( $data['to_status'] ?? null ) === $definition['to'] );
+		return ( $source['kind'] ?? '' ) === $definition['kind']
+			&& ( ! isset( $definition['from'] ) || ( ( $data['from_status'] ?? null ) === $definition['from'] && ( $data['to_status'] ?? null ) === $definition['to'] ) );
 	}
 
-	/**
-	 * Resolve only current exact active venue members from locked rows.
-	 *
-	 * @param array $rows          Locked membership rows.
-	 * @param int   $venue_term_id Exact booking venue.
-	 * @return int[] Recipient user IDs.
-	 */
-	private function active_recipient_ids( array $rows, int $venue_term_id ): array {
+	/** Resolve active exact-venue users from membership rows held under lock. */
+	private function active_recipient_ids( array $rows, int $venue_id ): array {
 		$ids        = array();
 		$repository = new VenueMembershipRepository();
 		foreach ( $rows as $row ) {
-			if ( (int) ( $row['venue_term_id'] ?? 0 ) !== $venue_term_id || VenueAuthorization::STATUS_ACTIVE !== ( $row['status'] ?? '' ) ) {
+			if ( (int) ( $row['venue_term_id'] ?? 0 ) !== $venue_id || VenueAuthorization::STATUS_ACTIVE !== ( $row['status'] ?? '' ) ) {
 				continue;
 			}
-			$membership = $repository->hydrate( $row );
-			if ( ! is_wp_error( $membership ) && get_userdata( $membership['user_id'] ) ) {
-				$ids[] = (int) $membership['user_id'];
+			$member = $repository->hydrate( $row );
+			if ( ! is_wp_error( $member ) && get_userdata( $member['user_id'] ) ) {
+				$ids[] = (int) $member['user_id'];
 			}
 		}
 		return array_values( array_unique( $ids ) );
 	}
 
-	/**
-	 * Resolve the user actor or bounded network bot actor.
-	 *
-	 * @param array $source Source activity.
-	 * @return int Valid network user ID, or zero.
-	 */
+	/** Resolve an authorized management destination, which #323 does not yet provide. */
+	private function resolve_destination( array $booking, array $recipient_ids, array $locked_members ) {
+		return $this->destination
+			? call_user_func( $this->destination, $booking, $recipient_ids, $locked_members )
+			: new \WP_Error( 'booking_notification_destination_unavailable', __( 'The authorized booking management destination is not available yet.', 'extrachill-events' ) );
+	}
+
+	/** Delegate only to an injected structured receipt primitive until Users #280 lands. */
+	private function deliver_structured( array $recipient_ids, array $payload, string $idempotency_key ) {
+		return $this->delivery
+			? call_user_func( $this->delivery, $recipient_ids, $payload, 'extrachill-events-booking', $idempotency_key )
+			: new \WP_Error( 'booking_notification_receipts_unavailable', __( 'Idempotent notification receipts are not available yet.', 'extrachill-events' ) );
+	}
+
+	/** Summarize a strict per-recipient Users receipt. */
+	private function receipt_summary( array $recipient_ids, $receipt ): array {
+		$summary = array(
+			'complete' => true,
+			'inserted' => 0,
+			'existing' => 0,
+			'failed'   => 0,
+		);
+		$rows    = is_array( $receipt ) && is_array( $receipt['recipients'] ?? null ) ? $receipt['recipients'] : array();
+		foreach ( $recipient_ids as $user_id ) {
+			$status = $rows[ $user_id ]['status'] ?? null;
+			if ( 'inserted' === $status ) {
+				++$summary['inserted'];
+			} elseif ( 'existing' === $status ) {
+				++$summary['existing'];
+			} else {
+				++$summary['failed'];
+				$summary['complete'] = false;
+			}
+		}
+		return $summary;
+	}
+
+	/** Resolve the source actor or bounded network bot. */
 	private function actor_id( array $source ): int {
 		if ( $this->actor_resolver ) {
 			return absint( call_user_func( $this->actor_resolver, $source ) );
 		}
-		$actor_id = absint( $source['actor_id'] ?? 0 );
-		if ( 0 < $actor_id && get_userdata( $actor_id ) ) {
-			return $actor_id;
+		$actor = absint( $source['actor_id'] ?? 0 );
+		if ( 0 < $actor && get_userdata( $actor ) ) {
+			return $actor;
 		}
-		$actor_id = function_exists( 'ec_get_network_bot_user_id' ) ? absint( ec_get_network_bot_user_id() ) : 0;
-		return 0 < $actor_id && get_userdata( $actor_id ) ? $actor_id : 0;
+		$actor = function_exists( 'ec_get_network_bot_user_id' ) ? absint( ec_get_network_bot_user_id() ) : 0;
+		return 0 < $actor && get_userdata( $actor ) ? $actor : 0;
 	}
 
-	/**
-	 * Build a same-site opaque booking management link.
-	 *
-	 * @param array $booking Booking record.
-	 * @return string Safe management URL, or empty string.
-	 */
-	private function management_link( array $booking ): string {
-		if ( $this->link_resolver ) {
-			return (string) call_user_func( $this->link_resolver, $booking );
-		}
-		$base = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'events' ) : home_url( '/' );
-		if ( ! is_string( $base ) || ! preg_match( '#^https?://#i', $base ) ) {
-			return '';
-		}
-		return esc_url_raw(
-			add_query_arg(
-				array(
-					'booking' => (string) $booking['public_id'],
-					'venue'   => (int) $booking['venue_term_id'],
+	/** Append one terminal suppression record. */
+	private function terminal_record( array $request, string $kind, string $reason, array $details ) {
+		return $this->activity->append(
+			array(
+				'booking_id'      => $request['booking_id'],
+				'kind'            => $kind,
+				'actor_type'      => 'system',
+				'external_id'     => (string) $request['id'],
+				'idempotency_key' => 'notification-terminal:' . $request['id'],
+				'payload'         => array_merge(
+					array(
+						'request_activity_id' => $request['id'],
+						'reason'              => $reason,
+					),
+					$details
 				),
-				trailingslashit( $base )
 			)
 		);
 	}
 
-	/** Start the recipient claim transaction. */
+	/** Stable source-request idempotency key. */
+	private function request_key( string $type, int $source_activity_id ): string {
+		return sprintf( 'notification-request:%s:%d', $type, $source_activity_id );
+	}
+
+	/** Best-effort single-action reconciliation scheduling. */
+	private function schedule_reconciliation(): void {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			return;
+		}
+		try {
+			as_schedule_single_action( time() + MINUTE_IN_SECONDS, self::RECONCILE_HOOK, array(), self::SCHEDULER_GROUP, true );
+		} catch ( \Throwable $throwable ) {
+			unset( $throwable );
+		}
+	}
+
+	/** Start a recipient authorization transaction. */
 	private function begin() {
 		global $wpdb;
-		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Notification claim transaction.
-			return new \WP_Error( 'booking_notification_transaction_failed', __( 'The booking notification transaction could not start.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reconciliation transaction.
+			return new \WP_Error( 'booking_notification_transaction_failed', __( 'The booking notification transaction could not start.', 'extrachill-events' ) );
 		}
 		$this->transaction_active = true;
 		return true;
 	}
 
-	/** Commit notification delivery and evidence together. */
-	private function commit() {
+	/** Commit the reconciliation transaction. */
+	private function finish( array $record ) {
 		global $wpdb;
-		$result                   = $wpdb->query( 'COMMIT' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Notification claim transaction.
+		$result                   = $wpdb->query( 'COMMIT' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reconciliation transaction.
 		$this->transaction_active = false;
-		return false === $result ? new \WP_Error( 'booking_notification_commit_uncertain', __( 'The booking notification outcome could not be confirmed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) : true;
+		return false === $result ? new \WP_Error( 'booking_notification_commit_uncertain', __( 'The booking notification outcome could not be confirmed.', 'extrachill-events' ) ) : $record;
 	}
 
-	/**
-	 * Roll back notification delivery while preserving its cause.
-	 *
-	 * @param \WP_Error $cause Delivery failure.
-	 * @return \WP_Error Original failure.
-	 */
-	private function rollback( \WP_Error $cause ) {
+	/** Roll back while preserving the cause. */
+	private function rollback( \WP_Error $cause ): \WP_Error {
 		global $wpdb;
 		if ( $this->transaction_active ) {
-			$wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Notification claim transaction.
+			$wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reconciliation transaction.
 			$this->transaction_active = false;
 		}
 		return $cause;

--- a/inc/Core/BookingNotificationService.php
+++ b/inc/Core/BookingNotificationService.php
@@ -1,0 +1,392 @@
+<?php
+/**
+ * Venue operator notifications for durable booking activity.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Selects booking events and delegates network notification delivery to Users. */
+class BookingNotificationService {
+
+	public const EMIT_HOOK = 'extrachill_events_emit_booking_notification';
+
+	public const TYPE_INQUIRY_SUBMITTED    = 'booking_inquiry_submitted';
+	public const TYPE_ASSIGNMENT_CHANGED   = 'booking_assignment_changed';
+	public const TYPE_INFORMATION_RECEIVED = 'booking_information_received';
+	public const TYPE_HOLD_EXPIRED         = 'booking_hold_expired';
+	public const TYPE_EVENT_HANDOFF_FAILED = 'booking_event_handoff_failed';
+
+	// Reserved extension types whose domain producers have not landed yet.
+	public const TYPE_ARTIST_REPLIED          = 'booking_artist_replied';
+	public const TYPE_HOLD_EXPIRING           = 'booking_hold_expiring';
+	public const TYPE_MARKETING_FAILED        = 'booking_marketing_failed';
+	public const TYPE_SETTLEMENT_READY        = 'booking_settlement_ready';
+	public const TYPE_OPERATOR_ACTION_OVERDUE = 'booking_operator_action_overdue';
+
+	/**
+	 * Booking persistence.
+	 *
+	 * @var BookingRepository
+	 */
+	private $bookings;
+	/**
+	 * Activity persistence.
+	 *
+	 * @var BookingActivityRepository
+	 */
+	private $activity;
+	/**
+	 * Optional delivery test double.
+	 *
+	 * @var callable|null
+	 */
+	private $notify;
+	/**
+	 * Optional actor resolver test double.
+	 *
+	 * @var callable|null
+	 */
+	private $actor_resolver;
+	/**
+	 * Optional management-link test double.
+	 *
+	 * @var callable|null
+	 */
+	private $link_resolver;
+	/**
+	 * Whether this instance owns an open transaction.
+	 *
+	 * @var bool
+	 */
+	private $transaction_active = false;
+
+	/**
+	 * Build the notification coordinator.
+	 *
+	 * @param BookingRepository|null         $bookings Booking persistence.
+	 * @param BookingActivityRepository|null $activity Activity persistence.
+	 * @param callable|null                  $notify   Optional delivery callback.
+	 * @param callable|null                  $actor_resolver Optional actor resolver.
+	 * @param callable|null                  $link_resolver  Optional link resolver.
+	 */
+	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, $notify = null, $actor_resolver = null, $link_resolver = null ) {
+		$this->bookings       = $bookings ? $bookings : new BookingRepository();
+		$this->activity       = $activity ? $activity : new BookingActivityRepository();
+		$this->notify         = $notify;
+		$this->actor_resolver = $actor_resolver;
+		$this->link_resolver  = $link_resolver;
+	}
+
+	/** Register the explicit producer seam used by later booking domains. */
+	public static function register(): void {
+		add_action( self::EMIT_HOOK, array( self::class, 'emit' ), 10, 2 );
+	}
+
+	/**
+	 * Dispatch without changing the owning domain result.
+	 *
+	 * @param string $type               Notification type.
+	 * @param int    $source_activity_id Owning activity ID.
+	 */
+	public static function emit( string $type, int $source_activity_id ): void {
+		if ( ! function_exists( 'ec_users_notify' ) ) {
+			return;
+		}
+		( new self() )->deliver( $type, $source_activity_id );
+	}
+
+	/**
+	 * Deliver one activity-backed event exactly once.
+	 *
+	 * @param string $type               Notification type.
+	 * @param int    $source_activity_id Owning activity ID.
+	 * @return array|\WP_Error Delivery evidence or an error.
+	 */
+	public function deliver( string $type, int $source_activity_id ) {
+		$definition = $this->definition( $type );
+		if ( null === $definition || $source_activity_id < 1 ) {
+			return new \WP_Error( 'booking_notification_event_invalid', __( 'The booking notification event is invalid.', 'extrachill-events' ) );
+		}
+		$source = $this->activity->get( $source_activity_id );
+		if ( ! is_array( $source ) || ! $this->source_matches( $definition, $source ) ) {
+			return new \WP_Error( 'booking_notification_source_invalid', __( 'The booking notification source activity is invalid.', 'extrachill-events' ) );
+		}
+		$booking = $this->bookings->get( $source['booking_id'] );
+		if ( ! is_array( $booking ) ) {
+			return is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
+		if ( ! $this->notify && ! function_exists( 'ec_users_notify' ) ) {
+			return new \WP_Error( 'booking_notification_service_unavailable', __( 'Operator notifications are temporarily unavailable.', 'extrachill-events' ) );
+		}
+
+		$started = $this->begin();
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		global $wpdb;
+		$members_table = BookingSchema::memberships_table();
+		$members       = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$members_table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $booking['venue_term_id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serializes recipient selection with membership changes.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return $this->rollback( new \WP_Error( 'booking_notification_membership_read_failed', __( 'Venue notification recipients could not be locked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
+		}
+		$locked = $this->bookings->get_for_update( $booking['id'] );
+		if ( ! is_array( $locked ) || (int) $locked['venue_term_id'] !== (int) $booking['venue_term_id'] ) {
+			return $this->rollback( is_wp_error( $locked ) ? $locked : new \WP_Error( 'booking_notification_booking_changed', __( 'The booking notification target changed.', 'extrachill-events' ) ) );
+		}
+		$source = $this->activity->get( $source_activity_id );
+		if ( ! is_array( $source ) || (int) $source['booking_id'] !== (int) $locked['id'] || ! $this->source_matches( $definition, $source ) ) {
+			return $this->rollback( new \WP_Error( 'booking_notification_source_invalid', __( 'The booking notification source activity is invalid.', 'extrachill-events' ) ) );
+		}
+
+		$key      = sprintf( 'notification:%s:%d', $type, $source_activity_id );
+		$existing = $this->activity->find_by_idempotency( $locked['id'], $key . ':receipt' );
+		if ( is_wp_error( $existing ) ) {
+			return $this->rollback( $existing );
+		}
+		if ( is_array( $existing ) ) {
+			$committed = $this->commit();
+			return is_wp_error( $committed ) ? $committed : $existing;
+		}
+		$claim = $this->activity->append(
+			array(
+				'booking_id'      => $locked['id'],
+				'kind'            => 'notification_claimed',
+				'actor_type'      => 'system',
+				'idempotency_key' => $key . ':claim',
+				'payload'         => array(
+					'notification_type'  => $type,
+					'source_activity_id' => $source_activity_id,
+				),
+			)
+		);
+		if ( is_wp_error( $claim ) ) {
+			return $this->rollback( $claim );
+		}
+
+		$recipient_ids = $this->active_recipient_ids( (array) $members, (int) $locked['venue_term_id'] );
+		$actor_id      = $this->actor_id( $source );
+		$link          = $this->management_link( $locked );
+		$inserted      = null;
+		$status        = 'skipped';
+		if ( empty( $recipient_ids ) ) {
+			$status = 'no_recipients';
+		} elseif ( $actor_id < 1 || '' === $link ) {
+			$status = 'unavailable';
+		} else {
+			try {
+				$payload = array(
+					'actor_id' => $actor_id,
+					'type'     => $type,
+					'link'     => $link,
+					'title'    => $definition['title'],
+					'item_id'  => (int) $locked['id'],
+				);
+				$result  = $this->notify ? call_user_func( $this->notify, $recipient_ids, $payload ) : ec_users_notify( $recipient_ids, $payload );
+				if ( is_int( $result ) && 0 <= $result ) {
+					$inserted = $result;
+					$status   = count( $recipient_ids ) === $result ? 'delivered' : ( 0 === $result ? 'failed' : 'partial' );
+				} else {
+					$status = 'unknown';
+				}
+			} catch ( \Throwable $throwable ) {
+				$status = 'unknown';
+			}
+		}
+
+		$receipt = $this->activity->append(
+			array(
+				'booking_id'      => $locked['id'],
+				'kind'            => 'notification_delivery_recorded',
+				'actor_type'      => 'system',
+				'idempotency_key' => $key . ':receipt',
+				'payload'         => array(
+					'notification_type'  => $type,
+					'source_activity_id' => $source_activity_id,
+					'claim_activity_id'  => (int) $claim['id'],
+					'recipient_user_ids' => $recipient_ids,
+					'expected_count'     => count( $recipient_ids ),
+					'inserted_count'     => $inserted,
+					'status'             => $status,
+				),
+			)
+		);
+		if ( is_wp_error( $receipt ) ) {
+			return $this->rollback( $receipt );
+		}
+		$committed = $this->commit();
+		return is_wp_error( $committed ) ? $committed : $receipt;
+	}
+
+	/**
+	 * Return landed definitions and explicit future producer seams.
+	 *
+	 * @param string $type Notification type.
+	 * @return array|null Event definition.
+	 */
+	private function definition( string $type ): ?array {
+		$definitions = array(
+			self::TYPE_INQUIRY_SUBMITTED       => array(
+				'kind'  => 'inquiry_submitted',
+				'title' => __( 'New booking inquiry', 'extrachill-events' ),
+			),
+			self::TYPE_ASSIGNMENT_CHANGED      => array(
+				'kind'  => 'assignment_changed',
+				'title' => __( 'Booking assignment changed', 'extrachill-events' ),
+			),
+			self::TYPE_INFORMATION_RECEIVED    => array(
+				'kind'  => 'status_changed',
+				'title' => __( 'Booking information received', 'extrachill-events' ),
+				'from'  => 'needs_info',
+				'to'    => 'submitted',
+			),
+			self::TYPE_HOLD_EXPIRED            => array(
+				'kind'  => 'hold_expired',
+				'title' => __( 'Booking hold expired', 'extrachill-events' ),
+			),
+			self::TYPE_EVENT_HANDOFF_FAILED    => array(
+				'kind'  => 'event_conversion_failed',
+				'title' => __( 'Booking event handoff failed', 'extrachill-events' ),
+			),
+			self::TYPE_ARTIST_REPLIED          => array(
+				'kind'  => 'artist_replied',
+				'title' => __( 'Artist replied about a booking', 'extrachill-events' ),
+			),
+			self::TYPE_HOLD_EXPIRING           => array(
+				'kind'  => 'hold_expiring',
+				'title' => __( 'Booking hold expiring', 'extrachill-events' ),
+			),
+			self::TYPE_MARKETING_FAILED        => array(
+				'kind'  => 'marketing_action_failed',
+				'title' => __( 'Booking marketing action failed', 'extrachill-events' ),
+			),
+			self::TYPE_SETTLEMENT_READY        => array(
+				'kind'  => 'settlement_ready',
+				'title' => __( 'Booking settlement ready', 'extrachill-events' ),
+			),
+			self::TYPE_OPERATOR_ACTION_OVERDUE => array(
+				'kind'  => 'operator_action_overdue',
+				'title' => __( 'Booking action overdue', 'extrachill-events' ),
+			),
+		);
+		return $definitions[ $type ] ?? null;
+	}
+
+	/**
+	 * Validate that an activity owns the requested event.
+	 *
+	 * @param array $definition Event definition.
+	 * @param array $source     Source activity.
+	 * @return bool Whether the activity matches.
+	 */
+	private function source_matches( array $definition, array $source ): bool {
+		if ( ( $source['kind'] ?? '' ) !== $definition['kind'] ) {
+			return false;
+		}
+		$data = $source['payload']['data'] ?? array();
+		return ! isset( $definition['from'] ) || ( ( $data['from_status'] ?? null ) === $definition['from'] && ( $data['to_status'] ?? null ) === $definition['to'] );
+	}
+
+	/**
+	 * Resolve only current exact active venue members from locked rows.
+	 *
+	 * @param array $rows          Locked membership rows.
+	 * @param int   $venue_term_id Exact booking venue.
+	 * @return int[] Recipient user IDs.
+	 */
+	private function active_recipient_ids( array $rows, int $venue_term_id ): array {
+		$ids        = array();
+		$repository = new VenueMembershipRepository();
+		foreach ( $rows as $row ) {
+			if ( (int) ( $row['venue_term_id'] ?? 0 ) !== $venue_term_id || VenueAuthorization::STATUS_ACTIVE !== ( $row['status'] ?? '' ) ) {
+				continue;
+			}
+			$membership = $repository->hydrate( $row );
+			if ( ! is_wp_error( $membership ) && get_userdata( $membership['user_id'] ) ) {
+				$ids[] = (int) $membership['user_id'];
+			}
+		}
+		return array_values( array_unique( $ids ) );
+	}
+
+	/**
+	 * Resolve the user actor or bounded network bot actor.
+	 *
+	 * @param array $source Source activity.
+	 * @return int Valid network user ID, or zero.
+	 */
+	private function actor_id( array $source ): int {
+		if ( $this->actor_resolver ) {
+			return absint( call_user_func( $this->actor_resolver, $source ) );
+		}
+		$actor_id = absint( $source['actor_id'] ?? 0 );
+		if ( 0 < $actor_id && get_userdata( $actor_id ) ) {
+			return $actor_id;
+		}
+		$actor_id = function_exists( 'ec_get_network_bot_user_id' ) ? absint( ec_get_network_bot_user_id() ) : 0;
+		return 0 < $actor_id && get_userdata( $actor_id ) ? $actor_id : 0;
+	}
+
+	/**
+	 * Build a same-site opaque booking management link.
+	 *
+	 * @param array $booking Booking record.
+	 * @return string Safe management URL, or empty string.
+	 */
+	private function management_link( array $booking ): string {
+		if ( $this->link_resolver ) {
+			return (string) call_user_func( $this->link_resolver, $booking );
+		}
+		$base = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'events' ) : home_url( '/' );
+		if ( ! is_string( $base ) || ! preg_match( '#^https?://#i', $base ) ) {
+			return '';
+		}
+		return esc_url_raw(
+			add_query_arg(
+				array(
+					'booking' => (string) $booking['public_id'],
+					'venue'   => (int) $booking['venue_term_id'],
+				),
+				trailingslashit( $base )
+			)
+		);
+	}
+
+	/** Start the recipient claim transaction. */
+	private function begin() {
+		global $wpdb;
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Notification claim transaction.
+			return new \WP_Error( 'booking_notification_transaction_failed', __( 'The booking notification transaction could not start.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		$this->transaction_active = true;
+		return true;
+	}
+
+	/** Commit notification delivery and evidence together. */
+	private function commit() {
+		global $wpdb;
+		$result                   = $wpdb->query( 'COMMIT' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Notification claim transaction.
+		$this->transaction_active = false;
+		return false === $result ? new \WP_Error( 'booking_notification_commit_uncertain', __( 'The booking notification outcome could not be confirmed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) : true;
+	}
+
+	/**
+	 * Roll back notification delivery while preserving its cause.
+	 *
+	 * @param \WP_Error $cause Delivery failure.
+	 * @return \WP_Error Original failure.
+	 */
+	private function rollback( \WP_Error $cause ) {
+		global $wpdb;
+		if ( $this->transaction_active ) {
+			$wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Notification claim transaction.
+			$this->transaction_active = false;
+		}
+		return $cause;
+	}
+}

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -15,6 +15,7 @@
 			<file>tests/BookingMutationTest.php</file>
 			<file>tests/BookingEventConversionTest.php</file>
 			<file>tests/BookingCommunicationTest.php</file>
+			<file>tests/BookingNotificationTest.php</file>
 			<file>tests/CanonicalEventPublicationGuardTest.php</file>
 			<file>tests/VenueMembershipAuthorizationTest.php</file>
 		</testsuite>

--- a/tests/BookingNotificationTest.php
+++ b/tests/BookingNotificationTest.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Booking operator notification tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Core\BookingActivityRepository;
+use ExtraChillEvents\Core\BookingNotificationService;
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\VenueAuthorization;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
+
+/** Covers booking-owned selection, authorization, and delivery evidence. */
+final class BookingNotificationTest extends TestCase {
+	/** Reset booking persistence. */
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id' => 7,
+			'stack'   => array(),
+			'uuid'    => 0,
+			'terms'   => array(
+				7 => array(
+					55 => (object) array(
+						'term_id'  => 55,
+						'taxonomy' => 'venue',
+						'name'     => 'The Room',
+					),
+				),
+			),
+			'meta'    => array(),
+			'posts'   => array(),
+		);
+		$GLOBALS['wpdb']           = new BookingWpdb();
+	}
+
+	/** Create one private booking fixture. */
+	private function booking(): array {
+		return ( new BookingRepository() )->create(
+			array(
+				'venue_term_id' => 55,
+				'artist_name'   => 'Private Artist',
+				'contact_name'  => 'Private Contact',
+				'contact_email' => 'private@example.com',
+				'contact_phone' => '555-0100',
+				'intake'        => array( 'private_note' => 'not for notifications' ),
+			)
+		);
+	}
+
+	/**
+	 * Append one source activity fixture.
+	 *
+	 * @param array  $booking Booking fixture.
+	 * @param string $kind    Activity kind.
+	 * @param array  $payload Activity payload.
+	 * @return array Activity record.
+	 */
+	private function activity( array $booking, string $kind = 'inquiry_submitted', array $payload = array( 'status' => 'submitted' ) ): array {
+		return ( new BookingActivityRepository() )->append(
+			array(
+				'booking_id' => $booking['id'],
+				'kind'       => $kind,
+				'actor_type' => 'anonymous',
+				'payload'    => $payload,
+			)
+		);
+	}
+
+	/**
+	 * Add one membership fixture.
+	 *
+	 * @param int    $id       Membership ID.
+	 * @param int    $venue    Venue term ID.
+	 * @param int    $user     User ID.
+	 * @param string $status   Membership status.
+	 * @param bool   $is_owner Structural ownership flag.
+	 */
+	private function member( int $id, int $venue, int $user, string $status, bool $is_owner ): void {
+		$GLOBALS['wpdb']->rows[ BookingSchema::memberships_table() ][ $id ] = array(
+			'id'                 => $id,
+			'venue_term_id'      => $venue,
+			'user_id'            => $user,
+			'is_owner'           => $is_owner ? 1 : 0,
+			'status'             => $status,
+			'version'            => 1,
+			'created_by_user_id' => 1,
+			'created_at'         => '2026-01-01 00:00:00',
+			'updated_at'         => '2026-01-01 00:00:00',
+			'revoked_at'         => VenueAuthorization::STATUS_REVOKED === $status ? '2026-01-02 00:00:00' : null,
+		);
+	}
+
+	/**
+	 * Build a service with isolated dependencies.
+	 *
+	 * @param callable $notify Users delivery test double.
+	 * @return BookingNotificationService Isolated service.
+	 */
+	private function service( callable $notify ): BookingNotificationService {
+		return new BookingNotificationService(
+			null,
+			null,
+			$notify,
+			static function (): int {
+				return 99;
+			},
+			static function ( array $booking ): string {
+				return 'https://events.example/?booking=' . rawurlencode( $booking['public_id'] ) . '&venue=' . (int) $booking['venue_term_id'];
+			}
+		);
+	}
+
+	/** Active owner and member receive one PII-free Users payload. */
+	public function test_exact_active_owner_and_member_receive_safe_digest_payload_once(): void {
+		$booking = $this->booking();
+		$source  = $this->activity( $booking );
+		$this->member( 1, 55, 10, VenueAuthorization::STATUS_ACTIVE, true );
+		$this->member( 2, 55, 11, VenueAuthorization::STATUS_ACTIVE, false );
+		$this->member( 3, 55, 12, VenueAuthorization::STATUS_INVITED, false );
+		$this->member( 4, 55, 13, VenueAuthorization::STATUS_REVOKED, true );
+		$this->member( 5, 77, 14, VenueAuthorization::STATUS_ACTIVE, true );
+		$calls   = array();
+		$notify  = static function ( array $recipients, array $payload ) use ( &$calls ): int {
+			$calls[] = array(
+				'recipients' => $recipients,
+				'payload'    => $payload,
+			);
+			return count( $recipients );
+		};
+		$service = $this->service( $notify );
+
+		$receipt = $service->deliver( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, $source['id'] );
+		$replay  = $service->deliver( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, $source['id'] );
+
+		$this->assertCount( 1, $calls );
+		$this->assertSame( array( 10, 11 ), $calls[0]['recipients'] );
+		$this->assertSame( array( 'actor_id', 'type', 'link', 'title', 'item_id' ), array_keys( $calls[0]['payload'] ) );
+		$this->assertSame( 99, $calls[0]['payload']['actor_id'] );
+		$this->assertSame( 'booking_inquiry_submitted', $calls[0]['payload']['type'] );
+		$this->assertSame( 'https://events.example/?booking=' . rawurlencode( $booking['public_id'] ) . '&venue=55', $calls[0]['payload']['link'] );
+		$this->assertStringNotContainsString( 'Private', wp_json_encode( $calls[0] ) );
+		$this->assertStringNotContainsString( 'private@example.com', wp_json_encode( $receipt ) );
+		$this->assertSame( 'delivered', $receipt['payload']['data']['status'] );
+		$this->assertSame( $receipt['id'], $replay['id'] );
+	}
+
+	/** A member revoked before locked selection is suppressed. */
+	public function test_revocation_race_is_resolved_from_locked_membership_rows(): void {
+		$booking = $this->booking();
+		$source  = $this->activity( $booking );
+		$this->member( 1, 55, 10, VenueAuthorization::STATUS_ACTIVE, true );
+		$this->member( 2, 55, 11, VenueAuthorization::STATUS_ACTIVE, false );
+		$GLOBALS['wpdb']->after_membership_lock = static function (): void {
+			$GLOBALS['wpdb']->rows[ BookingSchema::memberships_table() ][2]['status'] = VenueAuthorization::STATUS_REVOKED;
+		};
+		$recipients                             = array();
+		$service                                = $this->service(
+			static function ( array $ids ) use ( &$recipients ): int {
+				$recipients = $ids;
+				return count( $ids );
+			}
+		);
+
+		$service->deliver( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, $source['id'] );
+
+		$this->assertSame( array( 10 ), $recipients );
+	}
+
+	/** An ambiguous Users result is durable and never blindly retried. */
+	public function test_unknown_result_is_recorded_and_replay_does_not_redeliver(): void {
+		$booking = $this->booking();
+		$source  = $this->activity(
+			$booking,
+			'assignment_changed',
+			array(
+				'from_assignee_user_id' => null,
+				'to_assignee_user_id'   => 10,
+			)
+		);
+		$this->member( 1, 55, 10, VenueAuthorization::STATUS_ACTIVE, true );
+		$calls   = 0;
+		$service = $this->service(
+			static function () use ( &$calls ) {
+				++$calls;
+				return array( 'unexpected' => true );
+			}
+		);
+
+		$receipt = $service->deliver( BookingNotificationService::TYPE_ASSIGNMENT_CHANGED, $source['id'] );
+		$replay  = $service->deliver( BookingNotificationService::TYPE_ASSIGNMENT_CHANGED, $source['id'] );
+
+		$this->assertSame( 1, $calls );
+		$this->assertSame( 'unknown', $receipt['payload']['data']['status'] );
+		$this->assertNull( $receipt['payload']['data']['inserted_count'] );
+		$this->assertSame( $receipt['id'], $replay['id'] );
+	}
+
+	/** Notification types cannot be paired with unrelated activity. */
+	public function test_source_contract_and_deep_link_fail_closed(): void {
+		$booking = $this->booking();
+		$source  = $this->activity(
+			$booking,
+			'status_changed',
+			array(
+				'from_status' => 'submitted',
+				'to_status'   => 'under_review',
+			)
+		);
+		$service = $this->service(
+			static function (): int {
+				return 1;
+			}
+		);
+
+		$result = $service->deliver( BookingNotificationService::TYPE_INFORMATION_RECEIVED, $source['id'] );
+
+		$this->assertSame( 'booking_notification_source_invalid', $result->get_error_code() );
+		$this->assertArrayNotHasKey( BookingSchema::memberships_table(), $GLOBALS['wpdb']->rows );
+	}
+
+	/** The landed activity contracts emit exactly the five current types. */
+	public function test_landed_source_contracts_emit_exact_notification_types(): void {
+		$booking = $this->booking();
+		$this->member( 1, 55, 10, VenueAuthorization::STATUS_ACTIVE, true );
+		$events = array(
+			array( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, 'inquiry_submitted', array( 'status' => 'submitted' ) ),
+			array( BookingNotificationService::TYPE_ASSIGNMENT_CHANGED, 'assignment_changed', array( 'to_assignee_user_id' => 10 ) ),
+			array( BookingNotificationService::TYPE_INFORMATION_RECEIVED, 'status_changed', array( 'from_status' => 'needs_info', 'to_status' => 'submitted' ) ),
+			array( BookingNotificationService::TYPE_HOLD_EXPIRED, 'hold_expired', array( 'hold_id' => 20 ) ),
+			array( BookingNotificationService::TYPE_EVENT_HANDOFF_FAILED, 'event_conversion_failed', array( 'attempt' => 1 ) ),
+		);
+		$types   = array();
+		$service = $this->service(
+			static function ( array $recipients, array $payload ) use ( &$types ): int {
+				$types[] = $payload['type'];
+				return count( $recipients );
+			}
+		);
+
+		foreach ( $events as $event ) {
+			$source = $this->activity( $booking, $event[1], $event[2] );
+			$result = $service->deliver( $event[0], $source['id'] );
+			$this->assertSame( 'delivered', $result['payload']['data']['status'] );
+		}
+
+		$this->assertSame( array_column( $events, 0 ), $types );
+	}
+}

--- a/tests/BookingNotificationTest.php
+++ b/tests/BookingNotificationTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Booking operator notification tests.
+ * Booking notification outbox tests.
  *
  * @package ExtraChillEvents\Tests
  */
@@ -14,8 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
-
-/** Covers booking-owned selection, authorization, and delivery evidence. */
+/** Covers recovery, authorization, and structured receipt reconciliation. */
 final class BookingNotificationTest extends TestCase {
 	/** Reset booking persistence. */
 	protected function setUp(): void {
@@ -52,15 +51,8 @@ final class BookingNotificationTest extends TestCase {
 		);
 	}
 
-	/**
-	 * Append one source activity fixture.
-	 *
-	 * @param array  $booking Booking fixture.
-	 * @param string $kind    Activity kind.
-	 * @param array  $payload Activity payload.
-	 * @return array Activity record.
-	 */
-	private function activity( array $booking, string $kind = 'inquiry_submitted', array $payload = array( 'status' => 'submitted' ) ): array {
+	/** Append one source activity fixture. */
+	private function source( array $booking, string $kind = 'inquiry_submitted', array $payload = array( 'status' => 'submitted' ) ): array {
 		return ( new BookingActivityRepository() )->append(
 			array(
 				'booking_id' => $booking['id'],
@@ -71,21 +63,13 @@ final class BookingNotificationTest extends TestCase {
 		);
 	}
 
-	/**
-	 * Add one membership fixture.
-	 *
-	 * @param int    $id       Membership ID.
-	 * @param int    $venue    Venue term ID.
-	 * @param int    $user     User ID.
-	 * @param string $status   Membership status.
-	 * @param bool   $is_owner Structural ownership flag.
-	 */
-	private function member( int $id, int $venue, int $user, string $status, bool $is_owner ): void {
+	/** Add one membership fixture. */
+	private function member( int $id, int $venue, int $user, string $status, bool $owner ): void {
 		$GLOBALS['wpdb']->rows[ BookingSchema::memberships_table() ][ $id ] = array(
 			'id'                 => $id,
 			'venue_term_id'      => $venue,
 			'user_id'            => $user,
-			'is_owner'           => $is_owner ? 1 : 0,
+			'is_owner'           => $owner ? 1 : 0,
 			'status'             => $status,
 			'version'            => 1,
 			'created_by_user_id' => 1,
@@ -95,159 +79,203 @@ final class BookingNotificationTest extends TestCase {
 		);
 	}
 
-	/**
-	 * Build a service with isolated dependencies.
-	 *
-	 * @param callable $notify Users delivery test double.
-	 * @return BookingNotificationService Isolated service.
-	 */
-	private function service( callable $notify ): BookingNotificationService {
-		return new BookingNotificationService(
-			null,
-			null,
-			$notify,
-			static function (): int {
-				return 99;
-			},
-			static function ( array $booking ): string {
-				return 'https://events.example/?booking=' . rawurlencode( $booking['public_id'] ) . '&venue=' . (int) $booking['venue_term_id'];
-			}
+	/** Build an authorized destination resolver that follows canonical policy. */
+	private function destination( array &$resolved ): callable {
+		$authorization = new BookingTestAuthorization(
+			array(
+				'10:55' => true,
+				'11:55' => true,
+			)
 		);
+		return static function ( array $booking, array $recipient_ids, array $members ) use ( &$resolved, $authorization ) {
+			foreach ( $recipient_ids as $recipient_id ) {
+				$allowed = $authorization->authorize_locked( $recipient_id, $booking['venue_term_id'], VenueAuthorization::ACTION_ACCESS_VENUE, $members );
+				if ( true !== $allowed ) {
+					return $allowed;
+				}
+			}
+			$resolved[] = array(
+				'booking_id' => $booking['id'],
+				'recipients' => $recipient_ids,
+			);
+			return 'https://events.example/manage/booking/' . rawurlencode( $booking['public_id'] );
+		};
 	}
 
-	/** Active owner and member receive one PII-free Users payload. */
-	public function test_exact_active_owner_and_member_receive_safe_digest_payload_once(): void {
+	/** Source recovery creates an idempotent outbox request after emit failure. */
+	public function test_recovery_creates_missing_request_once(): void {
 		$booking = $this->booking();
-		$source  = $this->activity( $booking );
+		$ignored = $this->source( $booking, 'status_changed', array( 'from_status' => 'submitted', 'to_status' => 'under_review' ) );
+		$source  = $this->source( $booking );
+		$service = new BookingNotificationService();
+
+		$first  = $service->reconcile_pending();
+		$second = $service->reconcile_pending();
+
+		$this->assertSame( 1, $first['recovered'] );
+		$this->assertSame( 0, $second['recovered'] );
+		$requests = array_values(
+			array_filter(
+				$GLOBALS['wpdb']->rows[ BookingSchema::activity_table() ],
+				static function ( $row ) {
+					return 'notification_requested' === $row['kind'];
+				}
+			)
+		);
+		$this->assertCount( 1, $requests );
+		$this->assertSame( (string) $source['id'], $requests[0]['external_id'] );
+		$ignored_rows = array_values( array_filter( $GLOBALS['wpdb']->rows[ BookingSchema::activity_table() ], static function ( $row ) { return 'notification_source_ignored' === $row['kind']; } ) );
+		$this->assertSame( (string) $ignored['id'], $ignored_rows[0]['external_id'] );
+	}
+
+	/** Production reconciliation remains pending until both dependencies land. */
+	public function test_missing_destination_and_users_receipts_do_not_terminally_dedupe(): void {
+		$booking = $this->booking();
+		$source  = $this->source( $booking );
+		$this->member( 1, 55, 10, VenueAuthorization::STATUS_ACTIVE, true );
+		$request = ( new BookingNotificationService() )->request( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, $source['id'] );
+
+		$result = ( new BookingNotificationService() )->reconcile( $request['id'] );
+
+		$this->assertSame( 'booking_notification_destination_unavailable', $result->get_error_code() );
+		$this->assertNull( ( new BookingActivityRepository() )->notification_terminal( $request['id'] ) );
+		$this->assertSame( 0, ( new BookingActivityRepository() )->notification_attempt_count( $request['id'] ) );
+		$resolved = array();
+		$result   = ( new BookingNotificationService( null, null, null, $this->destination( $resolved ), static function (): int { return 99; } ) )->reconcile( $request['id'] );
+		$this->assertSame( 'booking_notification_receipts_unavailable', $result->get_error_code() );
+		$this->assertNull( ( new BookingActivityRepository() )->notification_terminal( $request['id'] ) );
+	}
+
+	/** Partial and zero delivery receipts remain retryable until every user resolves. */
+	public function test_partial_and_zero_receipts_retry_safely_to_completion(): void {
+		$booking = $this->booking();
+		$source  = $this->source( $booking );
 		$this->member( 1, 55, 10, VenueAuthorization::STATUS_ACTIVE, true );
 		$this->member( 2, 55, 11, VenueAuthorization::STATUS_ACTIVE, false );
 		$this->member( 3, 55, 12, VenueAuthorization::STATUS_INVITED, false );
-		$this->member( 4, 55, 13, VenueAuthorization::STATUS_REVOKED, true );
-		$this->member( 5, 77, 14, VenueAuthorization::STATUS_ACTIVE, true );
-		$calls   = array();
-		$notify  = static function ( array $recipients, array $payload ) use ( &$calls ): int {
-			$calls[] = array(
-				'recipients' => $recipients,
-				'payload'    => $payload,
+		$this->member( 4, 77, 13, VenueAuthorization::STATUS_ACTIVE, true );
+		$request  = ( new BookingNotificationService() )->request( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, $source['id'] );
+		$resolved = array();
+		$calls    = 0;
+		$delivery = function ( array $recipients, array $payload, string $producer, string $key ) use ( &$calls ): array {
+			++$calls;
+			$this_call = $calls;
+			if ( 1 === $this_call ) {
+				return array(
+					'recipients' => array(
+						10 => array( 'status' => 'failed' ),
+						11 => array( 'status' => 'failed' ),
+					),
+				);
+			}
+			if ( 2 === $this_call ) {
+				return array(
+					'recipients' => array(
+						10 => array(
+							'status'          => 'inserted',
+							'notification_id' => 100,
+						),
+						11 => array( 'status' => 'failed' ),
+					),
+				);
+			}
+			$this->assertSame( array( 10, 11 ), $recipients );
+			$this->assertSame( 'extrachill-events-booking', $producer );
+			$this->assertStringStartsWith( 'notification-request:', $key );
+			$this->assertStringNotContainsString( 'Private', wp_json_encode( $payload ) );
+			return array(
+				'recipients' => array(
+					10 => array(
+						'status'          => 'existing',
+						'notification_id' => 100,
+					),
+					11 => array(
+						'status'          => 'inserted',
+						'notification_id' => 101,
+					),
+				),
 			);
-			return count( $recipients );
 		};
-		$service = $this->service( $notify );
+		$service  = new BookingNotificationService(
+			null,
+			null,
+			$delivery,
+			$this->destination( $resolved ),
+			static function (): int {
+				return 99;
+			}
+		);
 
-		$receipt = $service->deliver( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, $source['id'] );
-		$replay  = $service->deliver( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, $source['id'] );
+		$zero     = $service->reconcile( $request['id'] );
+		$partial  = $service->reconcile( $request['id'] );
+		$complete = $service->reconcile( $request['id'] );
+		$replay   = $service->reconcile( $request['id'] );
 
-		$this->assertCount( 1, $calls );
-		$this->assertSame( array( 10, 11 ), $calls[0]['recipients'] );
-		$this->assertSame( array( 'actor_id', 'type', 'link', 'title', 'item_id' ), array_keys( $calls[0]['payload'] ) );
-		$this->assertSame( 99, $calls[0]['payload']['actor_id'] );
-		$this->assertSame( 'booking_inquiry_submitted', $calls[0]['payload']['type'] );
-		$this->assertSame( 'https://events.example/?booking=' . rawurlencode( $booking['public_id'] ) . '&venue=55', $calls[0]['payload']['link'] );
-		$this->assertStringNotContainsString( 'Private', wp_json_encode( $calls[0] ) );
-		$this->assertStringNotContainsString( 'private@example.com', wp_json_encode( $receipt ) );
-		$this->assertSame( 'delivered', $receipt['payload']['data']['status'] );
-		$this->assertSame( $receipt['id'], $replay['id'] );
+		$this->assertSame( 'notification_delivery_attempted', $zero['kind'] );
+		$this->assertSame( 2, $zero['payload']['data']['failed_count'] );
+		$this->assertSame( 'notification_delivery_attempted', $partial['kind'] );
+		$this->assertSame( 'notification_delivered', $complete['kind'] );
+		$this->assertSame( $complete['id'], $replay['id'] );
+		$this->assertSame( 3, $calls );
+		$this->assertCount( 3, $resolved );
 	}
 
-	/** A member revoked before locked selection is suppressed. */
-	public function test_revocation_race_is_resolved_from_locked_membership_rows(): void {
+	/** Revocation between attempts suppresses the user before retry delivery. */
+	public function test_revocation_race_reselects_exact_active_recipients(): void {
 		$booking = $this->booking();
-		$source  = $this->activity( $booking );
+		$source  = $this->source( $booking, 'assignment_changed', array( 'to_assignee_user_id' => 11 ) );
 		$this->member( 1, 55, 10, VenueAuthorization::STATUS_ACTIVE, true );
 		$this->member( 2, 55, 11, VenueAuthorization::STATUS_ACTIVE, false );
-		$GLOBALS['wpdb']->after_membership_lock = static function (): void {
-			$GLOBALS['wpdb']->rows[ BookingSchema::memberships_table() ][2]['status'] = VenueAuthorization::STATUS_REVOKED;
-		};
-		$recipients                             = array();
-		$service                                = $this->service(
-			static function ( array $ids ) use ( &$recipients ): int {
-				$recipients = $ids;
-				return count( $ids );
-			}
-		);
-
-		$service->deliver( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, $source['id'] );
-
-		$this->assertSame( array( 10 ), $recipients );
-	}
-
-	/** An ambiguous Users result is durable and never blindly retried. */
-	public function test_unknown_result_is_recorded_and_replay_does_not_redeliver(): void {
-		$booking = $this->booking();
-		$source  = $this->activity(
-			$booking,
-			'assignment_changed',
-			array(
-				'from_assignee_user_id' => null,
-				'to_assignee_user_id'   => 10,
-			)
-		);
-		$this->member( 1, 55, 10, VenueAuthorization::STATUS_ACTIVE, true );
-		$calls   = 0;
-		$service = $this->service(
-			static function () use ( &$calls ) {
-				++$calls;
-				return array( 'unexpected' => true );
-			}
-		);
-
-		$receipt = $service->deliver( BookingNotificationService::TYPE_ASSIGNMENT_CHANGED, $source['id'] );
-		$replay  = $service->deliver( BookingNotificationService::TYPE_ASSIGNMENT_CHANGED, $source['id'] );
-
-		$this->assertSame( 1, $calls );
-		$this->assertSame( 'unknown', $receipt['payload']['data']['status'] );
-		$this->assertNull( $receipt['payload']['data']['inserted_count'] );
-		$this->assertSame( $receipt['id'], $replay['id'] );
-	}
-
-	/** Notification types cannot be paired with unrelated activity. */
-	public function test_source_contract_and_deep_link_fail_closed(): void {
-		$booking = $this->booking();
-		$source  = $this->activity(
-			$booking,
-			'status_changed',
-			array(
-				'from_status' => 'submitted',
-				'to_status'   => 'under_review',
-			)
-		);
-		$service = $this->service(
+		$request    = ( new BookingNotificationService() )->request( BookingNotificationService::TYPE_ASSIGNMENT_CHANGED, $source['id'] );
+		$deliveries = array();
+		$resolved   = array();
+		$service    = new BookingNotificationService(
+			null,
+			null,
+			static function ( array $recipients ) use ( &$deliveries ): array {
+				$deliveries[] = $recipients;
+				$rows         = array();
+				foreach ( $recipients as $recipient ) {
+					$rows[ $recipient ] = array( 'status' => 1 === count( $deliveries ) ? 'failed' : 'existing' );
+				}
+				return array( 'recipients' => $rows );
+			},
+			$this->destination( $resolved ),
 			static function (): int {
-				return 1;
-			}
+				return 99; }
 		);
 
-		$result = $service->deliver( BookingNotificationService::TYPE_INFORMATION_RECEIVED, $source['id'] );
+		$service->reconcile( $request['id'] );
+		$GLOBALS['wpdb']->rows[ BookingSchema::memberships_table() ][2]['status'] = VenueAuthorization::STATUS_REVOKED;
+		$service->reconcile( $request['id'] );
 
-		$this->assertSame( 'booking_notification_source_invalid', $result->get_error_code() );
-		$this->assertArrayNotHasKey( BookingSchema::memberships_table(), $GLOBALS['wpdb']->rows );
+		$this->assertSame( array( 10, 11 ), $deliveries[0] );
+		$this->assertSame( array( 10 ), $deliveries[1] );
 	}
 
-	/** The landed activity contracts emit exactly the five current types. */
-	public function test_landed_source_contracts_emit_exact_notification_types(): void {
+	/** Recovery emits only the five landed event mappings. */
+	public function test_landed_and_future_source_seams_remain_explicit(): void {
 		$booking = $this->booking();
-		$this->member( 1, 55, 10, VenueAuthorization::STATUS_ACTIVE, true );
-		$events = array(
-			array( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, 'inquiry_submitted', array( 'status' => 'submitted' ) ),
-			array( BookingNotificationService::TYPE_ASSIGNMENT_CHANGED, 'assignment_changed', array( 'to_assignee_user_id' => 10 ) ),
-			array( BookingNotificationService::TYPE_INFORMATION_RECEIVED, 'status_changed', array( 'from_status' => 'needs_info', 'to_status' => 'submitted' ) ),
-			array( BookingNotificationService::TYPE_HOLD_EXPIRED, 'hold_expired', array( 'hold_id' => 20 ) ),
-			array( BookingNotificationService::TYPE_EVENT_HANDOFF_FAILED, 'event_conversion_failed', array( 'attempt' => 1 ) ),
+		$events  = array(
+			array( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, 'inquiry_submitted', array() ),
+			array( BookingNotificationService::TYPE_ASSIGNMENT_CHANGED, 'assignment_changed', array() ),
+			array(
+				BookingNotificationService::TYPE_INFORMATION_RECEIVED,
+				'status_changed',
+				array(
+					'from_status' => 'needs_info',
+					'to_status'   => 'submitted',
+				),
+			),
+			array( BookingNotificationService::TYPE_HOLD_EXPIRED, 'hold_expired', array() ),
+			array( BookingNotificationService::TYPE_EVENT_HANDOFF_FAILED, 'event_conversion_failed', array() ),
 		);
-		$types   = array();
-		$service = $this->service(
-			static function ( array $recipients, array $payload ) use ( &$types ): int {
-				$types[] = $payload['type'];
-				return count( $recipients );
-			}
-		);
-
+		$service = new BookingNotificationService();
 		foreach ( $events as $event ) {
-			$source = $this->activity( $booking, $event[1], $event[2] );
-			$result = $service->deliver( $event[0], $source['id'] );
-			$this->assertSame( 'delivered', $result['payload']['data']['status'] );
+			$source = $this->source( $booking, $event[1], $event[2] );
+			$this->assertSame( $event[0], $service->request( $event[0], $source['id'] )['payload']['data']['notification_type'] );
 		}
-
-		$this->assertSame( array_column( $events, 0 ), $types );
+		$future = $this->source( $booking, 'settlement_ready', array() );
+		$this->assertSame( BookingNotificationService::TYPE_SETTLEMENT_READY, $service->request( BookingNotificationService::TYPE_SETTLEMENT_READY, $future['id'] )['payload']['data']['notification_type'] );
 	}
 }

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -618,6 +618,15 @@ final class BookingWpdb {
 			}
 			return $count;
 		}
+		if ( preg_match( "/SELECT COUNT\(\*\) FROM .*ec_booking_activity WHERE external_id = '(\d+)' AND kind = 'notification_delivery_attempted'/", $query, $match ) ) {
+			$count = 0;
+			foreach ( $this->rows[ $this->prefix . 'ec_booking_activity' ] ?? array() as $row ) {
+				if ( (string) ( $row['external_id'] ?? '' ) === $match[1] && 'notification_delivery_attempted' === $row['kind'] ) {
+					++$count;
+				}
+			}
+			return $count;
+		}
 		++$this->schema_queries;
 		if ( $this->fail_reads ) {
 			$this->last_error = 'simulated schema read failure';
@@ -671,6 +680,11 @@ final class BookingWpdb {
 		if ( $is_activity && preg_match( '/WHERE communication_intent_id = (\d+) ORDER BY id DESC LIMIT 1/', $query, $match ) ) {
 			++$this->communication_state_queries;
 			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static function ( $row ) use ( $match ) { return (int) ( $row['communication_intent_id'] ?? 0 ) === (int) $match[1]; } ) );
+			usort( $rows, static function ( $left, $right ) { return $right['id'] <=> $left['id']; } );
+			return $rows[0] ?? null;
+		}
+		if ( $is_activity && preg_match( "/WHERE external_id = '(\d+)' AND kind IN \('notification_delivered', 'notification_suppressed'\)/", $query, $match ) ) {
+			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static function ( $row ) use ( $match ) { return (string) ( $row['external_id'] ?? '' ) === $match[1] && in_array( $row['kind'], array( 'notification_delivered', 'notification_suppressed' ), true ); } ) );
 			usort( $rows, static function ( $left, $right ) { return $right['id'] <=> $left['id']; } );
 			return $rows[0] ?? null;
 		}
@@ -838,6 +852,30 @@ final class BookingWpdb {
 		if ( $this->fail_reads ) {
 			$this->last_error = 'simulated result read failure';
 			return null; }
+		if ( false !== strpos( $query, 'SELECT source.* FROM' ) && false !== strpos( $query, "source.kind IN ('inquiry_submitted'" ) ) {
+			preg_match( '/LIMIT (\d+)/', $query, $limit );
+			$requests = array();
+			foreach ( $this->rows[ $this->prefix . 'ec_booking_activity' ] ?? array() as $row ) {
+				if ( in_array( $row['kind'], array( 'notification_requested', 'notification_source_ignored' ), true ) ) {
+					$requests[] = (string) $row['external_id'];
+				}
+			}
+			$rows = array_values( array_filter( $this->rows[ $this->prefix . 'ec_booking_activity' ] ?? array(), static function ( $row ) use ( $requests ) { return in_array( $row['kind'], array( 'inquiry_submitted', 'assignment_changed', 'status_changed', 'hold_expired', 'event_conversion_failed' ), true ) && ! in_array( (string) $row['id'], $requests, true ); } ) );
+			usort( $rows, static function ( $left, $right ) { return $left['id'] <=> $right['id']; } );
+			return array_slice( $rows, 0, (int) ( $limit[1] ?? 50 ) );
+		}
+		if ( false !== strpos( $query, 'SELECT request.* FROM' ) && false !== strpos( $query, "request.kind = 'notification_requested'" ) ) {
+			preg_match( '/LIMIT (\d+)/', $query, $limit );
+			$terminals = array();
+			foreach ( $this->rows[ $this->prefix . 'ec_booking_activity' ] ?? array() as $row ) {
+				if ( in_array( $row['kind'], array( 'notification_delivered', 'notification_suppressed' ), true ) ) {
+					$terminals[] = (string) $row['external_id'];
+				}
+			}
+			$rows = array_values( array_filter( $this->rows[ $this->prefix . 'ec_booking_activity' ] ?? array(), static function ( $row ) use ( $terminals ) { return 'notification_requested' === $row['kind'] && ! in_array( (string) $row['id'], $terminals, true ); } ) );
+			usort( $rows, static function ( $left, $right ) { return $left['id'] <=> $right['id']; } );
+			return array_slice( $rows, 0, (int) ( $limit[1] ?? 50 ) );
+		}
 		if ( false !== strpos( $query, 'ec_booking_communication_state' ) && false !== strpos( $query, 'INNER JOIN' ) && preg_match( "/s\.booking_id = (\d+) AND s\.status = 'scheduled' AND s\.intent_id > (\d+).*LIMIT (\d+)/", $query, $match ) ) {
 			++$this->communication_state_queries;
 			$this->pending_reminder_query_cursors[] = (int) $match[2];

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -7,6 +7,7 @@
 
 use ExtraChillEvents\Core\BookingActivityRepository;
 use ExtraChillEvents\Core\BookingCommunicationService;
+use ExtraChillEvents\Core\BookingNotificationService;
 use ExtraChillEvents\Core\BookingPrivateFileProvider;
 use ExtraChillEvents\Core\BookingLifecycle;
 use ExtraChillEvents\Core\BookingHoldRepository;
@@ -1364,6 +1365,7 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueMembershipRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueAuthorization.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingActivityRepository.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingNotificationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingCommunicationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingHoldRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingMutationService.php';


### PR DESCRIPTION
## Summary
- persist booking-owned notification requests from durable source activity and recover requests missed after domain commit
- reconcile exact active venue recipients under fresh membership locks with retryable attempt evidence
- keep production delivery fail-closed until Users #280 provides structured idempotent receipts and Events #323 provides an authorized management destination

This is an independently useful partial infrastructure PR for #312. It does not close #312 and does not currently send operator notifications.

## Landed Source Mappings
The outbox recognizes only source contracts that currently exist:
- `booking_inquiry_submitted` from `inquiry_submitted`
- `booking_assignment_changed` from `assignment_changed`
- `booking_information_received` from `status_changed` only for `needs_info -> submitted`
- `booking_hold_expired` from `hold_expired`
- `booking_event_handoff_failed` from `event_conversion_failed`

Non-matching lifecycle activity is durably marked ignored so recovery scans cannot starve. Future source constants remain explicit seams but are not recovered or synthesized.

## Retry Contract
- recurring and post-commit reconciliation recover missing outbox requests from source booking activity
- request, attempt, ignored-source, delivered, and suppressed evidence stays in Events-owned booking activity
- invited, revoked, invalid, and cross-venue users are excluded on every attempt
- zero, partial, malformed, missing, and uncertain structured receipts remain pending and retryable
- only complete per-recipient `inserted`/`existing` receipt sets become terminal delivery evidence
- all-active-recipient revocation may terminate as a suppression, without exposing booking data
- no Users notification table is queried or written directly

## Blocked Delivery Dependencies
- Extra-Chill/extrachill-users#280: canonical structured, idempotent per-recipient receipt primitive
- #323: actual authenticated booking-management destination and canonical resolver

Production has no fallback to count-only `ec_users_notify()` and no placeholder URL. Delivery stays disabled until both contracts land; this PR is intended to remain open/stacked meanwhile.

## Remaining Producer Seams
These #312 producers do not have landed owning source events and are not emitted:
- `booking_artist_replied`
- `booking_hold_expiring`
- `booking_marketing_failed`
- `booking_settlement_ready`
- `booking_operator_action_overdue`

## Verification
- focused outbox: 5 tests, 29 assertions
- full booking suite: 279 tests, 1,802 assertions
- Homeboy audit: passed; one baseline-only informational harness-size finding
- Homeboy PHPCS + PHPStan level 7: passed with zero findings
- JS lint and frontend build: passed
- changed-file PHP syntax and whitespace checks: passed

The default repository-wide PHPUnit aggregate still reproduces 21 unrelated order/dependency failures, tracked in #349. Homeboy run `a2943fc7-ebe4-47e2-9eb1-0d57df33dfdf` likewise passed audit/lint but hit the existing Codebox aggregate/Playground failures.

Related to #312