### PR TITLE
fix: clear complete release lint baseline

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,18 @@
 	"env": {
 		"browser": true
 	},
+	"overrides": [
+		{
+			"files": [ "**/*.test.js" ],
+			"env": {
+				"jest": true
+			},
+			"globals": {
+				"MouseEvent": "readonly",
+				"PopStateEvent": "readonly"
+			}
+		}
+	],
 	"rules": {
 		"no-console": [ "error", { "allow": [ "warn", "error" ] } ],
 		"no-unused-vars": [ "error", { "argsIgnorePattern": "^_" } ],

--- a/assets/js/discovery.test.js
+++ b/assets/js/discovery.test.js
@@ -1,7 +1,7 @@
 /**
  * Discovery scope navigation request-state coverage.
  */
-/* eslint-env jest */
+/* global MouseEvent, PopStateEvent, beforeAll, beforeEach, describe, expect, it, jest */
 
 function deferred() {
 	let resolve;

--- a/blocks/concert-stats/src/components/ShowList.js
+++ b/blocks/concert-stats/src/components/ShowList.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { ActionRow, InlineStatus } from '@extrachill/components';
 

--- a/blocks/concert-stats/src/components/ShowList.test.js
+++ b/blocks/concert-stats/src/components/ShowList.test.js
@@ -1,11 +1,22 @@
 /**
  * ShowList load-more behavior.
  */
-/* eslint-env jest */
+/* global MouseEvent, afterAll, beforeAll, beforeEach, describe, expect, it, jest */
 
-import { createRoot } from '@wordpress/element';
-import { act } from 'react';
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
+import { createRoot } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+
+/**
+ * Internal dependencies
+ */
 import ShowList from './ShowList';
 
 jest.mock( '@wordpress/api-fetch', () => ( {

--- a/blocks/concert-stats/src/hooks/useShows.test.js
+++ b/blocks/concert-stats/src/hooks/useShows.test.js
@@ -1,11 +1,22 @@
 /**
  * useShows pagination and query identity behavior.
  */
-/* eslint-env jest */
+/* global MouseEvent, afterAll, beforeAll, beforeEach, describe, expect, it, jest */
 
-import { createRoot } from '@wordpress/element';
-import { act } from 'react';
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
+import { createRoot } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+
+/**
+ * Internal dependencies
+ */
 import useShows from './useShows';
 
 jest.mock( '@wordpress/api-fetch', () => ( {
@@ -105,12 +116,12 @@ describe( 'useShows', () => {
 
 	it( 'starts a selected year at page one after multiple pages', async () => {
 		apiFetch.mockImplementation( ( { path } ) => {
-			const page = Number(
-				new URLSearchParams( path.split( '?' )[ 1 ] ).get( 'page' )
-			);
 			if ( path.includes( 'year=2025' ) ) {
 				return Promise.resolve( response( [ 25 ], 1, 1, 1 ) );
 			}
+			const page = Number(
+				new URLSearchParams( path.split( '?' )[ 1 ] ).get( 'page' )
+			);
 			return Promise.resolve( response( [ page ], 3, 3, page ) );
 		} );
 		const initial = {

--- a/blocks/concert-stats/src/hooks/useStats.test.js
+++ b/blocks/concert-stats/src/hooks/useStats.test.js
@@ -1,11 +1,22 @@
 /**
  * useStats request isolation and authorization behavior.
  */
-/* eslint-env jest */
+/* global afterAll, beforeAll, beforeEach, describe, expect, it, jest */
 
-import { createRoot } from '@wordpress/element';
-import { act } from 'react';
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
+import { createRoot } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+
+/**
+ * Internal dependencies
+ */
 import useStats from './useStats';
 
 jest.mock( '@wordpress/api-fetch', () => ( {

--- a/blocks/concert-stats/src/view.test.js
+++ b/blocks/concert-stats/src/view.test.js
@@ -1,11 +1,22 @@
 /**
  * Concert stats public/owner request boundaries.
  */
-/* eslint-env jest */
+/* global afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, jest */
 
-import { createRoot } from '@wordpress/element';
-import { act } from 'react';
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
+import { createRoot } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+
+/**
+ * Internal dependencies
+ */
 import { ConcertStatsApp } from './view';
 
 jest.mock( '@wordpress/api-fetch', () => ( {

--- a/inc/Abilities/VenueBookingEventAbilities.php
+++ b/inc/Abilities/VenueBookingEventAbilities.php
@@ -63,7 +63,7 @@ class VenueBookingEventAbilities {
 	}
 
 	public function execute( array $input ) {
-		$booking = $this->bookings->get( (int) $input['booking_id'] );
+		$booking                 = $this->bookings->get( (int) $input['booking_id'] );
 		$this->active_conversion = is_array( $booking ) ? $booking : null;
 		try {
 			return $this->conversion->convert( (int) $input['booking_id'], (int) $input['expected_version'], get_current_user_id() );
@@ -79,7 +79,7 @@ class VenueBookingEventAbilities {
 		}
 		if ( ! is_array( $this->active_conversion )
 			|| BookingEventConversionService::SOURCE !== ( $input['source'] ?? '' )
-			|| $this->active_conversion['public_id'] !== ( $input['source_id'] ?? '' ) ) {
+			|| ( $input['source_id'] ?? '' ) !== $this->active_conversion['public_id'] ) {
 			return false;
 		}
 
@@ -96,21 +96,24 @@ class VenueBookingEventAbilities {
 		if ( ! is_array( $this->active_conversion ) ) {
 			return 0;
 		}
-		$candidate_match = false;
+		$candidate_match     = false;
 		$candidate_intervals = (array) ( $publication['_candidate_intervals'] ?? array() );
 		if ( empty( $candidate_intervals ) && isset( $publication['start_at'], $publication['end_at'] ) ) {
-			$candidate_intervals[] = array( 'start_at' => $publication['start_at'], 'end_at' => $publication['end_at'] );
+			$candidate_intervals[] = array(
+				'start_at' => $publication['start_at'],
+				'end_at'   => $publication['end_at'],
+			);
 		}
 		foreach ( $candidate_intervals as $interval ) {
-			if ( $this->active_conversion['performance_start_at'] === ( $interval['start_at'] ?? '' )
-				&& $this->active_conversion['performance_end_at'] === ( $interval['end_at'] ?? '' ) ) {
+			if ( ( $interval['start_at'] ?? '' ) === $this->active_conversion['performance_start_at']
+				&& ( $interval['end_at'] ?? '' ) === $this->active_conversion['performance_end_at'] ) {
 				$candidate_match = true;
 				break;
 			}
 		}
 		if ( BookingEventConversionService::SOURCE !== ( $input['source'] ?? '' )
-			|| $this->active_conversion['public_id'] !== ( $input['source_id'] ?? '' )
-			|| (int) $this->active_conversion['venue_term_id'] !== (int) ( $publication['venue_id'] ?? 0 )
+			|| ( $input['source_id'] ?? '' ) !== $this->active_conversion['public_id']
+			|| (int) ( $publication['venue_id'] ?? 0 ) !== (int) $this->active_conversion['venue_term_id']
 			|| ! $candidate_match ) {
 			return 0;
 		}

--- a/inc/Abilities/VenueQualificationAbilities.php
+++ b/inc/Abilities/VenueQualificationAbilities.php
@@ -128,15 +128,15 @@ class VenueQualificationAbilities {
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
-							'url'  => array(
+							'url'             => array(
 								'type'        => 'string',
 								'description' => 'Venue website URL (homepage). The ability will find the events page and test the scraper.',
 							),
-							'name' => array(
+							'name'            => array(
 								'type'        => 'string',
 								'description' => 'Venue name (optional, for display).',
 							),
-							'flow_id' => array(
+							'flow_id'         => array(
 								'type'        => 'integer',
 								'description' => 'Existing flow whose persisted scraper config and lifecycle scope must be diagnosed.',
 							),
@@ -150,15 +150,15 @@ class VenueQualificationAbilities {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'qualified'        => array( 'type' => 'boolean' ),
-							'verdict'          => array( 'type' => 'string' ),
-							'events_url'       => array( 'type' => 'string' ),
-							'method'           => array( 'type' => 'string' ),
-							'event_count'      => array( 'type' => 'integer' ),
-							'fingerprint'      => array( 'type' => 'object' ),
-							'improvement_hint' => array( 'type' => 'string' ),
-							'agent_guidance'   => array( 'type' => 'string' ),
-							'warnings'         => array( 'type' => 'array' ),
+							'qualified'          => array( 'type' => 'boolean' ),
+							'verdict'            => array( 'type' => 'string' ),
+							'events_url'         => array( 'type' => 'string' ),
+							'method'             => array( 'type' => 'string' ),
+							'event_count'        => array( 'type' => 'integer' ),
+							'fingerprint'        => array( 'type' => 'object' ),
+							'improvement_hint'   => array( 'type' => 'string' ),
+							'agent_guidance'     => array( 'type' => 'string' ),
+							'warnings'           => array( 'type' => 'array' ),
 							'production_context' => array( 'type' => 'object' ),
 							'repair_proposal'    => array( 'type' => array( 'object', 'null' ) ),
 						),
@@ -311,7 +311,7 @@ class VenueQualificationAbilities {
 					null !== $flow_context ? $flow_context['handler_config'] : null
 				);
 				if ( null !== $flow_context && $candidate['url'] === $url ) {
-					$attempt                          = QualifyFingerprinter::add_production_eligibility( $attempt, $flow_context );
+					$attempt                           = QualifyFingerprinter::add_production_eligibility( $attempt, $flow_context );
 					$fingerprint['production_context'] = $attempt['production_context'];
 				}
 				unset( $attempt['_diagnostic_identifiers'] );
@@ -517,27 +517,27 @@ class VenueQualificationAbilities {
 			&& '' !== $events_url
 			&& untrailingslashit( $events_url ) !== untrailingslashit( $url ) ) {
 			$repair_proposal = array(
-				'type'            => 'source_url',
-				'current'         => $url,
-				'proposed'        => $events_url,
-				'same_host'       => strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) ) === strtolower( (string) wp_parse_url( $events_url, PHP_URL_HOST ) ),
-				'applied'         => false,
-				'confirmation'    => 'A separate explicit apply with confirmation is required.',
+				'type'         => 'source_url',
+				'current'      => $url,
+				'proposed'     => $events_url,
+				'same_host'    => strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) ) === strtolower( (string) wp_parse_url( $events_url, PHP_URL_HOST ) ),
+				'applied'      => false,
+				'confirmation' => 'A separate explicit apply with confirmation is required.',
 			);
 		}
 
 		return array(
-			'qualified'        => QualifyVerdict::is_qualified( $resolved['verdict'] ),
-			'verdict'          => $resolved['verdict'],
-			'events_url'       => $resolved['events_url'],
-			'method'           => $method,
-			'name'             => $name,
-			'event_count'      => $resolved['event_count'],
-			'fingerprint'      => $fingerprint,
-			'improvement_hint' => $resolved['improvement_hint'],
-			'agent_guidance'   => $resolved['agent_guidance'],
-			'warnings'         => $warnings,
-			'urls_tested'      => isset( $fingerprint['urls_tested'] ) ? $fingerprint['urls_tested'] : array(),
+			'qualified'          => QualifyVerdict::is_qualified( $resolved['verdict'] ),
+			'verdict'            => $resolved['verdict'],
+			'events_url'         => $resolved['events_url'],
+			'method'             => $method,
+			'name'               => $name,
+			'event_count'        => $resolved['event_count'],
+			'fingerprint'        => $fingerprint,
+			'improvement_hint'   => $resolved['improvement_hint'],
+			'agent_guidance'     => $resolved['agent_guidance'],
+			'warnings'           => $warnings,
+			'urls_tested'        => isset( $fingerprint['urls_tested'] ) ? $fingerprint['urls_tested'] : array(),
 			'production_context' => $fingerprint['production_context'] ?? array(),
 			'repair_proposal'    => $repair_proposal,
 		);

--- a/inc/Cli/FlowOps.php
+++ b/inc/Cli/FlowOps.php
@@ -457,7 +457,7 @@ class FlowOps {
 			$table,
 			array( 'flow_config' => wp_json_encode( $patched['config'] ) ),
 			array(
-				'flow_id'    => $flow_id,
+				'flow_id'     => $flow_id,
 				'flow_config' => (string) $encoded,
 			),
 			array( '%s' ),

--- a/inc/Cli/UnqualifiableFlowsCommand.php
+++ b/inc/Cli/UnqualifiableFlowsCommand.php
@@ -195,24 +195,24 @@ class UnqualifiableFlowsCommand {
 			$progress->tick();
 
 			$row = array(
-				'flow_id'     => $c['flow_id'],
-				'flow_name'   => $c['flow_name'],
-				'source_url'  => $c['source_url'],
-				'new_verdict' => '',
-				'event_count' => 0,
-				'raw_extracted' => 0,
-				'unique_source' => 0,
-				'processed'     => null,
-				'active_claim'  => null,
-				'reprocess_eligible' => null,
+				'flow_id'               => $c['flow_id'],
+				'flow_name'             => $c['flow_name'],
+				'source_url'            => $c['source_url'],
+				'new_verdict'           => '',
+				'event_count'           => 0,
+				'raw_extracted'         => 0,
+				'unique_source'         => 0,
+				'processed'             => null,
+				'active_claim'          => null,
+				'reprocess_eligible'    => null,
 				'selected_by_max_items' => null,
-				'production_eligible' => null,
-				'context_supplied' => false,
-				'complete'         => false,
-				'identifier_source' => '',
-				'diagnostic_error' => '',
-				'repair_proposal' => null,
-				'action'      => 'none',
+				'production_eligible'   => null,
+				'context_supplied'      => false,
+				'complete'              => false,
+				'identifier_source'     => '',
+				'diagnostic_error'      => '',
+				'repair_proposal'       => null,
+				'action'                => 'none',
 			);
 
 			if ( is_wp_error( $result ) ) {
@@ -222,21 +222,21 @@ class UnqualifiableFlowsCommand {
 				continue;
 			}
 
-			$row['new_verdict'] = (string) ( $result['verdict'] ?? '' );
-			$row['event_count'] = (int) ( $result['event_count'] ?? 0 );
-			$production = is_array( $result['production_context'] ?? null ) ? $result['production_context'] : array();
+			$row['new_verdict']           = (string) ( $result['verdict'] ?? '' );
+			$row['event_count']           = (int) ( $result['event_count'] ?? 0 );
+			$production                   = is_array( $result['production_context'] ?? null ) ? $result['production_context'] : array();
 			$row['raw_extracted']         = (int) ( $production['raw_extracted'] ?? 0 );
-			$row['unique_source']        = (int) ( $production['unique_source'] ?? 0 );
-			$row['processed']            = $production['processed'] ?? null;
-			$row['active_claim']         = $production['active_claim'] ?? null;
+			$row['unique_source']         = (int) ( $production['unique_source'] ?? 0 );
+			$row['processed']             = $production['processed'] ?? null;
+			$row['active_claim']          = $production['active_claim'] ?? null;
 			$row['reprocess_eligible']    = $production['reprocess_eligible'] ?? null;
 			$row['selected_by_max_items'] = $production['selected_by_max_items'] ?? null;
-			$row['production_eligible']  = $production['production_eligible'] ?? null;
-			$row['context_supplied']     = ! empty( $production['context_supplied'] );
-			$row['complete']             = true === ( $production['complete'] ?? false );
-			$row['identifier_source']    = (string) ( $production['identifier_source'] ?? '' );
-			$row['diagnostic_error']     = (string) ( $production['error'] ?? '' );
-			$row['repair_proposal']      = $result['repair_proposal'] ?? null;
+			$row['production_eligible']   = $production['production_eligible'] ?? null;
+			$row['context_supplied']      = ! empty( $production['context_supplied'] );
+			$row['complete']              = true === ( $production['complete'] ?? false );
+			$row['identifier_source']     = (string) ( $production['identifier_source'] ?? '' );
+			$row['diagnostic_error']      = (string) ( $production['error'] ?? '' );
+			$row['repair_proposal']       = $result['repair_proposal'] ?? null;
 
 			if ( QualifyVerdict::QUALIFIED_STRUCTURED === $row['new_verdict'] ) {
 				$row['action'] = $this->classify_qualified_action( $production, $row['repair_proposal'] );

--- a/inc/Core/BookingAttachmentService.php
+++ b/inc/Core/BookingAttachmentService.php
@@ -720,7 +720,7 @@ class BookingAttachmentService {
 			}
 		);
 		if ( is_wp_error( $result ) && is_resource( $opened ) ) {
-			fclose( $opened );
+			fclose( $opened ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- The provider returned an open stream that this error path must close directly.
 		}
 		return $result;
 	}

--- a/inc/Core/CanonicalEventPublicationGuard.php
+++ b/inc/Core/CanonicalEventPublicationGuard.php
@@ -82,11 +82,11 @@ class CanonicalEventPublicationGuard {
 			return $result;
 		}
 
-		$this->active_context       = 'dme';
-		$this->active_post_id       = (int) ( $context['existing_post_id'] ?? 0 );
-		$this->active_publication   = $publication;
-		$this->active_lifecycle_key = $this->lifecycle_key( $context );
-		$this->active_poisoned      = false;
+		$this->active_context           = 'dme';
+		$this->active_post_id           = (int) ( $context['existing_post_id'] ?? 0 );
+		$this->active_publication       = $publication;
+		$this->active_lifecycle_key     = $this->lifecycle_key( $context );
+		$this->active_poisoned          = false;
 		$this->active_boundary_consumed = false;
 		return $preflight;
 	}
@@ -105,7 +105,14 @@ class CanonicalEventPublicationGuard {
 			return;
 		}
 		if ( $post_id < 1 || ( $this->active_post_id > 0 && $post_id !== $this->active_post_id ) ) {
-			$error = new \WP_Error( 'canonical_event_publication_identity_mismatch', __( 'Canonical event publication could not bind its reserved post identity.', 'extrachill-events' ), array( 'status' => 409, 'post_id' => $post_id ) );
+			$error                 = new \WP_Error(
+				'canonical_event_publication_identity_mismatch',
+				__( 'Canonical event publication could not bind its reserved post identity.', 'extrachill-events' ),
+				array(
+					'status'  => 409,
+					'post_id' => $post_id,
+				)
+			);
 			$this->active_poisoned = true;
 			$this->audit_denial( 'dme', $error );
 			return;
@@ -145,11 +152,11 @@ class CanonicalEventPublicationGuard {
 			return $result;
 		}
 
-		$this->active_context     = 'rest';
-		$this->active_post_id     = $post_id;
-		$this->active_publication = $publication;
+		$this->active_context           = 'rest';
+		$this->active_post_id           = $post_id;
+		$this->active_publication       = $publication;
 		$this->active_boundary_consumed = false;
-		$this->active_rest_request = is_object( $request ) ? $request : null;
+		$this->active_rest_request      = is_object( $request ) ? $request : null;
 		return $prepared_post;
 	}
 
@@ -176,19 +183,26 @@ class CanonicalEventPublicationGuard {
 		if ( $maybe_empty ) {
 			return true;
 		}
-		if ( $post_type !== ( $postarr['post_type'] ?? '' ) || 'publish' !== ( $postarr['post_status'] ?? '' ) ) {
+		if ( ( $postarr['post_type'] ?? '' ) !== $post_type || 'publish' !== ( $postarr['post_status'] ?? '' ) ) {
 			return $maybe_empty;
 		}
 
 		$post_id = absint( $postarr['ID'] ?? 0 );
 		if ( 'dme' === $this->active_context ) {
-			$matches_reserved = $post_id > 0 && $post_id === $this->active_post_id;
+			$matches_reserved       = $post_id > 0 && $post_id === $this->active_post_id;
 			$matches_sourceless_new = 0 === $post_id && 0 === $this->active_post_id;
 			if ( ! $this->active_poisoned && ! $this->active_boundary_consumed && ( $matches_reserved || $matches_sourceless_new ) ) {
 				$this->active_boundary_consumed = true;
 				return false;
 			}
-			$error = new \WP_Error( 'canonical_event_publication_post_mismatch', __( 'This event write does not match the active canonical publication.', 'extrachill-events' ), array( 'status' => 409, 'post_id' => $post_id ) );
+			$error                 = new \WP_Error(
+				'canonical_event_publication_post_mismatch',
+				__( 'This event write does not match the active canonical publication.', 'extrachill-events' ),
+				array(
+					'status'  => 409,
+					'post_id' => $post_id,
+				)
+			);
 			$this->active_poisoned = true;
 			$this->audit_denial( 'wp_insert_post_empty_content', $error );
 			return true;
@@ -198,7 +212,14 @@ class CanonicalEventPublicationGuard {
 				$this->active_boundary_consumed = true;
 				return false;
 			}
-			$error = new \WP_Error( 'canonical_event_publication_post_mismatch', __( 'This event write does not match the active canonical publication.', 'extrachill-events' ), array( 'status' => 409, 'post_id' => $post_id ) );
+			$error                 = new \WP_Error(
+				'canonical_event_publication_post_mismatch',
+				__( 'This event write does not match the active canonical publication.', 'extrachill-events' ),
+				array(
+					'status'  => 409,
+					'post_id' => $post_id,
+				)
+			);
 			$this->active_poisoned = true;
 			$this->audit_denial( 'wp_insert_post_empty_content', $error );
 			return true;
@@ -221,9 +242,9 @@ class CanonicalEventPublicationGuard {
 			return true;
 		}
 		if ( true === $result ) {
-			$this->active_context     = 'post';
-			$this->active_post_id     = $post_id;
-			$this->active_publication = $publication;
+			$this->active_context           = 'post';
+			$this->active_post_id           = $post_id;
+			$this->active_publication       = $publication;
 			$this->active_boundary_consumed = true;
 		}
 		return false;
@@ -234,7 +255,7 @@ class CanonicalEventPublicationGuard {
 		unset( $update, $post_before );
 		$post      = is_object( $post ) ? $post : get_post( $post_id );
 		$post_type = defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events';
-		if ( 'post' === $this->active_context && $post && $post_type === ( $post->post_type ?? '' ) && ( 0 === $this->active_post_id || $post_id === $this->active_post_id ) ) {
+		if ( 'post' === $this->active_context && $post && ( $post->post_type ?? '' ) === $post_type && ( 0 === $this->active_post_id || $post_id === $this->active_post_id ) ) {
 			$this->active_post_id = $post_id;
 			$this->release();
 		}
@@ -245,15 +266,22 @@ class CanonicalEventPublicationGuard {
 		if ( is_wp_error( $preflight ) || false === $preflight || 'publish' !== ( $context['post_status'] ?? '' ) ) {
 			return $preflight;
 		}
-		$post_id  = absint( $context['post_id'] ?? 0 );
-		$venue_id = absint( $context['next_venue_id'] ?? 0 );
+		$post_id            = absint( $context['post_id'] ?? 0 );
+		$venue_id           = absint( $context['next_venue_id'] ?? 0 );
 		$previous_venue_ids = array_values( array_unique( array_filter( array_map( 'absint', (array) ( $context['previous_venue_ids'] ?? array() ) ) ) ) );
 		if ( $post_id < 1 ) {
 			return $preflight;
 		}
 		if ( $venue_id < 1 ) {
 			if ( count( $previous_venue_ids ) > 1 ) {
-				$error = new \WP_Error( 'canonical_event_venue_ambiguous', __( 'The published event has multiple retained venue assignments and cannot be updated safely.', 'extrachill-events' ), array( 'status' => 409, 'venue_ids' => $previous_venue_ids ) );
+				$error = new \WP_Error(
+					'canonical_event_venue_ambiguous',
+					__( 'The published event has multiple retained venue assignments and cannot be updated safely.', 'extrachill-events' ),
+					array(
+						'status'    => 409,
+						'venue_ids' => $previous_venue_ids,
+					)
+				);
 				$this->audit_denial( 'event_update', $error );
 				return $error;
 			}
@@ -274,11 +302,11 @@ class CanonicalEventPublicationGuard {
 			$this->audit_denial( 'event_update', $result );
 			return $result;
 		}
-		$this->active_context       = 'event_update';
-		$this->active_post_id       = $post_id;
-		$this->active_publication   = $publication;
-		$this->active_lifecycle_key = $this->lifecycle_key( $context );
-		$this->active_poisoned      = false;
+		$this->active_context           = 'event_update';
+		$this->active_post_id           = $post_id;
+		$this->active_publication       = $publication;
+		$this->active_lifecycle_key     = $this->lifecycle_key( $context );
+		$this->active_poisoned          = false;
 		$this->active_boundary_consumed = false;
 		return $preflight;
 	}
@@ -297,12 +325,24 @@ class CanonicalEventPublicationGuard {
 		$name     = BookingHoldRepository::venue_lock_name( $venue_id );
 		$acquired = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $name, 5 ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Cross-connection venue booking serialization.
 		if ( 1 !== (int) $acquired || '' !== (string) $wpdb->last_error ) {
-			return new \WP_Error( 'canonical_event_booking_lock_not_acquired', __( 'Venue booking availability is busy; retry publication.', 'extrachill-events' ), array( 'status' => 503, 'database_error' => $wpdb->last_error ) );
+			return new \WP_Error(
+				'canonical_event_booking_lock_not_acquired',
+				__( 'Venue booking availability is busy; retry publication.', 'extrachill-events' ),
+				array(
+					'status'         => 503,
+					'database_error' => $wpdb->last_error,
+				)
+			);
 		}
 		$this->acquired_locks[] = $name;
 
-		$candidate_intervals = empty( $candidate_intervals ) ? array( array( 'start_at' => $start_at, 'end_at' => $end_at ) ) : $candidate_intervals;
-		$conflict = $this->find_booking_conflict( $venue_id, $start_at, $end_at, $post_id, $excluded_booking_id, $candidate_intervals );
+		$candidate_intervals = empty( $candidate_intervals ) ? array(
+			array(
+				'start_at' => $start_at,
+				'end_at'   => $end_at,
+			),
+		) : $candidate_intervals;
+		$conflict            = $this->find_booking_conflict( $venue_id, $start_at, $end_at, $post_id, $excluded_booking_id, $candidate_intervals );
 		if ( is_wp_error( $conflict ) ) {
 			$this->release();
 			return $conflict;
@@ -344,14 +384,14 @@ class CanonicalEventPublicationGuard {
 				)
 			);
 		}
-		$this->acquired_locks = array();
-		$this->active_context = null;
-		$this->active_post_id = 0;
-		$this->active_publication = null;
-		$this->active_lifecycle_key = '';
-		$this->active_poisoned = false;
+		$this->acquired_locks           = array();
+		$this->active_context           = null;
+		$this->active_post_id           = 0;
+		$this->active_publication       = null;
+		$this->active_lifecycle_key     = '';
+		$this->active_poisoned          = false;
 		$this->active_boundary_consumed = false;
-		$this->active_rest_request = null;
+		$this->active_rest_request      = null;
 	}
 
 	/** Match only the REST request object which acquired the active lock. */
@@ -361,9 +401,9 @@ class CanonicalEventPublicationGuard {
 
 	private function find_booking_conflict( int $venue_id, string $start_at, string $end_at, int $post_id, int $excluded_booking_id, array $candidate_intervals ) {
 		global $wpdb;
-		$hold_exact       = array();
-		$booking_exact    = array();
-		$exact_values     = array();
+		$hold_exact    = array();
+		$booking_exact = array();
+		$exact_values  = array();
 		foreach ( $candidate_intervals as $interval ) {
 			$hold_exact[]    = '(start_at = %s AND end_at = %s)';
 			$booking_exact[] = '(performance_start_at = %s AND performance_end_at = %s)';
@@ -376,7 +416,14 @@ class CanonicalEventPublicationGuard {
 		if ( $post_id > 0 ) {
 			$linked = $wpdb->get_row( $wpdb->prepare( "SELECT id, venue_term_id, space_key, performance_start_at, performance_end_at, 'confirmed_booking' AS conflict_type FROM {$bookings} WHERE event_id = %d AND status = 'confirmed' LIMIT 1", $post_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- A linked booking may not be silently detached by moving its event.
 			if ( '' !== (string) $wpdb->last_error ) {
-				return new \WP_Error( 'canonical_event_booking_conflict_check_failed', __( 'The event-linked booking could not be checked safely.', 'extrachill-events' ), array( 'status' => 503, 'database_error' => $wpdb->last_error ) );
+				return new \WP_Error(
+					'canonical_event_booking_conflict_check_failed',
+					__( 'The event-linked booking could not be checked safely.', 'extrachill-events' ),
+					array(
+						'status'         => 503,
+						'database_error' => $wpdb->last_error,
+					)
+				);
 			}
 			if ( is_array( $linked ) ) {
 				$exact = (int) $linked['venue_term_id'] === $venue_id;
@@ -391,20 +438,34 @@ class CanonicalEventPublicationGuard {
 				}
 			}
 		}
-		$holds = BookingSchema::holds_table();
+		$holds       = BookingSchema::holds_table();
 		$hold_values = array_merge( array( $venue_id, $end_at, $start_at, $excluded_booking_id ), $exact_values );
-		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT id, booking_id, space_key, 'hold' AS conflict_type FROM {$holds} WHERE venue_term_id = %d AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND start_at < %s AND end_at > %s AND NOT (booking_id = %d AND ({$hold_exact_sql})) LIMIT 1", $hold_values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Checked while the stable venue-wide lock is held.
+		$row         = $wpdb->get_row( $wpdb->prepare( "SELECT id, booking_id, space_key, 'hold' AS conflict_type FROM {$holds} WHERE venue_term_id = %d AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND start_at < %s AND end_at > %s AND NOT (booking_id = %d AND ({$hold_exact_sql})) LIMIT 1", $hold_values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Dynamic exact-interval placeholders are matched by the flattened value array while the stable venue-wide lock is held.
 		if ( '' !== (string) $wpdb->last_error ) {
-			return new \WP_Error( 'canonical_event_booking_conflict_check_failed', __( 'Venue booking holds could not be checked safely.', 'extrachill-events' ), array( 'status' => 503, 'database_error' => $wpdb->last_error ) );
+			return new \WP_Error(
+				'canonical_event_booking_conflict_check_failed',
+				__( 'Venue booking holds could not be checked safely.', 'extrachill-events' ),
+				array(
+					'status'         => 503,
+					'database_error' => $wpdb->last_error,
+				)
+			);
 		}
 		if ( is_array( $row ) ) {
 			return $row;
 		}
 
 		$booking_values = array_merge( array( $venue_id, $end_at, $start_at, $excluded_booking_id, $post_id ), $exact_values );
-		$row      = $wpdb->get_row( $wpdb->prepare( "SELECT id, space_key, 'confirmed_booking' AS conflict_type FROM {$bookings} WHERE venue_term_id = %d AND status = 'confirmed' AND performance_start_at < %s AND performance_end_at > %s AND NOT ((id = %d OR event_id = %d) AND ({$booking_exact_sql})) LIMIT 1", $booking_values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Only an exact originating booking is exempt from the venue-wide policy.
+		$row            = $wpdb->get_row( $wpdb->prepare( "SELECT id, space_key, 'confirmed_booking' AS conflict_type FROM {$bookings} WHERE venue_term_id = %d AND status = 'confirmed' AND performance_start_at < %s AND performance_end_at > %s AND NOT ((id = %d OR event_id = %d) AND ({$booking_exact_sql})) LIMIT 1", $booking_values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Dynamic exact-interval placeholders are matched by the flattened value array; only an exact originating booking is exempt.
 		if ( '' !== (string) $wpdb->last_error ) {
-			return new \WP_Error( 'canonical_event_booking_conflict_check_failed', __( 'Confirmed venue bookings could not be checked safely.', 'extrachill-events' ), array( 'status' => 503, 'database_error' => $wpdb->last_error ) );
+			return new \WP_Error(
+				'canonical_event_booking_conflict_check_failed',
+				__( 'Confirmed venue bookings could not be checked safely.', 'extrachill-events' ),
+				array(
+					'status'         => 503,
+					'database_error' => $wpdb->last_error,
+				)
+			);
 		}
 		return is_array( $row ) ? $row : null;
 	}
@@ -412,7 +473,7 @@ class CanonicalEventPublicationGuard {
 	private function publication_from_post( $post, $request, int $post_id ) {
 		$venue_id = $this->venue_id_from_request( $request );
 		if ( $venue_id < 1 && $post_id > 0 ) {
-			$venues   = wp_get_object_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
+			$venues = wp_get_object_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
 			if ( is_wp_error( $venues ) ) {
 				return new \WP_Error(
 					'canonical_event_venue_read_failed',
@@ -454,7 +515,7 @@ class CanonicalEventPublicationGuard {
 		} else {
 			$value = null;
 		}
-		$ids   = array_values( array_filter( array_map( 'absint', (array) $value ) ) );
+		$ids = array_values( array_filter( array_map( 'absint', (array) $value ) ) );
 		return 1 === count( $ids ) ? $ids[0] : 0;
 	}
 
@@ -504,21 +565,31 @@ class CanonicalEventPublicationGuard {
 			return $end_candidates;
 		}
 
-		$start_timestamps = array_map( static function ( \DateTimeImmutable $date ): int { return $date->getTimestamp(); }, $start_candidates );
-		$end_timestamps   = array_map( static function ( \DateTimeImmutable $date ): int { return $date->getTimestamp(); }, $end_candidates );
+		$start_timestamps = array_map(
+			static function ( \DateTimeImmutable $date ): int {
+				return $date->getTimestamp();
+			},
+			$start_candidates
+		);
+		$end_timestamps   = array_map(
+			static function ( \DateTimeImmutable $date ): int {
+				return $date->getTimestamp();
+			},
+			$end_candidates
+		);
 		$start_timestamp  = min( $start_timestamps );
 		$end_timestamp    = max( $end_timestamps );
 		if ( $end_timestamp <= $start_timestamp ) {
 			return new \WP_Error( 'canonical_event_datetime_invalid', __( 'The event end must be later than its start.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
-		$utc = new \DateTimeZone( 'UTC' );
+		$utc                 = new \DateTimeZone( 'UTC' );
 		$candidate_intervals = array();
 		foreach ( $start_timestamps as $candidate_start ) {
 			foreach ( $end_timestamps as $candidate_end ) {
 				if ( $candidate_end <= $candidate_start ) {
 					continue;
 				}
-				$key = $candidate_start . ':' . $candidate_end;
+				$key                         = $candidate_start . ':' . $candidate_end;
 				$candidate_intervals[ $key ] = array(
 					'start_at' => ( new \DateTimeImmutable( '@' . $candidate_start ) )->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
 					'end_at'   => ( new \DateTimeImmutable( '@' . $candidate_end ) )->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
@@ -526,9 +597,9 @@ class CanonicalEventPublicationGuard {
 			}
 		}
 		return array(
-			'venue_id' => $venue_id,
-			'start_at' => ( new \DateTimeImmutable( '@' . $start_timestamp ) )->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
-			'end_at'   => ( new \DateTimeImmutable( '@' . $end_timestamp ) )->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
+			'venue_id'             => $venue_id,
+			'start_at'             => ( new \DateTimeImmutable( '@' . $start_timestamp ) )->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
+			'end_at'               => ( new \DateTimeImmutable( '@' . $end_timestamp ) )->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
 			'_candidate_intervals' => array_values( $candidate_intervals ),
 		);
 	}
@@ -564,15 +635,20 @@ class CanonicalEventPublicationGuard {
 	}
 
 	private function lifecycle_key( array $context ): string {
-		return hash( 'sha256', wp_json_encode( array(
-			'invocation_id'    => (string) ( $context['invocation_id'] ?? '' ),
-			'venue_term_id'   => (int) ( $context['venue_term_id'] ?? $context['next_venue_id'] ?? 0 ),
-			'existing_post_id' => (int) ( $context['existing_post_id'] ?? $context['post_id'] ?? 0 ),
-			'source'          => (string) ( $context['source'] ?? '' ),
-			'source_id'       => (string) ( $context['source_id'] ?? '' ),
-			'source_identity' => (string) ( $context['source_identity'] ?? '' ),
-			'event'           => $context['event'] ?? array(),
-		) ) );
+		return hash(
+			'sha256',
+			wp_json_encode(
+				array(
+					'invocation_id'    => (string) ( $context['invocation_id'] ?? '' ),
+					'venue_term_id'    => (int) ( $context['venue_term_id'] ?? $context['next_venue_id'] ?? 0 ),
+					'existing_post_id' => (int) ( $context['existing_post_id'] ?? $context['post_id'] ?? 0 ),
+					'source'           => (string) ( $context['source'] ?? '' ),
+					'source_id'        => (string) ( $context['source_id'] ?? '' ),
+					'source_identity'  => (string) ( $context['source_identity'] ?? '' ),
+					'event'            => $context['event'] ?? array(),
+				)
+			)
+		);
 	}
 
 	private function audit_denial( string $context, \WP_Error $error ): void {

--- a/inc/Core/LocalBookingPrivateFileProvider.php
+++ b/inc/Core/LocalBookingPrivateFileProvider.php
@@ -126,7 +126,7 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 		}
 
 		try {
-			if ( ! copy( $source_path, $temporary ) || ! chmod( $temporary, 0600 ) ) {
+			if ( ! copy( $source_path, $temporary ) || ! chmod( $temporary, 0600 ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- Private staging requires an exact owner-only mode before validation.
 				return new \WP_Error( 'booking_private_stage_failed', __( 'The private attachment could not be copied securely.', 'extrachill-events' ) );
 			}
 			clearstatcache( true, $temporary );
@@ -172,12 +172,12 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 			}
 			$blob_path     = $this->blob_path( $reference );
 			$metadata_path = $this->metadata_path( $reference );
-			if ( file_exists( $blob_path ) || file_exists( $metadata_path ) || ! rename( $temporary, $blob_path ) ) {
+			if ( file_exists( $blob_path ) || file_exists( $metadata_path ) || ! rename( $temporary, $blob_path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Same-filesystem rename provides the required atomic private-file commit.
 				return new \WP_Error( 'booking_private_finalize_failed', __( 'The private attachment could not be finalized atomically.', 'extrachill-events' ) );
 			}
 			$temporary = '';
-			if ( ! chmod( $blob_path, 0600 ) ) {
-				unlink( $blob_path );
+			if ( ! chmod( $blob_path, 0600 ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- Stored private blobs require an exact owner-only mode.
+				unlink( $blob_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Failed private blobs must be removed immediately before returning.
 				return new \WP_Error( 'booking_private_finalize_failed', __( 'The private attachment could not be secured.', 'extrachill-events' ) );
 			}
 			$record = array(
@@ -194,13 +194,13 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 				'created_at'   => gmdate( 'Y-m-d H:i:s' ),
 			);
 			if ( ! $this->write_metadata_atomic( $metadata_path, $record ) ) {
-				unlink( $blob_path );
+				unlink( $blob_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- A blob without its atomic metadata commit must be removed immediately.
 				return new \WP_Error( 'booking_private_finalize_failed', __( 'The private attachment metadata could not be finalized atomically.', 'extrachill-events' ) );
 			}
 			return $reference;
 		} finally {
 			if ( '' !== $temporary && file_exists( $temporary ) ) {
-				unlink( $temporary );
+				unlink( $temporary ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- The provider owns this contained temporary file and must clean it in finally.
 			}
 		}
 	}
@@ -406,15 +406,15 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 		}
 		$handoff_path = $this->handoff_path( $stream_token );
 		$consuming    = $handoff_path . '.consuming';
-		if ( ! $this->handoffs_directory_is_safe() || ! $this->is_contained( $handoff_path ) || is_link( $handoff_path ) || ! is_file( $handoff_path ) || ! rename( $handoff_path, $consuming ) ) {
+		if ( ! $this->handoffs_directory_is_safe() || ! $this->is_contained( $handoff_path ) || is_link( $handoff_path ) || ! is_file( $handoff_path ) || ! rename( $handoff_path, $consuming ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Atomic rename is the one-time token consumption boundary.
 			return new \WP_Error( 'booking_private_stream_invalid', __( 'The private stream token is invalid.', 'extrachill-events' ), array( 'status' => 403 ) );
 		}
 		if ( ! $this->handoffs_directory_is_safe() || is_link( $consuming ) || ! is_file( $consuming ) ) {
 			return new \WP_Error( 'booking_private_handoff_directory_unsafe', __( 'The private handoff directory changed unexpectedly.', 'extrachill-events' ) );
 		}
-		$contents = file_get_contents( $consuming );
+		$contents = file_get_contents( $consuming ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- This reads a validated contained local handoff, not a remote URL.
 		$decoded  = false !== $contents ? json_decode( $contents, true ) : null;
-		if ( ! $this->handoffs_directory_is_safe() || ! unlink( $consuming ) ) {
+		if ( ! $this->handoffs_directory_is_safe() || ! unlink( $consuming ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Consumed one-time handoffs must be deleted synchronously.
 			return new \WP_Error( 'booking_private_handoff_consume_failed', __( 'The private stream handoff could not be consumed safely.', 'extrachill-events' ) );
 		}
 		if ( ! is_array( $decoded ) || time() >= (int) ( $decoded['expires'] ?? 0 ) || ! hash_equals( (string) ( $decoded['attachment_public_id'] ?? '' ), $attachment_public_id ) || (int) ( $decoded['actor_id'] ?? 0 ) !== $actor_id || ! hash_equals( (string) ( $decoded['purpose'] ?? '' ), $purpose ) ) {
@@ -460,10 +460,10 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 						return new \WP_Error( 'booking_private_retirement_tombstone_failed', __( 'Private object retirement could not be made recoverable.', 'extrachill-events' ) );
 					}
 				}
-				if ( file_exists( $blob ) && ! unlink( $blob ) ) {
+				if ( file_exists( $blob ) && ! unlink( $blob ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Retirement synchronously removes the exact contained private blob.
 					return new \WP_Error( 'booking_private_retirement_partial', __( 'Private object retirement remains incomplete and recoverable.', 'extrachill-events' ) );
 				}
-				if ( file_exists( $metadata ) && ! unlink( $metadata ) ) {
+				if ( file_exists( $metadata ) && ! unlink( $metadata ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Retirement synchronously removes the exact contained metadata sidecar.
 					return new \WP_Error( 'booking_private_retirement_partial', __( 'Private object retirement remains incomplete and recoverable.', 'extrachill-events' ) );
 				}
 				return true;
@@ -520,7 +520,7 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 			if ( is_wp_error( $held ) ) {
 				return $held;
 			}
-			if ( false === $held && ( $is_temporary || $is_handoff || $is_metadata_temp || $is_orphan_blob || $is_orphan_sidecar ) && file_exists( $path ) && unlink( $path ) ) {
+			if ( false === $held && ( $is_temporary || $is_handoff || $is_metadata_temp || $is_orphan_blob || $is_orphan_sidecar ) && file_exists( $path ) && unlink( $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Approved cleanup deletes only contained provider-owned private artifacts.
 				++$deleted;
 			}
 		}
@@ -551,7 +551,7 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 				}
 				$deleted = 0;
 				foreach ( array( $this->blob_path( $reference ), $this->metadata_path( $reference ) ) as $path ) {
-					if ( file_exists( $path ) && unlink( $path ) ) {
+					if ( file_exists( $path ) && unlink( $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Approved cleanup deletes the exact contained unclaimed object files.
 						++$deleted;
 					}
 				}
@@ -574,7 +574,7 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 			return new \WP_Error( 'booking_private_storage_unsafe', __( 'The configured private storage root is missing or unsafe.', 'extrachill-events' ), array( 'status' => 503 ) );
 		}
 		$real = realpath( $configured );
-		if ( false === $real || str_replace( '\\', '/', $real ) !== $configured || ! is_writable( $real ) ) {
+		if ( false === $real || str_replace( '\\', '/', $real ) !== $configured || ! is_writable( $real ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- Storage admission must verify host-level writability of the configured private root.
 			return new \WP_Error( 'booking_private_storage_unsafe', __( 'The configured private storage root is unwritable or resolves through a symlink.', 'extrachill-events' ), array( 'status' => 503 ) );
 		}
 		$permissions = fileperms( $real );
@@ -619,11 +619,11 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 		if ( is_link( $existing ) || false === $existing_real || ! $this->is_contained( $existing_real ) ) {
 			return false;
 		}
-		if ( ! is_dir( $directory ) && ! mkdir( $directory, 0700, true ) ) {
+		if ( ! is_dir( $directory ) && ! mkdir( $directory, 0700, true ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- Private directories require an exact owner-only creation mode.
 			return false;
 		}
 		$real = realpath( $directory );
-		return false !== $real && ! is_link( $directory ) && $this->is_contained( $real ) && chmod( $real, 0700 ) && is_writable( $real );
+		return false !== $real && ! is_link( $directory ) && $this->is_contained( $real ) && chmod( $real, 0700 ) && is_writable( $real ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod,WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- Revalidate exact private permissions and host-level writability after creation.
 	}
 
 	/**
@@ -666,7 +666,7 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 		if ( false === $metadata_path || false === $blob_path || ! $this->is_contained( $metadata_path ) || ! $this->is_contained( $blob_path ) || is_link( $metadata_candidate ) || is_link( $blob_candidate ) || ! is_file( $metadata_path ) || ! is_file( $blob_path ) ) {
 			return new \WP_Error( 'booking_private_object_missing', __( 'The private object was not found.', 'extrachill-events' ), array( 'status' => 404 ) );
 		}
-		$contents = file_get_contents( $metadata_path );
+		$contents = file_get_contents( $metadata_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- This reads a validated contained local metadata sidecar, not a remote URL.
 		$record   = false !== $contents ? json_decode( $contents, true ) : null;
 		if ( ! is_array( $record ) || 1 !== (int) ( $record['version'] ?? 0 ) || ( $record['object_id'] ?? '' ) !== $reference || ! is_array( $record['claims'] ?? null ) || ! in_array( ( $record['state'] ?? '' ), array( 'ready', 'retiring' ), true ) ) {
 			return new \WP_Error( 'booking_private_metadata_invalid', __( 'The private object metadata is invalid.', 'extrachill-events' ) );
@@ -705,7 +705,7 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 		if ( is_link( $metadata ) || ! is_file( $metadata ) || ! $this->is_contained( (string) realpath( $metadata ) ) ) {
 			return new \WP_Error( 'booking_private_object_missing', __( 'The private object was not found.', 'extrachill-events' ), array( 'status' => 404 ) );
 		}
-		$contents = file_get_contents( $metadata );
+		$contents = file_get_contents( $metadata ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- This reads a validated contained local retirement sidecar, not a remote URL.
 		$record   = false !== $contents ? json_decode( $contents, true ) : null;
 		return is_array( $record ) && ( $record['object_id'] ?? '' ) === $reference && 'retiring' === ( $record['state'] ?? '' )
 			? $record
@@ -724,7 +724,7 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 		if ( false === $real || is_link( $candidate ) || ! $this->is_contained( $real ) ) {
 			return new \WP_Error( 'booking_private_object_missing', __( 'The private object was not found.', 'extrachill-events' ), array( 'status' => 404 ) );
 		}
-		$stream = fopen( $candidate, 'rb' );
+		$stream = fopen( $candidate, 'rb' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- The open resource is required for inode and content verification before streaming.
 		if ( false === $stream ) {
 			return new \WP_Error( 'booking_private_stream_failed', __( 'The private object could not be opened.', 'extrachill-events' ) );
 		}
@@ -734,7 +734,7 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 		$hashed  = hash_update_stream( $hash, $stream );
 		$digest  = hash_final( $hash );
 		if ( false === $opened || false === $current || $opened['dev'] !== $current['dev'] || $opened['ino'] !== $current['ino'] || 0100000 !== ( $opened['mode'] & 0170000 ) || false === $hashed || ! hash_equals( (string) $record['content_hash'], $digest ) ) {
-			fclose( $stream );
+			fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- This closes the directly owned verification stream on failure.
 			return new \WP_Error( 'booking_private_object_corrupt', __( 'The private object changed before it could be opened safely.', 'extrachill-events' ) );
 		}
 		rewind( $stream );
@@ -776,15 +776,15 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 			return false;
 		}
 		$encoded = wp_json_encode( $record );
-		$written = false !== $encoded && false !== file_put_contents( $temporary, $encoded, LOCK_EX ) && chmod( $temporary, 0600 );
-		if ( $written && ( ( ! $is_handoff || $this->handoffs_directory_is_safe() ) && rename( $temporary, $path ) ) ) {
+		$written = false !== $encoded && false !== file_put_contents( $temporary, $encoded, LOCK_EX ) && chmod( $temporary, 0600 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents,WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- Atomic metadata staging requires an exclusive write and exact owner-only mode.
+		if ( $written && ( ( ! $is_handoff || $this->handoffs_directory_is_safe() ) && rename( $temporary, $path ) ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Same-directory rename atomically commits the private metadata sidecar.
 			return true;
 		}
 		if ( ! $written && file_exists( $temporary ) ) {
-			unlink( $temporary );
+			unlink( $temporary ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Failed provider-owned metadata staging files must be removed immediately.
 		}
 		if ( file_exists( $temporary ) ) {
-			unlink( $temporary );
+			unlink( $temporary ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Uncommitted provider-owned metadata staging files must be removed immediately.
 		}
 		return false;
 	}
@@ -801,10 +801,10 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 			return new \WP_Error( 'booking_private_lock_failed', __( 'The private object could not be locked.', 'extrachill-events' ) );
 		}
 		$lock_path = $directory . '/' . $reference . '.lock';
-		$lock      = fopen( $lock_path, 'c' );
-		if ( false === $lock || ! chmod( $lock_path, 0600 ) || ! flock( $lock, LOCK_EX ) ) {
+		$lock      = fopen( $lock_path, 'c' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- A persistent local stream is required for flock-based object serialization.
+		if ( false === $lock || ! chmod( $lock_path, 0600 ) || ! flock( $lock, LOCK_EX ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- Lock files require an exact owner-only mode.
 			if ( is_resource( $lock ) ) {
-				fclose( $lock );
+				fclose( $lock ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- This closes the directly owned lock stream after acquisition failure.
 			}
 			return new \WP_Error( 'booking_private_lock_failed', __( 'The private object could not be locked.', 'extrachill-events' ) );
 		}
@@ -812,7 +812,7 @@ final class LocalBookingPrivateFileProvider implements BookingPrivateFileProvide
 			return $callback();
 		} finally {
 			flock( $lock, LOCK_UN );
-			fclose( $lock );
+			fclose( $lock ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- This closes the directly owned flock stream after unlocking.
 		}
 	}
 

--- a/inc/Core/QualifyFingerprinter.php
+++ b/inc/Core/QualifyFingerprinter.php
@@ -226,19 +226,19 @@ class QualifyFingerprinter {
 	 */
 	public static function run_extractor_attempt( string $url, ?array $handler_config = null ): array {
 		$attempt = array(
-			'url'                       => $url,
-			'events_url'                => $url,
-			'events'                    => 0,
-			'raw_extracted'             => 0,
-			'unique_source_events'      => 0,
-			'production_max_items'      => null,
-			'production_context'        => null,
-			'_diagnostic_identifiers'   => array(),
-			'ran'                       => false,
-			'name'                      => '',
-			'exists'                    => true,
-			'matched'                   => false,
-			'source_type'               => '',
+			'url'                     => $url,
+			'events_url'              => $url,
+			'events'                  => 0,
+			'raw_extracted'           => 0,
+			'unique_source_events'    => 0,
+			'production_max_items'    => null,
+			'production_context'      => null,
+			'_diagnostic_identifiers' => array(),
+			'ran'                     => false,
+			'name'                    => '',
+			'exists'                  => true,
+			'matched'                 => false,
+			'source_type'             => '',
 		);
 
 		$ability = function_exists( 'wp_get_ability' )
@@ -255,9 +255,9 @@ class QualifyFingerprinter {
 		if ( null !== $handler_config ) {
 			$ability_config = $handler_config;
 			if ( method_exists( $ability, 'get_input_schema' ) ) {
-				$input_schema       = (array) $ability->get_input_schema();
-				$config_properties  = (array) ( $input_schema['properties']['handler_config']['properties'] ?? array() );
-				$ability_config     = array_intersect_key( $handler_config, $config_properties );
+				$input_schema      = (array) $ability->get_input_schema();
+				$config_properties = (array) ( $input_schema['properties']['handler_config']['properties'] ?? array() );
+				$ability_config    = array_intersect_key( $handler_config, $config_properties );
 			}
 			$ability_input['handler_config'] = $ability_config;
 		}
@@ -275,10 +275,10 @@ class QualifyFingerprinter {
 		$source_type       = (string) ( $extraction['source_type'] ?? '' );
 		$payload_type      = (string) ( $extraction['payload_type'] ?? '' );
 
-		$attempt['ran']         = true;
-		$attempt['matched']     = ! empty( $result['success'] );
-		$attempt['source_type'] = $source_type ? $source_type : $payload_type;
-		$attempt['name']        = self::extractor_class_from_method( $extraction_method, $payload_type, $source_type );
+		$attempt['ran']                  = true;
+		$attempt['matched']              = ! empty( $result['success'] );
+		$attempt['source_type']          = $source_type ? $source_type : $payload_type;
+		$attempt['name']                 = self::extractor_class_from_method( $extraction_method, $payload_type, $source_type );
 		$attempt['raw_extracted']        = (int) ( $extraction['extracted_packet_count'] ?? 0 );
 		$attempt['unique_source_events'] = (int) ( $extraction['unique_source_event_count'] ?? 0 );
 		$attempt['production_max_items'] = isset( $extraction['production_max_items'] )
@@ -311,27 +311,27 @@ class QualifyFingerprinter {
 	 */
 	public static function add_production_eligibility( array $attempt, array $flow_context ): array {
 		$diagnostics = array(
-			'context_supplied'     => true,
-			'flow_id'              => (int) ( $flow_context['flow_id'] ?? 0 ),
-			'flow_step_id'         => (string) ( $flow_context['flow_step_id'] ?? '' ),
-			'job_id'               => (string) ( $flow_context['job_id'] ?? '' ),
+			'context_supplied'      => true,
+			'flow_id'               => (int) ( $flow_context['flow_id'] ?? 0 ),
+			'flow_step_id'          => (string) ( $flow_context['flow_step_id'] ?? '' ),
+			'job_id'                => (string) ( $flow_context['job_id'] ?? '' ),
 			'raw_extracted'         => (int) ( $attempt['raw_extracted'] ?? 0 ),
-			'unique_source'        => (int) ( $attempt['unique_source_events'] ?? 0 ),
-			'processed'            => null,
-			'active_claim'         => null,
+			'unique_source'         => (int) ( $attempt['unique_source_events'] ?? 0 ),
+			'processed'             => null,
+			'active_claim'          => null,
 			'reprocess_eligible'    => null,
 			'selected_by_max_items' => null,
-			'production_eligible'  => null,
-			'complete'             => false,
-			'bounded'              => true,
-			'identifier_limit'     => self::MAX_LIFECYCLE_IDENTIFIERS,
-			'identifier_source'    => '',
-			'error'                => '',
+			'production_eligible'   => null,
+			'complete'              => false,
+			'bounded'               => true,
+			'identifier_limit'      => self::MAX_LIFECYCLE_IDENTIFIERS,
+			'identifier_source'     => '',
+			'error'                 => '',
 		);
 
 		$test_handler = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/test-handler' ) : null;
 		if ( ! $test_handler || ! class_exists( '\\DataMachine\\Core\\ExecutionContext' ) ) {
-			$diagnostics['error']             = 'Production lifecycle diagnostics are unavailable.';
+			$diagnostics['error']          = 'Production lifecycle diagnostics are unavailable.';
 			$attempt['production_context'] = $diagnostics;
 			return $attempt;
 		}
@@ -350,7 +350,7 @@ class QualifyFingerprinter {
 		);
 
 		if ( is_wp_error( $raw_result ) || empty( $raw_result['success'] ) ) {
-			$diagnostics['error'] = is_wp_error( $raw_result )
+			$diagnostics['error']          = is_wp_error( $raw_result )
 				? $raw_result->get_error_message()
 				: (string) ( $raw_result['error'] ?? 'Handler diagnostics failed.' );
 			$attempt['production_context'] = $diagnostics;
@@ -382,8 +382,8 @@ class QualifyFingerprinter {
 			$identifier_source = 'verified_event_inventory';
 		}
 
-		$unique_identifiers = array_values( array_unique( $identifiers ) );
-		$complete           = count( $unique_identifiers ) === $expected_identifiers
+		$unique_identifiers                  = array_values( array_unique( $identifiers ) );
+		$complete                            = count( $unique_identifiers ) === $expected_identifiers
 			&& $expected_identifiers <= self::MAX_LIFECYCLE_IDENTIFIERS;
 		$diagnostics['complete']             = $complete;
 		$diagnostics['identifier_source']    = $identifier_source;
@@ -391,7 +391,7 @@ class QualifyFingerprinter {
 		$diagnostics['truncation']           = (array) ( $raw_result['truncation'] ?? array() );
 
 		if ( ! $complete ) {
-			$diagnostics['error'] = sprintf(
+			$diagnostics['error']          = sprintf(
 				'Lifecycle coverage is incomplete: observed %d of %d unique identifiers within the %d-item safety ceiling.',
 				count( $unique_identifiers ),
 				$expected_identifiers,
@@ -407,11 +407,11 @@ class QualifyFingerprinter {
 			$diagnostics['reprocess_eligible']    = 0;
 			$diagnostics['selected_by_max_items'] = 0;
 			$diagnostics['production_eligible']   = 0;
-			$attempt['production_context']         = $diagnostics;
+			$attempt['production_context']        = $diagnostics;
 			return $attempt;
 		}
 
-		$context = \DataMachine\Core\ExecutionContext::fromFlow(
+		$context        = \DataMachine\Core\ExecutionContext::fromFlow(
 			(int) ( $flow_context['pipeline_id'] ?? 0 ),
 			(int) $flow_context['flow_id'],
 			(string) $flow_context['flow_step_id'],
@@ -422,8 +422,8 @@ class QualifyFingerprinter {
 			$unique_identifiers,
 			max( 0, (int) ( $flow_context['handler_config']['max_items'] ?? 0 ) )
 		);
-		$counts = (array) ( $classification['diagnostics'] ?? array() );
-		$processed = 0;
+		$counts         = (array) ( $classification['diagnostics'] ?? array() );
+		$processed      = 0;
 		foreach ( (array) ( $classification['classifications'] ?? array() ) as $item ) {
 			if ( ! empty( $item['processed'] ) ) {
 				++$processed;
@@ -432,7 +432,7 @@ class QualifyFingerprinter {
 
 		$diagnostics['processed']             = $processed;
 		$diagnostics['active_claim']          = (int) ( $counts['actively_claimed'] ?? 0 );
-		$diagnostics['reprocess_eligible']     = (int) ( $counts['processed_reprocess_eligible'] ?? 0 );
+		$diagnostics['reprocess_eligible']    = (int) ( $counts['processed_reprocess_eligible'] ?? 0 );
 		$diagnostics['selected_by_max_items'] = (int) ( $counts['selected'] ?? 0 );
 		$diagnostics['production_eligible']   = (int) ( $counts['selected'] ?? 0 );
 

--- a/inc/core/discovery-pages.php
+++ b/inc/core/discovery-pages.php
@@ -413,7 +413,7 @@ function extrachill_events_render_scope_nav( \WP_Term $term, string $current, st
 		return;
 	}
 
-	$tabs = array(
+	$tabs       = array(
 		'tonight'      => 'Tonight',
 		'this-weekend' => 'This Weekend',
 		'this-week'    => 'This Week',


### PR DESCRIPTION
## Summary

- clear all 207 PHPCS findings across CLI diagnostics, booking abilities, publication guards, qualification fingerprints, and discovery navigation
- clear all 184 ESLint findings with scoped Jest/browser test globals, correct dependency grouping, and the remaining test-helper ordering fix
- preserve private-file atomicity, permission hardening, lock ownership, and inode verification while documenting each required direct filesystem operation locally

## Finding Groups

- PHP formatting: array/assignment alignment, multiline associative arrays, statement layout, and Yoda comparisons
- Dynamic SQL: exact annotations for the two variable-length interval placeholder arrays whose flattened replacement counts cannot be inferred statically
- Private filesystem: exact call-site annotations for same-filesystem atomic rename, owner-only `0600`/`0700` permissions, synchronous contained cleanup, local sidecar reads, stream lifecycle, and `flock` serialization
- JavaScript tests: scoped Jest and jsdom event-constructor declarations, legacy `eslint-env` removal, WordPress/external/internal dependency groups, and deferred `page` assignment after the early-return branch
- Source imports: classify `@extrachill/components` as an external dependency

Homeboy currently loads only its extension-owned flat ESLint config, so repository overrides are not composed into release lint. The repository now owns the canonical `**/*.test.js` override and uses exact test-file global declarations for the Homeboy gate; the runner composition defect is tracked at Extra-Chill/homeboy-extensions#2407.

## Verification

- `homeboy review lint extrachill-events --placement local --path /var/lib/datamachine/workspace/extrachill-events@fix-307-release-lint-baseline --summary`
  - PHPCS: 0 findings
  - ESLint: 0 findings
  - PHPStan: 0 findings
  - run: `f5249809-2d63-4f55-a7f9-be0adae76e89`
- `npm run lint:js`
- `npm run test:js -- --runInBand` (5 suites, 24 tests)
- `php -l` for all 9 touched PHP files
- `git diff --check`

Closes #307