### PR TITLE
fix: disambiguate canonical event locations

### DIFF
--- a/inc/Abilities/EventLocationAlignmentAbilities.php
+++ b/inc/Abilities/EventLocationAlignmentAbilities.php
@@ -280,11 +280,12 @@ class EventLocationAlignmentAbilities {
 			);
 		}
 
-		$venue       = $venue_terms[0];
-		$venue_city  = trim( (string) get_term_meta( $venue->term_id, '_venue_city', true ) );
-		$venue_state = trim( (string) get_term_meta( $venue->term_id, '_venue_state', true ) );
-		$venue_zip   = trim( (string) get_term_meta( $venue->term_id, '_venue_zip', true ) );
-		$expected    = $this->resolveExpectedLocationTerm( $venue_city, $venue_state, $venue_zip, $flow_location['term'] );
+		$venue         = $venue_terms[0];
+		$venue_city    = trim( (string) get_term_meta( $venue->term_id, '_venue_city', true ) );
+		$venue_state   = trim( (string) get_term_meta( $venue->term_id, '_venue_state', true ) );
+		$venue_zip     = trim( (string) get_term_meta( $venue->term_id, '_venue_zip', true ) );
+		$venue_country = trim( (string) get_term_meta( $venue->term_id, '_venue_country', true ) );
+		$expected      = $this->resolveExpectedLocationTerm( $venue_city, $venue_state, $venue_zip, $venue_country, $flow_location['term'] );
 
 		if ( ! $expected['term'] ) {
 			return array(
@@ -370,13 +371,14 @@ class EventLocationAlignmentAbilities {
 	 * This ensures that a Ticketmaster flow with a 50mi radius centered on Worcester
 	 * does not override the actual venue location for Boston-area events.
 	 *
-	 * @param string        $venue_city  Venue city name.
-	 * @param string        $venue_state Venue state name.
-	 * @param string        $venue_zip   Venue zip code.
-	 * @param \WP_Term|null $flow_term   Flow-configured location term.
+	 * @param string        $venue_city    Venue city name.
+	 * @param string        $venue_state   Venue state name.
+	 * @param string        $venue_zip     Venue zip code.
+	 * @param string        $venue_country Venue country name or code.
+	 * @param \WP_Term|null $flow_term     Flow-configured location term.
 	 * @return array{term: \WP_Term|null, reason: string}
 	 */
-	private function resolveExpectedLocationTerm( string $venue_city, string $venue_state, string $venue_zip, ?\WP_Term $flow_term ): array {
+	private function resolveExpectedLocationTerm( string $venue_city, string $venue_state, string $venue_zip, string $venue_country, ?\WP_Term $flow_term ): array {
 		if ( '' === $venue_city ) {
 			// No venue city — fall back to flow config if available.
 			if ( $flow_term ) {
@@ -395,11 +397,20 @@ class EventLocationAlignmentAbilities {
 		// inc/core/location-normalizer.php so the create-time normalizer and
 		// this audit ability stay in lockstep (extrachill-events#145).
 		if ( function_exists( 'extrachill_events_resolve_location_term_for_venue_city' ) ) {
-			$resolved = extrachill_events_resolve_location_term_for_venue_city( $venue_city, $venue_state, $venue_zip );
+			$resolved = extrachill_events_resolve_location_term_for_venue_city( $venue_city, $venue_state, $venue_zip, $venue_country );
 			if ( $resolved instanceof \WP_Term ) {
 				return array(
 					'term'   => $resolved,
 					'reason' => 'matched_venue_city',
+				);
+			}
+
+			$city_key     = strtolower( trim( $venue_city ) );
+			$city_matches = extrachill_events_get_location_terms_by_name()[ $city_key ] ?? array();
+			if ( ! empty( $city_matches ) ) {
+				return array(
+					'term'   => null,
+					'reason' => 'ambiguous_location_hierarchy',
 				);
 			}
 		}

--- a/inc/core/location-normalizer.php
+++ b/inc/core/location-normalizer.php
@@ -59,8 +59,9 @@ function extrachill_events_normalize_location( $post_id ) {
 	$venue_city  = (string) get_term_meta( $venue->term_id, '_venue_city', true );
 	$venue_state = (string) get_term_meta( $venue->term_id, '_venue_state', true );
 	$zip         = (string) get_term_meta( $venue->term_id, '_venue_zip', true );
+	$country     = (string) get_term_meta( $venue->term_id, '_venue_country', true );
 
-	$correct_term = extrachill_events_resolve_location_term_for_venue_city( $venue_city, $venue_state, $zip );
+	$correct_term = extrachill_events_resolve_location_term_for_venue_city( $venue_city, $venue_state, $zip, $country );
 	if ( ! $correct_term ) {
 		return;
 	}
@@ -98,16 +99,17 @@ function extrachill_events_normalize_location( $post_id ) {
  * @param string $venue_city  Venue city.
  * @param string $venue_state Venue state (abbreviation like "SC" or full name).
  * @param string $venue_zip   Venue zip.
+ * @param string $country     Venue country name or code.
  * @return \WP_Term|null Resolved location term, or null when unresolved.
  */
-function extrachill_events_resolve_location_term_for_venue_city( $venue_city, $venue_state = '', $venue_zip = '' ): ?\WP_Term {
+function extrachill_events_resolve_location_term_for_venue_city( $venue_city, $venue_state = '', $venue_zip = '', $country = '' ): ?\WP_Term {
 	$venue_city = trim( (string) $venue_city );
 	if ( '' === $venue_city ) {
 		return null;
 	}
 
 	// 1. Market mapping.
-	$market_slug = extrachill_events_get_market_slug_for_venue( $venue_city, $venue_state, $venue_zip );
+	$market_slug = extrachill_events_get_market_slug_for_venue( $venue_city, $venue_state, $venue_zip, $country );
 	if ( $market_slug ) {
 		$market_term = get_term_by( 'slug', $market_slug, 'location' );
 		if ( $market_term instanceof \WP_Term ) {
@@ -119,19 +121,20 @@ function extrachill_events_resolve_location_term_for_venue_city( $venue_city, $v
 	$city_key = strtolower( $venue_city );
 	$matches  = extrachill_events_get_location_terms_by_name()[ $city_key ] ?? array();
 
-	if ( 1 === count( $matches ) ) {
-		return reset( $matches );
+	$has_hierarchy_context = '' !== trim( (string) $venue_state ) || '' !== trim( (string) $country );
+	if ( $has_hierarchy_context ) {
+		$matches = extrachill_events_filter_locations_by_hierarchy( $matches, (string) $venue_state, (string) $country );
 	}
 
-	if ( count( $matches ) > 1 ) {
-		return extrachill_events_disambiguate_location_by_state( $matches, (string) $venue_state );
+	if ( 1 === count( $matches ) ) {
+		return reset( $matches );
 	}
 
 	return null;
 }
 
 /**
- * Disambiguate multiple same-named location terms using venue state.
+ * Filter same-named location terms using canonical state/country ancestry.
  *
  * Location terms are hierarchical (Country > State > City). Compares the
  * venue's state (abbreviation or full name) against each candidate's parent
@@ -139,17 +142,19 @@ function extrachill_events_resolve_location_term_for_venue_city( $venue_city, $v
  *
  * @param array<int, \WP_Term> $matches     Location terms sharing a city name.
  * @param string               $venue_state Venue state ("SC" or "South Carolina").
- * @return \WP_Term|null Matched term, or null if state doesn't resolve it.
+ * @param string               $country     Venue country name or code.
+ * @return array<int, \WP_Term> Hierarchy-consistent candidates.
  */
-function extrachill_events_disambiguate_location_by_state( array $matches, string $venue_state ): ?\WP_Term {
+function extrachill_events_filter_locations_by_hierarchy( array $matches, string $venue_state, string $country ): array {
 	$venue_state = trim( $venue_state );
-	if ( '' === $venue_state ) {
-		return null;
+	$country     = trim( $country );
+	$state_names = array( strtolower( $venue_state ) );
+	$full_name   = extrachill_events_get_state_abbreviation_map()[ strtoupper( $venue_state ) ] ?? null;
+	if ( $full_name ) {
+		$state_names[] = strtolower( $full_name );
 	}
-
-	$state_lower = strtolower( $venue_state );
-	$abbrev_map  = extrachill_events_get_state_abbreviation_map();
-	$full_name   = $abbrev_map[ strtoupper( $venue_state ) ] ?? null;
+	$country_name = extrachill_events_normalize_country_name( $country );
+	$filtered     = array();
 
 	foreach ( $matches as $match ) {
 		if ( $match->parent <= 0 ) {
@@ -161,18 +166,45 @@ function extrachill_events_disambiguate_location_by_state( array $matches, strin
 			continue;
 		}
 
-		$parent_lower = strtolower( $parent->name );
-
-		if ( $parent_lower === $state_lower ) {
-			return $match;
+		if ( '' !== $venue_state && ! in_array( strtolower( $parent->name ), $state_names, true ) ) {
+			continue;
 		}
 
-		if ( $full_name && strtolower( $full_name ) === $parent_lower ) {
-			return $match;
+		if ( '' !== $country ) {
+			$country_term = $parent->parent > 0 ? get_term( $parent->parent, 'location' ) : null;
+			if ( ! $country_term instanceof \WP_Term || extrachill_events_normalize_country_name( $country_term->name ) !== $country_name ) {
+				continue;
+			}
 		}
+
+		$filtered[] = $match;
 	}
 
-	return null;
+	return $filtered;
+}
+
+/**
+ * Normalize common country names and ISO codes for hierarchy comparisons.
+ *
+ * @param string $country Country name or code.
+ * @return string Normalized country identity.
+ */
+function extrachill_events_normalize_country_name( string $country ): string {
+	$country = strtolower( trim( $country ) );
+	$aliases = array(
+		'us'                       => 'united states',
+		'usa'                      => 'united states',
+		'united states of america' => 'united states',
+		'ca'                       => 'canada',
+		'can'                      => 'canada',
+		'mx'                       => 'mexico',
+		'mex'                      => 'mexico',
+		'gb'                       => 'united kingdom',
+		'gbr'                      => 'united kingdom',
+		'uk'                       => 'united kingdom',
+	);
+
+	return $aliases[ $country ] ?? $country;
 }
 
 /**
@@ -301,12 +333,13 @@ function extrachill_events_get_state_abbreviation_map(): array {
  * 2. Explicit municipality → market mapping
  * 3. No opinion (null)
  *
- * @param string $city  Venue city.
- * @param string $state Venue state.
- * @param string $zip   Venue zip.
+ * @param string $city    Venue city.
+ * @param string $state   Venue state.
+ * @param string $zip     Venue zip.
+ * @param string $country Venue country name or code.
  * @return string|null Canonical location slug, or null if no mapping exists.
  */
-function extrachill_events_get_market_slug_for_venue( $city, $state = '', $zip = '' ) {
+function extrachill_events_get_market_slug_for_venue( $city, $state = '', $zip = '', $country = '' ) {
 	$borough_slug = extrachill_events_get_location_slug_for_zip( $zip );
 	if ( $borough_slug ) {
 		return $borough_slug;
@@ -327,6 +360,10 @@ function extrachill_events_get_market_slug_for_venue( $city, $state = '', $zip =
 	$mapping = $market_map[ $city ];
 
 	if ( is_string( $mapping ) ) {
+		$country_name = extrachill_events_normalize_country_name( (string) $country );
+		if ( '' !== $country_name && 'united states' !== $country_name ) {
+			return null;
+		}
 		return $mapping;
 	}
 
@@ -669,7 +706,10 @@ function extrachill_events_get_city_market_map() {
 			'bc'               => 'vancouver-bc',
 		),
 		'westland'            => 'detroit',
-		'wilmington'          => 'philadelphia',
+		'wilmington'          => array(
+			'delaware' => 'philadelphia',
+			'de'       => 'philadelphia',
+		),
 		'wilton manors'       => 'fort-lauderdale',
 		'windsor'             => array(
 			'michigan' => 'detroit',

--- a/tests/location-resolution-smoke.php
+++ b/tests/location-resolution-smoke.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Canonical venue-city location resolution smoke test.
+ *
+ * Run directly: php tests/location-resolution-smoke.php
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+// phpcs:disable -- Isolated test doubles intentionally mirror WordPress globals.
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! class_exists( 'WP_Term' ) ) {
+	class WP_Term {
+		public int $term_id;
+		public string $name;
+		public string $slug;
+		public int $parent;
+
+		public function __construct( int $term_id, string $name, string $slug, int $parent = 0 ) {
+			$this->term_id = $term_id;
+			$this->name    = $name;
+			$this->slug    = $slug;
+			$this->parent  = $parent;
+		}
+	}
+}
+
+$GLOBALS['ec_resolution_terms'] = array(
+	1  => new WP_Term( 1, 'USA', 'usa' ),
+	2  => new WP_Term( 2, 'North Carolina', 'north-carolina', 1 ),
+	3  => new WP_Term( 3, 'Delaware', 'delaware', 1 ),
+	4  => new WP_Term( 4, 'Canada', 'canada' ),
+	5  => new WP_Term( 5, 'Ontario', 'ontario', 4 ),
+	6  => new WP_Term( 6, 'United Kingdom', 'united-kingdom' ),
+	7  => new WP_Term( 7, 'England', 'england', 6 ),
+	10 => new WP_Term( 10, 'Wilmington', 'wilmington-nc', 2 ),
+	11 => new WP_Term( 11, 'Wilmington', 'wilmington-de', 3 ),
+	12 => new WP_Term( 12, 'London', 'london-on', 5 ),
+	13 => new WP_Term( 13, 'London', 'london-uk', 7 ),
+	14 => new WP_Term( 14, 'Oxford', 'oxford-uk', 7 ),
+);
+$GLOBALS['ec_resolution_venue']       = new WP_Term( 20, 'Resolution Venue', 'resolution-venue' );
+$GLOBALS['ec_resolution_location']    = $GLOBALS['ec_resolution_terms'][10];
+$GLOBALS['ec_resolution_assignments'] = array();
+$GLOBALS['ec_resolution_meta']        = array(
+	'_venue_city'    => 'Wilmington',
+	'_venue_state'   => 'NC',
+	'_venue_zip'     => '28401',
+	'_venue_country' => 'US',
+);
+
+function add_action() {}
+function is_wp_error() {
+	return false;
+}
+function wp_is_post_revision() {
+	return false;
+}
+function wp_is_post_autosave() {
+	return false;
+}
+function get_the_terms( $post_id, $taxonomy ) {
+	return 'venue' === $taxonomy
+		? array( $GLOBALS['ec_resolution_venue'] )
+		: array( $GLOBALS['ec_resolution_location'] );
+}
+function get_term_meta( $term_id, $key ) {
+	return $GLOBALS['ec_resolution_meta'][ $key ] ?? '';
+}
+function wp_set_object_terms( $post_id, $terms, $taxonomy ) {
+	$GLOBALS['ec_resolution_assignments'][] = compact( 'post_id', 'terms', 'taxonomy' );
+	return $terms;
+}
+function get_term_by( $field, $value ) {
+	foreach ( $GLOBALS['ec_resolution_terms'] as $term ) {
+		if ( isset( $term->{$field} ) && $term->{$field} === $value ) {
+			return $term;
+		}
+	}
+	return false;
+}
+function get_term( $term_id ) {
+	return $GLOBALS['ec_resolution_terms'][ $term_id ] ?? null;
+}
+function get_terms() {
+	return array_values( $GLOBALS['ec_resolution_terms'] );
+}
+
+require_once dirname( __DIR__ ) . '/inc/core/location-normalizer.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/EventLocationAlignmentAbilities.php';
+
+$cases = array(
+	array( 'Wilmington', 'NC', '', 'US', 10, 'state abbreviation selects North Carolina' ),
+	array( 'Wilmington', 'North Carolina', '', 'United States', 10, 'full state name selects North Carolina' ),
+	array( 'Wilmington', 'DE', '', 'USA', 11, 'Delaware remains independently resolvable' ),
+	array( 'Wilmington', '', '', 'US', null, 'country alone leaves duplicate US cities unresolved' ),
+	array( 'Wilmington', 'PA', '', 'US', null, 'conflicting state fails safely' ),
+	array( 'London', '', '', 'Canada', 12, 'country context selects Canada hierarchy' ),
+	array( 'London', '', '', 'GB', 13, 'country code selects United Kingdom hierarchy' ),
+	array( 'Oxford', 'Mississippi', '', 'US', null, 'sole city match rejects conflicting hierarchy' ),
+);
+
+$failures = 0;
+foreach ( $cases as $case ) {
+	list( $city, $state, $zip, $country, $expected_id, $label ) = $case;
+	$resolved = extrachill_events_resolve_location_term_for_venue_city( $city, $state, $zip, $country );
+	$actual   = $resolved instanceof WP_Term ? $resolved->term_id : null;
+	if ( $expected_id !== $actual ) {
+		++$failures;
+		printf( "FAIL: %s: got %s, expected %s\n", $label, var_export( $actual, true ), var_export( $expected_id, true ) );
+	}
+}
+
+if ( 'philadelphia' !== extrachill_events_get_market_slug_for_venue( 'Wilmington', 'DE', '', 'US' ) ) {
+	++$failures;
+	printf( "FAIL: Wilmington, DE must retain the Philadelphia market rollup\n" );
+}
+if ( null !== extrachill_events_get_market_slug_for_venue( 'Wilmington', 'NC', '', 'US' ) ) {
+	++$failures;
+	printf( "FAIL: Wilmington, NC must not roll up to Philadelphia\n" );
+}
+
+extrachill_events_normalize_location( 150479 );
+if ( array() !== $GLOBALS['ec_resolution_assignments'] ) {
+	++$failures;
+	printf( "FAIL: an already-correct canonical assignment must not be rewritten\n" );
+}
+
+$ability = new ExtraChillEvents\Abilities\EventLocationAlignmentAbilities();
+$method  = new ReflectionMethod( $ability, 'resolveExpectedLocationTerm' );
+$result  = $method->invoke( $ability, 'Wilmington', '', '', 'US', $GLOBALS['ec_resolution_terms'][11] );
+if ( null !== $result['term'] || 'ambiguous_location_hierarchy' !== $result['reason'] ) {
+	++$failures;
+	printf( "FAIL: ambiguous hierarchy must not fall back to a flow term in audit/fix mode\n" );
+}
+
+printf( "%d passed, %d failed\n", count( $cases ) + 4 - $failures, $failures );
+exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary
- restrict the Wilmington-to-Philadelphia market rollup to Delaware venue data
- validate every exact city match, including a sole candidate, against authoritative venue state and country hierarchy
- keep create-time normalization and audit/fix resolution aligned while refusing flow fallback when canonical city hierarchy remains ambiguous

## Root cause
`Wilmington` was an unconditional municipality-to-market mapping to Philadelphia. In addition, exact city resolution returned a sole name match without checking the venue's state or country against the canonical `Country > State > City` taxonomy hierarchy. That allowed Wilmington, North Carolina venue data to resolve as Philadelphia and made the reconciliation audit report the bad assignment as aligned.

## Resolution precedence
1. Explicit market mapping, now state-scoped for ambiguous municipalities and blocked for unconditional US mappings when venue country is explicitly non-US.
2. Exact city-name candidates filtered by venue state, accepting abbreviations or full names.
3. Country hierarchy validation when venue country is available.
4. A unique hierarchy-consistent candidate is accepted.
5. Flow location fallback remains available only when no canonical city candidate exists.

## Ambiguity behavior
When city candidates exist but state/country context cannot select exactly one, resolution returns no term. The audit reports `ambiguous_location_hierarchy`; apply mode does not mutate the event from a flow fallback. Existing correct assignments are left unchanged.

## Existing data
Dry-run a bounded audit before applying repairs:

```bash
wp --url=events.extrachill.com extrachill events audit-locations --ids=150479 --include-matches --format=json
wp --url=events.extrachill.com extrachill events audit-locations --limit=500 --format=json
```

After reviewing the audit output, use the existing apply surface for only the approved IDs:

```bash
wp --url=events.extrachill.com extrachill events fix-locations --ids=150479 --format=json
```

## Tests
- `php tests/location-resolution-smoke.php` - 12 passed, 0 failed
- `php tests/location-market-map-smoke.php` - 51 passed, 0 failed
- `php -l` on both changed runtime files and the new smoke test - clean
- `git diff --check` - clean

Coverage includes Wilmington NC/DE disambiguation, state abbreviations and full names, country names and codes, sole-city hierarchy conflicts, unresolved ambiguity without flow mutation, and preservation of valid assignments.

## Residual risks
Resolution depends on venue state/country metadata matching the canonical hierarchy and on supported country aliases. Missing hierarchy context preserves legacy unique-city behavior; conflicting or incomplete hierarchy data now fails safely for audit review.

Fixes Extra-Chill/data-machine-events#593