### PR TITLE
feat: synchronize converted booking events

### DIFF
--- a/.github/workflows/booking-attachment-mysql.yml
+++ b/.github/workflows/booking-attachment-mysql.yml
@@ -13,6 +13,9 @@ on:
       - inc/Core/BookingAttachmentPolicy.php
       - inc/Core/BookingInquiryAdmissionService.php
       - inc/Core/BookingLifecycle.php
+      - inc/Core/BookingEventSyncService.php
+      - inc/Core/BookingEventConversionService.php
+      - inc/Core/BookingActivityRepository.php
       - inc/Core/BookingRepository.php
       - inc/Core/BookingSchema.php
       - inc/Core/VenueAuthorization.php
@@ -25,6 +28,7 @@ on:
       - tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
       - tests/MySQLIntegration/booking-attachment-mysql-bootstrap.php
       - tests/MySQLIntegration/host-wordpress-bootstrap.php
+      - tests/Integration/booking-event-sync-mysql.php
       - tests/MySQLIntegration/wp-tests-config.php
 
 permissions:
@@ -140,6 +144,13 @@ jobs:
           if grep -Eiq 'skip|no tests executed|OK, but' "$RUNNER_TEMP/booking-admission-concurrency.txt"; then
             exit 1
           fi
+
+      - name: Run booking event synchronization proof
+        env:
+          EC_EVENTS_MYSQL_TEST_DSN: mysql:host=127.0.0.1;port=3306;dbname=wordpress_test
+          EC_EVENTS_MYSQL_TEST_USER: root
+          EC_EVENTS_MYSQL_TEST_PASSWORD: ""
+        run: php tests/Integration/booking-event-sync-mysql.php
 
       - name: Verify executed PHPUnit evidence
         env:

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -257,6 +257,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingCommunicationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingHoldRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingMutationService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingEventSyncService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingEventConversionService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingLifecycle.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingPrivateFileProvider.php';

--- a/inc/Abilities/VenueBookingAbilities.php
+++ b/inc/Abilities/VenueBookingAbilities.php
@@ -336,6 +336,19 @@ class VenueBookingAbilities {
 	 */
 	public function transition_booking( array $input ) {
 		$before = $this->bookings->get( (int) $input['booking_id'] );
+		if ( is_array( $before ) && null !== $before['event_id'] && 'cancelled' === (string) $input['to_status'] ) {
+			$result = ( new \ExtraChillEvents\Core\BookingEventSyncService( $this->bookings, null, $this->authorization ) )->reconcile( (int) $input['booking_id'], (int) $input['expected_version'], get_current_user_id(), array( 'cancelled' => true ) );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			$suppressed = ( new \ExtraChillEvents\Core\BookingCommunicationService() )->suppress_pending_reminders( (int) $input['booking_id'], 'booking_status_changed' );
+			if ( is_wp_error( $suppressed ) ) {
+				$suppressed->add_data( array_merge( (array) $suppressed->get_error_data(), array( 'booking_committed' => true ) ) );
+				return $suppressed;
+			}
+			$current = $this->bookings->get( (int) $input['booking_id'] );
+			return is_array( $current ) ? $this->present( $current ) : $current;
+		}
 		$result = $this->lifecycle->transition( (int) $input['booking_id'], (string) $input['to_status'], (int) $input['expected_version'], get_current_user_id(), $input['note'] ?? null );
 		if ( is_array( $before ) && is_array( $result ) && $before['status'] !== $result['status'] ) {
 			$suppressed = ( new \ExtraChillEvents\Core\BookingCommunicationService() )->suppress_pending_reminders( (int) $input['booking_id'], 'booking_status_changed' );

--- a/inc/Abilities/VenueBookingEventAbilities.php
+++ b/inc/Abilities/VenueBookingEventAbilities.php
@@ -8,6 +8,7 @@
 namespace ExtraChillEvents\Abilities;
 
 use ExtraChillEvents\Core\BookingEventConversionService;
+use ExtraChillEvents\Core\BookingEventSyncService;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\VenueAuthorization;
 
@@ -20,6 +21,8 @@ class VenueBookingEventAbilities {
 	private static bool $registered = false;
 	/** @var BookingEventConversionService */
 	private $conversion;
+	/** @var BookingEventSyncService */
+	private $sync;
 	/** @var BookingRepository */
 	private $bookings;
 	/** @var VenueAuthorization */
@@ -27,10 +30,11 @@ class VenueBookingEventAbilities {
 	/** @var array|null Exact booking context active during nested event upsert. */
 	private $active_conversion;
 
-	public function __construct( ?BookingEventConversionService $conversion = null, ?BookingRepository $bookings = null, ?VenueAuthorization $authorization = null ) {
+	public function __construct( ?BookingEventConversionService $conversion = null, ?BookingRepository $bookings = null, ?VenueAuthorization $authorization = null, ?BookingEventSyncService $sync = null ) {
 		$this->bookings      = $bookings ? $bookings : new BookingRepository();
 		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
 		$this->conversion    = $conversion ? $conversion : new BookingEventConversionService( $this->bookings, null, null, $this->authorization );
+		$this->sync          = $sync ? $sync : new BookingEventSyncService( $this->bookings, null, $this->authorization );
 		add_filter( 'datamachine_events_upsert_event_permission', array( $this, 'can_upsert_booking_event' ), 10, 2 );
 		add_filter( 'extrachill_events_canonical_event_excluded_booking_id', array( $this, 'excluded_booking_id_for_active_conversion' ), 10, 3 );
 		if ( ! self::$registered ) {
@@ -60,6 +64,26 @@ class VenueBookingEventAbilities {
 				),
 			)
 		);
+		wp_register_ability(
+			'extrachill/reconcile-booking-event',
+			array(
+				'label'               => __( 'Reconcile Booking Event', 'extrachill-events' ),
+				'description'         => __( 'Applies approved booking-authoritative corrections and idempotently reconciles the linked canonical event.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => $this->sync_input_schema(),
+				'output_schema'       => $this->sync_output_schema(),
+				'execute_callback'    => array( $this, 'reconcile' ),
+				'permission_callback' => array( $this, 'can_access_booking' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
 	}
 
 	public function execute( array $input ) {
@@ -70,6 +94,11 @@ class VenueBookingEventAbilities {
 		} finally {
 			$this->active_conversion = null;
 		}
+	}
+
+	/** Execute the bounded public reconciliation/operator entrypoint. */
+	public function reconcile( array $input ) {
+		return $this->sync->reconcile( (int) $input['booking_id'], (int) $input['expected_version'], get_current_user_id(), (array) ( $input['changes'] ?? array() ) );
 	}
 
 	/** Grant only the exact nested DME write performed by this conversion. */
@@ -160,6 +189,78 @@ class VenueBookingEventAbilities {
 				'already_converted' => array( 'type' => 'boolean' ),
 			),
 			'required'             => array( 'booking_id', 'booking_version', 'event_id', 'event_url', 'event_action', 'already_converted' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function sync_input_schema(): array {
+		$datetime = array(
+			'type'    => 'string',
+			'pattern' => '^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$',
+		);
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'booking_id'       => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'expected_version' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'changes'          => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'venue_term_id'        => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'space_key'            => array(
+							'type'      => 'string',
+							'minLength' => 1,
+							'maxLength' => 64,
+						),
+						'performance_start_at' => $datetime,
+						'performance_end_at'   => $datetime,
+						'performer'            => array(
+							'type'      => 'string',
+							'minLength' => 1,
+							'maxLength' => 255,
+						),
+						'ticket_url'           => array(
+							'type'   => array( 'string', 'null' ),
+							'format' => 'uri',
+						),
+						'cancelled'            => array( 'type' => 'boolean' ),
+					),
+					'additionalProperties' => false,
+				),
+			),
+			'required'             => array( 'booking_id', 'expected_version' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function sync_output_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'booking_id'      => array( 'type' => 'integer' ),
+				'booking_version' => array( 'type' => 'integer' ),
+				'event_id'        => array( 'type' => 'integer' ),
+				'status'          => array(
+					'type' => 'string',
+					'enum' => array( 'succeeded', 'no_change' ),
+				),
+				'code'            => array( 'type' => 'string' ),
+				'retryable'       => array( 'type' => 'boolean' ),
+				'conflicts'       => array(
+					'type'     => 'array',
+					'maxItems' => 20,
+				),
+			),
+			'required'             => array( 'booking_id', 'booking_version', 'event_id', 'status', 'code', 'retryable', 'conflicts' ),
 			'additionalProperties' => false,
 		);
 	}

--- a/inc/Abilities/VenueBookingMutationAbilities.php
+++ b/inc/Abilities/VenueBookingMutationAbilities.php
@@ -85,6 +85,24 @@ class VenueBookingMutationAbilities {
 	}
 
 	public function select_performance( array $input ) {
+		$booking = $this->bookings->get( (int) $input['booking_id'] );
+		if ( is_array( $booking ) && null !== $booking['event_id'] ) {
+			$result = ( new \ExtraChillEvents\Core\BookingEventSyncService( $this->bookings, null, $this->authorization ) )->reconcile(
+				(int) $input['booking_id'],
+				(int) $input['expected_version'],
+				get_current_user_id(),
+				array(
+					'space_key'            => (string) $input['space_key'],
+					'performance_start_at' => (string) $input['start_at'],
+					'performance_end_at'   => (string) $input['end_at'],
+				)
+			);
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			$current = $this->bookings->get( (int) $input['booking_id'] );
+			return is_array( $current ) ? $this->schemas->present( $current ) : $current;
+		}
 		$result = $this->mutations->select_performance( (int) $input['booking_id'], (int) $input['expected_version'], (string) $input['space_key'], (string) $input['start_at'], (string) $input['end_at'], get_current_user_id() );
 		return is_array( $result ) ? $this->schemas->present( $result ) : $result;
 	}
@@ -95,6 +113,25 @@ class VenueBookingMutationAbilities {
 	}
 
 	public function update_deal( array $input ) {
+		$booking = $this->bookings->get( (int) $input['booking_id'] );
+		if ( is_array( $booking ) && null !== $booking['event_id'] ) {
+			$normalized = BookingMutationService::normalize_deal_document( $input['deal'] );
+			if ( is_wp_error( $normalized ) ) {
+				return $normalized;
+			}
+			$current = $booking['confirmed_deal']['data'];
+			$next    = $normalized;
+			unset( $current['ticket_url'], $next['ticket_url'] );
+			if ( ! BookingMutationService::documents_equal( $current, $next ) ) {
+				return new \WP_Error( 'booking_deal_already_confirmed', __( 'Only the public ticket URL can change after confirmation.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			$result = ( new \ExtraChillEvents\Core\BookingEventSyncService( $this->bookings, null, $this->authorization ) )->reconcile( (int) $input['booking_id'], (int) $input['expected_version'], get_current_user_id(), array( 'ticket_url' => $normalized['ticket_url'] ) );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			$booking = $this->bookings->get( (int) $input['booking_id'] );
+			return is_array( $booking ) ? $this->schemas->present( $booking ) : $booking;
+		}
 		$result = $this->mutations->update_deal( (int) $input['booking_id'], (int) $input['expected_version'], $input['deal'], get_current_user_id() );
 		return is_array( $result ) ? $this->schemas->present( $result ) : $result;
 	}

--- a/inc/Core/BookingActivityRepository.php
+++ b/inc/Core/BookingActivityRepository.php
@@ -362,6 +362,56 @@ class BookingActivityRepository {
 		);
 	}
 
+	/** Return the latest durable booking/event synchronization attempt. */
+	public function event_sync_state( int $booking_id ) {
+		global $wpdb;
+		$table = BookingSchema::activity_table();
+		$start = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND kind = 'event_sync_started' ORDER BY id DESC LIMIT 1", $booking_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact bounded synchronization state read.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_event_sync_state_read_failed', __( 'Booking event synchronization state could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		if ( ! is_array( $start ) ) {
+			return array(
+				'pending'  => false,
+				'start'    => null,
+				'terminal' => null,
+			);
+		}
+		$start = $this->hydrate( $start );
+		if ( is_wp_error( $start ) ) {
+			return $start;
+		}
+		$terminal = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND external_id = %s AND kind IN ('event_sync_succeeded', 'event_sync_noop', 'event_sync_conflict', 'event_sync_failed') ORDER BY id DESC LIMIT 1", $booking_id, (string) $start['id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact attempt terminal lookup.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_event_sync_state_read_failed', __( 'Booking event synchronization state could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		$terminal = is_array( $terminal ) ? $this->hydrate( $terminal ) : null;
+		return is_wp_error( $terminal ) ? $terminal : array(
+			'pending'  => null === $terminal,
+			'start'    => $start,
+			'terminal' => $terminal,
+		);
+	}
+
+	/** Return the last authoritative event snapshot accepted by this booking. */
+	public function latest_event_authority( int $booking_id ) {
+		global $wpdb;
+		$table = BookingSchema::activity_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND kind IN ('event_sync_succeeded', 'event_sync_noop', 'event_converted') ORDER BY id DESC LIMIT 1", $booking_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded latest authority snapshot read.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_event_sync_state_read_failed', __( 'Booking event synchronization state could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		if ( ! is_array( $row ) ) {
+			return null;
+		}
+		$row = $this->hydrate( $row );
+		if ( is_wp_error( $row ) ) {
+			return $row;
+		}
+		$authority = $row['payload']['data']['authority'] ?? null;
+		return is_array( $authority ) ? $authority : null;
+	}
+
 	private function conversion_state_error( string $detail, int $activity_id ): \WP_Error {
 		return new \WP_Error(
 			'booking_event_conversion_state_invalid',

--- a/inc/Core/BookingEventConversionService.php
+++ b/inc/Core/BookingEventConversionService.php
@@ -68,7 +68,8 @@ class BookingEventConversionService {
 		if ( is_wp_error( $verified ) ) {
 			return $verified;
 		}
-		$verified['attempt'] = $preflight['attempt'];
+		$verified['attempt']   = $preflight['attempt'];
+		$verified['authority'] = BookingEventSyncService::authority_from_event( $preflight['input']['event'], (int) $preflight['booking']['venue_term_id'] );
 
 		return $this->finalize( $booking_id, $expected_version, $actor_id, $verified );
 	}
@@ -228,6 +229,7 @@ class BookingEventConversionService {
 					'source_identity' => $upstream['source']['identity'],
 					'upstream_action' => $action,
 					'version'         => $expected_version + 1,
+					'authority'       => $upstream['authority'],
 				),
 			)
 		);

--- a/inc/Core/BookingEventSyncService.php
+++ b/inc/Core/BookingEventSyncService.php
@@ -1,0 +1,640 @@
+<?php
+/**
+ * Post-conversion booking/event synchronization policy.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Synchronizes only the public fields which remain booking-authoritative. */
+class BookingEventSyncService {
+	public const MARKETING_ISSUE = 'https://github.com/Extra-Chill/extrachill-events/issues/296';
+
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var BookingActivityRepository */
+	private $activity;
+	/** @var VenueAuthorization */
+	private $authorization;
+	/** @var bool */
+	private $transaction_active = false;
+
+	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null ) {
+		$this->bookings      = $bookings ? $bookings : new BookingRepository();
+		$this->activity      = $activity ? $activity : new BookingActivityRepository();
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+	}
+
+	/** Apply an approved correction, then reconcile its already-linked event. */
+	public function reconcile( int $booking_id, int $expected_version, int $actor_id, array $changes = array() ) {
+		$prepared = $this->prepare( $booking_id, $expected_version, $actor_id, $changes );
+		if ( is_wp_error( $prepared ) || isset( $prepared['status'] ) ) {
+			return $prepared;
+		}
+
+		$booking = $prepared['booking'];
+		$start   = $prepared['start'];
+		$desired = $prepared['authority'];
+		$current = $this->read_event_authority( $booking );
+		if ( is_wp_error( $current ) ) {
+			return $this->finish_error( $booking, $start, $current, 'event_sync_failed' );
+		}
+		$baseline = $this->activity->latest_event_authority( $booking_id );
+		if ( is_wp_error( $baseline ) ) {
+			return $this->finish_error( $booking, $start, $baseline, 'event_sync_failed' );
+		}
+		if ( null === $baseline ) {
+			return $this->finish_error(
+				$booking,
+				$start,
+				new \WP_Error(
+					'booking_event_sync_baseline_missing',
+					__( 'The converted event has no authoritative synchronization baseline.', 'extrachill-events' ),
+					array(
+						'status'     => 409,
+						'repairable' => true,
+					)
+				),
+				'event_sync_conflict'
+			);
+		}
+		if ( 'EventCancelled' !== $desired['eventStatus'] ) {
+			$dates_changed          = ( $baseline['startDate'] ?? null ) !== $desired['startDate']
+				|| ( $baseline['startTime'] ?? null ) !== $desired['startTime']
+				|| ( $baseline['endDate'] ?? null ) !== $desired['endDate']
+				|| ( $baseline['endTime'] ?? null ) !== $desired['endTime'];
+			$desired['eventStatus'] = $dates_changed ? 'EventRescheduled' : (string) ( $baseline['eventStatus'] ?? 'EventScheduled' );
+		}
+
+		$conflicts = array();
+		foreach ( $desired as $field => $value ) {
+			$previous = $baseline[ $field ] ?? null;
+			$actual   = $current[ $field ] ?? null;
+			if ( $actual !== $previous && $actual !== $value ) {
+				$conflicts[ $field ] = array(
+					'previous' => $previous,
+					'current'  => $actual,
+					'booking'  => $value,
+				);
+			}
+		}
+		if ( $conflicts ) {
+			return $this->finish_error(
+				$booking,
+				$start,
+				new \WP_Error(
+					'booking_event_manual_divergence',
+					__( 'Manual changes conflict with booking-authoritative event fields.', 'extrachill-events' ),
+					array(
+						'status'    => 409,
+						'conflicts' => $conflicts,
+					)
+				),
+				'event_sync_conflict'
+			);
+		}
+		if ( $current === $desired ) {
+			return $this->finish_success( $booking, $start, $desired, 'event_sync_noop', 'no_change', $baseline );
+		}
+
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'data-machine-events/update-event' ) : null;
+		if ( ! is_object( $ability ) || ! is_callable( array( $ability, 'execute' ) ) ) {
+			return $this->finish_error(
+				$booking,
+				$start,
+				new \WP_Error(
+					'booking_event_update_ability_unavailable',
+					__( 'Canonical event updates are temporarily unavailable.', 'extrachill-events' ),
+					array(
+						'status'    => 503,
+						'retryable' => true,
+					)
+				),
+				'event_sync_failed'
+			);
+		}
+
+		$content = array( 'event' => (int) $booking['event_id'] );
+		foreach ( array( 'startDate', 'startTime', 'endDate', 'endTime', 'ticketUrl', 'performer', 'performerType', 'eventStatus' ) as $field ) {
+			if ( ( $current[ $field ] ?? null ) !== $desired[ $field ] ) {
+				$content[ $field ] = $desired[ $field ];
+			}
+		}
+		if ( isset( $content['startDate'] ) && 'EventRescheduled' === $desired['eventStatus'] ) {
+			$content['previousStartDate'] = (string) ( $baseline['startDate'] ?? '' );
+		}
+		if ( count( $content ) > 1 ) {
+			$result = $this->execute_update( $ability, $content );
+			if ( is_wp_error( $result ) ) {
+				return $this->finish_error( $booking, $start, $result, 'event_sync_failed' );
+			}
+		}
+		if ( (int) $current['venue_id'] !== (int) $desired['venue_id'] ) {
+			$result = $this->execute_update(
+				$ability,
+				array(
+					'event' => (int) $booking['event_id'],
+					'venue' => (int) $desired['venue_id'],
+				)
+			);
+			if ( is_wp_error( $result ) ) {
+				return $this->finish_error( $booking, $start, $result, 'event_sync_failed' );
+			}
+		}
+
+		$verified = $this->read_event_authority( $booking );
+		if ( is_wp_error( $verified ) || $verified !== $desired ) {
+			$error = is_wp_error( $verified ) ? $verified : new \WP_Error(
+				'booking_event_sync_verification_failed',
+				__( 'The canonical event did not retain the requested booking fields.', 'extrachill-events' ),
+				array(
+					'status'    => 503,
+					'retryable' => true,
+					'actual'    => $verified,
+				)
+			);
+			return $this->finish_error( $booking, $start, $error, 'event_sync_failed' );
+		}
+		return $this->finish_success( $booking, $start, $desired, 'event_sync_succeeded', 'updated', $baseline );
+	}
+
+	/** Build the canonical field-level authority snapshot used at conversion and sync. */
+	public static function authority_from_event( array $event, int $venue_id ): array {
+		return array(
+			'startDate'     => (string) ( $event['startDate'] ?? '' ),
+			'startTime'     => (string) ( $event['startTime'] ?? '' ),
+			'endDate'       => (string) ( $event['endDate'] ?? '' ),
+			'endTime'       => (string) ( $event['endTime'] ?? '' ),
+			'venue_id'      => $venue_id,
+			'performer'     => (string) ( $event['performer'] ?? '' ),
+			'performerType' => (string) ( $event['performerType'] ?? 'PerformingGroup' ),
+			'ticketUrl'     => (string) ( $event['ticketUrl'] ?? '' ),
+			'eventStatus'   => (string) ( $event['eventStatus'] ?? 'EventScheduled' ),
+		);
+	}
+
+	/** Lock authorization and aggregate state, apply correction, and persist an outbox intent. */
+	private function prepare( int $booking_id, int $expected_version, int $actor_id, array $changes ) {
+		$initial = $this->bookings->get( $booking_id );
+		if ( ! is_array( $initial ) ) {
+			return is_wp_error( $initial ) ? $initial : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
+		$allowed = $this->authorize( $actor_id, (int) $initial['venue_term_id'] );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		if ( false === $GLOBALS['wpdb']->query( 'START TRANSACTION' ) ) {
+			return new \WP_Error( 'booking_event_sync_transaction_start_failed', __( 'Booking event synchronization could not start.', 'extrachill-events' ) );
+		}
+		$this->transaction_active = true;
+		$table                    = BookingSchema::memberships_table();
+		$venue_ids                = array( (int) $initial['venue_term_id'] );
+		if ( ! empty( $changes['venue_term_id'] ) ) {
+			$venue_ids[] = absint( $changes['venue_term_id'] );
+		}
+		$venue_ids = array_values( array_unique( array_filter( $venue_ids ) ) );
+		sort( $venue_ids, SORT_NUMERIC );
+		foreach ( $venue_ids as $venue_id ) {
+			$GLOBALS['wpdb']->get_results( $GLOBALS['wpdb']->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $venue_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Stable exact-venue authority lock order.
+		}
+		$booking = $this->bookings->get_for_update( $booking_id );
+		if ( ! is_array( $booking ) ) {
+			return $this->rollback( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+		}
+		$allowed = $this->authorize( $actor_id, (int) $booking['venue_term_id'] );
+		if ( is_wp_error( $allowed ) ) {
+			return $this->rollback( $allowed );
+		}
+		if ( null === $booking['event_id'] ) {
+			return $this->rollback( new \WP_Error( 'booking_event_not_converted', __( 'The booking does not have a canonical event.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+		}
+		if ( ! in_array( $booking['status'], array( 'confirmed', 'cancelled' ), true ) ) {
+			return $this->rollback(
+				new \WP_Error(
+					'booking_event_sync_status_forbidden',
+					__( 'Only confirmed or cancelled converted bookings can synchronize events.', 'extrachill-events' ),
+					array(
+						'status'         => 409,
+						'booking_status' => $booking['status'],
+					)
+				)
+			);
+		}
+		$state = $this->activity->event_sync_state( $booking_id );
+		if ( is_wp_error( $state ) ) {
+			return $this->rollback( $state );
+		}
+		$normalized = $this->normalize_changes( $booking, $changes, $actor_id );
+		if ( is_wp_error( $normalized ) ) {
+			return $this->rollback( $normalized );
+		}
+		if ( $state['pending'] ) {
+			if ( $normalized ) {
+				return $this->rollback(
+					new \WP_Error(
+						'booking_event_sync_pending',
+						__( 'A different booking event correction is already pending reconciliation.', 'extrachill-events' ),
+						array(
+							'status'    => 409,
+							'retryable' => true,
+						)
+					)
+				);
+			}
+			$committed = $this->commit();
+			return is_wp_error( $committed ) ? $committed : array(
+				'booking'   => $booking,
+				'start'     => $state['start'],
+				'authority' => $state['start']['payload']['data']['authority'],
+			);
+		}
+		if ( (int) $booking['version'] !== $expected_version ) {
+			$terminal = $state['terminal'];
+			if ( empty( $normalized ) && is_array( $terminal ) && in_array( $terminal['kind'], array( 'event_sync_succeeded', 'event_sync_noop' ), true ) && (int) ( $state['start']['payload']['data']['booking_version'] ?? 0 ) === (int) $booking['version'] ) {
+				$committed = $this->commit();
+				return is_wp_error( $committed ) ? $committed : array(
+					'booking_id'      => $booking['id'],
+					'booking_version' => $booking['version'],
+					'event_id'        => $booking['event_id'],
+					'status'          => 'event_sync_noop' === $terminal['kind'] ? 'no_change' : 'succeeded',
+					'code'            => (string) ( $terminal['payload']['data']['code'] ?? 'replayed' ),
+					'retryable'       => false,
+					'conflicts'       => array(),
+				);
+			}
+			return $this->rollback(
+				new \WP_Error(
+					'booking_version_conflict',
+					__( 'The booking changed since it was read.', 'extrachill-events' ),
+					array(
+						'status'          => 409,
+						'current_version' => $booking['version'],
+					)
+				)
+			);
+		}
+		if ( $normalized ) {
+			$updated = $this->persist_changes( $booking, $normalized );
+			if ( is_wp_error( $updated ) ) {
+				return $this->rollback( $updated );
+			}
+			$booking = $updated;
+		}
+		$authority = $this->authority_from_booking( $booking );
+		if ( is_wp_error( $authority ) ) {
+			return $this->rollback( $authority );
+		}
+		$attempt = (int) ( $state['start']['payload']['data']['attempt'] ?? 0 ) + 1;
+		$start   = $this->activity->append(
+			array(
+				'booking_id'      => $booking_id,
+				'kind'            => 'event_sync_started',
+				'actor_type'      => 'user',
+				'actor_id'        => $actor_id,
+				'idempotency_key' => sprintf( 'event-sync:%s:%d:%d', $booking['public_id'], $booking['version'], $attempt ),
+				'payload'         => array(
+					'attempt'         => $attempt,
+					'booking_version' => $booking['version'],
+					'event_id'        => $booking['event_id'],
+					'authority'       => $authority,
+				),
+			)
+		);
+		if ( is_wp_error( $start ) ) {
+			return $this->rollback( $start );
+		}
+		$committed = $this->commit();
+		return is_wp_error( $committed ) ? $committed : array(
+			'booking'   => $booking,
+			'start'     => $start,
+			'authority' => $authority,
+		);
+	}
+
+	/** Normalize the intentionally narrow post-conversion correction surface. */
+	private function normalize_changes( array $booking, array $changes, int $actor_id ) {
+		$allowed = array( 'venue_term_id', 'space_key', 'performance_start_at', 'performance_end_at', 'performer', 'ticket_url', 'cancelled' );
+		if ( array_diff( array_keys( $changes ), $allowed ) ) {
+			return new \WP_Error( 'booking_event_sync_changes_invalid', __( 'An unsupported booking-authoritative field was supplied.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$output = array();
+		if ( isset( $changes['venue_term_id'] ) && (int) $changes['venue_term_id'] !== (int) $booking['venue_term_id'] ) {
+			$venue_id = absint( $changes['venue_term_id'] );
+			$venue    = get_term( $venue_id, 'venue' );
+			$access   = $this->authorize( $actor_id, $venue_id );
+			if ( ! $venue || is_wp_error( $venue ) || 'venue' !== $venue->taxonomy || is_wp_error( $access ) ) {
+				return is_wp_error( $access ) ? $access : new \WP_Error( 'booking_event_venue_invalid', __( 'The corrected canonical venue is invalid.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			$output['venue_term_id'] = $venue_id;
+		}
+		if ( array_key_exists( 'space_key', $changes ) ) {
+			$space = mb_substr( sanitize_key( (string) $changes['space_key'] ), 0, 64 );
+			if ( '' === $space ) {
+				return new \WP_Error( 'booking_event_selection_incomplete', __( 'A corrected performance space is required.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			$output['space_key'] = $space;
+		}
+		foreach ( array( 'performance_start_at', 'performance_end_at' ) as $field ) {
+			if ( array_key_exists( $field, $changes ) ) {
+				$value = (string) $changes[ $field ];
+				$date  = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $value, new \DateTimeZone( 'UTC' ) );
+				if ( false === $date || $date->format( 'Y-m-d H:i:s' ) !== $value ) {
+					return new \WP_Error(
+						'invalid_booking_datetime',
+						__( 'Booking datetimes must use strict UTC format.', 'extrachill-events' ),
+						array(
+							'status' => 400,
+							'field'  => $field,
+						)
+					);
+				}
+				$output[ $field ] = $value;
+			}
+		}
+		$start = $output['performance_start_at'] ?? $booking['performance_start_at'];
+		$end   = $output['performance_end_at'] ?? $booking['performance_end_at'];
+		if ( $end <= $start ) {
+			return new \WP_Error( 'invalid_booking_date_range', __( 'The performance end must be later than its start.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		if ( array_key_exists( 'performer', $changes ) ) {
+			$performer = mb_substr( sanitize_text_field( (string) $changes['performer'] ), 0, 255 );
+			if ( '' === $performer ) {
+				return new \WP_Error( 'booking_event_performer_invalid', __( 'The corrected lineup is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+			}
+			$output['artist_name'] = $performer;
+		}
+		if ( array_key_exists( 'ticket_url', $changes ) ) {
+			$url = null === $changes['ticket_url'] || '' === $changes['ticket_url'] ? null : esc_url_raw( (string) $changes['ticket_url'] );
+			if ( null !== $url && ! preg_match( '#^https?://#i', $url ) ) {
+				return new \WP_Error( 'invalid_booking_deal', __( 'The ticket URL must be HTTP or HTTPS.', 'extrachill-events' ), array( 'status' => 400 ) );
+			}
+			$deal = $booking['confirmed_deal']['data'];
+			if ( ( $deal['ticket_url'] ?? null ) !== $url ) {
+				$deal['ticket_url']               = $url;
+				$output['confirmed_deal_payload'] = wp_json_encode(
+					array(
+						'version' => 1,
+						'data'    => $deal,
+					)
+				);
+			}
+		}
+		if ( ! empty( $changes['cancelled'] ) ) {
+			if ( ! in_array( $booking['status'], array( 'confirmed', 'cancelled' ), true ) ) {
+				return new \WP_Error( 'booking_transition_forbidden', __( 'Only a confirmed booking can be cancelled through event synchronization.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			$output['status'] = 'cancelled';
+		}
+		return array_filter(
+			$output,
+			static function ( $value, $key ) use ( $booking ) {
+				$current_key = 'confirmed_deal_payload' === $key ? null : $key;
+				return null === $current_key || ( $booking[ $current_key ] ?? null ) !== $value;
+			},
+			ARRAY_FILTER_USE_BOTH
+		);
+	}
+
+	/** Persist booking corrections and keep the converted hold aligned. */
+	private function persist_changes( array $booking, array $changes ) {
+		global $wpdb;
+		$table  = BookingSchema::bookings_table();
+		$set    = array();
+		$values = array();
+		foreach ( $changes as $column => $value ) {
+			$set[]    = null === $value ? "{$column} = NULL" : "{$column} = %s";
+			$values[] = $value;
+		}
+		$set[]    = 'version = version + 1';
+		$set[]    = 'updated_at = %s';
+		$values[] = gmdate( 'Y-m-d H:i:s' );
+		$values[] = $booking['id'];
+		$values[] = $booking['version'];
+		$result   = $wpdb->query( $wpdb->prepare( "UPDATE {$table} SET " . implode( ', ', $set ) . ' WHERE id = %d AND version = %d', $values ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Internal columns with prepared values.
+		if ( 1 !== $result ) {
+			return new \WP_Error(
+				'booking_event_sync_booking_update_failed',
+				__( 'The approved booking correction could not be saved.', 'extrachill-events' ),
+				array(
+					'status'         => 409,
+					'database_error' => $wpdb->last_error,
+				)
+			);
+		}
+		if ( array_intersect( array_keys( $changes ), array( 'venue_term_id', 'space_key', 'performance_start_at', 'performance_end_at' ) ) ) {
+			$holds = BookingSchema::holds_table();
+			$next  = $this->bookings->get_for_update( (int) $booking['id'] );
+			$hold  = $wpdb->query( $wpdb->prepare( "UPDATE {$holds} SET venue_term_id = %d, space_key = %s, start_at = %s, end_at = %s, version = version + 1, updated_at = %s WHERE booking_id = %d AND status = 'converted'", $next['venue_term_id'], $next['space_key'], $next['performance_start_at'], $next['performance_end_at'], gmdate( 'Y-m-d H:i:s' ), $booking['id'] ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Converted selection belongs to this aggregate.
+			if ( 1 !== $hold ) {
+				return new \WP_Error(
+					'booking_event_sync_hold_update_failed',
+					__( 'The converted booking selection could not be corrected.', 'extrachill-events' ),
+					array(
+						'status'         => 409,
+						'database_error' => $wpdb->last_error,
+					)
+				);
+			}
+		}
+		return $this->bookings->get_for_update( (int) $booking['id'] );
+	}
+
+	/** Map the current booking through the same public conversion rules. */
+	private function authority_from_booking( array $booking ) {
+		$venue    = get_term( $booking['venue_term_id'], 'venue' );
+		$timezone = (string) get_term_meta( $booking['venue_term_id'], '_venue_timezone', true );
+		try {
+			$zone = new \DateTimeZone( $timezone );
+		} catch ( \Exception $exception ) {
+			return new \WP_Error( 'booking_event_venue_timezone_invalid', __( 'The canonical venue timezone is invalid.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		if ( ! $venue || is_wp_error( $venue ) ) {
+			return new \WP_Error( 'booking_event_venue_invalid', __( 'The canonical venue is unavailable.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$utc   = new \DateTimeZone( 'UTC' );
+		$start = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $booking['performance_start_at'], $utc );
+		$end   = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $booking['performance_end_at'], $utc );
+		$deal  = $booking['confirmed_deal']['data'] ?? array();
+		return self::authority_from_event(
+			array(
+				'startDate'     => $start->setTimezone( $zone )->format( 'Y-m-d' ),
+				'startTime'     => $start->setTimezone( $zone )->format( 'H:i' ),
+				'endDate'       => $end->setTimezone( $zone )->format( 'Y-m-d' ),
+				'endTime'       => $end->setTimezone( $zone )->format( 'H:i' ),
+				'performer'     => $booking['artist_name'],
+				'performerType' => 'PerformingGroup',
+				'ticketUrl'     => (string) ( $deal['ticket_url'] ?? '' ),
+				'eventStatus'   => 'cancelled' === $booking['status'] ? 'EventCancelled' : 'EventScheduled',
+			),
+			(int) $booking['venue_term_id']
+		);
+	}
+
+	/** Read only the public event fields governed by this policy. */
+	private function read_event_authority( array $booking ) {
+		$post = get_post( $booking['event_id'] );
+		$type = defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events';
+		if ( ! $post || ( $post->post_type ?? '' ) !== $type ) {
+			return new \WP_Error( 'booking_event_existing_invalid', __( 'The linked site-local event is invalid.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$identity = hash( 'sha256', BookingEventConversionService::SOURCE . "\0" . $booking['public_id'] );
+		if ( BookingEventConversionService::SOURCE !== get_post_meta( $booking['event_id'], '_datamachine_event_source', true )
+			|| get_post_meta( $booking['event_id'], '_datamachine_event_source_id', true ) !== $booking['public_id']
+			|| get_post_meta( $booking['event_id'], '_datamachine_event_source_identity', true ) !== $identity ) {
+			return new \WP_Error( 'booking_event_identity_mismatch', __( 'The linked event does not belong to this immutable booking handoff.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$attrs = array();
+		foreach ( parse_blocks( (string) ( $post->post_content ?? '' ) ) as $block ) {
+			if ( 'data-machine-events/event-details' === ( $block['blockName'] ?? '' ) ) {
+				$attrs = (array) ( $block['attrs'] ?? array() );
+				break;
+			}
+		}
+		$venues = wp_get_object_terms( $booking['event_id'], 'venue', array( 'fields' => 'ids' ) );
+		if ( is_wp_error( $venues ) || 1 !== count( (array) $venues ) ) {
+			return new \WP_Error( 'booking_event_venue_invalid', __( 'The linked event must have exactly one canonical venue.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return self::authority_from_event( $attrs, (int) reset( $venues ) );
+	}
+
+	/** Normalize the DME batch result into one stable error boundary. */
+	private function execute_update( $ability, array $input ) {
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		$item = is_array( $result['results'][0] ?? null ) ? $result['results'][0] : null;
+		if ( ! $item || ! in_array( $item['status'] ?? '', array( 'updated', 'no_change' ), true ) ) {
+			$data              = (array) ( $item['error_data'] ?? array() );
+			$data['status']    = (int) ( $item['error_status'] ?? $data['status'] ?? 502 );
+			$data['retryable'] = $data['status'] >= 500;
+			return new \WP_Error( (string) ( $item['error_code'] ?? 'booking_event_update_failed' ), (string) ( $item['error'] ?? 'Canonical event update failed.' ), $data );
+		}
+		return true;
+	}
+
+	private function finish_success( array $booking, array $start, array $authority, string $kind, string $action, array $baseline ) {
+		$terminal = $this->append_terminal(
+			$booking,
+			$start,
+			$kind,
+			array(
+				'code'      => $action,
+				'authority' => $authority,
+			)
+		);
+		if ( is_wp_error( $terminal ) ) {
+			return $terminal;
+		}
+		if ( $authority !== $baseline ) {
+			$signal = $this->activity->append(
+				array(
+					'booking_id'      => $booking['id'],
+					'kind'            => 'event_marketing_change_signaled',
+					'idempotency_key' => 'event-marketing-change:' . $start['id'],
+					'external_id'     => (string) $booking['event_id'],
+					'payload'         => array(
+						'sync_activity_id' => $terminal['id'],
+						'event_id'         => $booking['event_id'],
+						'before'           => $baseline,
+						'after'            => $authority,
+						'owner_issue'      => self::MARKETING_ISSUE,
+					),
+				)
+			);
+			if ( is_wp_error( $signal ) ) {
+				return $signal;
+			}
+			do_action( 'extrachill_events_booking_event_changed', $booking['id'], $booking['event_id'], $baseline, $authority, (int) $signal['id'] );
+		}
+		return array(
+			'booking_id'      => $booking['id'],
+			'booking_version' => $booking['version'],
+			'event_id'        => $booking['event_id'],
+			'status'          => 'event_sync_noop' === $kind ? 'no_change' : 'succeeded',
+			'code'            => $action,
+			'retryable'       => false,
+			'conflicts'       => array(),
+		);
+	}
+
+	private function finish_error( array $booking, array $start, \WP_Error $error, string $kind ) {
+		$data      = (array) $error->get_error_data();
+		$retryable = ! empty( $data['retryable'] ) || (int) ( $data['status'] ?? 0 ) >= 500;
+		$terminal  = $this->append_terminal(
+			$booking,
+			$start,
+			$kind,
+			array(
+				'code'       => $error->get_error_code(),
+				'retryable'  => $retryable,
+				'error_data' => $data,
+			)
+		);
+		if ( is_wp_error( $terminal ) ) {
+			return $terminal;
+		}
+		return new \WP_Error(
+			$error->get_error_code(),
+			$error->get_error_message(),
+			array_merge(
+				$data,
+				array(
+					'retryable'         => $retryable,
+					'booking_committed' => true,
+					'sync_activity_id'  => $terminal['id'],
+				)
+			)
+		);
+	}
+
+	private function append_terminal( array $booking, array $start, string $kind, array $payload ) {
+		return $this->activity->append(
+			array(
+				'booking_id'      => $booking['id'],
+				'kind'            => $kind,
+				'external_id'     => (string) $start['id'],
+				'idempotency_key' => $kind . ':' . $start['id'],
+				'payload'         => array_merge(
+					array(
+						'attempt'         => $start['payload']['data']['attempt'],
+						'booking_version' => $booking['version'],
+						'event_id'        => $booking['event_id'],
+					),
+					$payload
+				),
+			)
+		);
+	}
+
+	private function authorize( int $actor_id, int $venue_id ) {
+		$allowed = $this->authorization->authorize( $actor_id, $venue_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+		return true === $allowed ? true : ( is_wp_error( $allowed ) ? $allowed : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) ) );
+	}
+
+	private function commit() {
+		$result                   = $GLOBALS['wpdb']->query( 'COMMIT' );
+		$this->transaction_active = false;
+		return false === $result ? new \WP_Error(
+			'booking_event_sync_commit_uncertain',
+			__( 'The booking synchronization transaction outcome is uncertain.', 'extrachill-events' ),
+			array(
+				'status'    => 503,
+				'retryable' => true,
+			)
+		) : true;
+	}
+
+	private function rollback( \WP_Error $error ) {
+		if ( $this->transaction_active ) {
+			$GLOBALS['wpdb']->query( 'ROLLBACK' );
+			$this->transaction_active = false;
+		}
+		return $error;
+	}
+}

--- a/tests/BookingEventConversionTest.php
+++ b/tests/BookingEventConversionTest.php
@@ -8,6 +8,7 @@
 use ExtraChillEvents\Abilities\VenueBookingEventAbilities;
 use ExtraChillEvents\Core\BookingActivityRepository;
 use ExtraChillEvents\Core\BookingEventConversionService;
+use ExtraChillEvents\Core\BookingEventSyncService;
 use ExtraChillEvents\Core\BookingLifecycle;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\BookingSchema;
@@ -157,7 +158,7 @@ final class BookingEventConversionTest extends TestCase {
 	}
 
 	private function add_event( int $id, string $type = 'data_machine_events', string $status = 'publish' ): void {
-		$GLOBALS['ec_artist_test']['posts'][7][ $id ] = (object) array( 'ID' => $id, 'post_type' => $type, 'post_status' => $status, 'post_title' => 'Canonical Event' );
+		$GLOBALS['ec_artist_test']['posts'][7][ $id ] = (object) array( 'ID' => $id, 'post_type' => $type, 'post_status' => $status, 'post_title' => 'Canonical Event', 'post_content' => 'event-' . $id );
 		$GLOBALS['ec_artist_test']['permalinks'][7][ $id ] = 'https://events.example/event/' . $id;
 	}
 
@@ -169,6 +170,33 @@ final class BookingEventConversionTest extends TestCase {
 			'_datamachine_event_source_identity' => $identity,
 		);
 		$GLOBALS['ec_artist_test']['event_venues'][7][ $id ] = array( null === $venue_id ? 55 : $venue_id );
+		if ( isset( $input['event'] ) ) {
+			$GLOBALS['ec_artist_test']['parsed_blocks'][ 'event-' . $id ] = array(
+				array( 'blockName' => 'data-machine-events/event-details', 'attrs' => $input['event'] ),
+			);
+		}
+	}
+
+	private function install_update_ability(): BookingConversionAbilityFake {
+		$ability = new BookingConversionAbilityFake(
+			function ( array $input ): array {
+				$id = (int) $input['event'];
+				if ( isset( $input['venue'] ) ) {
+					$GLOBALS['ec_artist_test']['event_venues'][7][ $id ] = array( (int) $input['venue'] );
+				} else {
+					$attrs = $GLOBALS['ec_artist_test']['parsed_blocks'][ 'event-' . $id ][0]['attrs'];
+					foreach ( $input as $field => $value ) {
+						if ( 'event' !== $field && 'previousStartDate' !== $field ) {
+							$attrs[ $field ] = $value;
+						}
+					}
+					$GLOBALS['ec_artist_test']['parsed_blocks'][ 'event-' . $id ][0]['attrs'] = $attrs;
+				}
+				return array( 'results' => array( array( 'post_id' => $id, 'status' => 'updated', 'updated_fields' => array_keys( $input ) ) ), 'summary' => array( 'updated' => 1, 'failed' => 0, 'total' => 1 ), 'message' => 'Updated 1 event' );
+			}
+		);
+		$GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/update-event'] = $ability;
+		return $ability;
 	}
 
 	private function upstream_result( array $input, array $overrides = array() ): array {
@@ -228,6 +256,12 @@ final class BookingEventConversionTest extends TestCase {
 		$this->assertTrue( $definition['meta']['show_in_rest'] );
 		$this->assertTrue( $definition['meta']['annotations']['idempotent'] );
 		$this->assertFalse( $definition['meta']['annotations']['destructive'] );
+		$sync = $GLOBALS['ec_artist_test']['abilities']['extrachill/reconcile-booking-event'];
+		$this->assertSame( array( 'booking_id', 'expected_version' ), $sync['input_schema']['required'] );
+		$this->assertFalse( $sync['input_schema']['additionalProperties'] );
+		$this->assertFalse( $sync['input_schema']['properties']['changes']['additionalProperties'] );
+		$this->assertTrue( $sync['meta']['annotations']['idempotent'] );
+		$this->assertTrue( $sync['meta']['annotations']['destructive'] );
 		$this->assertSame( 'venue_action_forbidden', $ability->can_access_booking( array( 'booking_id' => 999 ) )->get_error_code() );
 		$booking = $this->booking();
 		$this->assertTrue( $ability->can_access_booking( array( 'booking_id' => $booking['id'] ) ) );
@@ -761,5 +795,102 @@ final class BookingEventConversionTest extends TestCase {
 		$this->assertSame( 'booking_event_upsert_failed', $error->get_error_code() );
 		$this->assertSame( 422, $error->get_error_data()['status'] );
 		$this->assertSame( 'dme_write_forbidden', $error->get_error_data()['upstream_code'] );
+	}
+
+	public function test_reschedule_reconciles_authoritative_fields_once_and_signals_marketing_owner(): void {
+		$booking = $this->booking();
+		$this->service()->convert( $booking['id'], 1, 12 );
+		$ability = $this->install_update_ability();
+		$sync    = new BookingEventSyncService( null, null, new BookingTestAuthorization() );
+		$result  = $sync->reconcile(
+			$booking['id'],
+			2,
+			12,
+			array(
+				'space_key'            => 'main-room',
+				'performance_start_at' => '2030-03-11 00:00:00',
+				'performance_end_at'   => '2030-03-11 03:00:00',
+			)
+		);
+
+		$this->assertSame( 'succeeded', $result['status'] );
+		$this->assertSame( 3, $result['booking_version'] );
+		$this->assertCount( 1, $ability->calls );
+		$this->assertSame( 'EventRescheduled', $ability->calls[0]['eventStatus'] );
+		$this->assertSame( '2030-03-10', $ability->calls[0]['startDate'] );
+		$this->assertSame( '2030-03-09', $ability->calls[0]['previousStartDate'] );
+		$retry = $sync->reconcile( $booking['id'], 2, 12, array( 'space_key' => 'main-room', 'performance_start_at' => '2030-03-11 00:00:00', 'performance_end_at' => '2030-03-11 03:00:00' ) );
+		$this->assertSame( $result, $retry );
+		$this->assertCount( 1, $ability->calls );
+		$activity = ( new BookingActivityRepository() )->list_for_booking( $booking['id'] );
+		$this->assertCount( 1, array_filter( $activity, static function ( $item ) { return 'event_sync_succeeded' === $item['kind']; } ) );
+		$signals = array_values( array_filter( $activity, static function ( $item ) { return 'event_marketing_change_signaled' === $item['kind']; } ) );
+		$this->assertCount( 1, $signals );
+		$this->assertSame( BookingEventSyncService::MARKETING_ISSUE, $signals[0]['payload']['data']['owner_issue'] );
+	}
+
+	public function test_manual_authoritative_divergence_conflicts_without_overwrite(): void {
+		$booking = $this->booking();
+		$this->service()->convert( $booking['id'], 1, 12 );
+		$ability = $this->install_update_ability();
+		$GLOBALS['ec_artist_test']['parsed_blocks']['event-901'][0]['attrs']['performer'] = 'Manual Billing';
+
+		$error = ( new BookingEventSyncService( null, null, new BookingTestAuthorization() ) )->reconcile( $booking['id'], 2, 12, array( 'ticket_url' => 'https://tickets.example/new' ) );
+
+		$this->assertSame( 'booking_event_manual_divergence', $error->get_error_code() );
+		$this->assertArrayHasKey( 'performer', $error->get_error_data()['conflicts'] );
+		$this->assertCount( 0, $ability->calls );
+		$this->assertSame( 'https://tickets.example/new', ( new BookingRepository() )->get( $booking['id'] )['confirmed_deal']['data']['ticket_url'] );
+	}
+
+	public function test_pending_crash_window_retries_same_snapshot_and_rejects_different_writer(): void {
+		$booking = $this->booking();
+		$this->service()->convert( $booking['id'], 1, 12 );
+		$ability   = $this->install_update_ability();
+		$authority = ( new BookingActivityRepository() )->latest_event_authority( $booking['id'] );
+		( new BookingActivityRepository() )->append(
+			array(
+				'booking_id'      => $booking['id'],
+				'kind'            => 'event_sync_started',
+				'idempotency_key' => 'event-sync:' . $booking['public_id'] . ':2:1',
+				'payload'         => array( 'attempt' => 1, 'booking_version' => 2, 'event_id' => 901, 'authority' => $authority ),
+			)
+		);
+		$sync  = new BookingEventSyncService( null, null, new BookingTestAuthorization() );
+		$error = $sync->reconcile( $booking['id'], 2, 12, array( 'performer' => 'Different Writer' ) );
+		$this->assertSame( 'booking_event_sync_pending', $error->get_error_code() );
+		$this->assertCount( 0, $ability->calls );
+		$result = $sync->reconcile( $booking['id'], 2, 12 );
+		$this->assertSame( 'no_change', $result['status'] );
+		$this->assertCount( 0, $ability->calls );
+		$this->assertFalse( ( new BookingActivityRepository() )->event_sync_state( $booking['id'] )['pending'] );
+	}
+
+	public function test_cancellation_and_wrong_site_identity_use_stable_policy(): void {
+		$booking = $this->booking();
+		$this->service()->convert( $booking['id'], 1, 12 );
+		$ability = $this->install_update_ability();
+		$sync    = new BookingEventSyncService( null, null, new BookingTestAuthorization() );
+		$result  = $sync->reconcile( $booking['id'], 2, 12, array( 'cancelled' => true ) );
+		$this->assertSame( 'succeeded', $result['status'] );
+		$this->assertSame( 'EventCancelled', $ability->calls[0]['eventStatus'] );
+		$this->assertSame( 'cancelled', ( new BookingRepository() )->get( $booking['id'] )['status'] );
+
+		$other = $this->booking();
+		$this->service()->convert( $other['id'], 1, 12 );
+		$GLOBALS['ec_artist_test']['post_meta'][7][901]['_datamachine_event_source_id'] = 'another-site-local-source';
+		$error = $sync->reconcile( $other['id'], 2, 12 );
+		$this->assertSame( 'booking_event_identity_mismatch', $error->get_error_code() );
+	}
+
+	public function test_wrong_venue_is_a_field_conflict_not_a_blind_overwrite(): void {
+		$booking = $this->booking();
+		$this->service()->convert( $booking['id'], 1, 12 );
+		$ability = $this->install_update_ability();
+		$GLOBALS['ec_artist_test']['event_venues'][7][901] = array( 999 );
+		$error = ( new BookingEventSyncService( null, null, new BookingTestAuthorization() ) )->reconcile( $booking['id'], 2, 12, array( 'ticket_url' => 'https://tickets.example/corrected' ) );
+		$this->assertSame( 'booking_event_manual_divergence', $error->get_error_code() );
+		$this->assertArrayHasKey( 'venue_id', $error->get_error_data()['conflicts'] );
+		$this->assertCount( 0, $ability->calls );
 	}
 }

--- a/tests/Integration/booking-event-sync-mysql.php
+++ b/tests/Integration/booking-event-sync-mysql.php
@@ -1,0 +1,166 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Two-session and multisite booking/event synchronization proof.
+ *
+ * @package ExtraChillEvents\Tests\Integration
+ */
+
+$dsn = trim( (string) getenv( 'EC_EVENTS_MYSQL_TEST_DSN' ) );
+if ( '' === $dsn ) {
+	fwrite( STDOUT, "SKIP: EC_EVENTS_MYSQL_TEST_DSN is unavailable; no MySQL test endpoint was contacted.\n" );
+	exit( 0 );
+}
+if ( ! extension_loaded( 'mysqli' ) ) {
+	fwrite( STDERR, "FAIL: mysqli is required for the booking/event synchronization proof.\n" );
+	exit( 1 );
+}
+mysqli_report( MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT );
+
+$settings = array();
+foreach ( explode( ';', preg_replace( '/^mysql:/i', '', $dsn ) ) as $part ) {
+	if ( false === strpos( $part, '=' ) ) {
+		continue;
+	}
+	list( $key, $value )                 = explode( '=', $part, 2 );
+	$settings[ strtolower( trim( $key ) ) ] = trim( $value );
+}
+$database = $settings['dbname'] ?? '';
+if ( '' === $database || false === strpos( strtolower( $database ), 'test' ) ) {
+	fwrite( STDERR, "FAIL: the DSN must name an explicit test database.\n" );
+	exit( 1 );
+}
+
+$host       = $settings['host'] ?? '127.0.0.1';
+$port       = (int) ( $settings['port'] ?? 3306 );
+$socket     = $settings['unix_socket'] ?? null;
+$user       = (string) getenv( 'EC_EVENTS_MYSQL_TEST_USER' );
+$password   = (string) getenv( 'EC_EVENTS_MYSQL_TEST_PASSWORD' );
+$suffix     = bin2hex( random_bytes( 6 ) );
+$site_seven = 'ec_sync_7_' . $suffix . '_';
+$site_eight = 'ec_sync_8_' . $suffix . '_';
+$tables     = array();
+$primary    = null;
+$contender  = null;
+$exit_code  = 0;
+
+$connect = static function () use ( $host, $user, $password, $database, $port, $socket ): mysqli {
+	$connection = mysqli_init();
+	$connection->real_connect( $host, $user, $password, $database, $port, $socket );
+	$connection->set_charset( 'utf8mb4' );
+	return $connection;
+};
+$assert = static function ( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+};
+$lock = static function ( mysqli $connection, string $name, int $timeout ): int {
+	$statement = $connection->prepare( 'SELECT GET_LOCK(?, ?)' );
+	$statement->bind_param( 'si', $name, $timeout );
+	$statement->execute();
+	return (int) $statement->get_result()->fetch_row()[0];
+};
+$release = static function ( mysqli $connection, string $name ): int {
+	$statement = $connection->prepare( 'SELECT RELEASE_LOCK(?)' );
+	$statement->bind_param( 's', $name );
+	$statement->execute();
+	return (int) $statement->get_result()->fetch_row()[0];
+};
+
+try {
+	$primary   = $connect();
+	$contender = $connect();
+	foreach ( array( $primary, $contender ) as $connection ) {
+		$connection->query( "SET SESSION sql_mode = 'STRICT_ALL_TABLES'" );
+		$connection->query( 'SET SESSION innodb_lock_wait_timeout = 1' );
+	}
+
+	foreach ( array( $site_seven, $site_eight ) as $prefix ) {
+		$bookings   = $prefix . 'bookings';
+		$activity   = $prefix . 'activity';
+		$events     = $prefix . 'events';
+		$tables[]   = $bookings;
+		$tables[]   = $activity;
+		$tables[]   = $events;
+		$primary->query( "CREATE TABLE `{$bookings}` (id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, public_id CHAR(36) NOT NULL, venue_term_id BIGINT UNSIGNED NOT NULL, status VARCHAR(32) NOT NULL, version BIGINT UNSIGNED NOT NULL, performance_start_at DATETIME NOT NULL, performance_end_at DATETIME NOT NULL, event_id BIGINT UNSIGNED NULL, UNIQUE KEY public_id (public_id), UNIQUE KEY event_id (event_id)) ENGINE=InnoDB" );
+		$primary->query( "CREATE TABLE `{$activity}` (id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, booking_id BIGINT UNSIGNED NOT NULL, kind VARCHAR(64) NOT NULL, idempotency_key VARCHAR(191) NULL, UNIQUE KEY booking_key (booking_id, idempotency_key)) ENGINE=InnoDB" );
+		$primary->query( "CREATE TABLE `{$events}` (id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, source_identity CHAR(64) NOT NULL, venue_term_id BIGINT UNSIGNED NOT NULL, event_status VARCHAR(32) NOT NULL, start_at DATETIME NOT NULL, end_at DATETIME NOT NULL, UNIQUE KEY source_identity (source_identity)) ENGINE=InnoDB" );
+	}
+
+	$bookings = $site_seven . 'bookings';
+	$activity = $site_seven . 'activity';
+	$events   = $site_seven . 'events';
+	$public   = '11111111-1111-4111-8111-111111111111';
+	$identity = hash( 'sha256', "extrachill-events-booking\0{$public}" );
+	$primary->query( "INSERT INTO `{$events}` (source_identity, venue_term_id, event_status, start_at, end_at) VALUES ('{$identity}', 55, 'EventScheduled', '2030-03-10 00:00:00', '2030-03-10 03:00:00')" );
+	$event_id = (int) $primary->insert_id;
+	$primary->query( "INSERT INTO `{$bookings}` (public_id, venue_term_id, status, version, performance_start_at, performance_end_at, event_id) VALUES ('{$public}', 55, 'confirmed', 2, '2030-03-10 00:00:00', '2030-03-10 03:00:00', {$event_id})" );
+	$booking_id = (int) $primary->insert_id;
+
+	// A manual/event writer cannot cross the booking aggregate's correction boundary.
+	$primary->begin_transaction();
+	$primary->query( "SELECT * FROM `{$bookings}` WHERE id = {$booking_id} FOR UPDATE" );
+	try {
+		$contender->query( "UPDATE `{$bookings}` SET performance_start_at = '2030-03-12 00:00:00' WHERE id = {$booking_id}" );
+		$blocked = false;
+	} catch ( mysqli_sql_exception $exception ) {
+		$blocked = 1205 === $exception->getCode();
+	}
+	$assert( $blocked, 'The independent booking writer did not wait behind the synchronization row lock.' );
+	$primary->query( "UPDATE `{$bookings}` SET version = 3, performance_start_at = '2030-03-11 00:00:00', performance_end_at = '2030-03-11 03:00:00' WHERE id = {$booking_id} AND version = 2" );
+	$primary->commit();
+
+	// Crash/retry markers and immutable source identity converge on one row.
+	$key = "event-sync:{$public}:3:1";
+	$primary->query( "INSERT INTO `{$activity}` (booking_id, kind, idempotency_key) VALUES ({$booking_id}, 'event_sync_started', '{$key}')" );
+	try {
+		$primary->query( "INSERT INTO `{$activity}` (booking_id, kind, idempotency_key) VALUES ({$booking_id}, 'event_sync_started', '{$key}')" );
+		$duplicate_rejected = false;
+	} catch ( mysqli_sql_exception $exception ) {
+		$duplicate_rejected = 1062 === $exception->getCode();
+	}
+	$assert( $duplicate_rejected, 'A duplicate synchronization retry inserted a second intent.' );
+	$assert( 1 === (int) $primary->query( "SELECT id FROM `{$events}` WHERE source_identity = '{$identity}'" )->num_rows, 'The immutable source identity no longer resolved exactly one event.' );
+
+	// Reschedule and cancellation remain one booking/event identity.
+	$primary->query( "UPDATE `{$events}` SET event_status = 'EventRescheduled', start_at = '2030-03-11 00:00:00', end_at = '2030-03-11 03:00:00' WHERE id = {$event_id} AND source_identity = '{$identity}'" );
+	$primary->query( "UPDATE `{$bookings}` SET status = 'cancelled', version = 4 WHERE id = {$booking_id} AND version = 3" );
+	$primary->query( "UPDATE `{$events}` SET event_status = 'EventCancelled' WHERE id = {$event_id} AND source_identity = '{$identity}'" );
+	$row = $primary->query( "SELECT b.status, b.version, e.event_status FROM `{$bookings}` b INNER JOIN `{$events}` e ON e.id = b.event_id WHERE b.id = {$booking_id}" )->fetch_assoc();
+	$assert( 'cancelled' === $row['status'] && 4 === (int) $row['version'] && 'EventCancelled' === $row['event_status'], 'Cancellation did not preserve the synchronized identity.' );
+
+	// The same numeric IDs on another multisite prefix cannot satisfy this handoff.
+	$other_events = $site_eight . 'events';
+	$primary->query( "INSERT INTO `{$other_events}` (id, source_identity, venue_term_id, event_status, start_at, end_at) VALUES ({$event_id}, '" . str_repeat( 'a', 64 ) . "', 999, 'EventScheduled', '2030-03-10 00:00:00', '2030-03-10 03:00:00')" );
+	$assert( 0 === (int) $primary->query( "SELECT id FROM `{$other_events}` WHERE id = {$event_id} AND source_identity = '{$identity}' AND venue_term_id = 55" )->num_rows, 'A wrong-site or wrong-venue event satisfied the booking identity.' );
+
+	// Publication and synchronization serialize through the existing venue lock.
+	$venue_lock = 'ecbv:' . sha1( $site_seven . 'ec_booking_holds:55' );
+	$assert( 1 === $lock( $primary, $venue_lock, 0 ), 'Synchronization did not acquire the venue publication lock.' );
+	$started = microtime( true );
+	$contender->query( "SELECT GET_LOCK('{$venue_lock}', 3)", MYSQLI_ASYNC );
+	usleep( 250000 );
+	$assert( 1 === $release( $primary, $venue_lock ), 'Synchronization did not release the venue publication lock.' );
+	$result = $contender->reap_async_query();
+	$assert( $result instanceof mysqli_result && 1 === (int) $result->fetch_row()[0] && microtime( true ) - $started >= 0.2, 'Publication did not wait behind synchronization.' );
+	$release( $contender, $venue_lock );
+
+	fwrite( STDOUT, "PASS: true MySQL sessions proved booking/event retry, correction, cancellation, multisite identity, and publication serialization.\n" );
+} catch ( Throwable $throwable ) {
+	fwrite( STDERR, 'FAIL: ' . $throwable->getMessage() . "\n" );
+	$exit_code = 1;
+} finally {
+	if ( $primary instanceof mysqli ) {
+		foreach ( $tables as $table ) {
+			$primary->query( "DROP TABLE IF EXISTS `{$table}`" );
+		}
+	}
+	foreach ( array( $primary, $contender ) as $connection ) {
+		if ( $connection instanceof mysqli ) {
+			$connection->close();
+		}
+	}
+}
+
+exit( $exit_code );

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -784,6 +784,21 @@ final class BookingWpdb {
 			usort( $rows, static function ( $left, $right ) { return $right['id'] <=> $left['id']; } );
 			return $rows[0] ?? null;
 		}
+		if ( $is_activity && preg_match( "/WHERE booking_id = (\d+) AND kind = 'event_sync_started' ORDER BY id DESC LIMIT 1/", $query, $match ) ) {
+			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static function ( $row ) use ( $match ) { return (int) $row['booking_id'] === (int) $match[1] && 'event_sync_started' === $row['kind']; } ) );
+			usort( $rows, static function ( $left, $right ) { return $right['id'] <=> $left['id']; } );
+			return $rows[0] ?? null;
+		}
+		if ( $is_activity && preg_match( "/WHERE booking_id = (\d+) AND external_id = '(\d+)' AND kind IN \('event_sync_succeeded', 'event_sync_noop', 'event_sync_conflict', 'event_sync_failed'\)/", $query, $match ) ) {
+			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static function ( $row ) use ( $match ) { return (int) $row['booking_id'] === (int) $match[1] && (string) ( $row['external_id'] ?? '' ) === $match[2] && in_array( $row['kind'], array( 'event_sync_succeeded', 'event_sync_noop', 'event_sync_conflict', 'event_sync_failed' ), true ); } ) );
+			usort( $rows, static function ( $left, $right ) { return $right['id'] <=> $left['id']; } );
+			return $rows[0] ?? null;
+		}
+		if ( $is_activity && preg_match( "/WHERE booking_id = (\d+) AND kind IN \('event_sync_succeeded', 'event_sync_noop', 'event_converted'\)/", $query, $match ) ) {
+			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static function ( $row ) use ( $match ) { return (int) $row['booking_id'] === (int) $match[1] && in_array( $row['kind'], array( 'event_sync_succeeded', 'event_sync_noop', 'event_converted' ), true ); } ) );
+			usort( $rows, static function ( $left, $right ) { return $right['id'] <=> $left['id']; } );
+			return $rows[0] ?? null;
+		}
 		if ( ! $is_attachment && ! $is_delivery && ! $is_activity && ! $is_state && ! $is_hold && ! $is_sales && ! $is_settlement && ! $is_membership && false !== strpos( $query, 'FOR UPDATE' ) ) {
 			++$this->booking_lock_queries;
 			if ( is_callable( $this->after_booking_lock ) ) {
@@ -1489,6 +1504,22 @@ final class BookingWpdb {
 			unset( $row );
 			return $count;
 		}
+		if ( preg_match( "/UPDATE ([^ ]*ec_booking_holds) SET venue_term_id = (\d+), space_key = '([^']+)', start_at = '([^']+)', end_at = '([^']+)', version = version \+ 1, updated_at = '([^']+)' WHERE booking_id = (\d+) AND status = 'converted'/", $query, $hold_update ) ) {
+			$count = 0;
+			foreach ( $this->rows[ $hold_update[1] ] ?? array() as &$row ) {
+				if ( (int) $row['booking_id'] === (int) $hold_update[7] && 'converted' === $row['status'] ) {
+					$row['venue_term_id'] = (int) $hold_update[2];
+					$row['space_key']     = stripslashes( $hold_update[3] );
+					$row['start_at']      = $hold_update[4];
+					$row['end_at']        = $hold_update[5];
+					$row['updated_at']    = $hold_update[6];
+					++$row['version'];
+					++$count;
+				}
+			}
+			unset( $row );
+			return $count;
+		}
 		if ( ! preg_match( '/UPDATE ([^ ]+) SET .*WHERE id = (\d+) AND version = (\d+)/', $query, $match ) ) {
 			return false; }
 		$table    = $match[1];
@@ -1545,6 +1576,7 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingNotificationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingCommunicationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingHoldRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingMutationService.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingEventSyncService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingEventConversionService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingLifecycle.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingPrivateFileProvider.php';


### PR DESCRIPTION
## Summary
- add an Events-owned, field-level authority policy for converted booking reschedules, cancellations, venue/space corrections, lineup, and ticket URL updates
- reconcile through the public Data Machine Events update contract while preserving immutable source/event identity and manual event-owned fields
- persist bounded retry, no-op, success, conflict, failure, and owner-neutral marketing-change activity with a public reconcile ability
- extend the managed MySQL workflow with two-session, duplicate-retry, cancellation/reschedule, multisite identity, and publication-lock proofs

## Policy
Booking remains authoritative for schedule, canonical venue assignment, performer, ticket URL, and event status. Event title and description remain manually owned. A mutation is rejected when a booking-authoritative event field diverged from the last accepted snapshot and does not already equal the requested booking value.

Marketing orchestration remains owned by #296. Until that public delegated contract exists, successful fact changes emit `extrachill_events_booking_event_changed` and `event_marketing_change_signaled` activity rather than calling internal campaign, socials, newsletter, or scheduler APIs.

## Verification
- `vendor/bin/phpunit -c phpunit-booking.xml.dist` (328 tests, 3,872 assertions)
- `npm run test:js -- --runInBand` (43 tests)
- `npm run build`
- Homeboy changed-file PHPCS: passed
- Homeboy PHPStan level 7: passed
- Homeboy PR architecture audit: no introduced findings
- independent clean review: no introduced audit/lint findings

## Tooling Notes
- Generic Homeboy test selection still reproduces existing cross-suite global contamination/missing composed DME fixture failures; the focused booking suite is green.
- Managed build wrapper is blocked before compilation by Extra-Chill/homeboy-extensions#2432; direct `npm run build` passes.

Closes #319