### PR TITLE
test: prove internal booking-to-calendar alpha

### DIFF
--- a/.github/workflows/booking-attachment-mysql.yml
+++ b/.github/workflows/booking-attachment-mysql.yml
@@ -139,7 +139,7 @@ jobs:
               wp_codebox_phpunit_preload_files: [$schema_preload, $preload],
               validation_dependencies: [$data_machine_source, $data_machine_events_source]
             }')
-          node .ci/homeboy-extensions/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+          node .ci/homeboy-extensions/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs --filter='BookingAttachmentMySQLIntegrationTest|BookingEventSyncMySQLIntegrationTest'
 
       - name: Install native WordPress test runtime
         run: |
@@ -188,7 +188,7 @@ jobs:
             | ($runs | length) == 1
               and $runs[0].exitCode == 0
               and $runs[0].result.status == "ok"
-              and ($runs[0].stdout | test("OK \\(4 tests, [1-9][0-9]* assertions?\\)"))
+              and ($runs[0].stdout | test("OK \\(3 tests, [1-9][0-9]* assertions?\\)"))
               and (($runs[0].stdout | test("skip|no tests executed|OK, but"; "i")) | not)
           ' "$commands" >/dev/null
           jq -e '
@@ -197,7 +197,7 @@ jobs:
           ' "$metadata" >/dev/null
           jq -rs '[.[] | select(.command == "wordpress.phpunit")][0].stdout' "$commands" > "$ARTIFACTS_DIR/booking-attachment-mysql-phpunit.txt"
           printf '%s\n' "Verified application-level MySQL proof:"
-          grep -E 'OK \(4 tests, [1-9][0-9]* assertions?\)' "$ARTIFACTS_DIR/booking-attachment-mysql-phpunit.txt"
+          grep -E 'OK \(3 tests, [1-9][0-9]* assertions?\)' "$ARTIFACTS_DIR/booking-attachment-mysql-phpunit.txt"
 
       - name: Upload WP Codebox evidence
         if: always()

--- a/.github/workflows/booking-attachment-mysql.yml
+++ b/.github/workflows/booking-attachment-mysql.yml
@@ -139,7 +139,7 @@ jobs:
               wp_codebox_phpunit_preload_files: [$schema_preload, $preload],
               validation_dependencies: [$data_machine_source, $data_machine_events_source]
             }')
-          node .ci/homeboy-extensions/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs --filter=BookingAttachmentMySQLIntegrationTest
+          node .ci/homeboy-extensions/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
 
       - name: Install native WordPress test runtime
         run: |

--- a/.github/workflows/booking-attachment-mysql.yml
+++ b/.github/workflows/booking-attachment-mysql.yml
@@ -139,7 +139,7 @@ jobs:
               wp_codebox_phpunit_preload_files: [$schema_preload, $preload],
               validation_dependencies: [$data_machine_source, $data_machine_events_source]
             }')
-          node .ci/homeboy-extensions/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+          node .ci/homeboy-extensions/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs --filter=BookingAttachmentMySQLIntegrationTest
 
       - name: Install native WordPress test runtime
         run: |

--- a/.github/workflows/internal-booking-calendar-alpha.yml
+++ b/.github/workflows/internal-booking-calendar-alpha.yml
@@ -24,7 +24,11 @@ on:
       - inc/Core/VenueBookingConfig.php
       - inc/Core/VenueMembershipRepository.php
       - phpunit-booking-alpha.xml.dist
+      - phpunit-booking-alpha-concurrency.xml.dist
       - tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
+      - tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
+      - tests/MySQLIntegration/host-wordpress-bootstrap.php
+      - tests/MySQLIntegration/wp-tests-config.php
 
 permissions:
   contents: read
@@ -152,7 +156,37 @@ jobs:
               wp_codebox_phpunit_cwd: "/wordpress/wp-content/plugins/extrachill-events",
               validation_dependencies: [$network, $api, $dm, $dme]
             }')
-          node .ci/homeboy-extensions/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+          node .ci/homeboy-extensions/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs --filter=test_internal_booking_to_calendar_alpha
+
+      - name: Install native WordPress test runtime
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes subversion
+          curl --fail --location --silent --show-error https://wordpress.org/latest.tar.gz | tar -xz -C /tmp
+          wp_version=$(php -r "include '/tmp/wordpress/wp-includes/version.php'; echo \$wp_version;")
+          wp_branch=$(printf '%s' "$wp_version" | cut -d. -f1,2)
+          mkdir -p /tmp/wordpress-tests-lib
+          svn export --quiet "https://develop.svn.wordpress.org/tags/${wp_branch}/tests/phpunit/includes" /tmp/wordpress-tests-lib/includes
+          svn export --quiet "https://develop.svn.wordpress.org/tags/${wp_branch}/tests/phpunit/data" /tmp/wordpress-tests-lib/data
+
+      - name: Run native overlapping hold proof
+        env:
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_USER: root
+          DB_PASSWORD: ""
+          DB_NAME: wordpress_test
+          WP_CORE_DIR: /tmp/wordpress
+          WP_TESTS_DIR: /tmp/wordpress-tests-lib
+          WP_TESTS_PHPUNIT_POLYFILLS_PATH: ${{ github.workspace }}/vendor/yoast/phpunit-polyfills
+        run: |
+          set -euo pipefail
+          vendor/bin/phpunit -c phpunit-booking-alpha-concurrency.xml.dist --filter test_overlapping_public_hold_abilities_allow_one_winner | tee "$RUNNER_TEMP/internal-booking-hold-concurrency.txt"
+          grep -E 'OK \(1 test, [1-9][0-9]* assertions?\)' "$RUNNER_TEMP/internal-booking-hold-concurrency.txt"
+          if grep -Eiq 'skip|no tests executed|OK, but' "$RUNNER_TEMP/internal-booking-hold-concurrency.txt"; then
+            exit 1
+          fi
 
       - name: Verify nonzero execution evidence
         env:
@@ -185,5 +219,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: internal-booking-calendar-alpha-evidence
-          path: ${{ runner.temp }}/internal-booking-calendar-alpha
+          path: |
+            ${{ runner.temp }}/internal-booking-calendar-alpha
+            ${{ runner.temp }}/internal-booking-hold-concurrency.txt
           if-no-files-found: error

--- a/.github/workflows/internal-booking-calendar-alpha.yml
+++ b/.github/workflows/internal-booking-calendar-alpha.yml
@@ -28,6 +28,7 @@ on:
       - tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
       - tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
       - tests/MySQLIntegration/host-wordpress-bootstrap.php
+      - tests/MySQLIntegration/internal-booking-alpha-bootstrap.php
       - tests/MySQLIntegration/wp-tests-config.php
 
 permissions:
@@ -151,6 +152,7 @@ jobs:
               phpunit_no_tests: "fail",
               wp_codebox_multisite: true,
               wp_codebox_phpunit_bootstrap_mode: "managed",
+              wp_codebox_phpunit_bootstrap_files: ["tests/MySQLIntegration/internal-booking-alpha-bootstrap.php"],
               wp_codebox_phpunit_test_root: $root,
               wp_codebox_phpunit_config: $config,
               wp_codebox_phpunit_cwd: "/wordpress/wp-content/plugins/extrachill-events",

--- a/.github/workflows/internal-booking-calendar-alpha.yml
+++ b/.github/workflows/internal-booking-calendar-alpha.yml
@@ -183,6 +183,7 @@ jobs:
           WP_CORE_DIR: /tmp/wordpress
           WP_TESTS_DIR: /tmp/wordpress-tests-lib
           WP_TESTS_PHPUNIT_POLYFILLS_PATH: ${{ github.workspace }}/vendor/yoast/phpunit-polyfills
+          DME_PLUGIN_DIR: ${{ github.workspace }}/.ci/data-machine-events
         run: |
           set -euo pipefail
           vendor/bin/phpunit -c phpunit-booking-alpha-concurrency.xml.dist --filter test_overlapping_public_hold_abilities_allow_one_winner | tee "$RUNNER_TEMP/internal-booking-hold-concurrency.txt"

--- a/.github/workflows/internal-booking-calendar-alpha.yml
+++ b/.github/workflows/internal-booking-calendar-alpha.yml
@@ -99,6 +99,12 @@ jobs:
         with:
           node-version: 24
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+
       - name: Install plugin test dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
 
@@ -136,7 +142,7 @@ jobs:
             --arg dm "${GITHUB_WORKSPACE}/.ci/data-machine" \
             --arg dme "${GITHUB_WORKSPACE}/.ci/data-machine-events" \
             '{
-              php: "8.4",
+              wordpress_runtime_php_version: "8.4",
               database_type: "mysql",
               phpunit_no_tests: "fail",
               wp_codebox_multisite: true,

--- a/.github/workflows/internal-booking-calendar-alpha.yml
+++ b/.github/workflows/internal-booking-calendar-alpha.yml
@@ -215,7 +215,7 @@ jobs:
           jq -e '
             any(.context.managedRuntimeServices[]; .kind == "mysql" and .readiness == "ready")
             and any(.context.recipe.workflow.steps[].args[]; . == "database-type=mysql")
-            and any(.context.recipe.workflow.steps[].args[]; . == "multisite=true")
+            and any(.context.recipe.workflow.steps[].args[]; . == "multisite=1")
           ' "$metadata" >/dev/null
 
       - name: Upload managed proof evidence

--- a/.github/workflows/internal-booking-calendar-alpha.yml
+++ b/.github/workflows/internal-booking-calendar-alpha.yml
@@ -142,6 +142,7 @@ jobs:
           HOMEBOY_SETTINGS_JSON=$(jq -nc \
             --arg root "/wordpress/wp-content/plugins/extrachill-events/tests/MySQLIntegration" \
             --arg config "/wordpress/wp-content/plugins/extrachill-events/phpunit-booking-alpha.xml.dist" \
+            --arg bootstrap "/wordpress/wp-content/plugins/extrachill-events/tests/MySQLIntegration/internal-booking-alpha-bootstrap.php" \
             --arg network "${GITHUB_WORKSPACE}/.ci/extrachill-network" \
             --arg api "${GITHUB_WORKSPACE}/.ci/extrachill-api" \
             --arg dm "${GITHUB_WORKSPACE}/.ci/data-machine" \
@@ -152,7 +153,7 @@ jobs:
               phpunit_no_tests: "fail",
               wp_codebox_multisite: true,
               wp_codebox_phpunit_bootstrap_mode: "managed",
-              wp_codebox_phpunit_bootstrap_files: ["tests/MySQLIntegration/internal-booking-alpha-bootstrap.php"],
+              wp_codebox_phpunit_preload_files: [$bootstrap],
               wp_codebox_phpunit_test_root: $root,
               wp_codebox_phpunit_config: $config,
               wp_codebox_phpunit_cwd: "/wordpress/wp-content/plugins/extrachill-events",

--- a/.github/workflows/internal-booking-calendar-alpha.yml
+++ b/.github/workflows/internal-booking-calendar-alpha.yml
@@ -1,0 +1,183 @@
+name: Internal booking calendar alpha
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/internal-booking-calendar-alpha.yml
+      - composer.json
+      - inc/Abilities/VenueBookingAbilities.php
+      - inc/Abilities/VenueBookingConfigAbilities.php
+      - inc/Abilities/VenueBookingEventAbilities.php
+      - inc/Abilities/VenueBookingHoldAbilities.php
+      - inc/Abilities/VenueBookingMutationAbilities.php
+      - inc/Abilities/VenueMembershipAbilities.php
+      - inc/Core/BookingActivityRepository.php
+      - inc/Core/BookingEventConversionService.php
+      - inc/Core/BookingHoldRepository.php
+      - inc/Core/BookingInquiryAdmissionService.php
+      - inc/Core/BookingLifecycle.php
+      - inc/Core/BookingMutationService.php
+      - inc/Core/BookingRepository.php
+      - inc/Core/BookingSchema.php
+      - inc/Core/VenueAuthorization.php
+      - inc/Core/VenueBookingConfig.php
+      - inc/Core/VenueMembershipRepository.php
+      - phpunit-booking-alpha.xml.dist
+      - tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
+
+permissions:
+  contents: read
+
+jobs:
+  managed-alpha:
+    name: Managed MySQL multisite alpha
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: wordpress_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --host=127.0.0.1 --silent"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+
+    steps:
+      - name: Checkout Extra Chill Events
+        uses: actions/checkout@v4
+
+      - name: Checkout Extra Chill Network
+        uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/extrachill-network
+          ref: main
+          path: .ci/extrachill-network
+
+      - name: Checkout Extra Chill API
+        uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/extrachill-api
+          ref: main
+          path: .ci/extrachill-api
+
+      - name: Checkout Data Machine
+        uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/data-machine
+          ref: main
+          path: .ci/data-machine
+
+      - name: Checkout Data Machine Events
+        uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/data-machine-events
+          ref: main
+          path: .ci/data-machine-events
+
+      - name: Checkout WP Codebox
+        uses: actions/checkout@v4
+        with:
+          repository: Automattic/wp-codebox
+          ref: main
+          path: .ci/wp-codebox
+
+      - name: Checkout Homeboy WordPress test adapter
+        uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/homeboy-extensions
+          ref: main
+          path: .ci/homeboy-extensions
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install plugin test dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Install Data Machine dependencies
+        working-directory: .ci/data-machine
+        run: composer install --no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative
+
+      - name: Install Homeboy WordPress PHPUnit harness
+        working-directory: .ci/homeboy-extensions/wordpress
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Build WP Codebox
+        working-directory: .ci/wp-codebox
+        run: |
+          set -euo pipefail
+          npm install
+          npm run build
+
+      - name: Run managed MySQL multisite alpha proof
+        env:
+          HOMEBOY_COMPONENT_ID: extrachill-events
+          HOMEBOY_COMPONENT_PATH: ${{ github.workspace }}
+          HOMEBOY_EXTENSION_PATH: ${{ github.workspace }}/.ci/homeboy-extensions/wordpress
+          HOMEBOY_WP_CODEBOX_BIN: ${{ github.workspace }}/.ci/wp-codebox/packages/cli/dist/index.js
+          HOMEBOY_WP_CODEBOX_CORE_MODULE: ${{ github.workspace }}/.ci/wp-codebox/packages/runtime-core/dist/index.js
+          HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: ${{ runner.temp }}/internal-booking-calendar-alpha
+        run: |
+          set -euo pipefail
+          export HOMEBOY_SETTINGS_JSON
+          HOMEBOY_SETTINGS_JSON=$(jq -nc \
+            --arg root "/wordpress/wp-content/plugins/extrachill-events/tests/MySQLIntegration" \
+            --arg config "/wordpress/wp-content/plugins/extrachill-events/phpunit-booking-alpha.xml.dist" \
+            --arg network "${GITHUB_WORKSPACE}/.ci/extrachill-network" \
+            --arg api "${GITHUB_WORKSPACE}/.ci/extrachill-api" \
+            --arg dm "${GITHUB_WORKSPACE}/.ci/data-machine" \
+            --arg dme "${GITHUB_WORKSPACE}/.ci/data-machine-events" \
+            '{
+              php: "8.4",
+              database_type: "mysql",
+              phpunit_no_tests: "fail",
+              wp_codebox_multisite: true,
+              wp_codebox_phpunit_bootstrap_mode: "managed",
+              wp_codebox_phpunit_test_root: $root,
+              wp_codebox_phpunit_config: $config,
+              wp_codebox_phpunit_cwd: "/wordpress/wp-content/plugins/extrachill-events",
+              validation_dependencies: [$network, $api, $dm, $dme]
+            }')
+          node .ci/homeboy-extensions/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+
+      - name: Verify nonzero execution evidence
+        env:
+          ARTIFACTS_DIR: ${{ runner.temp }}/internal-booking-calendar-alpha
+        run: |
+          set -euo pipefail
+          run_artifacts_dir=$(find "$ARTIFACTS_DIR" -maxdepth 1 -type d -name 'wp-codebox-phpunit.*' -print -quit)
+          test -n "$run_artifacts_dir"
+          runtime_dir=$(jq -er '.paths.runtimeDirectory' "$run_artifacts_dir/latest-runtime.json")
+          commands="$run_artifacts_dir/$runtime_dir/commands.jsonl"
+          metadata="$run_artifacts_dir/$runtime_dir/metadata.json"
+          test -f "$commands"
+          test -f "$metadata"
+          jq -ers '
+            [.[] | select(.command == "wordpress.phpunit")] as $runs
+            | ($runs | length) == 1
+              and $runs[0].exitCode == 0
+              and $runs[0].result.status == "ok"
+              and ($runs[0].stdout | test("OK \\(1 test, [1-9][0-9]* assertions?\\)"))
+              and (($runs[0].stdout | test("skip|no tests executed|OK, but"; "i")) | not)
+          ' "$commands" >/dev/null
+          jq -e '
+            any(.context.managedRuntimeServices[]; .kind == "mysql" and .readiness == "ready")
+            and any(.context.recipe.workflow.steps[].args[]; . == "database-type=mysql")
+            and any(.context.recipe.workflow.steps[].args[]; . == "multisite=true")
+          ' "$metadata" >/dev/null
+
+      - name: Upload managed proof evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: internal-booking-calendar-alpha-evidence
+          path: ${{ runner.temp }}/internal-booking-calendar-alpha
+          if-no-files-found: error

--- a/inc/Abilities/VenueBookingAbilities.php
+++ b/inc/Abilities/VenueBookingAbilities.php
@@ -720,7 +720,7 @@ class VenueBookingAbilities {
 	 * @param array $booking Hydrated storage record.
 	 */
 	public function present( array $booking ): array {
-		unset( $booking['inquiry_idempotency_key'], $booking['inquiry_request_hash'] );
+		unset( $booking['inquiry_idempotency_key'], $booking['inquiry_request_hash'], $booking['admission_owner_token'] );
 		return $booking;
 	}
 

--- a/phpunit-booking-alpha-concurrency.xml.dist
+++ b/phpunit-booking-alpha-concurrency.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="tests/MySQLIntegration/host-wordpress-bootstrap.php"
+	colors="true"
+	beStrictAboutOutputDuringTests="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	failOnRisky="true"
+	failOnWarning="true">
+	<testsuites>
+		<testsuite name="internal-booking-hold-concurrency">
+			<file>tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/phpunit-booking-alpha.xml.dist
+++ b/phpunit-booking-alpha.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	colors="true"
+	beStrictAboutOutputDuringTests="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	failOnRisky="true"
+	failOnWarning="true">
+	<testsuites>
+		<testsuite name="internal-booking-calendar-alpha">
+			<file>tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -1167,6 +1167,19 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertSame( $receipt, call_user_func( $registered['extrachill/create-booking-inquiry']['execute_callback'], $receipt_input ) );
 
 		$booking = $this->create_booking();
+		$presented = $abilities->present(
+			array_merge(
+				$booking,
+				array(
+					'inquiry_idempotency_key' => 'private-key',
+					'inquiry_request_hash'    => str_repeat( 'a', 64 ),
+					'admission_owner_token'   => wp_generate_uuid4(),
+				)
+			)
+		);
+		$this->assertArrayNotHasKey( 'inquiry_idempotency_key', $presented );
+		$this->assertArrayNotHasKey( 'inquiry_request_hash', $presented );
+		$this->assertArrayNotHasKey( 'admission_owner_token', $presented );
 		$this->assertTrue( $abilities->can_access_booking( array( 'booking_id' => $booking['id'] ) ) );
 		$this->assertSame( array( array( 12, 55, VenueAuthorization::ACTION_ACCESS_VENUE ) ), $authorization->calls );
 		$this->assertSame( 'venue_action_forbidden', $abilities->can_access_booking( array( 'booking_id' => 999 ) )->get_error_code() );

--- a/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
+++ b/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
@@ -229,11 +229,15 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 		$this->assertSame( $cancel, $this->ability_data( 'extrachill/reconcile-booking-event', $cancel_input, $operator_a ) );
 		$this->assertSame( 'cancelled', $this->ability_data( 'extrachill/get-venue-booking', array( 'booking_id' => $booking['id'] ), $operator_a )['status'] );
 		$this->assertSame( 'EventCancelled', $this->event_authority( $cancel['event_id'] )['eventStatus'] );
-		$communications = $this->ability_data( 'extrachill/list-booking-communications', array( 'booking_id' => $booking['id'] ), $operator_a );
-		$reminders      = array_values( array_filter( $communications, static fn( array $communication ): bool => 'hold_expiring' === ( $communication['message']['template'] ?? null ) ) );
-		$this->assertCount( 1, $reminders );
-		$this->assertSame( 'suppressed', $reminders[0]['state']['status'] );
-		$this->assertSame( 'booking_status_changed', $reminders[0]['state']['reason'] );
+		$communications        = $this->ability_data( 'extrachill/list-booking-communications', array( 'booking_id' => $booking['id'] ), $operator_a );
+		$reminder_suppressions = array_values(
+			array_filter(
+				$communications,
+				static fn( array $communication ): bool => (int) ( $communication['state']['intent_id'] ?? 0 ) === (int) $reminder['intent_id'] && 'suppressed' === ( $communication['state']['status'] ?? null )
+			)
+		);
+		$this->assertCount( 1, $reminder_suppressions );
+		$this->assertSame( 'booking_status_changed', $reminder_suppressions[0]['state']['reason'] );
 		$this->assertSame( 1, $this->count_canonical_events( $anonymous['public_id'] ) );
 
 		$this->assert_main_site_has_no_booking_writes();

--- a/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
+++ b/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
@@ -7,6 +7,7 @@
 
 use DataMachineEvents\Core\EventDatesTable;
 use ExtraChillEvents\Core\BookingActivityRepository;
+use ExtraChillEvents\Core\BookingEventSyncService;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\VenueAuthorization;
 
@@ -155,20 +156,84 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $this->count_canonical_events( $anonymous['public_id'] ) );
 		$this->assertSame( $this->events_blog_id, get_current_blog_id() );
 		$booking['version'] = $conversion['booking_version'];
-		$booking = $this->transition( $booking, 'completed', $operator_a );
-		$this->assertSame( 'completed', $booking['status'] );
 
-		$cancel = $this->booking_by_public_id( $venue_b, $authenticated['public_id'], $operator_b );
-		$cancel = $this->transition( $cancel, 'under_review', $operator_b );
-		$cancel = $this->transition( $cancel, 'negotiating', $operator_b );
-		$cancel = $this->select_performance( $cancel, 'club-room', '2031-06-02 00:00:00', '2031-06-02 03:00:00', $operator_b );
-		$cancel = $this->update_deal( $cancel, $operator_b );
-		$cancel_hold = $this->ability_data( 'extrachill/create-booking-hold', array( 'booking_id' => $cancel['id'], 'expected_booking_version' => $cancel['version'] ), $operator_b );
-		$cancel['version'] = $cancel_hold['booking_version'];
-		$cancel = $this->transition( $cancel, 'held', $operator_b );
-		$cancel = $this->transition( $cancel, 'confirmed', $operator_b );
-		$cancel = $this->transition( $cancel, 'cancelled', $operator_b );
-		$this->assertSame( 'cancelled', $cancel['status'] );
+		$reminder = $this->ability_data(
+			'extrachill/send-booking-message',
+			array(
+				'booking_id'      => $booking['id'],
+				'idempotency_key' => 'alpha-cancellation-cleanup',
+				'template'        => 'hold_expiring',
+				'recipient'       => 'anonymous@example.test',
+				'message'         => 'This reminder must be suppressed if the event is cancelled.',
+				'reply_to'        => 'bookings@example.test',
+			),
+			$operator_a
+		);
+		$this->assertSame( 'scheduled', $reminder['state']['status'] );
+
+		$sync_input = array(
+			'booking_id'       => $booking['id'],
+			'expected_version' => $booking['version'],
+			'changes'          => array(
+				'venue_term_id'        => $venue_b,
+				'space_key'            => 'patio',
+				'performance_start_at' => '2031-06-03 00:00:00',
+				'performance_end_at'   => '2031-06-03 03:00:00',
+				'performer'            => 'Anonymous Alpha and Friends',
+				'ticket_url'           => 'https://tickets.example.test/alpha-corrected',
+			),
+		);
+		$this->assert_ability_denied( 'extrachill/reconcile-booking-event', $sync_input, $operator_b );
+		$this->grant_venue_owner( $venue_b, $operator_a, $operator_b );
+
+		$stale_sync = $sync_input;
+		$stale_sync['expected_version'] -= 1;
+		$stale = $this->ability_request( 'extrachill/reconcile-booking-event', $stale_sync, $operator_a );
+		$this->assertSame( 409, $stale->get_status() );
+		$this->assertSame( 'booking_version_conflict', $stale->get_data()['code'] );
+
+		$sync = $this->ability_data( 'extrachill/reconcile-booking-event', $sync_input, $operator_a );
+		$this->assertSame( 'succeeded', $sync['status'] );
+		$this->assertSame( $conversion['event_id'], $sync['event_id'] );
+		$this->assertSame( $sync, $this->ability_data( 'extrachill/reconcile-booking-event', $sync_input, $operator_a ) );
+		$booking = $this->ability_data( 'extrachill/get-venue-booking', array( 'booking_id' => $booking['id'] ), $operator_a );
+		$this->assertSame( $venue_b, $booking['venue_term_id'] );
+		$this->assertSame( 'patio', $booking['space_key'] );
+		$this->assertSame( '2031-06-03 00:00:00', $booking['performance_start_at'] );
+		$this->assertSame( '2031-06-03 03:00:00', $booking['performance_end_at'] );
+		$this->assertSame( 'Anonymous Alpha and Friends', $booking['artist_name'] );
+		$this->assertSame( 'https://tickets.example.test/alpha-corrected', $booking['confirmed_deal']['data']['ticket_url'] );
+		$corrected_hold = $this->ability_data( 'extrachill/list-booking-holds', array( 'venue_term_id' => $venue_b, 'booking_id' => $booking['id'] ), $operator_a )[0];
+		$this->assertSame( 'converted', $corrected_hold['status'] );
+		$this->assertSame( 'patio', $corrected_hold['space_key'] );
+		$this->assertSame( '2031-06-03 00:00:00', $corrected_hold['start_at'] );
+		$this->assertSame( '2031-06-03 03:00:00', $corrected_hold['end_at'] );
+
+		$authority = $this->event_authority( $sync['event_id'] );
+		$this->assertSame( '2031-06-02', $authority['startDate'] );
+		$this->assertSame( '20:00', $authority['startTime'] );
+		$this->assertSame( '23:00', $authority['endTime'] );
+		$this->assertSame( 'EventRescheduled', $authority['eventStatus'] );
+		$this->assertSame( 'Anonymous Alpha and Friends', $authority['performer'] );
+		$this->assertSame( 'https://tickets.example.test/alpha-corrected', $authority['ticketUrl'] );
+		$this->assertSame( $venue_b, $authority['venue_id'] );
+		$this->assertSame( 1, $this->count_canonical_events( $anonymous['public_id'] ) );
+
+		$cancel_input = array(
+			'booking_id'       => $booking['id'],
+			'expected_version' => $sync['booking_version'],
+			'changes'          => array( 'cancelled' => true ),
+		);
+		$cancel = $this->ability_data( 'extrachill/reconcile-booking-event', $cancel_input, $operator_a );
+		$this->assertSame( 'succeeded', $cancel['status'] );
+		$this->assertSame( $cancel, $this->ability_data( 'extrachill/reconcile-booking-event', $cancel_input, $operator_a ) );
+		$this->assertSame( 'cancelled', $this->ability_data( 'extrachill/get-venue-booking', array( 'booking_id' => $booking['id'] ), $operator_a )['status'] );
+		$this->assertSame( 'EventCancelled', $this->event_authority( $cancel['event_id'] )['eventStatus'] );
+		$communications = $this->ability_data( 'extrachill/list-booking-communications', array( 'booking_id' => $booking['id'] ), $operator_a );
+		$this->assertCount( 1, $communications );
+		$this->assertSame( 'suppressed', $communications[0]['state']['status'] );
+		$this->assertSame( 'booking_status_changed', $communications[0]['state']['reason'] );
+		$this->assertSame( 1, $this->count_canonical_events( $anonymous['public_id'] ) );
 
 		$this->assert_main_site_has_no_booking_writes();
 		$this->assert_bounded_recovery_activity( $booking['id'] );
@@ -178,7 +243,7 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 	private function assert_required_contracts(): void {
 		$this->assertTrue( function_exists( 'extrachill_api_route_affinity_dispatch' ), 'Extra Chill API must be an active validation dependency.' );
 		$this->assertTrue( function_exists( 'ec_cross_site_rest_request' ), 'Extra Chill Network must be an active validation dependency.' );
-		foreach ( array( 'extrachill/create-booking-inquiry', 'extrachill/create-venue-membership', 'extrachill/update-venue-booking-config', 'extrachill/transition-venue-booking', 'extrachill/select-venue-booking-performance', 'extrachill/update-venue-booking-deal', 'extrachill/create-booking-hold', 'extrachill/convert-booking-to-event', 'data-machine-events/upsert-event' ) as $name ) {
+		foreach ( array( 'extrachill/create-booking-inquiry', 'extrachill/create-venue-membership', 'extrachill/update-venue-booking-config', 'extrachill/transition-venue-booking', 'extrachill/select-venue-booking-performance', 'extrachill/update-venue-booking-deal', 'extrachill/create-booking-hold', 'extrachill/convert-booking-to-event', 'extrachill/reconcile-booking-event', 'extrachill/send-booking-message', 'extrachill/list-booking-communications', 'data-machine-events/upsert-event', 'data-machine-events/update-source-event' ) as $name ) {
 			$this->assertInstanceOf( WP_Ability::class, wp_get_ability( $name ), $name . ' is unavailable.' );
 		}
 		$routes = rest_get_server()->get_routes();
@@ -216,8 +281,8 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 	}
 
 	/** Grant the first explicit owner through the public membership ability. */
-	private function grant_venue_owner( int $venue_id, int $operator_id ): void {
-		$membership = $this->ability_data( 'extrachill/create-venue-membership', array( 'venue_term_id' => $venue_id, 'user_id' => $operator_id, 'is_owner' => true ), $operator_id );
+	private function grant_venue_owner( int $venue_id, int $operator_id, ?int $actor_id = null ): void {
+		$membership = $this->ability_data( 'extrachill/create-venue-membership', array( 'venue_term_id' => $venue_id, 'user_id' => $operator_id, 'is_owner' => true ), $actor_id ?? $operator_id );
 		$this->assertSame( $venue_id, $membership['venue_term_id'] );
 		$this->assertTrue( $membership['is_owner'] );
 	}
@@ -229,6 +294,9 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 		unset( $config['revision'], $config['updated_by_user_id'], $config['updated_at'] );
 		$config['enabled'] = true;
 		$config['spaces']  = array();
+		$config['correspondence']['reminder_policies']['hold_expiring']['enabled']           = true;
+		$config['correspondence']['reminder_policies']['hold_expiring']['delay_minutes']     = 60;
+		$config['correspondence']['reminder_policies']['hold_expiring']['expected_statuses'] = array( 'confirmed' );
 		foreach ( $space_keys as $index => $key ) {
 			$config['spaces'][] = array( 'key' => $key, 'name' => ucwords( str_replace( '-', ' ', $key ) ), 'is_default' => 0 === $index );
 		}
@@ -326,6 +394,24 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 			)
 		);
 		return count( $query->posts );
+	}
+
+	/** Read the public event authority after reconciliation. */
+	private function event_authority( int $event_id ): array {
+		$post = get_post( $event_id );
+		$this->assertInstanceOf( WP_Post::class, $post );
+		$attrs = array();
+		foreach ( parse_blocks( $post->post_content ) as $block ) {
+			if ( 'data-machine-events/event-details' === ( $block['blockName'] ?? '' ) ) {
+				$attrs = (array) ( $block['attrs'] ?? array() );
+				break;
+			}
+		}
+		$this->assertNotEmpty( $attrs );
+		$venues = wp_get_object_terms( $event_id, 'venue', array( 'fields' => 'ids' ) );
+		$this->assertNotWPError( $venues );
+		$this->assertCount( 1, $venues );
+		return BookingEventSyncService::authority_from_event( $attrs, (int) reset( $venues ) );
 	}
 
 	/** Assert route affinity never wrote booking state under the main prefix. */

--- a/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
+++ b/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
@@ -230,9 +230,10 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 		$this->assertSame( 'cancelled', $this->ability_data( 'extrachill/get-venue-booking', array( 'booking_id' => $booking['id'] ), $operator_a )['status'] );
 		$this->assertSame( 'EventCancelled', $this->event_authority( $cancel['event_id'] )['eventStatus'] );
 		$communications = $this->ability_data( 'extrachill/list-booking-communications', array( 'booking_id' => $booking['id'] ), $operator_a );
-		$this->assertCount( 1, $communications );
-		$this->assertSame( 'suppressed', $communications[0]['state']['status'] );
-		$this->assertSame( 'booking_status_changed', $communications[0]['state']['reason'] );
+		$reminders      = array_values( array_filter( $communications, static fn( array $communication ): bool => 'hold_expiring' === ( $communication['message']['template'] ?? null ) ) );
+		$this->assertCount( 1, $reminders );
+		$this->assertSame( 'suppressed', $reminders[0]['state']['status'] );
+		$this->assertSame( 'booking_status_changed', $reminders[0]['state']['reason'] );
 		$this->assertSame( 1, $this->count_canonical_events( $anonymous['public_id'] ) );
 
 		$this->assert_main_site_has_no_booking_writes();

--- a/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
+++ b/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
@@ -294,6 +294,7 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 		unset( $config['revision'], $config['updated_by_user_id'], $config['updated_at'] );
 		$config['enabled'] = true;
 		$config['spaces']  = array();
+		$config['correspondence']['reminder_policies']['hold_expiring']['version']          += 1;
 		$config['correspondence']['reminder_policies']['hold_expiring']['enabled']           = true;
 		$config['correspondence']['reminder_policies']['hold_expiring']['delay_minutes']     = 60;
 		$config['correspondence']['reminder_policies']['hold_expiring']['expected_statuses'] = array( 'confirmed' );

--- a/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
+++ b/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
@@ -5,7 +5,6 @@
  * @package ExtraChillEvents\Tests\MySQLIntegration
  */
 
-use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
 use DataMachineEvents\Core\EventDatesTable;
 use ExtraChillEvents\Core\BookingActivityRepository;
 use ExtraChillEvents\Core\BookingSchema;
@@ -43,9 +42,6 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 		$_SERVER['HTTP_HOST']   = 'example.org';
 
 		switch_to_blog( $this->events_blog_id );
-		$this->assertTrue( BookingSchema::install() );
-		EventDatesTable::create_table();
-		( new PostIdentityIndex() )->create_table();
 		$this->assertTrue( BookingSchema::is_ready() );
 		$this->assertTrue( EventDatesTable::table_exists() );
 		restore_current_blog();

--- a/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
+++ b/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
@@ -169,7 +169,7 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 			),
 			$operator_a
 		);
-		$this->assertSame( 'scheduled', $reminder['state']['status'] );
+		$this->assertSame( 'scheduled', $reminder['status'] );
 
 		$sync_input = array(
 			'booking_id'       => $booking['id'],

--- a/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
+++ b/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
@@ -400,7 +400,8 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 		switch_to_blog( $this->events_blog_id );
 		try {
-			$response = rest_get_server()->dispatch( $request );
+			$authentication = apply_filters( 'rest_authentication_errors', null );
+			$response       = is_wp_error( $authentication ) ? rest_convert_error_to_response( $authentication ) : rest_get_server()->dispatch( $request );
 		} finally {
 			restore_current_blog();
 			wp_set_current_user( $source_user );

--- a/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
+++ b/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
@@ -8,7 +8,6 @@
 use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
 use DataMachineEvents\Core\EventDatesTable;
 use ExtraChillEvents\Core\BookingActivityRepository;
-use ExtraChillEvents\Core\BookingHoldRepository;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\VenueAuthorization;
 
@@ -31,7 +30,6 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 
 		$this->assertTrue( is_multisite(), 'The alpha proof requires WordPress multisite.' );
 		$this->assertTrue( extension_loaded( 'mysqli' ), 'The alpha proof requires mysqli.' );
-		$this->assertTrue( function_exists( 'pcntl_fork' ), 'The alpha proof requires pcntl_fork().' );
 		$this->assertNotSame( ':memory:', DB_NAME, 'The alpha proof requires managed MySQL.' );
 
 		$this->main_blog_id   = get_current_blog_id();
@@ -80,7 +78,7 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	/** Execute the complete current alpha and its real two-process hold race. */
+	/** Execute the complete current alpha through public REST and Abilities. */
 	public function test_internal_booking_to_calendar_alpha(): void {
 		$this->assert_required_contracts();
 		list( $operator_a, $operator_b ) = $this->create_operators();
@@ -176,7 +174,6 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 		$cancel = $this->transition( $cancel, 'cancelled', $operator_b );
 		$this->assertSame( 'cancelled', $cancel['status'] );
 
-		$this->prove_overlapping_hold_race( $venue_a, $operator_a );
 		$this->assert_main_site_has_no_booking_writes();
 		$this->assert_bounded_recovery_activity( $booking['id'] );
 	}
@@ -333,91 +330,6 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 			)
 		);
 		return count( $query->posts );
-	}
-
-	/** Prove two native PHP processes cannot win the same venue-space interval. */
-	private function prove_overlapping_hold_race( int $venue_id, int $operator_id ): void {
-		$first  = $this->prepare_race_booking( $venue_id, $operator_id, 'Race One' );
-		$second = $this->prepare_race_booking( $venue_id, $operator_id, 'Race Two' );
-		$blocker = $this->connect_mysql();
-		$lock    = BookingHoldRepository::venue_lock_name( $venue_id );
-		$escaped = $blocker->real_escape_string( $lock );
-		$this->assertSame( 1, (int) $blocker->query( "SELECT GET_LOCK('{$escaped}', 5)" )->fetch_row()[0] );
-		$directory = sys_get_temp_dir() . '/ec-alpha-' . wp_generate_uuid4();
-		$this->assertTrue( mkdir( $directory, 0700 ) );
-		$pids = array();
-		foreach ( array( $first, $second ) as $index => $booking ) {
-			$pid = pcntl_fork();
-			$this->assertGreaterThanOrEqual( 0, $pid );
-			if ( 0 === $pid ) {
-				$this->reconnect_database();
-				file_put_contents( $directory . '/ready-' . $index, '1', LOCK_EX );
-				$response = $this->ability_request( 'extrachill/create-booking-hold', array( 'booking_id' => $booking['id'], 'expected_booking_version' => $booking['version'] ), $operator_id );
-				file_put_contents( $directory . '/result-' . $index, wp_json_encode( array( 'status' => $response->get_status(), 'data' => $response->get_data() ) ), LOCK_EX );
-				exit( 0 );
-			}
-			$pids[] = $pid;
-		}
-		$deadline = microtime( true ) + 5;
-		while ( ( ! file_exists( $directory . '/ready-0' ) || ! file_exists( $directory . '/ready-1' ) ) && microtime( true ) < $deadline ) {
-			usleep( 10000 );
-		}
-		$this->assertFileExists( $directory . '/ready-0' );
-		$this->assertFileExists( $directory . '/ready-1' );
-		$this->assertSame( 1, (int) $blocker->query( "SELECT RELEASE_LOCK('{$escaped}')" )->fetch_row()[0] );
-		$blocker->close();
-		foreach ( $pids as $pid ) {
-			$status = 0;
-			pcntl_waitpid( $pid, $status );
-			$this->assertTrue( pcntl_wifexited( $status ) && 0 === pcntl_wexitstatus( $status ) );
-		}
-		$this->assertFileExists( $directory . '/result-0' );
-		$this->assertFileExists( $directory . '/result-1' );
-		$results  = array( json_decode( (string) file_get_contents( $directory . '/result-0' ), true ), json_decode( (string) file_get_contents( $directory . '/result-1' ), true ) );
-		$statuses = array_map( static function ( array $result ): int { return (int) $result['status']; }, $results );
-		sort( $statuses );
-		$this->assertSame( array( 200, 409 ), $statuses );
-		$this->assertSame( 1, count( $this->ability_data( 'extrachill/list-booking-holds', array( 'venue_term_id' => $venue_id, 'status' => 'active', 'range_start' => '2031-07-01 00:00:00', 'range_end' => '2031-07-01 03:00:00' ), $operator_id ) ) );
-		foreach ( glob( $directory . '/*' ) as $file ) {
-			unlink( $file );
-		}
-		rmdir( $directory );
-	}
-
-	/** Prepare one negotiating booking for the concurrent hold race. */
-	private function prepare_race_booking( int $venue_id, int $operator_id, string $artist ): array {
-		switch_to_blog( $this->main_blog_id );
-		$receipt = $this->submit_inquiry( $venue_id, 0, sanitize_key( $artist ) . '-race', array( 'artist_name' => $artist ) );
-		restore_current_blog();
-		$booking = $this->booking_by_public_id( $venue_id, $receipt['public_id'], $operator_id );
-		$booking = $this->transition( $booking, 'under_review', $operator_id );
-		$booking = $this->transition( $booking, 'negotiating', $operator_id );
-		return $this->select_performance( $booking, 'main-room', '2031-07-01 00:00:00', '2031-07-01 03:00:00', $operator_id );
-	}
-
-	/** Reconnect a forked WordPress process to managed MySQL. */
-	private function reconnect_database(): void {
-		global $wpdb, $table_prefix;
-		if ( $wpdb->dbh instanceof mysqli ) {
-			$wpdb->dbh->close();
-		}
-		$wpdb = new wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
-		$wpdb->set_prefix( $table_prefix );
-		$wpdb->set_blog_id( $this->events_blog_id );
-	}
-
-	/** Open one independent managed MySQL session. */
-	private function connect_mysql(): mysqli {
-		$host = (string) DB_HOST;
-		$port = 3306;
-		if ( 1 === preg_match( '/^(.+):(\d+)$/', $host, $matches ) ) {
-			$host = $matches[1];
-			$port = (int) $matches[2];
-		}
-		$connection = mysqli_init();
-		$this->assertTrue( mysqli_real_connect( $connection, $host, DB_USER, DB_PASSWORD, DB_NAME, $port ), mysqli_connect_error() );
-		$connection->set_charset( 'utf8mb4' );
-		return $connection;
 	}
 
 	/** Assert route affinity never wrote booking state under the main prefix. */

--- a/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
+++ b/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
@@ -1,0 +1,512 @@
+<?php
+/**
+ * Internal booking-to-calendar alpha through public REST and Abilities contracts.
+ *
+ * @package ExtraChillEvents\Tests\MySQLIntegration
+ */
+
+use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
+use DataMachineEvents\Core\EventDatesTable;
+use ExtraChillEvents\Core\BookingActivityRepository;
+use ExtraChillEvents\Core\BookingHoldRepository;
+use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\VenueAuthorization;
+
+require_once __DIR__ . '/booking-attachment-mysql-bootstrap.php';
+
+/** Proves the supported internal alpha without private files or finance. */
+final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
+	/** @var int */
+	private $main_blog_id;
+
+	/** @var int */
+	private $events_blog_id;
+
+	/** @var array<string, mixed> */
+	private $original_server = array();
+
+	/** Install the real site-scoped schemas and controlled HTTP loopback. */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->assertTrue( is_multisite(), 'The alpha proof requires WordPress multisite.' );
+		$this->assertTrue( extension_loaded( 'mysqli' ), 'The alpha proof requires mysqli.' );
+		$this->assertTrue( function_exists( 'pcntl_fork' ), 'The alpha proof requires pcntl_fork().' );
+		$this->assertNotSame( ':memory:', DB_NAME, 'The alpha proof requires managed MySQL.' );
+
+		$this->main_blog_id   = get_current_blog_id();
+		$this->events_blog_id = $this->ensure_events_site();
+		$this->assertSame( 7, $this->events_blog_id, 'The managed network must expose the canonical Events site ID.' );
+
+		foreach ( array( 'REMOTE_ADDR', 'HTTP_HOST' ) as $key ) {
+			$this->original_server[ $key ] = $_SERVER[ $key ] ?? null;
+		}
+		$_SERVER['REMOTE_ADDR'] = '198.51.100.42';
+		$_SERVER['HTTP_HOST']   = 'example.org';
+
+		switch_to_blog( $this->events_blog_id );
+		$this->assertTrue( BookingSchema::install() );
+		EventDatesTable::create_table();
+		( new PostIdentityIndex() )->create_table();
+		$this->assertTrue( BookingSchema::is_ready() );
+		$this->assertTrue( EventDatesTable::table_exists() );
+		restore_current_blog();
+
+		add_filter( 'pre_http_request', array( $this, 'dispatch_affinity_loopback' ), 1, 3 );
+		add_filter( 'extrachill_bypass_turnstile_verification', '__return_true' );
+		add_filter( 'extrachill_api_booking_inquiry_rate_limit', '__return_zero' );
+	}
+
+	/** Remove disposable state without touching production storage. */
+	public function tear_down(): void {
+		remove_filter( 'pre_http_request', array( $this, 'dispatch_affinity_loopback' ), 1 );
+		remove_filter( 'extrachill_bypass_turnstile_verification', '__return_true' );
+		remove_filter( 'extrachill_api_booking_inquiry_rate_limit', '__return_zero' );
+
+		while ( ms_is_switched() ) {
+			restore_current_blog();
+		}
+		if ( get_current_blog_id() !== $this->main_blog_id ) {
+			switch_to_blog( $this->main_blog_id );
+		}
+		foreach ( $this->original_server as $key => $value ) {
+			if ( null === $value ) {
+				unset( $_SERVER[ $key ] );
+			} else {
+				$_SERVER[ $key ] = $value;
+			}
+		}
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/** Execute the complete current alpha and its real two-process hold race. */
+	public function test_internal_booking_to_calendar_alpha(): void {
+		$this->assert_required_contracts();
+		list( $operator_a, $operator_b ) = $this->create_operators();
+
+		switch_to_blog( $this->events_blog_id );
+		$venue_a = $this->create_venue( 'Alpha Room A' );
+		$venue_b = $this->create_venue( 'Alpha Room B' );
+		$this->grant_venue_owner( $venue_a, $operator_a );
+		$this->grant_venue_owner( $venue_b, $operator_b );
+		$this->configure_venue( $venue_a, $operator_a, array( 'main-room', 'side-room' ) );
+		$this->configure_venue( $venue_b, $operator_b, array( 'club-room', 'patio' ) );
+		restore_current_blog();
+
+		$anonymous = $this->submit_inquiry(
+			$venue_a,
+			0,
+			'alpha-anonymous',
+			array(
+				'artist_name'         => 'Anonymous Alpha',
+				'contact_name'        => 'Anonymous Contact',
+				'contact_email'       => 'anonymous@example.test',
+				'requested_space_key' => 'main-room',
+				'requested_start_at'  => '2031-06-01 00:00:00',
+				'requested_end_at'    => '2031-06-01 03:00:00',
+			)
+		);
+		$this->assertSame( $anonymous, $this->submit_inquiry( $venue_a, 0, 'alpha-anonymous', array( 'artist_name' => 'Anonymous Alpha', 'contact_name' => 'Anonymous Contact', 'contact_email' => 'anonymous@example.test', 'requested_space_key' => 'main-room', 'requested_start_at' => '2031-06-01 00:00:00', 'requested_end_at' => '2031-06-01 03:00:00' ) ), 'An exact anonymous retry changed its receipt.' );
+
+		$authenticated = $this->submit_inquiry(
+			$venue_b,
+			$operator_b,
+			'alpha-authenticated',
+			array(
+				'artist_name'         => 'Authenticated Alpha',
+				'contact_email'       => 'authenticated@example.test',
+				'requested_space_key' => 'club-room',
+			)
+		);
+		switch_to_blog( $this->events_blog_id );
+		$this->assertSame( $operator_b, $this->booking_by_public_id( $venue_b, $authenticated['public_id'], $operator_b )['submitter_user_id'] );
+
+		$booking = $this->booking_by_public_id( $venue_a, $anonymous['public_id'], $operator_a );
+		$this->assertSame( 'submitted', $booking['status'] );
+		$this->assert_ability_denied( 'extrachill/get-venue-booking', array( 'booking_id' => $booking['id'] ), $operator_b );
+
+		$booking = $this->transition( $booking, 'needs_info', $operator_a );
+		$booking = $this->transition( $booking, 'submitted', $operator_a );
+		$booking = $this->transition( $booking, 'under_review', $operator_a );
+		$stale   = $this->ability_request( 'extrachill/transition-venue-booking', array( 'booking_id' => $booking['id'], 'to_status' => 'negotiating', 'expected_version' => $booking['version'] - 1 ), $operator_a );
+		$this->assertSame( 409, $stale->get_status() );
+		$this->assertSame( 'booking_version_conflict', $stale->get_data()['code'] );
+		$booking = $this->transition( $booking, 'negotiating', $operator_a );
+		$booking = $this->select_performance( $booking, 'main-room', '2031-06-01 00:00:00', '2031-06-01 03:00:00', $operator_a );
+		$booking = $this->update_deal( $booking, $operator_a );
+		$hold    = $this->ability_data( 'extrachill/create-booking-hold', array( 'booking_id' => $booking['id'], 'expected_booking_version' => $booking['version'] ), $operator_a );
+		$this->assertSame( 'active', $hold['hold']['status'] );
+		$booking['version'] = $hold['booking_version'];
+		$booking = $this->transition( $booking, 'held', $operator_a );
+		$booking = $this->transition( $booking, 'confirmed', $operator_a );
+		$this->assertSame( 'converted', $this->ability_data( 'extrachill/list-booking-holds', array( 'venue_term_id' => $venue_a, 'booking_id' => $booking['id'] ), $operator_a )[0]['status'] );
+
+		$fail_nested_upsert = static function (): bool {
+			return false;
+		};
+		add_filter( 'datamachine_events_upsert_event_permission', $fail_nested_upsert, PHP_INT_MAX );
+		$failed = $this->ability_request( 'extrachill/convert-booking-to-event', array( 'booking_id' => $booking['id'], 'expected_version' => $booking['version'] ), $operator_a );
+		remove_filter( 'datamachine_events_upsert_event_permission', $fail_nested_upsert, PHP_INT_MAX );
+		$this->assertGreaterThanOrEqual( 400, $failed->get_status() );
+		$this->assertSame( 'booking_event_upsert_failed', $failed->get_data()['code'] );
+		$this->assertNull( $this->ability_data( 'extrachill/get-venue-booking', array( 'booking_id' => $booking['id'] ), $operator_a )['event_id'] );
+
+		$conversion = $this->ability_data( 'extrachill/convert-booking-to-event', array( 'booking_id' => $booking['id'], 'expected_version' => $booking['version'] ), $operator_a );
+		$this->assertFalse( $conversion['already_converted'] );
+		$this->assertSame( 'created', $conversion['event_action'] );
+		$retry = $this->ability_data( 'extrachill/convert-booking-to-event', array( 'booking_id' => $booking['id'], 'expected_version' => $booking['version'] ), $operator_a );
+		$this->assertTrue( $retry['already_converted'] );
+		$this->assertSame( $conversion['event_id'], $retry['event_id'] );
+		$this->assertSame( 1, $this->count_canonical_events( $anonymous['public_id'] ) );
+		$this->assertSame( $this->events_blog_id, get_current_blog_id() );
+		$booking['version'] = $conversion['booking_version'];
+		$booking = $this->transition( $booking, 'completed', $operator_a );
+		$this->assertSame( 'completed', $booking['status'] );
+
+		$cancel = $this->booking_by_public_id( $venue_b, $authenticated['public_id'], $operator_b );
+		$cancel = $this->transition( $cancel, 'under_review', $operator_b );
+		$cancel = $this->transition( $cancel, 'negotiating', $operator_b );
+		$cancel = $this->select_performance( $cancel, 'club-room', '2031-06-02 00:00:00', '2031-06-02 03:00:00', $operator_b );
+		$cancel = $this->update_deal( $cancel, $operator_b );
+		$cancel_hold = $this->ability_data( 'extrachill/create-booking-hold', array( 'booking_id' => $cancel['id'], 'expected_booking_version' => $cancel['version'] ), $operator_b );
+		$cancel['version'] = $cancel_hold['booking_version'];
+		$cancel = $this->transition( $cancel, 'held', $operator_b );
+		$cancel = $this->transition( $cancel, 'confirmed', $operator_b );
+		$cancel = $this->transition( $cancel, 'cancelled', $operator_b );
+		$this->assertSame( 'cancelled', $cancel['status'] );
+
+		$this->prove_overlapping_hold_race( $venue_a, $operator_a );
+		$this->assert_main_site_has_no_booking_writes();
+		$this->assert_bounded_recovery_activity( $booking['id'] );
+	}
+
+	/** Assert all dependencies are public and loaded before creating fixtures. */
+	private function assert_required_contracts(): void {
+		$this->assertTrue( function_exists( 'extrachill_api_route_affinity_dispatch' ), 'Extra Chill API must be an active validation dependency.' );
+		$this->assertTrue( function_exists( 'ec_cross_site_rest_request' ), 'Extra Chill Network must be an active validation dependency.' );
+		foreach ( array( 'extrachill/create-booking-inquiry', 'extrachill/create-venue-membership', 'extrachill/update-venue-booking-config', 'extrachill/transition-venue-booking', 'extrachill/select-venue-booking-performance', 'extrachill/update-venue-booking-deal', 'extrachill/create-booking-hold', 'extrachill/convert-booking-to-event', 'data-machine-events/upsert-event' ) as $name ) {
+			$this->assertInstanceOf( WP_Ability::class, wp_get_ability( $name ), $name . ' is unavailable.' );
+		}
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/extrachill/v1/venues/(?P<venue>\d+)/booking-inquiries', $routes );
+	}
+
+	/** Create two explicit internal operators. */
+	private function create_operators(): array {
+		$operator_a = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$operator_b = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->assertTrue( add_user_to_blog( $this->events_blog_id, $operator_a, 'administrator' ) );
+		$this->assertTrue( add_user_to_blog( $this->events_blog_id, $operator_b, 'administrator' ) );
+		switch_to_blog( $this->events_blog_id );
+		get_user_by( 'id', $operator_a )->add_cap( VenueAuthorization::ACCESS_CAPABILITY );
+		get_user_by( 'id', $operator_b )->add_cap( VenueAuthorization::ACCESS_CAPABILITY );
+		restore_current_blog();
+		return array( $operator_a, $operator_b );
+	}
+
+	/** Create one canonical venue with conversion metadata. */
+	private function create_venue( string $name ): int {
+		$term = self::factory()->term->create_and_get( array( 'taxonomy' => 'venue', 'name' => $name . ' ' . wp_generate_uuid4() ) );
+		$this->assertNotWPError( $term );
+		$meta = array(
+			'_venue_address'  => '1 Alpha Way',
+			'_venue_city'     => 'Charleston',
+			'_venue_state'    => 'SC',
+			'_venue_country'  => 'US',
+			'_venue_timezone' => 'America/New_York',
+		);
+		foreach ( $meta as $key => $value ) {
+			$this->assertNotFalse( update_term_meta( $term->term_id, $key, $value ) );
+		}
+		return (int) $term->term_id;
+	}
+
+	/** Grant the first explicit owner through the public membership ability. */
+	private function grant_venue_owner( int $venue_id, int $operator_id ): void {
+		$membership = $this->ability_data( 'extrachill/create-venue-membership', array( 'venue_term_id' => $venue_id, 'user_id' => $operator_id, 'is_owner' => true ), $operator_id );
+		$this->assertSame( $venue_id, $membership['venue_term_id'] );
+		$this->assertTrue( $membership['is_owner'] );
+	}
+
+	/** Configure admission and multiple spaces through the public config ability. */
+	private function configure_venue( int $venue_id, int $operator_id, array $space_keys ): void {
+		$config = $this->ability_data( 'extrachill/get-venue-booking-config', array( 'venue_term_id' => $venue_id ), $operator_id );
+		$revision = $config['revision'];
+		unset( $config['revision'], $config['updated_by_user_id'], $config['updated_at'] );
+		$config['enabled'] = true;
+		$config['spaces']  = array();
+		foreach ( $space_keys as $index => $key ) {
+			$config['spaces'][] = array( 'key' => $key, 'name' => ucwords( str_replace( '-', ' ', $key ) ), 'is_default' => 0 === $index );
+		}
+		$updated = $this->ability_data( 'extrachill/update-venue-booking-config', array( 'venue_term_id' => $venue_id, 'expected_revision' => $revision, 'config' => $config ), $operator_id );
+		$this->assertTrue( $updated['enabled'] );
+		$this->assertCount( count( $space_keys ), $updated['spaces'] );
+	}
+
+	/** Submit through the protected REST route from the main site. */
+	private function submit_inquiry( int $venue_id, int $actor_id, string $key, array $fields ): array {
+		$this->assertSame( $this->main_blog_id, get_current_blog_id() );
+		wp_set_current_user( $actor_id );
+		$request = new WP_REST_Request( 'POST', '/extrachill/v1/venues/' . $venue_id . '/booking-inquiries' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array_merge( array( 'venue' => $venue_id, 'idempotency_key' => $key, 'intake' => array( 'message' => 'Internal alpha inquiry.' ), 'turnstile_response' => 'managed-alpha' ), $fields ) ) );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 201, $response->get_status(), wp_json_encode( $response->get_data() ) );
+		$this->assertSame( $venue_id, $response->get_data()['venue_term_id'] );
+		return $response->get_data();
+	}
+
+	/** Resolve one private booking through its authorized public list contract. */
+	private function booking_by_public_id( int $venue_id, string $public_id, int $operator_id ): array {
+		$bookings = $this->ability_data( 'extrachill/list-venue-bookings', array( 'venue_term_id' => $venue_id ), $operator_id );
+		foreach ( $bookings as $booking ) {
+			if ( $public_id === $booking['public_id'] ) {
+				return $booking;
+			}
+		}
+		$this->fail( 'The admitted booking was not visible to its venue operator.' );
+	}
+
+	/** Execute one optimistic lifecycle transition. */
+	private function transition( array $booking, string $status, int $actor_id ): array {
+		$result = $this->ability_data( 'extrachill/transition-venue-booking', array( 'booking_id' => $booking['id'], 'to_status' => $status, 'expected_version' => $booking['version'], 'note' => 'Alpha proof transition.' ), $actor_id );
+		$this->assertSame( $status, $result['status'] );
+		return $result;
+	}
+
+	/** Select a configured performance through its public contract. */
+	private function select_performance( array $booking, string $space, string $start, string $end, int $actor_id ): array {
+		return $this->ability_data( 'extrachill/select-venue-booking-performance', array( 'booking_id' => $booking['id'], 'expected_version' => $booking['version'], 'space_key' => $space, 'start_at' => $start, 'end_at' => $end ), $actor_id );
+	}
+
+	/** Persist one complete 20 percent deal without exercising settlement. */
+	private function update_deal( array $booking, int $actor_id ): array {
+		$deal = array(
+			'version' => 1, 'type' => 'door_split', 'guarantee_cents' => 0,
+			'revenue_share_basis_points' => 2000, 'revenue_share_basis' => 'gross_ticket_sales', 'currency' => 'USD',
+			'capacity' => 300, 'advance_ticket_price_cents' => 2000, 'door_ticket_price_cents' => 2500,
+			'ticket_fee_cents' => 300, 'tickets_on_sale_at' => '2031-01-01 15:00:00',
+			'ticket_url' => 'https://tickets.example.test/alpha', 'additional_terms' => null,
+		);
+		return $this->ability_data( 'extrachill/update-venue-booking-deal', array( 'booking_id' => $booking['id'], 'expected_version' => $booking['version'], 'deal' => $deal ), $actor_id );
+	}
+
+	/** Execute one public Ability through Core's generic REST controller. */
+	private function ability_request( string $name, array $input, int $actor_id ): WP_REST_Response {
+		wp_set_current_user( $actor_id );
+		$ability = wp_get_ability( $name );
+		$this->assertInstanceOf( WP_Ability::class, $ability );
+		$annotations = (array) $ability->get_meta_item( 'annotations' );
+		$method = ! empty( $annotations['readonly'] ) ? 'GET' : ( ! empty( $annotations['destructive'] ) && ! empty( $annotations['idempotent'] ) ? 'DELETE' : 'POST' );
+		$request = new WP_REST_Request( $method, '/wp-abilities/v1/abilities/' . $name . '/run' );
+		if ( 'POST' === $method ) {
+			$request->set_header( 'Content-Type', 'application/json' );
+			$request->set_body( wp_json_encode( array( 'input' => $input ) ) );
+		} else {
+			$request->set_query_params( array( 'input' => $input ) );
+		}
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/** Return successful public Ability output. */
+	private function ability_data( string $name, array $input, int $actor_id ): array {
+		$response = $this->ability_request( $name, $input, $actor_id );
+		$this->assertSame( 200, $response->get_status(), $name . ': ' . wp_json_encode( $response->get_data() ) );
+		$this->assertIsArray( $response->get_data() );
+		return $response->get_data();
+	}
+
+	/** Assert an exact venue permission denial through public REST. */
+	private function assert_ability_denied( string $name, array $input, int $actor_id ): void {
+		$response = $this->ability_request( $name, $input, $actor_id );
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'venue_action_forbidden', $response->get_data()['code'] );
+	}
+
+	/** Count DME events with the immutable booking source identity. */
+	private function count_canonical_events( string $booking_public_id ): int {
+		$query = new WP_Query(
+			array(
+				'post_type' => DATA_MACHINE_EVENTS_POST_TYPE, 'post_status' => 'any', 'fields' => 'ids', 'posts_per_page' => -1,
+				'meta_query' => array( array( 'key' => '_datamachine_event_source', 'value' => 'extrachill-events-booking' ), array( 'key' => '_datamachine_event_source_id', 'value' => $booking_public_id ) ),
+			)
+		);
+		return count( $query->posts );
+	}
+
+	/** Prove two native PHP processes cannot win the same venue-space interval. */
+	private function prove_overlapping_hold_race( int $venue_id, int $operator_id ): void {
+		$first  = $this->prepare_race_booking( $venue_id, $operator_id, 'Race One' );
+		$second = $this->prepare_race_booking( $venue_id, $operator_id, 'Race Two' );
+		$blocker = $this->connect_mysql();
+		$lock    = BookingHoldRepository::venue_lock_name( $venue_id );
+		$escaped = $blocker->real_escape_string( $lock );
+		$this->assertSame( 1, (int) $blocker->query( "SELECT GET_LOCK('{$escaped}', 5)" )->fetch_row()[0] );
+		$directory = sys_get_temp_dir() . '/ec-alpha-' . wp_generate_uuid4();
+		$this->assertTrue( mkdir( $directory, 0700 ) );
+		$pids = array();
+		foreach ( array( $first, $second ) as $index => $booking ) {
+			$pid = pcntl_fork();
+			$this->assertGreaterThanOrEqual( 0, $pid );
+			if ( 0 === $pid ) {
+				$this->reconnect_database();
+				file_put_contents( $directory . '/ready-' . $index, '1', LOCK_EX );
+				$response = $this->ability_request( 'extrachill/create-booking-hold', array( 'booking_id' => $booking['id'], 'expected_booking_version' => $booking['version'] ), $operator_id );
+				file_put_contents( $directory . '/result-' . $index, wp_json_encode( array( 'status' => $response->get_status(), 'data' => $response->get_data() ) ), LOCK_EX );
+				exit( 0 );
+			}
+			$pids[] = $pid;
+		}
+		$deadline = microtime( true ) + 5;
+		while ( ( ! file_exists( $directory . '/ready-0' ) || ! file_exists( $directory . '/ready-1' ) ) && microtime( true ) < $deadline ) {
+			usleep( 10000 );
+		}
+		$this->assertFileExists( $directory . '/ready-0' );
+		$this->assertFileExists( $directory . '/ready-1' );
+		$this->assertSame( 1, (int) $blocker->query( "SELECT RELEASE_LOCK('{$escaped}')" )->fetch_row()[0] );
+		$blocker->close();
+		foreach ( $pids as $pid ) {
+			$status = 0;
+			pcntl_waitpid( $pid, $status );
+			$this->assertTrue( pcntl_wifexited( $status ) && 0 === pcntl_wexitstatus( $status ) );
+		}
+		$this->assertFileExists( $directory . '/result-0' );
+		$this->assertFileExists( $directory . '/result-1' );
+		$results  = array( json_decode( (string) file_get_contents( $directory . '/result-0' ), true ), json_decode( (string) file_get_contents( $directory . '/result-1' ), true ) );
+		$statuses = array_map( static function ( array $result ): int { return (int) $result['status']; }, $results );
+		sort( $statuses );
+		$this->assertSame( array( 200, 409 ), $statuses );
+		$this->assertSame( 1, count( $this->ability_data( 'extrachill/list-booking-holds', array( 'venue_term_id' => $venue_id, 'status' => 'active', 'range_start' => '2031-07-01 00:00:00', 'range_end' => '2031-07-01 03:00:00' ), $operator_id ) ) );
+		foreach ( glob( $directory . '/*' ) as $file ) {
+			unlink( $file );
+		}
+		rmdir( $directory );
+	}
+
+	/** Prepare one negotiating booking for the concurrent hold race. */
+	private function prepare_race_booking( int $venue_id, int $operator_id, string $artist ): array {
+		switch_to_blog( $this->main_blog_id );
+		$receipt = $this->submit_inquiry( $venue_id, 0, sanitize_key( $artist ) . '-race', array( 'artist_name' => $artist ) );
+		restore_current_blog();
+		$booking = $this->booking_by_public_id( $venue_id, $receipt['public_id'], $operator_id );
+		$booking = $this->transition( $booking, 'under_review', $operator_id );
+		$booking = $this->transition( $booking, 'negotiating', $operator_id );
+		return $this->select_performance( $booking, 'main-room', '2031-07-01 00:00:00', '2031-07-01 03:00:00', $operator_id );
+	}
+
+	/** Reconnect a forked WordPress process to managed MySQL. */
+	private function reconnect_database(): void {
+		global $wpdb, $table_prefix;
+		if ( $wpdb->dbh instanceof mysqli ) {
+			$wpdb->dbh->close();
+		}
+		$wpdb = new wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+		$wpdb->set_prefix( $table_prefix );
+		$wpdb->set_blog_id( $this->events_blog_id );
+	}
+
+	/** Open one independent managed MySQL session. */
+	private function connect_mysql(): mysqli {
+		$host = (string) DB_HOST;
+		$port = 3306;
+		if ( 1 === preg_match( '/^(.+):(\d+)$/', $host, $matches ) ) {
+			$host = $matches[1];
+			$port = (int) $matches[2];
+		}
+		$connection = mysqli_init();
+		$this->assertTrue( mysqli_real_connect( $connection, $host, DB_USER, DB_PASSWORD, DB_NAME, $port ), mysqli_connect_error() );
+		$connection->set_charset( 'utf8mb4' );
+		return $connection;
+	}
+
+	/** Assert route affinity never wrote booking state under the main prefix. */
+	private function assert_main_site_has_no_booking_writes(): void {
+		global $wpdb;
+		$events_table = BookingSchema::bookings_table();
+		$this->assertStringStartsWith( $wpdb->get_blog_prefix( $this->events_blog_id ), $events_table );
+		restore_current_blog();
+		$main_table = BookingSchema::bookings_table();
+		$this->assertStringStartsWith( $wpdb->get_blog_prefix( $this->main_blog_id ), $main_table );
+		$this->assertNotSame( $events_table, $main_table );
+		$main_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $main_table ) );
+		$this->assertTrue( null === $main_exists || 0 === (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$main_table}" ), 'The protected route wrote a main-site booking row.' ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Disposable integration proof.
+		switch_to_blog( $this->events_blog_id );
+		$this->assertGreaterThan( 0, (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$events_table}" ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Disposable integration proof.
+	}
+
+	/** Assert the injected failure converged to one bounded failed and completed attempt. */
+	private function assert_bounded_recovery_activity( int $booking_id ): void {
+		$activity = ( new BookingActivityRepository() )->list_for_booking( $booking_id );
+		$counts   = array_count_values( array_column( $activity, 'kind' ) );
+		$this->assertSame( 2, $counts['event_conversion_started'] ?? 0 );
+		$this->assertSame( 1, $counts['event_conversion_failed'] ?? 0 );
+		$this->assertSame( 1, $counts['event_converted'] ?? 0 );
+	}
+
+	/** Materialize canonical blog ID 7 in the disposable managed network. */
+	private function ensure_events_site(): int {
+		$site = get_site( 7 );
+		while ( ! $site ) {
+			$id = self::factory()->blog->create( array( 'domain' => 'site-' . wp_generate_uuid4() . '.example.org', 'path' => '/' ) );
+			if ( $id > 7 ) {
+				$this->fail( 'The disposable network skipped canonical Events blog ID 7.' );
+			}
+			$site = get_site( 7 );
+		}
+		return (int) $site->blog_id;
+	}
+
+	/** Execute the real signed API HTTP hop inside the managed PHPUnit process. */
+	public function dispatch_affinity_loopback( $preempt, array $args, string $url ) {
+		if ( false === strpos( $url, '127.0.0.1/wp-json/' ) ) {
+			return $preempt;
+		}
+		$route = '/' . ltrim( (string) wp_parse_url( $url, PHP_URL_PATH ), '/' );
+		$route = preg_replace( '#^/wp-json#', '', $route );
+		$request = new WP_REST_Request( (string) $args['method'], $route );
+		foreach ( (array) ( $args['headers'] ?? array() ) as $name => $value ) {
+			$request->set_header( $name, $value );
+		}
+		if ( ! empty( $args['body'] ) ) {
+			$request->set_header( 'Content-Type', 'application/json' );
+			$request->set_body( (string) $args['body'] );
+		}
+		$server_keys = array( 'REMOTE_ADDR', 'HTTP_HOST', 'HTTP_X_EC_INTERNAL_USER', 'HTTP_X_EC_INTERNAL_TIMESTAMP', 'HTTP_X_EC_INTERNAL_SIGNATURE' );
+		$server      = array();
+		foreach ( $server_keys as $key ) {
+			$server[ $key ] = $_SERVER[ $key ] ?? null;
+		}
+		$source_user = get_current_user_id();
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+		$_SERVER['HTTP_HOST']   = (string) ( $args['headers']['Host'] ?? 'events.extrachill.com' );
+		foreach ( array( 'User', 'Timestamp', 'Signature' ) as $suffix ) {
+			$key = 'HTTP_X_EC_INTERNAL_' . strtoupper( $suffix );
+			$header = 'X-EC-Internal-' . $suffix;
+			if ( isset( $args['headers'][ $header ] ) ) {
+				$_SERVER[ $key ] = $args['headers'][ $header ];
+			} else {
+				unset( $_SERVER[ $key ] );
+			}
+		}
+		wp_set_current_user( 0 );
+		switch_to_blog( $this->events_blog_id );
+		try {
+			$response = rest_get_server()->dispatch( $request );
+		} finally {
+			restore_current_blog();
+			wp_set_current_user( $source_user );
+			foreach ( $server as $key => $value ) {
+				if ( null === $value ) {
+					unset( $_SERVER[ $key ] );
+				} else {
+					$_SERVER[ $key ] = $value;
+				}
+			}
+		}
+		return array(
+			'headers' => $response->get_headers(), 'body' => wp_json_encode( $response->get_data() ),
+			'response' => array( 'code' => $response->get_status(), 'message' => '' ), 'cookies' => array(), 'filename' => null,
+		);
+	}
+}

--- a/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
@@ -13,6 +13,7 @@ final class InternalBookingHoldConcurrencyMySQLProof extends BookingAttachmentMy
 		$this->assertTrue( function_exists( 'pcntl_fork' ), 'The native hold proof requires pcntl_fork().' );
 		$this->register_booking_abilities();
 		wp_set_current_user( $this->actor_id );
+		$this->assertNotFalse( update_term_meta( $this->venue_id, '_venue_timezone', 'America/New_York' ) );
 
 		$config            = wp_get_ability( 'extrachill/get-venue-booking-config' )->execute( array( 'venue_term_id' => $this->venue_id ) );
 		$this->assertIsArray( $config, is_wp_error( $config ) ? $config->get_error_code() : 'Venue config was not returned.' );

--- a/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
@@ -164,7 +164,7 @@ final class InternalBookingHoldConcurrencyMySQLProof extends BookingAttachmentMy
 	/** Open an independent MySQL session that controls the venue lock. */
 	private function connect_lock_session(): mysqli {
 		$connection = mysqli_init();
-		$this->assertTrue( mysqli_real_connect( $connection, (string) getenv( 'DB_HOST' ), (string) getenv( 'DB_USER' ), (string) getenv( 'DB_PASSWORD' ), (string) getenv( 'DB_NAME' ), (int) getenv( 'DB_PORT' ) ), mysqli_connect_error() );
+		$this->assertTrue( mysqli_real_connect( $connection, (string) getenv( 'DB_HOST' ), (string) getenv( 'DB_USER' ), (string) getenv( 'DB_PASSWORD' ), (string) getenv( 'DB_NAME' ), (int) getenv( 'DB_PORT' ) ), (string) mysqli_connect_error() );
 		$connection->set_charset( 'utf8mb4' );
 		return $connection;
 	}

--- a/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
@@ -14,6 +14,11 @@ final class InternalBookingHoldConcurrencyMySQLProof extends BookingAttachmentMy
 		$this->register_booking_abilities();
 		wp_set_current_user( $this->actor_id );
 		$this->assertNotFalse( update_term_meta( $this->venue_id, '_venue_timezone', 'America/New_York' ) );
+		$dme_directory = rtrim( (string) getenv( 'DME_PLUGIN_DIR' ), '/\\' );
+		$this->assertFileExists( $dme_directory . '/inc/Core/EventDatesTable.php' );
+		require_once $dme_directory . '/inc/Core/EventDatesTable.php';
+		DataMachineEvents\Core\EventDatesTable::create_table();
+		$this->assertTrue( DataMachineEvents\Core\EventDatesTable::table_exists() );
 
 		$config            = wp_get_ability( 'extrachill/get-venue-booking-config' )->execute( array( 'venue_term_id' => $this->venue_id ) );
 		$this->assertIsArray( $config, is_wp_error( $config ) ? $config->get_error_code() : 'Venue config was not returned.' );

--- a/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
@@ -14,10 +14,6 @@ final class InternalBookingHoldConcurrencyMySQLProof extends BookingAttachmentMy
 		$this->register_booking_abilities();
 		wp_set_current_user( $this->actor_id );
 		$this->assertNotFalse( update_term_meta( $this->venue_id, '_venue_timezone', 'America/New_York' ) );
-		$dme_directory = rtrim( (string) getenv( 'DME_PLUGIN_DIR' ), '/\\' );
-		$this->assertFileExists( $dme_directory . '/inc/Core/EventDatesTable.php' );
-		require_once $dme_directory . '/inc/Core/EventDatesTable.php';
-		DataMachineEvents\Core\EventDatesTable::create_table();
 		$this->assertTrue( DataMachineEvents\Core\EventDatesTable::table_exists() );
 
 		$config            = wp_get_ability( 'extrachill/get-venue-booking-config' )->execute( array( 'venue_term_id' => $this->venue_id ) );

--- a/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
@@ -1,0 +1,169 @@
+<?php
+/** Native two-process hold contention proof for the internal calendar alpha. */
+
+require_once __DIR__ . '/BookingAttachmentMySQLIntegrationTest.php';
+
+use ExtraChillEvents\Core\BookingHoldRepository;
+use ExtraChillEvents\Core\BookingRepository;
+
+/** Prove overlapping public Ability calls converge to one active hold. */
+final class InternalBookingHoldConcurrencyMySQLProof extends BookingAttachmentMySQLIntegrationTest {
+	/** Run two native contenders against one venue-space interval. */
+	public function test_overlapping_public_hold_abilities_allow_one_winner(): void {
+		$this->assertTrue( function_exists( 'pcntl_fork' ), 'The native hold proof requires pcntl_fork().' );
+		$this->register_booking_abilities();
+		wp_set_current_user( $this->actor_id );
+
+		$config            = wp_get_ability( 'extrachill/get-venue-booking-config' )->execute( array( 'venue_term_id' => $this->venue_id ) );
+		$this->assertIsArray( $config, is_wp_error( $config ) ? $config->get_error_code() : 'Venue config was not returned.' );
+		$revision = (int) $config['revision'];
+		unset( $config['revision'], $config['updated_by_user_id'], $config['updated_at'] );
+		$config['enabled'] = true;
+		$config['spaces']  = array(
+			array(
+				'key'        => 'main-room',
+				'name'       => 'Main Room',
+				'is_default' => true,
+			),
+		);
+		$config = wp_get_ability( 'extrachill/update-venue-booking-config' )->execute(
+			array(
+				'venue_term_id'    => $this->venue_id,
+				'expected_revision' => $revision,
+				'config'           => $config,
+			)
+		);
+		$this->assertIsArray( $config, is_wp_error( $config ) ? $config->get_error_code() : 'Venue config was not committed.' );
+
+		$bookings = array(
+			$this->prepare_booking( 'Native Race One' ),
+			$this->prepare_booking( 'Native Race Two' ),
+		);
+		$blocker  = $this->connect_lock_session();
+		$lock     = BookingHoldRepository::venue_lock_name( $this->venue_id );
+		$escaped  = $blocker->real_escape_string( $lock );
+		$this->assertSame( 1, (int) $blocker->query( "SELECT GET_LOCK('{$escaped}', 5)" )->fetch_row()[0] );
+
+		$directory = sys_get_temp_dir() . '/ec-hold-alpha-' . wp_generate_uuid4();
+		$this->assertTrue( mkdir( $directory, 0700 ) );
+		$pids = array();
+		foreach ( $bookings as $index => $booking ) {
+			$pid = pcntl_fork();
+			$this->assertGreaterThanOrEqual( 0, $pid, 'A native hold contender could not be created.' );
+			if ( 0 === $pid ) {
+				$this->reconnect_wordpress_database();
+				wp_set_current_user( $this->actor_id );
+				file_put_contents( $directory . '/ready-' . $index, '1', LOCK_EX );
+				$result = wp_get_ability( 'extrachill/create-booking-hold' )->execute(
+					array(
+						'booking_id'              => $booking['id'],
+						'expected_booking_version' => $booking['version'],
+					)
+				);
+				file_put_contents(
+					$directory . '/result-' . $index,
+					wp_json_encode(
+						is_wp_error( $result )
+							? array( 'error' => $result->get_error_code(), 'data' => $result->get_error_data() )
+							: array( 'hold' => $result )
+					),
+					LOCK_EX
+				);
+				exit( 0 );
+			}
+			$pids[] = $pid;
+		}
+
+		$deadline = microtime( true ) + 5;
+		while ( ( ! file_exists( $directory . '/ready-0' ) || ! file_exists( $directory . '/ready-1' ) ) && microtime( true ) < $deadline ) {
+			usleep( 10000 );
+		}
+		$this->assertFileExists( $directory . '/ready-0' );
+		$this->assertFileExists( $directory . '/ready-1' );
+		$this->assertSame( 1, (int) $blocker->query( "SELECT RELEASE_LOCK('{$escaped}')" )->fetch_row()[0] );
+		$blocker->close();
+
+		foreach ( $pids as $pid ) {
+			$status = 0;
+			pcntl_waitpid( $pid, $status );
+			$this->assertTrue( pcntl_wifexited( $status ) && 0 === pcntl_wexitstatus( $status ), 'A native hold contender did not exit cleanly.' );
+		}
+		$this->assertFileExists( $directory . '/result-0' );
+		$this->assertFileExists( $directory . '/result-1' );
+		$results = array(
+			json_decode( (string) file_get_contents( $directory . '/result-0' ), true ),
+			json_decode( (string) file_get_contents( $directory . '/result-1' ), true ),
+		);
+		$this->assertCount( 1, array_filter( $results, static fn( array $result ): bool => isset( $result['hold'] ) ) );
+		$this->assertCount( 1, array_filter( $results, static fn( array $result ): bool => 'booking_time_conflict' === ( $result['error'] ?? '' ) ) );
+
+		wp_set_current_user( $this->actor_id );
+		$holds = wp_get_ability( 'extrachill/list-booking-holds' )->execute(
+			array(
+				'venue_term_id' => $this->venue_id,
+				'status'        => 'active',
+				'range_start'   => '2031-07-01 00:00:00',
+				'range_end'     => '2031-07-01 03:00:00',
+			)
+		);
+		$this->assertIsArray( $holds, is_wp_error( $holds ) ? $holds->get_error_code() : 'Active holds were not returned.' );
+		$this->assertCount( 1, $holds );
+
+		foreach ( glob( $directory . '/*' ) as $file ) {
+			unlink( $file );
+		}
+		rmdir( $directory );
+	}
+
+	/** Prepare one negotiating booking through public lifecycle Abilities. */
+	private function prepare_booking( string $artist_name ): array {
+		$booking = ( new BookingRepository() )->create(
+			array(
+				'venue_term_id' => $this->venue_id,
+				'artist_name'   => $artist_name,
+				'intake'        => array(),
+			)
+		);
+		$this->assertIsArray( $booking, is_wp_error( $booking ) ? $booking->get_error_code() : 'Booking was not created.' );
+		foreach ( array( 'under_review', 'negotiating' ) as $status ) {
+			$booking = wp_get_ability( 'extrachill/transition-venue-booking' )->execute(
+				array(
+					'booking_id'      => $booking['id'],
+					'to_status'       => $status,
+					'expected_version' => $booking['version'],
+					'note'            => 'Native alpha race setup.',
+				)
+			);
+			$this->assertIsArray( $booking, is_wp_error( $booking ) ? $booking->get_error_code() : 'Lifecycle transition failed.' );
+		}
+		$booking = wp_get_ability( 'extrachill/select-venue-booking-performance' )->execute(
+			array(
+				'booking_id'      => $booking['id'],
+				'expected_version' => $booking['version'],
+				'space_key'       => 'main-room',
+				'start_at'        => '2031-07-01 00:00:00',
+				'end_at'          => '2031-07-01 03:00:00',
+			)
+		);
+		$this->assertIsArray( $booking, is_wp_error( $booking ) ? $booking->get_error_code() : 'Performance selection failed.' );
+		return $booking;
+	}
+
+	/** Register booking definitions in Core's public Abilities registry. */
+	private function register_booking_abilities(): void {
+		if ( ! wp_has_ability( 'extrachill/create-booking-hold' ) ) {
+			do_action( 'wp_abilities_api_init' );
+		}
+		foreach ( array( 'extrachill/get-venue-booking-config', 'extrachill/update-venue-booking-config', 'extrachill/transition-venue-booking', 'extrachill/select-venue-booking-performance', 'extrachill/create-booking-hold', 'extrachill/list-booking-holds' ) as $name ) {
+			$this->assertInstanceOf( WP_Ability::class, wp_get_ability( $name ), $name . ' is unavailable.' );
+		}
+	}
+
+	/** Open an independent MySQL session that controls the venue lock. */
+	private function connect_lock_session(): mysqli {
+		$connection = mysqli_init();
+		$this->assertTrue( mysqli_real_connect( $connection, (string) getenv( 'DB_HOST' ), (string) getenv( 'DB_USER' ), (string) getenv( 'DB_PASSWORD' ), (string) getenv( 'DB_NAME' ), (int) getenv( 'DB_PORT' ) ), mysqli_connect_error() );
+		$connection->set_charset( 'utf8mb4' );
+		return $connection;
+	}
+}

--- a/tests/MySQLIntegration/host-wordpress-bootstrap.php
+++ b/tests/MySQLIntegration/host-wordpress-bootstrap.php
@@ -13,3 +13,12 @@ tests_add_filter(
 );
 
 require getenv( 'WP_TESTS_DIR' ) . '/includes/bootstrap.php';
+
+$dme_directory = rtrim( (string) getenv( 'DME_PLUGIN_DIR' ), '/\\' );
+if ( '' !== $dme_directory ) {
+	require_once $dme_directory . '/inc/Core/EventDatesTable.php';
+	DataMachineEvents\Core\EventDatesTable::create_table();
+	if ( ! DataMachineEvents\Core\EventDatesTable::table_exists() ) {
+		throw new RuntimeException( 'The native hold proof requires the DME event dates table.' );
+	}
+}

--- a/tests/MySQLIntegration/internal-booking-alpha-bootstrap.php
+++ b/tests/MySQLIntegration/internal-booking-alpha-bootstrap.php
@@ -21,6 +21,10 @@ try {
 	}
 	DataMachineEvents\Core\EventDatesTable::create_table();
 	( new DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex() )->create_table();
+	if ( class_exists( 'ActionScheduler_StoreSchema' ) && class_exists( 'ActionScheduler_LoggerSchema' ) ) {
+		( new ActionScheduler_StoreSchema() )->register_tables();
+		( new ActionScheduler_LoggerSchema() )->register_tables();
+	}
 } finally {
 	restore_current_blog();
 }

--- a/tests/MySQLIntegration/internal-booking-alpha-bootstrap.php
+++ b/tests/MySQLIntegration/internal-booking-alpha-bootstrap.php
@@ -1,0 +1,26 @@
+<?php
+/** Provision the canonical Events site before the managed alpha test starts. */
+
+if ( ! is_multisite() ) {
+	throw new RuntimeException( 'The internal booking calendar alpha requires multisite.' );
+}
+
+while ( ! get_site( 7 ) ) {
+	$next_id = count( get_sites( array( 'fields' => 'ids' ) ) ) + 1;
+	$created = wpmu_create_blog( 'site-' . $next_id . '.example.org', '/', 'Test Site ' . $next_id, 1 );
+	if ( is_wp_error( $created ) || (int) $created > 7 ) {
+		throw new RuntimeException( 'Unable to provision the canonical Events test site.' );
+	}
+}
+
+switch_to_blog( 7 );
+try {
+	$booking_schema = ExtraChillEvents\Core\BookingSchema::install();
+	if ( is_wp_error( $booking_schema ) ) {
+		throw new RuntimeException( $booking_schema->get_error_code() . ': ' . wp_json_encode( $booking_schema->get_error_data() ) );
+	}
+	DataMachineEvents\Core\EventDatesTable::create_table();
+	( new DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex() )->create_table();
+} finally {
+	restore_current_blog();
+}


### PR DESCRIPTION
## Summary
- add a real-MySQL/multisite proof for the internal booking-to-calendar alpha
- drive anonymous and authenticated inquiry admission through the protected Extra Chill API route, then use public Abilities REST contracts for venue configuration, membership, lifecycle, holds, conversion, reconciliation, communications, and cancellation
- prove exact retries, stale-version rejection, cross-venue authorization, signed route affinity, recoverable conversion failure, private-field redaction, canonical event uniqueness, and native two-process race convergence
- prove reschedule, venue/space correction, lineup and ticket URL synchronization, cancellation propagation, and intent-scoped reminder suppression

## Scope
This is the narrower internal calendar alpha from #382. It does not include marketing, Roadie, private files, or full finance, and it does not close or weaken #299.

## Dependencies
- DME atomic canonical event update #613 merged as `1ef45710`.
- Events synchronization hardening #401 merged as `bd47f50`.
- This branch is rebased onto current `main` and consumes both contracts through public Abilities.

## Exact-Head Evidence
Head: `e018b16a9650984d44def91c8db45732802fc391`

- Internal booking calendar alpha: https://github.com/Extra-Chill/extrachill-events/actions/runs/30262572763
  - managed PHP 8.4 / MySQL 8.4 / multisite: 1 test, 227 assertions
  - native overlapping public hold proof: 1 test, 41 assertions
  - nonzero execution, no-skip, MySQL readiness, and canonical multisite evidence checks passed
- Booking attachment MySQL concurrency: https://github.com/Extra-Chill/extrachill-events/actions/runs/30262572759
  - managed baseline attachment and event-sync classes: 3 tests, 64 assertions
  - native admission race: 1 test, 25 assertions
  - exact class isolation and structured evidence checks passed
- Homeboy review: https://github.com/Extra-Chill/extrachill-events/actions/runs/30262572752
  - review lint passed
  - review test passed
- PHP syntax, `actionlint`, and `git diff --check` passed before push.

Closes #382.