### PR TITLE
Preserve scoped query pagination canonicals

### DIFF
--- a/inc/core/discovery-pages.php
+++ b/inc/core/discovery-pages.php
@@ -45,7 +45,7 @@ define(
 // --- Rewrite Rules ---
 
 /**
- * Register the event_scope rewrite tag and discovery page rewrite rules.
+ * Register the event_scope rewrite tag and discovery page rewrite rule.
  *
  * The rewrite tag auto-registers the query var. The rule uses 'top' priority
  * to match before the existing location catch-all rule.
@@ -61,12 +61,6 @@ function extrachill_events_discovery_rewrite_rules() {
 	$scope_pattern = implode( '|', array_keys( EXTRACHILL_EVENTS_DISCOVERY_SCOPES ) );
 
 	add_rewrite_tag( '%event_scope%', '(' . $scope_pattern . ')' );
-
-	add_rewrite_rule(
-		'location/(.+?)/(' . $scope_pattern . ')/page/([0-9]{1,})/?$',
-		'index.php?location=$matches[1]&event_scope=$matches[2]&paged=$matches[3]',
-		'top'
-	);
 
 	add_rewrite_rule(
 		'location/(.+?)/(' . $scope_pattern . ')/?$',
@@ -204,7 +198,7 @@ add_filter( 'extrachill_seo_meta_description', 'extrachill_events_discovery_desc
 /**
  * Override canonical URL for discovery pages via extrachill-seo filter.
  *
- * Appends the scope and pagination segments to the base location term URL.
+ * Appends the scope segment and preserves query-string pagination.
  *
  * @hook extrachill_seo_canonical_url
  * @param string $canonical Default canonical from extrachill-seo.
@@ -225,11 +219,11 @@ function extrachill_events_discovery_canonical( string $canonical ): string {
 		return $canonical;
 	}
 
-	$canonical = trailingslashit( $term_link ) . extrachill_events_get_current_scope() . '/';
+	$canonical = trailingslashit( $term_link ) . extrachill_events_get_current_scope();
 	$paged     = max( 1, (int) get_query_var( 'paged', 1 ) );
 
 	if ( $paged > 1 ) {
-		$canonical .= 'page/' . $paged . '/';
+		$canonical = add_query_arg( 'paged', $paged, $canonical );
 	}
 
 	return $canonical;

--- a/inc/core/discovery-pages.php
+++ b/inc/core/discovery-pages.php
@@ -45,7 +45,7 @@ define(
 // --- Rewrite Rules ---
 
 /**
- * Register the event_scope rewrite tag and discovery page rewrite rule.
+ * Register the event_scope rewrite tag and discovery page rewrite rules.
  *
  * The rewrite tag auto-registers the query var. The rule uses 'top' priority
  * to match before the existing location catch-all rule.
@@ -61,6 +61,12 @@ function extrachill_events_discovery_rewrite_rules() {
 	$scope_pattern = implode( '|', array_keys( EXTRACHILL_EVENTS_DISCOVERY_SCOPES ) );
 
 	add_rewrite_tag( '%event_scope%', '(' . $scope_pattern . ')' );
+
+	add_rewrite_rule(
+		'location/(.+?)/(' . $scope_pattern . ')/page/([0-9]{1,})/?$',
+		'index.php?location=$matches[1]&event_scope=$matches[2]&paged=$matches[3]',
+		'top'
+	);
 
 	add_rewrite_rule(
 		'location/(.+?)/(' . $scope_pattern . ')/?$',
@@ -198,7 +204,7 @@ add_filter( 'extrachill_seo_meta_description', 'extrachill_events_discovery_desc
 /**
  * Override canonical URL for discovery pages via extrachill-seo filter.
  *
- * Appends the scope segment to the base location term URL.
+ * Appends the scope and pagination segments to the base location term URL.
  *
  * @hook extrachill_seo_canonical_url
  * @param string $canonical Default canonical from extrachill-seo.
@@ -219,7 +225,14 @@ function extrachill_events_discovery_canonical( string $canonical ): string {
 		return $canonical;
 	}
 
-	return trailingslashit( $term_link ) . extrachill_events_get_current_scope() . '/';
+	$canonical = trailingslashit( $term_link ) . extrachill_events_get_current_scope() . '/';
+	$paged     = max( 1, (int) get_query_var( 'paged', 1 ) );
+
+	if ( $paged > 1 ) {
+		$canonical .= 'page/' . $paged . '/';
+	}
+
+	return $canonical;
 }
 add_filter( 'extrachill_seo_canonical_url', 'extrachill_events_discovery_canonical' );
 

--- a/inc/core/router-pages.php
+++ b/inc/core/router-pages.php
@@ -64,10 +64,10 @@ function extrachill_events_location_directory_enabled(): bool {
 }
 
 /**
- * Flush rewrites once when public event route definitions change.
+ * Flush rewrites once when the public location directory route is introduced.
  */
 function extrachill_events_maybe_flush_router_rewrites(): void {
-	$rewrite_version = '4';
+	$rewrite_version = '3';
 	if ( get_option( 'extrachill_events_router_rewrite_version' ) === $rewrite_version ) {
 		return;
 	}

--- a/inc/core/router-pages.php
+++ b/inc/core/router-pages.php
@@ -64,10 +64,10 @@ function extrachill_events_location_directory_enabled(): bool {
 }
 
 /**
- * Flush rewrites once when the public location directory route is introduced.
+ * Flush rewrites once when public event route definitions change.
  */
 function extrachill_events_maybe_flush_router_rewrites(): void {
-	$rewrite_version = '3';
+	$rewrite_version = '4';
 	if ( get_option( 'extrachill_events_router_rewrite_version' ) === $rewrite_version ) {
 		return;
 	}

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -95,6 +95,18 @@ if ( ! function_exists( 'is_tax' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id() {
+		if ( isset( $GLOBALS['venue_membership_test']['current_blog_id'] ) ) {
+			return (int) $GLOBALS['venue_membership_test']['current_blog_id'];
+		}
+		if ( isset( $GLOBALS['ec_artist_test']['blog_id'] ) ) {
+			return (int) $GLOBALS['ec_artist_test']['blog_id'];
+		}
+		return (int) ( $GLOBALS['ec_locations_blog_id'] ?? 7 );
+	}
+}
+
 if ( ! function_exists( 'is_front_page' ) ) {
 	function is_front_page() {
 		return (bool) ( $GLOBALS['test_is_front_page'] ?? false );
@@ -597,11 +609,9 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['test_term_link']     = 'https://events.example/location/usa/south-carolina/charleston/';
 
 		$canonical = extrachill_events_discovery_canonical( 'https://events.example/?paged=2' );
-		$og_data   = extrachill_events_discovery_og_data( array( 'og:url' => $canonical ) );
-		unset( $GLOBALS['test_term_link'] );
+		unset( $GLOBALS['ec_locations_blog_id'], $GLOBALS['test_term_link'] );
 
 		$this->assertSame( 'https://events.example/location/usa/south-carolina/charleston/this-weekend?paged=2', $canonical );
-		$this->assertSame( $canonical, $og_data['og:url'] );
 	}
 
 	public function test_scoped_page_one_canonical_matches_slashless_serving_url(): void {
@@ -615,7 +625,7 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['test_term_link']     = 'https://events.example/location/usa/south-carolina/charleston/';
 
 		$canonical = extrachill_events_discovery_canonical( 'https://events.example/?paged=1' );
-		unset( $GLOBALS['test_term_link'] );
+		unset( $GLOBALS['ec_locations_blog_id'], $GLOBALS['test_term_link'] );
 
 		$this->assertSame(
 			'https://events.example/location/usa/south-carolina/charleston/tonight',

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -145,6 +145,9 @@ if ( ! function_exists( 'apply_filters' ) ) {
 
 if ( ! function_exists( 'get_query_var' ) ) {
 	function get_query_var( $name, $default = '' ) {
+		if ( array_key_exists( $name, $GLOBALS['test_query_vars'] ?? array() ) ) {
+			return $GLOBALS['test_query_vars'][ $name ];
+		}
 		if ( 'ec_events_router' === $name && ! empty( $GLOBALS['test_is_all_events_page'] ) ) {
 			return 'all';
 		}
@@ -292,6 +295,7 @@ if ( ! function_exists( 'wp_verify_nonce' ) ) {
 }
 
 require_once dirname( __DIR__, 3 ) . '/inc/core/router-pages.php';
+require_once dirname( __DIR__, 3 ) . '/inc/core/discovery-pages.php';
 require_once dirname( __DIR__, 3 ) . '/inc/core/account-market.php';
 require_once dirname( __DIR__, 3 ) . '/inc/core/my-shows-map-filter.php';
 
@@ -580,6 +584,96 @@ final class AccountMarketTest extends TestCase {
 		$this->assertCount( 1, $pagination_rule );
 		$this->assertSame( 'index.php?ec_events_router=all&paged=$matches[1]', $pagination_rule[0]['query'] );
 		$this->assertSame( 'past=1', (string) wp_parse_url( 'https://events.example/all/page/2/?past=1', PHP_URL_QUERY ) );
+	}
+
+	public function test_scoped_location_pagination_rewrite_precedes_base_route(): void {
+		$GLOBALS['ec_locations_blog_id'] = 7;
+		$GLOBALS['test_rewrite_rules']   = array();
+
+		extrachill_events_discovery_rewrite_rules();
+
+		$this->assertSame(
+			array(
+				'regex' => 'location/(.+?)/(today|tonight|this-weekend|this-week)/page/([0-9]{1,})/?$',
+				'query' => 'index.php?location=$matches[1]&event_scope=$matches[2]&paged=$matches[3]',
+				'after' => 'top',
+			),
+			$GLOBALS['test_rewrite_rules'][0]
+		);
+		$this->assertSame( 'location/(.+?)/(today|tonight|this-weekend|this-week)/?$', $GLOBALS['test_rewrite_rules'][1]['regex'] );
+	}
+
+	/**
+	 * @dataProvider scoped_pagination_paths
+	 */
+	public function test_scoped_location_pretty_route_preserves_identity( string $path ): void {
+		$GLOBALS['ec_locations_blog_id'] = 7;
+		$GLOBALS['test_rewrite_rules']   = array();
+		extrachill_events_discovery_rewrite_rules();
+		$rule = $GLOBALS['test_rewrite_rules'][0];
+
+		$this->assertSame( 1, preg_match( '#^' . $rule['regex'] . '#', $path, $matches ) );
+		$this->assertSame( 'usa/south-carolina/charleston', $matches[1] );
+		$this->assertSame( 'this-weekend', $matches[2] );
+		$this->assertSame( '2', $matches[3] );
+		$this->assertSame(
+			'index.php?location=usa/south-carolina/charleston&event_scope=this-weekend&paged=2',
+			str_replace(
+				array( '$matches[1]', '$matches[2]', '$matches[3]' ),
+				array( $matches[1], $matches[2], $matches[3] ),
+				$rule['query']
+			)
+		);
+	}
+
+	public static function scoped_pagination_paths(): array {
+		return array(
+			'without trailing slash' => array( 'location/usa/south-carolina/charleston/this-weekend/page/2' ),
+			'with trailing slash'    => array( 'location/usa/south-carolina/charleston/this-weekend/page/2/' ),
+		);
+	}
+
+	public function test_scoped_query_pagination_canonicalizes_to_pretty_self_url(): void {
+		$GLOBALS['ec_locations_blog_id'] = 7;
+		$GLOBALS['test_is_tax']           = true;
+		$GLOBALS['test_query_vars']       = array(
+			'event_scope' => 'this-weekend',
+			'paged'       => 2,
+		);
+		$GLOBALS['test_queried_term'] = new WP_Term( 1618, 'Charleston', 'charleston' );
+
+		$canonical = extrachill_events_discovery_canonical( 'https://events.example/?paged=2' );
+		$og_data   = extrachill_events_discovery_og_data( array( 'og:url' => $canonical ) );
+
+		$this->assertSame( 'https://events.example/location/charleston/this-weekend/page/2/', $canonical );
+		$this->assertSame( $canonical, $og_data['og:url'] );
+	}
+
+	public function test_scoped_page_one_canonical_omits_pagination_segment(): void {
+		$GLOBALS['ec_locations_blog_id'] = 7;
+		$GLOBALS['test_is_tax']           = true;
+		$GLOBALS['test_query_vars']       = array(
+			'event_scope' => 'tonight',
+			'paged'       => 1,
+		);
+		$GLOBALS['test_queried_term'] = new WP_Term( 1618, 'Charleston', 'charleston' );
+
+		$this->assertSame(
+			'https://events.example/location/charleston/tonight/',
+			extrachill_events_discovery_canonical( 'https://events.example/?paged=1' )
+		);
+	}
+
+	public function test_discovery_canonical_and_open_graph_preserve_other_pages(): void {
+		$GLOBALS['test_is_tax']     = false;
+		$GLOBALS['test_query_vars'] = array();
+		$og_data                    = array(
+			'og:url'   => 'https://events.example/original/',
+			'og:title' => 'Original',
+		);
+
+		$this->assertSame( 'https://events.example/original/', extrachill_events_discovery_canonical( 'https://events.example/original/' ) );
+		$this->assertSame( $og_data, extrachill_events_discovery_og_data( $og_data ) );
 	}
 
 	public function test_router_query_flags_use_the_query_being_parsed(): void {

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -272,7 +272,7 @@ if ( ! function_exists( 'get_ancestors' ) ) {
 
 if ( ! function_exists( 'get_term_link' ) ) {
 	function get_term_link( $term ) {
-		return 'https://events.example/location/' . $term->slug . '/';
+		return $GLOBALS['test_term_link'] ?? 'https://events.example/location/' . $term->slug . '/';
 	}
 }
 
@@ -586,54 +586,7 @@ final class AccountMarketTest extends TestCase {
 		$this->assertSame( 'past=1', (string) wp_parse_url( 'https://events.example/all/page/2/?past=1', PHP_URL_QUERY ) );
 	}
 
-	public function test_scoped_location_pagination_rewrite_precedes_base_route(): void {
-		$GLOBALS['ec_locations_blog_id'] = 7;
-		$GLOBALS['test_rewrite_rules']   = array();
-
-		extrachill_events_discovery_rewrite_rules();
-
-		$this->assertSame(
-			array(
-				'regex' => 'location/(.+?)/(today|tonight|this-weekend|this-week)/page/([0-9]{1,})/?$',
-				'query' => 'index.php?location=$matches[1]&event_scope=$matches[2]&paged=$matches[3]',
-				'after' => 'top',
-			),
-			$GLOBALS['test_rewrite_rules'][0]
-		);
-		$this->assertSame( 'location/(.+?)/(today|tonight|this-weekend|this-week)/?$', $GLOBALS['test_rewrite_rules'][1]['regex'] );
-	}
-
-	/**
-	 * @dataProvider scoped_pagination_paths
-	 */
-	public function test_scoped_location_pretty_route_preserves_identity( string $path ): void {
-		$GLOBALS['ec_locations_blog_id'] = 7;
-		$GLOBALS['test_rewrite_rules']   = array();
-		extrachill_events_discovery_rewrite_rules();
-		$rule = $GLOBALS['test_rewrite_rules'][0];
-
-		$this->assertSame( 1, preg_match( '#^' . $rule['regex'] . '#', $path, $matches ) );
-		$this->assertSame( 'usa/south-carolina/charleston', $matches[1] );
-		$this->assertSame( 'this-weekend', $matches[2] );
-		$this->assertSame( '2', $matches[3] );
-		$this->assertSame(
-			'index.php?location=usa/south-carolina/charleston&event_scope=this-weekend&paged=2',
-			str_replace(
-				array( '$matches[1]', '$matches[2]', '$matches[3]' ),
-				array( $matches[1], $matches[2], $matches[3] ),
-				$rule['query']
-			)
-		);
-	}
-
-	public static function scoped_pagination_paths(): array {
-		return array(
-			'without trailing slash' => array( 'location/usa/south-carolina/charleston/this-weekend/page/2' ),
-			'with trailing slash'    => array( 'location/usa/south-carolina/charleston/this-weekend/page/2/' ),
-		);
-	}
-
-	public function test_scoped_query_pagination_canonicalizes_to_pretty_self_url(): void {
+	public function test_scoped_query_pagination_preserves_serving_url_identity(): void {
 		$GLOBALS['ec_locations_blog_id'] = 7;
 		$GLOBALS['test_is_tax']           = true;
 		$GLOBALS['test_query_vars']       = array(
@@ -641,15 +594,17 @@ final class AccountMarketTest extends TestCase {
 			'paged'       => 2,
 		);
 		$GLOBALS['test_queried_term'] = new WP_Term( 1618, 'Charleston', 'charleston' );
+		$GLOBALS['test_term_link']     = 'https://events.example/location/usa/south-carolina/charleston/';
 
 		$canonical = extrachill_events_discovery_canonical( 'https://events.example/?paged=2' );
 		$og_data   = extrachill_events_discovery_og_data( array( 'og:url' => $canonical ) );
+		unset( $GLOBALS['test_term_link'] );
 
-		$this->assertSame( 'https://events.example/location/charleston/this-weekend/page/2/', $canonical );
+		$this->assertSame( 'https://events.example/location/usa/south-carolina/charleston/this-weekend?paged=2', $canonical );
 		$this->assertSame( $canonical, $og_data['og:url'] );
 	}
 
-	public function test_scoped_page_one_canonical_omits_pagination_segment(): void {
+	public function test_scoped_page_one_canonical_matches_slashless_serving_url(): void {
 		$GLOBALS['ec_locations_blog_id'] = 7;
 		$GLOBALS['test_is_tax']           = true;
 		$GLOBALS['test_query_vars']       = array(
@@ -657,10 +612,14 @@ final class AccountMarketTest extends TestCase {
 			'paged'       => 1,
 		);
 		$GLOBALS['test_queried_term'] = new WP_Term( 1618, 'Charleston', 'charleston' );
+		$GLOBALS['test_term_link']     = 'https://events.example/location/usa/south-carolina/charleston/';
+
+		$canonical = extrachill_events_discovery_canonical( 'https://events.example/?paged=1' );
+		unset( $GLOBALS['test_term_link'] );
 
 		$this->assertSame(
-			'https://events.example/location/charleston/tonight/',
-			extrachill_events_discovery_canonical( 'https://events.example/?paged=1' )
+			'https://events.example/location/usa/south-carolina/charleston/tonight',
+			$canonical
 		);
 	}
 


### PR DESCRIPTION
## Summary
- preserve the existing slashless scoped location URL as page one's canonical
- preserve `?paged=N` in canonicals for paginated scoped discovery requests
- avoid unsupported pretty routes and rewrite flushing
- make the changed focused test file runnable independently with its own compatible blog-ID harness

Closes #357

## Corrected root cause
Live production verification disproved part of the original issue premise. WordPress is not currently redirecting scoped query pagination to a pretty `/page/N/` route:

- `/location/usa/south-carolina/charleston/this-week` returns 200
- the trailing-slash variant redirects to the slashless URL
- `...?paged=2` returns 200
- both `/this-week/page/2` variants return 404

The actual defect is canonical identity. Page one and `?paged=2` currently emit the same page-one trailing-slash canonical, collapsing page 2 onto page one while also pointing page one at a redirecting URL.

## Before and after
Before: page one and every query-paginated page canonicalize to `/location/.../{scope}/`.

After: page one canonicalizes to the serving slashless `/location/.../{scope}` URL. Page N canonicalizes to the serving `/location/.../{scope}?paged=N` URL. Non-discovery filters remain pass-through.

No `/page/N/` rewrite is added and the rewrite version is unchanged because pretty scoped pagination is not an observed site convention.

Open Graph alignment is not claimed as repository test coverage. The prior assertion initialized `og:url` from the already-computed canonical and was tautological, so it was removed rather than presented as integration evidence.

## Tests
- live response and rendered canonical verification with `curl` against the exact production URLs above
- `./vendor/bin/phpunit tests/Unit/Core/AccountMarketTest.php` - pass: 27 tests, 71 assertions
- `./vendor/bin/phpunit --filter AccountMarketTest` - pass: 27 tests, 71 assertions
- `./vendor/bin/phpcs --standard=WordPress inc/core/discovery-pages.php` - pass
- `php -l inc/core/discovery-pages.php` and `php -l tests/Unit/Core/AccountMarketTest.php` - pass
- `git diff --check` - pass
- `./vendor/bin/phpunit` - existing unrelated baseline: 279 tests, 873 assertions, 2 errors, 19 failures. Failures remain in qualification recheck shared state, canonical-location stubs, missing composed Data Machine Events contract fixtures, festival notification stubs, and concert-stats shared rendering stubs; both focused canonical runs pass.

## Residual risk
The post-change HTML metadata cannot be live-verified until the PR is merged and deployed. Unit coverage exercises canonical construction against the verified production URL convention; no routing behavior changes.