### PR TITLE
fix: restore venue settings release gates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,9 @@
 			"globals": {
 				"MouseEvent": "readonly",
 				"PopStateEvent": "readonly"
+			},
+			"rules": {
+				"no-redeclare": "off"
 			}
 		}
 	],

--- a/blocks/venue-settings/src/api.js
+++ b/blocks/venue-settings/src/api.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
 
 const METHODS = {

--- a/blocks/venue-settings/src/api.test.js
+++ b/blocks/venue-settings/src/api.test.js
@@ -1,4 +1,13 @@
+/* global beforeEach, describe, expect, it, jest */
+
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
 import { runAbility } from './api';
 
 jest.mock( '@wordpress/api-fetch', () => ( {

--- a/blocks/venue-settings/src/index.js
+++ b/blocks/venue-settings/src/index.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
 import metadata from '../block.json';
 import './style.scss';
 

--- a/blocks/venue-settings/src/state.test.js
+++ b/blocks/venue-settings/src/state.test.js
@@ -1,3 +1,8 @@
+/* global describe, expect, it */
+
+/**
+ * Internal dependencies
+ */
 import {
 	editableConfig,
 	normalizeKey,

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -1,4 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { createRoot, useEffect, useRef, useState } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
 import {
 	ActionRow,
 	Badge,
@@ -11,6 +18,10 @@ import {
 	PanelHeader,
 	ResponsiveTabs,
 } from '@extrachill/components';
+
+/**
+ * Internal dependencies
+ */
 import { errorDetails, runAbility } from './api';
 import {
 	editableConfig,
@@ -1151,7 +1162,6 @@ export function VenueSettingsApp( { context } ) {
 	}, [ dirty ] );
 
 	const switchVenue = ( event ) => {
-		const venueId = Number( event.target.value );
 		if (
 			dirty &&
 			// eslint-disable-next-line no-alert -- Native navigation guard is keyboard and screen-reader accessible.
@@ -1159,6 +1169,7 @@ export function VenueSettingsApp( { context } ) {
 		) {
 			return;
 		}
+		const venueId = Number( event.target.value );
 		const url = new URL( context.route_url );
 		if ( venueId ) {
 			url.searchParams.set( 'venue_id', venueId );
@@ -1461,7 +1472,7 @@ document
 					context={ JSON.parse( contextElement.textContent ) }
 				/>
 			);
-		} catch ( error ) {
+		} catch {
 			element.innerHTML =
 				'<div class="ec-inline-status ec-inline-status--error" role="alert">Venue settings could not start. Refresh the page to try again.</div>';
 		}

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -1,6 +1,19 @@
+/* global HTMLInputElement, afterAll, beforeAll, beforeEach, describe, expect, it, jest */
+
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
 import { createRoot } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
 import { act } from 'react';
+
+/**
+ * Internal dependencies
+ */
 import { VenueSettingsApp } from './view';
 
 jest.mock( '@wordpress/api-fetch', () => ( {
@@ -227,11 +240,11 @@ describe( 'venue settings authorization-facing states', () => {
 
 	it( 'keeps successful config data available when profile loading fails', async () => {
 		apiFetch.mockImplementation( ( request ) => {
-			const input = requestInput( request.path );
 			if ( request.path.includes( 'get-venue-profile' ) ) {
 				return Promise.reject( { message: 'Profile unavailable.' } );
 			}
 			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				const input = requestInput( request.path );
 				return Promise.resolve( config( input.venue_term_id ) );
 			}
 			return Promise.resolve( [] );


### PR DESCRIPTION
## Summary

- restore the managed JavaScript release gate for the venue-settings block without weakening production lint rules
- make test globals portable across the repository `wp-scripts` config and Homeboy's stricter managed ESLint profile
- isolate the remaining managed WordPress failure as Homeboy/WP Codebox composition and result-adapter debt

Fixes #378.

## Root Cause

PR #374 added the venue-settings JavaScript files without the dependency-group headers required by Homeboy's managed WordPress ESLint profile. Its tests relied on the repository Jest/browser environment, while Homeboy lint applies a separate portable profile and therefore treated Jest and `HTMLInputElement` names as undefined. Two variables were also assigned before an early return and one caught error was unused.

The repository's own `.eslintrc.json` then treated the portable `/* global */` declarations required by Homeboy as Jest/browser redeclarations. The test-only override now disables `no-redeclare`; production files retain the full rule set.

## Exact Lint Corrections

- add WordPress, external, and internal dependency-group headers to the new venue-settings modules
- declare only the Jest and DOM globals each new test file uses, matching existing repository test conventions
- scope `no-redeclare: off` to `**/*.test.js` so the repository Jest/browser environment and Homeboy portable declarations coexist without changing production rules
- defer `venueId` creation until after the dirty-navigation early return
- defer booking request input parsing until its matching request branch
- replace an unused `catch ( error )` binding with optional catch binding

## Before / After

- `homeboy review lint`: 84 ESLint errors across `blocks/venue-settings/src/` -> 0 findings
- managed producers: PHPCS 0, ESLint 84, PHPStan 0 -> PHPCS 0, ESLint 0, PHPStan 0
- full repository `wp-scripts` lint: test-global redeclaration conflict after portable declarations -> 0 findings after the test-only config correction
- venue-settings Jest: 3 suites / 19 tests passing before and after
- full Jest: 8 suites / 43 tests passing

## Test Composition Finding

`homeboy review test` does execute an underlying PHPUnit workload, but the Codebox WordPress recipe does not honor the repository bootstrap/composed dependency contract and the result adapter rewrites the failed aggregate to zero tests.

Underlying PHPUnit output:

```text
Tests: 281, Assertions: 329, Errors: 46, Failures: 100.
```

Homeboy result:

```text
test runner reported zero executed tests
total=0 passed=0 failed=0 skipped=0
```

Exact composition symptoms include missing `VenueQualificationAbilities` and `QualifyFingerprinter` classes despite `tests/bootstrap.php` requiring them, an empty Data Machine Events contract source, a null `$wpdb` fixture, broad child-process exits, Festival notification failures, and unrelated concert-history failures. None were introduced by #374, which added a JavaScript block and only extended `AccountMarketTest.php`; no consumer workaround is included here.

Upstream: https://github.com/Extra-Chill/homeboy-extensions/issues/2422

Persisted Homeboy run: `4a9f7581-8db0-4436-8994-52537439477e`

## Verification

- `npm run lint:js -- --format stylish blocks/venue-settings/src` - passed, 0 findings
- `npm run lint:js -- --format stylish` - passed, 0 findings
- `npm run test:js -- --runInBand blocks/venue-settings/src` - 3 suites, 19 tests passed
- `npm run test:js -- --runInBand` - 8 suites, 43 tests passed
- `npm run build` - passed
- `php tests/location-resolution-smoke.php` - 12 passed, 0 failed
- `php tests/location-market-map-smoke.php` - 51 passed, 0 failed
- `homeboy review lint extrachill-events --path /var/lib/datamachine/workspace/extrachill-events@fix-378-venue-settings-release-gates --placement local --errors-only --summary` - passed; PHPCS, ESLint, and PHPStan all 0 findings
- `homeboy review test extrachill-events --path /var/lib/datamachine/workspace/extrachill-events@fix-378-venue-settings-release-gates --placement local --skip-lint --analyze --json-summary` - blocked upstream; underlying 281-test failing aggregate misreported as zero tests
- `git diff --check` - passed

Local `vendor/bin/phpunit` suites were not available because Composer development dependencies are not hydrated in this worktree. The managed Codebox PHPUnit attempt and focused dependency-free smoke suites provide the PHP evidence above.

## Residual Risks

The broad WordPress gate remains untrustworthy until homeboy-extensions#2422 composes the declared sibling contracts, honors `phpunit.xml.dist` bootstrap semantics, supplies the expected WordPress fixtures, and preserves PHPUnit counts on workload failure. This PR proves the largest trustworthy consumer-owned surface and leaves that generic runner defect in its owning layer.