### PR TITLE
Fix live discovery pagination canonical

### DIFF
--- a/inc/core/discovery-pages.php
+++ b/inc/core/discovery-pages.php
@@ -220,7 +220,10 @@ function extrachill_events_discovery_canonical( string $canonical ): string {
 	}
 
 	$canonical = trailingslashit( $term_link ) . extrachill_events_get_current_scope();
-	$paged     = max( 1, (int) get_query_var( 'paged', 1 ) );
+	// The calendar reads query-string pagination before falling back to the
+	// main query, where scoped taxonomy requests do not retain `paged`.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only public pagination state.
+	$paged = isset( $_GET['paged'] ) && is_scalar( $_GET['paged'] ) ? max( 1, absint( wp_unslash( $_GET['paged'] ) ) ) : 1;
 
 	if ( $paged > 1 ) {
 		$canonical = add_query_arg( 'paged', $paged, $canonical );

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -600,32 +600,37 @@ final class AccountMarketTest extends TestCase {
 
 	public function test_scoped_query_pagination_preserves_serving_url_identity(): void {
 		$GLOBALS['ec_locations_blog_id'] = 7;
-		$GLOBALS['test_is_tax']           = true;
-		$GLOBALS['test_query_vars']       = array(
-			'event_scope' => 'this-weekend',
-			'paged'       => 2,
+		$GLOBALS['test_is_tax']          = true;
+		$GLOBALS['test_query_vars']      = array( 'event_scope' => 'this-weekend' );
+		$GLOBALS['test_queried_term']    = new WP_Term( 1618, 'Charleston', 'charleston' );
+		$GLOBALS['test_term_link']        = 'https://events.example/location/usa/south-carolina/charleston/';
+		$_GET                            = array(
+			'paged'      => '2',
+			'past'       => '1',
+			'utm_source' => 'newsletter',
 		);
-		$GLOBALS['test_queried_term'] = new WP_Term( 1618, 'Charleston', 'charleston' );
-		$GLOBALS['test_term_link']     = 'https://events.example/location/usa/south-carolina/charleston/';
 
 		$canonical = extrachill_events_discovery_canonical( 'https://events.example/?paged=2' );
 		unset( $GLOBALS['ec_locations_blog_id'], $GLOBALS['test_term_link'] );
+		$_GET = array();
 
 		$this->assertSame( 'https://events.example/location/usa/south-carolina/charleston/this-weekend?paged=2', $canonical );
 	}
 
 	public function test_scoped_page_one_canonical_matches_slashless_serving_url(): void {
 		$GLOBALS['ec_locations_blog_id'] = 7;
-		$GLOBALS['test_is_tax']           = true;
-		$GLOBALS['test_query_vars']       = array(
-			'event_scope' => 'tonight',
-			'paged'       => 1,
+		$GLOBALS['test_is_tax']          = true;
+		$GLOBALS['test_query_vars']      = array( 'event_scope' => 'tonight' );
+		$GLOBALS['test_queried_term']    = new WP_Term( 1618, 'Charleston', 'charleston' );
+		$GLOBALS['test_term_link']        = 'https://events.example/location/usa/south-carolina/charleston/';
+		$_GET                            = array(
+			'paged'  => '1',
+			'fbclid' => 'tracking-value',
 		);
-		$GLOBALS['test_queried_term'] = new WP_Term( 1618, 'Charleston', 'charleston' );
-		$GLOBALS['test_term_link']     = 'https://events.example/location/usa/south-carolina/charleston/';
 
 		$canonical = extrachill_events_discovery_canonical( 'https://events.example/?paged=1' );
 		unset( $GLOBALS['ec_locations_blog_id'], $GLOBALS['test_term_link'] );
+		$_GET = array();
 
 		$this->assertSame(
 			'https://events.example/location/usa/south-carolina/charleston/tonight',


### PR DESCRIPTION
## Summary
- read scoped discovery pagination from the raw HTTP query source used by the calendar instead of the main WordPress query object
- preserve only sanitized `paged > 1` state in canonical identity while keeping page one slashless
- model the live lifecycle in regression tests, including absent `paged` query-var state and ignored filter/tracking arguments

Fixes #365.

## Root Cause
The canonical filter runs from `wp_head` after WordPress has resolved the scoped taxonomy request, but the live main query does not retain the request's `paged` value for this route. `get_query_var( 'paged' )` therefore returns the page-one default even though the calendar is rendering page two.

The Data Machine Events calendar is authoritative for this request state: its server render starts from raw `$_GET`, reads `paged` there, and only falls back to the WordPress query var when the HTTP argument is absent. The canonical now follows that same precedence for scoped discovery pagination.

## Canonical Behavior
- Page one: `/location/.../this-week` remains the slashless canonical, including when `?paged=1` is supplied.
- Page N: `/location/.../this-week?paged=N` self-canonicalizes with the sanitized page number.
- The location and date scope are already encoded in the path. Calendar controls such as `past`, search/filter state, and tracking parameters are not admitted into canonical identity, preventing arbitrary query-string variants.

## Verification
- `./vendor/bin/phpunit --filter 'test_scoped_(query_pagination_preserves_serving_url_identity|page_one_canonical_matches_slashless_serving_url)' tests/Unit/Core/AccountMarketTest.php` - passed, 2 tests / 2 assertions.
- `./vendor/bin/phpunit tests/Unit/Core/AccountMarketTest.php` - passed, 27 tests / 71 assertions.
- `./vendor/bin/phpcs --standard=WordPress inc/core/discovery-pages.php` - passed.
- `./vendor/bin/phpcs --standard=WordPress --sniffs=WordPress.WhiteSpace.OperatorSpacing tests/Unit/Core/AccountMarketTest.php` - passed.
- `php -l inc/core/discovery-pages.php && php -l tests/Unit/Core/AccountMarketTest.php` - passed.
- `git diff --check` - passed.
- `./vendor/bin/phpunit` - ran 279 tests; the aggregate suite remains red with 2 errors and 19 failures in unrelated qualification, canonical-location, dependency-contract, notification, and concert-stats tests caused by shared fixture state and an absent composed Data Machine Events contract path.
- `npm test -- --runInBand` - unavailable because this repository defines no `test` script.

## Limitations
The worktree regression exercises the production request shape and canonical callback but does not boot a separate full WordPress HTTP stack. Final live HTTP verification requires a later user-approved release and deployment; this PR does not release, deploy, or modify production.