### PR TITLE
feat: add weekly Local Scene digest

### DIFF
--- a/assets/js/local-scene-digest.js
+++ b/assets/js/local-scene-digest.js
@@ -1,0 +1,82 @@
+( function () {
+	'use strict';
+
+	const button = document.querySelector( '[data-local-scene-digest]' );
+	if ( ! button ) {
+		return;
+	}
+	const status = button
+		.closest( '[data-local-scene-digest-control]' )
+		.querySelector( '[data-local-scene-digest-status]' );
+	const input = {
+		entity_type: 'local_scene_digest',
+		taxonomy: 'location',
+		slug: button.dataset.slug,
+	};
+
+	function setState( subscribed, message ) {
+		button.setAttribute( 'aria-pressed', subscribed ? 'true' : 'false' );
+		button.textContent = subscribed
+			? 'Subscribed to email + updates'
+			: 'Subscribe to email + updates';
+		status.textContent =
+			message ||
+			( subscribed
+				? 'Weekly email and in-app updates are on.'
+				: 'Weekly email and in-app updates are off.' );
+	}
+
+	function request( ability, method ) {
+		let url = button.dataset.endpoint + 'extrachill/' + ability + '/run';
+		const options = {
+			method,
+			credentials: 'same-origin',
+			headers: { 'X-WP-Nonce': button.dataset.nonce },
+		};
+		if ( 'GET' === method ) {
+			const query = new URLSearchParams();
+			Object.keys( input ).forEach( ( key ) =>
+				query.set( `input[${ key }]`, input[ key ] )
+			);
+			url += `?${ query.toString() }`;
+		} else {
+			options.headers[ 'Content-Type' ] = 'application/json';
+			options.body = JSON.stringify( { input } );
+		}
+		return window.fetch( url, options ).then( ( response ) =>
+			response.json().then( ( data ) => {
+				if ( ! response.ok ) {
+					throw new Error( data.message || 'Request failed.' );
+				}
+				return data;
+			} )
+		);
+	}
+
+	request( 'entity-subscription-status', 'GET' )
+		.then( ( data ) => setState( Boolean( data.subscribed ) ) )
+		.catch( () => {
+			status.textContent =
+				'Subscription status is unavailable. Please try again.';
+		} )
+		.finally( () => {
+			button.disabled = false;
+		} );
+
+	button.addEventListener( 'click', () => {
+		const subscribed = 'true' === button.getAttribute( 'aria-pressed' );
+		button.disabled = true;
+		request(
+			subscribed ? 'entity-unsubscribe' : 'entity-subscribe',
+			'POST'
+		)
+			.then( ( data ) => setState( Boolean( data.subscribed ) ) )
+			.catch( () => {
+				status.textContent =
+					'Unable to update your subscription. Please try again.';
+			} )
+			.finally( () => {
+				button.disabled = false;
+			} );
+	} );
+} )();

--- a/assets/js/local-scene-digest.test.js
+++ b/assets/js/local-scene-digest.test.js
@@ -1,0 +1,75 @@
+/** Local Scene digest progressive subscription control. */
+/* global beforeEach, describe, expect, it, jest */
+
+async function flushPromises() {
+	await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+}
+
+describe( 'Local Scene digest subscription', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		document.body.innerHTML = `
+			<div data-local-scene-digest-control>
+				<span data-local-scene-digest-status></span>
+				<button disabled aria-pressed="false" data-local-scene-digest
+					data-endpoint="https://example.com/wp-json/wp-abilities/v1/abilities/"
+					data-nonce="nonce" data-slug="austin"></button>
+			</div>`;
+		global.fetch = jest.fn();
+	} );
+
+	it( 'checks status without subscribing on load', async () => {
+		fetch.mockResolvedValue( {
+			ok: true,
+			json: () => Promise.resolve( { subscribed: false } ),
+		} );
+		require( './local-scene-digest' );
+		await flushPromises();
+
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+		expect( fetch.mock.calls[ 0 ][ 1 ].method ).toBe( 'GET' );
+		expect( fetch.mock.calls[ 0 ][ 0 ] ).toContain(
+			'entity-subscription-status'
+		);
+		expect( fetch.mock.calls[ 0 ][ 0 ] ).not.toContain(
+			'entity-subscribe/run'
+		);
+		expect(
+			document.querySelector( '[data-local-scene-digest-status]' )
+				.textContent
+		).toBe( 'Weekly email and in-app updates are off.' );
+	} );
+
+	it( 'subscribes only after an explicit click', async () => {
+		fetch
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: () => Promise.resolve( { subscribed: false } ),
+			} )
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: () => Promise.resolve( { subscribed: true } ),
+			} );
+		require( './local-scene-digest' );
+		await flushPromises();
+		document.querySelector( 'button' ).click();
+		await flushPromises();
+
+		expect( fetch.mock.calls[ 1 ][ 0 ] ).toContain(
+			'entity-subscribe/run'
+		);
+		expect( fetch.mock.calls[ 1 ][ 1 ].method ).toBe( 'POST' );
+		expect( JSON.parse( fetch.mock.calls[ 1 ][ 1 ].body ).input ).toEqual( {
+			entity_type: 'local_scene_digest',
+			taxonomy: 'location',
+			slug: 'austin',
+		} );
+		expect( document.querySelector( 'button' ).textContent ).toBe(
+			'Subscribed to email + updates'
+		);
+		expect(
+			document.querySelector( '[data-local-scene-digest-status]' )
+				.textContent
+		).toBe( 'Weekly email and in-app updates are on.' );
+	} );
+} );

--- a/docs/local-scene-weekly-digest.md
+++ b/docs/local-scene-weekly-digest.md
@@ -1,0 +1,29 @@
+# Local Scene Weekly Digest
+
+The weekly digest is an explicit opt-in to both a weekly email and its in-app update through the Events-owned `local_scene_digest/location/<slug>` entity subscription. Events registers that entity-to-taxonomy mapping through `extrachill_users_entity_subscription_entities`; the generic Users layer does not know about this product. Saving Local Scene does not create a subscription. The location archive renders a read-only status check followed by a user-triggered subscribe/unsubscribe toggle only when that archive is the user's current Local Scene.
+
+## Delivery
+
+The `extrachill_local_scene_digest` Data Machine SystemTask runs weekly when `extrachill_local_scene_digest_enabled` is enabled in Data Machine's `PluginSettings` store. It declares mutation and dry-run support and accepts only bounded `days` (1-14), `limit` (1-20), and `dry_run` parameters. The default-disabled schedule uses a seven-day window, eight-event cap, and explicit `dry_run=false`. It does not use WP-Cron.
+
+The v1 task is intentionally one bounded, single-step scan rather than a fan-out workflow. Each city query currently hydrates at most 250 candidates (configurable within the hard 20-1000 range) after requesting one overflow row to detect truncation. Retryable aggregate failures fail the Data Machine job so its existing whole-task retry can replay safely through notification receipts; this PR does not add a speculative fan-out substrate.
+
+For each canonical selectable location term, Events:
+
+- queries published posts through `data_machine_events_query_events()` and hydrates each through `data_machine_events_parse_event_data()`;
+- queries a safe cross-timezone date envelope with a configurable, hard-bounded per-city candidate cap, then requires the exact location term and hard-gates each event into the rolling `days` window from venue-local now using its valid IANA `venueTimezone`;
+- records aggregate query failure or truncation evidence when the canonical result reports more events than the bounded fetch returned, without recording city identity;
+- rejects unknown/midnight starts, invalid timezones, unsupported statuses, malformed explicit ends, and ends that are not later than their starts; rendered start/end times remain venue-local;
+- collapses local duplicates by normalized title, venue term, and local start date;
+- orders Going events first for each recipient, then priority event, priority venue, completeness, known price/free status, datetime, and post ID;
+- caps repeated venues and performers when enough inventory exists, sends all qualified sparse inventory, and sends nothing for an empty scene;
+- resolves only explicit digest subscribers and rechecks that the canonical location slug still equals `extrachill_users_get_local_scene()` at execution time;
+- resolves Going attendance only against the canonical Events blog returned by `ec_get_blog_id( 'events' )` and fails closed if that identity is unavailable.
+
+`ec_users_notify_with_receipts()` claims one delivery per user, ISO week, and location with `producer_owns_email=true`, which suppresses the generic Users email sweep. Only an `inserted` receipt for a recipient still eligible under the master email preference queues the branded email through `ec_send_email_queued()`; an `existing` replay and a master-suppressed delivery never queue or release. Explicit rich-email preflight or queue-admission failures release the exact notification receipt through `ec_users_release_notification_receipt()` so a later full replay can retry. The network bot is the notification actor.
+
+Task evidence contains aggregate counts and stable generic failure reasons only, including released notification receipts and bounded-query truncation. It never includes recipient identity, location identity, or event identity.
+
+## Unsubscribe
+
+Every email includes a location-specific REST unsubscribe URL signed with the WordPress auth salt and valid for at most 30 days. GET verifies the signature and renders a standalone noindex confirmation form without mutating consent, making scanner visits safe. The form POSTs the same signed payload; only that POST removes `local_scene_digest/location/<slug>` through Extra Chill Users. It stops both the weekly email and its in-app update without changing the user's saved Local Scene or global notification-email preference. Events continues to rely on the Users #294/#297 producer-owned email and unsubscribe contracts and never accesses Users tables directly.

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -116,11 +116,13 @@ add_action(
 			return;
 		}
 		require_once __DIR__ . '/inc/Steps/QualifyDigest/QualifyDigestSystemTask.php';
+		require_once __DIR__ . '/inc/Steps/LocalSceneDigest/LocalSceneDigestSystemTask.php';
 
 		add_filter(
 			'datamachine_tasks',
 			function ( array $tasks ): array {
-				$tasks[ \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::TASK_TYPE ] = \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::class;
+				$tasks[ \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::TASK_TYPE ]       = \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::class;
+				$tasks[ \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask::TASK_TYPE ] = \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask::class;
 				return $tasks;
 			}
 		);
@@ -128,6 +130,23 @@ add_action(
 		add_filter(
 			'datamachine_recurring_schedules',
 			function ( array $schedules ): array {
+				$schedules['extrachill_local_scene_digest'] = apply_filters(
+					'extrachill_local_scene_digest_schedule',
+					array(
+						'task_type'          => \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask::TASK_TYPE,
+						'interval'           => 'weekly',
+						'enabled_setting'    => 'extrachill_local_scene_digest_enabled',
+						'default_enabled'    => false,
+						'label'              => 'Weekly Local Scene Digest — Thursdays 15:00 UTC',
+						'first_run_callback' => 'strtotime',
+						'first_run_arg'      => 'next thursday 15:00 UTC',
+						'task_params'        => array(
+							'days'    => 7,
+							'limit'   => 8,
+							'dry_run' => false,
+						),
+					)
+				);
 				/**
 				 * Filter the qualify digest schedule definition. Allows
 				 * operators to flip interval, change the first-run anchor,
@@ -293,6 +312,8 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/artist-map.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-seo.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/account-market.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/local-scene-digest.php';
+		extrachill_events_init_local_scene_digest();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/near-me.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/discovery-pages.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/router-pages.php';

--- a/inc/Steps/LocalSceneDigest/LocalSceneDigestSystemTask.php
+++ b/inc/Steps/LocalSceneDigest/LocalSceneDigestSystemTask.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Weekly Local Scene digest system task.
+ *
+ * @package ExtraChillEvents\Steps\LocalSceneDigest
+ */
+
+namespace ExtraChillEvents\Steps\LocalSceneDigest;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachine\Core\PluginSettings;
+
+/** Bridge the digest runner into Data Machine's recurring task registry. */
+class LocalSceneDigestSystemTask extends SystemTask {
+	public const TASK_TYPE = 'extrachill_local_scene_digest';
+
+	/** Return the stable task type. */
+	public function getTaskType(): string {
+		return self::TASK_TYPE;
+	}
+
+	/** Allow this site-scoped recurring task to run without agent ownership. */
+	public function requiresAgentContext(): bool {
+		return false;
+	}
+
+	/** Return task registry metadata. */
+	public static function getTaskMeta(): array {
+		return array(
+			'label'            => 'Local Scene Digest (weekly)',
+			'description'      => 'Delivers bounded weekly event picks to explicit Local Scene subscribers.',
+			'setting_key'      => 'extrachill_local_scene_digest_enabled',
+			'default_enabled'  => false,
+			'supports_run'     => true,
+			'mutates'          => true,
+			'supports_dry_run' => true,
+			'params_schema'    => array(
+				'type'       => 'object',
+				'accepted'   => array( 'days', 'limit', 'dry_run' ),
+				'properties' => array(
+					'days'    => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+						'maximum' => 14,
+					),
+					'limit'   => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+						'maximum' => 20,
+					),
+					'dry_run' => array( 'type' => 'boolean' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Run the feature-gated digest.
+	 *
+	 * @param int   $jobId  Data Machine job ID.
+	 * @param array $params Digest parameters.
+	 */
+	public function executeTask( int $jobId, array $params ): void {
+		if ( ! (bool) PluginSettings::get( 'extrachill_local_scene_digest_enabled', false ) ) {
+			$this->completeJob(
+				$jobId,
+				array(
+					'skipped' => true,
+					'reason'  => 'Weekly Local Scene digest disabled.',
+				)
+			);
+			return;
+		}
+		$result = $this->runDigest( $params );
+		if ( ! empty( $result['retryable_failure'] ) ) {
+			$this->failJob( $jobId, 'Local Scene digest encountered a retryable delivery failure.' );
+			return;
+		}
+		$this->completeJob( $jobId, $result );
+	}
+
+	/**
+	 * Run the digest and return its privacy-safe aggregate evidence.
+	 *
+	 * @param array $params Bounded digest parameters.
+	 * @return array
+	 */
+	protected function runDigest( array $params ): array {
+		return extrachill_events_run_local_scene_digest( $params );
+	}
+}

--- a/inc/core/local-scene-digest.php
+++ b/inc/core/local-scene-digest.php
@@ -1,0 +1,882 @@
+<?php
+/**
+ * Weekly Local Scene event digest.
+ *
+ * @package ExtraChillEvents
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_PRODUCER = 'extrachill-events-local-scene-digest';
+const EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_TYPE     = 'local_scene_weekly_digest';
+const EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_ENTITY   = 'local_scene_digest';
+const EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_TAXONOMY = 'location';
+const EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_LIMIT    = 8;
+
+/** Register recipient authorization and the scoped unsubscribe route. */
+function extrachill_events_init_local_scene_digest(): void {
+	add_filter( 'extrachill_users_entity_subscription_entities', 'extrachill_events_local_scene_digest_subscription_entities' );
+	add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_events_authorize_local_scene_digest_producer', 10, 4 );
+	add_action( 'rest_api_init', 'extrachill_events_register_local_scene_digest_routes' );
+}
+
+/**
+ * Register the digest-owned consent identity against the canonical location taxonomy.
+ *
+ * @param array $entities Registered entity-to-taxonomy mappings.
+ * @return array
+ */
+function extrachill_events_local_scene_digest_subscription_entities( array $entities ): array {
+	$entities[ EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_ENTITY ] = EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_TAXONOMY;
+	return $entities;
+}
+
+/**
+ * Authorize only canonical location subscriptions for digest delivery.
+ *
+ * @param bool   $authorized Existing authorization decision.
+ * @param string $producer   Requesting producer.
+ * @param array  $entity     Normalized entity identity.
+ * @param string $delivery   Delivery channel.
+ * @return bool
+ */
+function extrachill_events_authorize_local_scene_digest_producer( $authorized, $producer, $entity, $delivery ): bool {
+	if ( EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_PRODUCER !== $producer ) {
+		return (bool) $authorized;
+	}
+
+	return is_array( $entity )
+		&& EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_ENTITY === ( $entity['entity_type'] ?? '' )
+		&& EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_TAXONOMY === ( $entity['taxonomy'] ?? '' )
+		&& in_array( $delivery, array( 'notification', 'email' ), true );
+}
+
+/**
+ * Run all canonical location digests and return privacy-safe task evidence.
+ *
+ * @param array $params Task parameters.
+ * @return array Aggregate counts only.
+ */
+function extrachill_events_run_local_scene_digest( array $params = array() ): array {
+	$days    = min( 14, max( 1, absint( $params['days'] ?? 7 ) ) );
+	$limit   = min( 20, max( 1, absint( $params['limit'] ?? EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_LIMIT ) ) );
+	$dry_run = ! empty( $params['dry_run'] );
+	$counts  = array(
+		'locations_scanned'           => 0,
+		'locations_with_events'       => 0,
+		'qualified_events'            => 0,
+		'candidate_query_failures'    => 0,
+		'candidate_queries_truncated' => 0,
+		'recipients'                  => 0,
+		'scene_mismatches'            => 0,
+		'notifications_inserted'      => 0,
+		'notifications_existing'      => 0,
+		'notifications_released'      => 0,
+		'notification_failures'       => 0,
+		'emails_queued'               => 0,
+		'email_failures'              => 0,
+		'retryable_failures'          => 0,
+	);
+
+	if ( ! function_exists( 'data_machine_events_query_events' ) || ! function_exists( 'data_machine_events_parse_event_data' ) || ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'extrachill_users_get_local_scene' ) || ! function_exists( 'ec_get_blog_id' ) || ! absint( ec_get_blog_id( 'events' ) ) ) {
+		$counts['retryable_failures'] = 1;
+		return array(
+			'dry_run'           => $dry_run,
+			'counts'            => $counts,
+			'failures'          => array( 'dependency_unavailable' => 1 ),
+			'retryable_failure' => true,
+		);
+	}
+
+	$terms = get_terms(
+		array(
+			'taxonomy'   => 'location',
+			'hide_empty' => false,
+		)
+	);
+	if ( is_wp_error( $terms ) ) {
+		$counts['retryable_failures'] = 1;
+		return array(
+			'dry_run'           => $dry_run,
+			'counts'            => $counts,
+			'failures'          => array( 'location_query_failed' => 1 ),
+			'retryable_failure' => true,
+		);
+	}
+
+	$failures = array();
+	foreach ( $terms as $term ) {
+		if ( ! $term instanceof WP_Term || count( get_ancestors( $term->term_id, 'location', 'taxonomy' ) ) < 2 ) {
+			continue;
+		}
+
+		++$counts['locations_scanned'];
+		$query_evidence              = array();
+		$candidates                  = extrachill_events_local_scene_digest_candidates( $term, $days, $query_evidence );
+		$counts['qualified_events'] += count( $candidates );
+		if ( ! empty( $query_evidence['failed'] ) ) {
+			++$counts['candidate_query_failures'];
+			++$counts['retryable_failures'];
+			$failures['candidate_query_failed'] = ( $failures['candidate_query_failed'] ?? 0 ) + 1;
+		}
+		if ( ! empty( $query_evidence['truncated'] ) ) {
+			++$counts['candidate_queries_truncated'];
+			$failures['candidate_query_truncated'] = ( $failures['candidate_query_truncated'] ?? 0 ) + 1;
+		}
+		if ( empty( $candidates ) ) {
+			continue;
+		}
+		++$counts['locations_with_events'];
+
+		$recipient_ids = extrachill_users_entity_subscription_recipients( EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_PRODUCER, EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_ENTITY, EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_TAXONOMY, $term->slug, 'notification' );
+		$email_ids     = extrachill_users_entity_subscription_recipients( EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_PRODUCER, EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_ENTITY, EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_TAXONOMY, $term->slug, 'email' );
+		if ( is_wp_error( $recipient_ids ) || ! is_array( $recipient_ids ) || is_wp_error( $email_ids ) || ! is_array( $email_ids ) ) {
+			++$counts['retryable_failures'];
+			$failures['recipient_resolution_failed'] = ( $failures['recipient_resolution_failed'] ?? 0 ) + 1;
+			continue;
+		}
+
+		$email_ids = array_fill_keys( array_map( 'absint', $email_ids ), true );
+		foreach ( array_values( array_unique( array_map( 'absint', $recipient_ids ) ) ) as $user_id ) {
+			$scene      = extrachill_users_get_local_scene( $user_id );
+			$scene_slug = is_array( $scene ) ? sanitize_title( $scene['slug'] ?? '' ) : '';
+			if ( $scene_slug !== $term->slug ) {
+				++$counts['scene_mismatches'];
+				continue;
+			}
+
+			++$counts['recipients'];
+			$selected = extrachill_events_select_local_scene_digest_events( $candidates, $user_id, $limit );
+			if ( empty( $selected ) || $dry_run ) {
+				continue;
+			}
+
+			$result = extrachill_events_deliver_local_scene_digest( $user_id, $term, $selected, isset( $email_ids[ $user_id ] ) );
+			$status = $result['status'] ?? 'failed';
+			if ( 'inserted' === $status ) {
+				++$counts['notifications_inserted'];
+			} elseif ( 'existing' === $status ) {
+				++$counts['notifications_existing'];
+			} else {
+				++$counts['notification_failures'];
+			}
+			$reason = sanitize_key( $result['reason'] ?? '' );
+			if ( '' !== $reason ) {
+				$failures[ $reason ] = ( $failures[ $reason ] ?? 0 ) + 1;
+			}
+			if ( ! empty( $result['email_queued'] ) ) {
+				++$counts['emails_queued'];
+			} elseif ( ! empty( $result['email_failed'] ) ) {
+				++$counts['email_failures'];
+			}
+			if ( ! empty( $result['receipt_released'] ) ) {
+				++$counts['notifications_released'];
+			}
+			if ( ! empty( $result['retryable_failure'] ) ) {
+				++$counts['retryable_failures'];
+			}
+		}
+	}
+
+	return array(
+		'dry_run'           => $dry_run,
+		'counts'            => $counts,
+		'failures'          => $failures,
+		'retryable_failure' => 0 < $counts['retryable_failures'],
+	);
+}
+
+/**
+ * Query, hydrate, and hard-gate one location's upcoming events.
+ *
+ * @param WP_Term    $location Canonical location term.
+ * @param int        $days     Upcoming window length.
+ * @param array|null $evidence Aggregate query evidence populated by reference.
+ * @return array Qualified event rows.
+ */
+function extrachill_events_local_scene_digest_candidates( WP_Term $location, int $days, ?array &$evidence = null ): array {
+	$evidence      = array(
+		'failed'    => false,
+		'truncated' => false,
+	);
+	$now_timestamp = (int) apply_filters( 'extrachill_local_scene_digest_now', time() );
+	$utc_now       = ( new DateTimeImmutable( '@' . $now_timestamp ) )->setTimezone( new DateTimeZone( 'UTC' ) );
+	$cap           = min( 1000, max( 20, absint( apply_filters( 'extrachill_local_scene_digest_candidate_cap', 250 ) ) ) );
+	$query         = data_machine_events_query_events(
+		array(
+			'status'      => 'publish',
+			'date_start'  => $utc_now->modify( '-1 day' )->format( 'Y-m-d' ),
+			'date_end'    => $utc_now->modify( '+' . ( $days + 1 ) . ' days' )->format( 'Y-m-d' ),
+			'per_page'    => $cap + 1,
+			'order'       => 'ASC',
+			'tax_filters' => array( 'location' => array( (int) $location->term_id ) ),
+		)
+	);
+	if ( ! is_array( $query ) ) {
+		$evidence['failed'] = true;
+		return array();
+	}
+	$posts                 = is_array( $query['posts'] ?? null ) ? $query['posts'] : array();
+	$evidence['truncated'] = count( $posts ) > $cap;
+	$posts                 = array_slice( $posts, 0, $cap );
+	$priority_events       = array_fill_keys( array_map( 'absint', function_exists( 'extrachill_get_priority_event_ids' ) ? extrachill_get_priority_event_ids() : array() ), true );
+	$priority_venues       = array_fill_keys( array_map( 'absint', function_exists( 'ec_get_priority_venue_ids' ) ? ec_get_priority_venue_ids() : array() ), true );
+	$candidates            = array();
+
+	foreach ( $posts as $post ) {
+		if ( ! $post instanceof WP_Post || 'publish' !== $post->post_status ) {
+			continue;
+		}
+
+		$location_ids = wp_get_post_terms( $post->ID, 'location', array( 'fields' => 'ids' ) );
+		$venue_terms  = wp_get_post_terms( $post->ID, 'venue' );
+		if ( is_wp_error( $location_ids ) || array( (int) $location->term_id ) !== array_values( array_unique( array_map( 'absint', $location_ids ) ) ) || is_wp_error( $venue_terms ) || 1 !== count( $venue_terms ) ) {
+			continue;
+		}
+
+		$data   = data_machine_events_parse_event_data( $post );
+		$status = is_array( $data ) ? (string) ( $data['eventStatus'] ?? '' ) : '';
+		if ( ! is_array( $data ) || ! in_array( $status, array( '', 'EventScheduled', 'EventRescheduled' ), true ) ) {
+			continue;
+		}
+
+		$timezone_name = (string) ( $data['venueTimezone'] ?? '' );
+		if ( ! in_array( $timezone_name, DateTimeZone::listIdentifiers( DateTimeZone::ALL_WITH_BC ), true ) ) {
+			continue;
+		}
+		$timezone   = new DateTimeZone( $timezone_name );
+		$start      = ( new DateTimeImmutable( '@' . $now_timestamp ) )->setTimezone( $timezone );
+		$end        = $start->modify( '+' . $days . ' days' );
+		$start_time = (string) ( $data['startTime'] ?? '' );
+		if ( preg_match( '/^\d{2}:\d{2}$/', $start_time ) ) {
+			$start_time .= ':00';
+		}
+		if ( in_array( $start_time, array( '00:00', '00:00:00' ), true ) ) {
+			continue;
+		}
+		$source_datetime = (string) ( $data['startDate'] ?? '' ) . ' ' . $start_time;
+		$date            = DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $source_datetime, $timezone );
+		$errors          = DateTimeImmutable::getLastErrors();
+		if ( ! $date || ( false !== $errors && ( $errors['warning_count'] || $errors['error_count'] ) ) || $date->format( 'Y-m-d H:i:s' ) !== $source_datetime || $date < $start || $date >= $end ) {
+			continue;
+		}
+
+		$end_date     = (string) ( $data['endDate'] ?? '' );
+		$end_time     = (string) ( $data['endTime'] ?? '' );
+		$end_datetime = null;
+		if ( '' !== $end_date || '' !== $end_time ) {
+			if ( '' === $end_time ) {
+				continue;
+			}
+			if ( preg_match( '/^\d{2}:\d{2}$/', $end_time ) ) {
+				$end_time .= ':00';
+			}
+			$end_source   = ( '' !== $end_date ? $end_date : (string) ( $data['startDate'] ?? '' ) ) . ' ' . $end_time;
+			$end_datetime = DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $end_source, $timezone );
+			$errors       = DateTimeImmutable::getLastErrors();
+			if ( ! $end_datetime || ( false !== $errors && ( $errors['warning_count'] || $errors['error_count'] ) ) || $end_datetime->format( 'Y-m-d H:i:s' ) !== $end_source || $end_datetime <= $date ) {
+				continue;
+			}
+		}
+
+		$url   = get_permalink( $post );
+		$venue = reset( $venue_terms );
+		if ( ! is_string( $url ) || ! wp_http_validate_url( $url ) || ! $venue instanceof WP_Term ) {
+			continue;
+		}
+
+		$artist_ids = wp_get_post_terms( $post->ID, 'artist', array( 'fields' => 'ids' ) );
+		$performers = ! is_wp_error( $artist_ids ) ? array_map( static fn( $id ) => 'term:' . absint( $id ), $artist_ids ) : array();
+		if ( empty( $performers ) && '' !== sanitize_title( $data['performer'] ?? '' ) ) {
+			$performers[] = sanitize_title( $data['performer'] );
+		}
+		$price = trim( (string) ( $data['price'] ?? '' ) );
+		$item  = array(
+			'post_id'        => (int) $post->ID,
+			'title'          => get_the_title( $post ),
+			'url'            => $url,
+			'datetime'       => $date,
+			'end_datetime'   => $end_datetime,
+			'venue_id'       => (int) $venue->term_id,
+			'venue_name'     => $venue->name,
+			'performer_keys' => array_values( array_unique( $performers ) ),
+			'price'          => $price,
+			'priority_event' => isset( $priority_events[ $post->ID ] ),
+			'priority_venue' => isset( $priority_venues[ $venue->term_id ] ),
+			'has_price'      => '' !== $price,
+			'completeness'   => count( array_filter( array( $data['performer'] ?? '', $data['ticketUrl'] ?? '', $data['image'] ?? '', $price ) ) ),
+		);
+		$key   = sanitize_title( $item['title'] ) . '|' . $item['venue_id'] . '|' . $date->format( 'Y-m-d' );
+		if ( ! isset( $candidates[ $key ] ) || extrachill_events_compare_local_scene_digest_events( $item, $candidates[ $key ] ) < 0 ) {
+			$candidates[ $key ] = $item;
+		}
+	}
+
+	$candidates = array_values( $candidates );
+	usort( $candidates, 'extrachill_events_compare_local_scene_digest_events' );
+	return $candidates;
+}
+
+/**
+ * Deterministic priority comparator.
+ *
+ * @param array $a First event.
+ * @param array $b Second event.
+ * @return int Sort comparison.
+ */
+function extrachill_events_compare_local_scene_digest_events( array $a, array $b ): int {
+	foreach ( array( 'priority_event', 'priority_venue', 'completeness', 'has_price' ) as $field ) {
+		$comparison = (int) $b[ $field ] <=> (int) $a[ $field ];
+		if ( 0 !== $comparison ) {
+			return $comparison;
+		}
+	}
+	$comparison = $a['datetime']->getTimestamp() <=> $b['datetime']->getTimestamp();
+	return 0 !== $comparison ? $comparison : ( $a['post_id'] <=> $b['post_id'] );
+}
+
+/**
+ * Select a bounded personalized list, with Going events in the first section.
+ *
+ * @param array $candidates Qualified location events.
+ * @param int   $user_id    Recipient user ID.
+ * @param int   $limit      Maximum selected events.
+ * @return array Selected event rows.
+ */
+function extrachill_events_select_local_scene_digest_events( array $candidates, int $user_id, int $limit ): array {
+	$going = array();
+	$more  = array();
+	$blog  = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'events' ) ) : 0;
+	if ( ! $blog ) {
+		return array();
+	}
+	foreach ( $candidates as $candidate ) {
+		if ( function_exists( 'ec_users_is_event_marked' ) && ec_users_is_event_marked( $user_id, $candidate['post_id'], $blog ) ) {
+			$going[] = $candidate;
+		} else {
+			$more[] = $candidate;
+		}
+	}
+
+	$ordered = array_merge( $going, $more );
+	if ( count( $ordered ) <= $limit ) {
+		return $ordered;
+	}
+	if ( count( $going ) >= $limit ) {
+		return array_slice( $going, 0, $limit );
+	}
+
+	$selected = $going;
+	$deferred = array();
+	$venues   = array();
+	$artists  = array();
+	foreach ( $going as $event ) {
+		$venues[ $event['venue_id'] ] = ( $venues[ $event['venue_id'] ] ?? 0 ) + 1;
+		foreach ( $event['performer_keys'] as $performer_key ) {
+			$artists[ $performer_key ] = ( $artists[ $performer_key ] ?? 0 ) + 1;
+		}
+	}
+	foreach ( $more as $event ) {
+		$venue_count = $venues[ $event['venue_id'] ] ?? 0;
+		$artist_cap  = false;
+		foreach ( $event['performer_keys'] as $performer_key ) {
+			if ( ( $artists[ $performer_key ] ?? 0 ) >= 2 ) {
+				$artist_cap = true;
+				break;
+			}
+		}
+		if ( $venue_count >= 2 || $artist_cap ) {
+			$deferred[] = $event;
+			continue;
+		}
+		$selected[]                   = $event;
+		$venues[ $event['venue_id'] ] = $venue_count + 1;
+		foreach ( $event['performer_keys'] as $performer_key ) {
+			$artists[ $performer_key ] = ( $artists[ $performer_key ] ?? 0 ) + 1;
+		}
+		if ( count( $selected ) >= $limit ) {
+			return $selected;
+		}
+	}
+
+	return array_slice( array_merge( $selected, $deferred ), 0, $limit );
+}
+
+/**
+ * Claim the weekly notification and enqueue email only for a new eligible claim.
+ *
+ * @param int     $user_id        Recipient user ID.
+ * @param WP_Term $location       Canonical location term.
+ * @param array   $events         Selected event rows.
+ * @param bool    $email_eligible Whether email delivery is enabled.
+ * @return array Delivery result.
+ */
+function extrachill_events_deliver_local_scene_digest( int $user_id, WP_Term $location, array $events, bool $email_eligible ): array {
+	if ( ! function_exists( 'ec_users_notify_with_receipts' ) || ! function_exists( 'ec_users_release_notification_receipt' ) || ! function_exists( 'ec_get_network_bot_user_id' ) ) {
+		return array(
+			'status'            => 'failed',
+			'reason'            => 'delivery_dependency_unavailable',
+			'retryable_failure' => true,
+		);
+	}
+
+	$actor_id = absint( ec_get_network_bot_user_id() );
+	$link     = extrachill_events_local_scene_digest_tracked_url( get_term_link( $location ) );
+	if ( ! $actor_id || is_wp_error( $link ) || ! wp_http_validate_url( $link ) ) {
+		return array(
+			'status' => 'failed',
+			'reason' => 'invalid_delivery_context',
+		);
+	}
+
+	$week              = ( new DateTimeImmutable( 'now', wp_timezone() ) )->format( 'o-W' );
+	$idempotency_key   = $week . ':' . $location->slug;
+	$receipt           = ec_users_notify_with_receipts(
+		array( $user_id ),
+		array(
+			'actor_id'            => $actor_id,
+			'type'                => EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_TYPE,
+			'title'               => __( 'Your Local Scene weekly picks are ready', 'extrachill-events' ),
+			'link'                => $link,
+			'item_id'             => $events[0]['post_id'],
+			'producer'            => EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_PRODUCER,
+			'idempotency_key'     => $idempotency_key,
+			'producer_owns_email' => true,
+		)
+	);
+	$recipient_receipt = is_array( $receipt ) && is_array( $receipt['recipients'][ $user_id ] ?? null ) ? $receipt['recipients'][ $user_id ] : array();
+	$status            = $recipient_receipt['status'] ?? 'failed';
+	$notification_id   = absint( $recipient_receipt['notification_id'] ?? 0 );
+	$result            = array(
+		'status'            => $status,
+		'email_queued'      => false,
+		'email_failed'      => false,
+		'receipt_released'  => false,
+		'retryable_failure' => false,
+	);
+	if ( 'failed' === $status ) {
+		$receipt_error    = sanitize_key( $recipient_receipt['error'] ?? '' );
+		$stable_errors    = array( 'invalid_payload', 'invalid_actor', 'incomplete_idempotency', 'invalid_producer', 'invalid_idempotency_key', 'email_ownership_requires_idempotency', 'invalid_user', 'insert_failed', 'row_id_unavailable' );
+		$result['reason'] = in_array( $receipt_error, $stable_errors, true ) ? 'notification_' . $receipt_error : 'notification_receipt_failed';
+	}
+	if ( 'inserted' === $status && ! $notification_id ) {
+		$result['status'] = 'failed';
+		$result['reason'] = 'invalid_delivery_receipt';
+		return $result;
+	}
+	if ( 'inserted' !== $status || ! $email_eligible ) {
+		return $result;
+	}
+
+	$user = get_userdata( $user_id );
+	if ( ! $user instanceof WP_User || empty( $user->user_email ) || ! is_email( $user->user_email ) || ! function_exists( 'ec_send_email_queued' ) ) {
+		return extrachill_events_release_local_scene_digest_receipt( $result, $notification_id, $user_id, $idempotency_key );
+	}
+
+	$email = extrachill_events_build_local_scene_digest_email( $user_id, $location, $events );
+	if ( empty( $email['subject'] ) || empty( $email['body_html'] ) ) {
+		return extrachill_events_release_local_scene_digest_receipt( $result, $notification_id, $user_id, $idempotency_key );
+	}
+	$queue = ec_send_email_queued( // phpcs:ignore Generic.Formatting.MultipleStatementAlignment.NotSameWarning -- separated from the validated email assignment by a guard.
+		array(
+			'to'       => $user->user_email,
+			'subject'  => $email['subject'],
+			'template' => 'extrachill/branded',
+			'context'  => array(
+				'subject_html'   => esc_html( $email['subject'] ),
+				'recipient_name' => $user->display_name,
+				'body_html'      => $email['body_html'],
+				'cta_url'        => $link,
+				'cta_label'      => __( 'See Every Show', 'extrachill-events' ),
+				'preheader'      => __( 'Upcoming shows picked for your Local Scene.', 'extrachill-events' ),
+			),
+		)
+	);
+	$result['email_queued'] = is_array( $queue ) && ! is_wp_error( $queue ) && ! empty( $queue['success'] );
+	if ( ! $result['email_queued'] ) {
+		return extrachill_events_release_local_scene_digest_receipt( $result, $notification_id, $user_id, $idempotency_key, true );
+	}
+	return $result;
+}
+
+/**
+ * Release a failed rich-email claim so a later task replay can retry.
+ *
+ * @param array  $result          Current delivery result.
+ * @param int    $notification_id Claimed notification ID.
+ * @param int    $user_id         Recipient user ID.
+ * @param string $idempotency_key Producer replay key.
+ * @param bool   $retryable       Whether successful release should retry the whole task.
+ * @return array Failed delivery result.
+ */
+function extrachill_events_release_local_scene_digest_receipt( array $result, int $notification_id, int $user_id, string $idempotency_key, bool $retryable = false ): array {
+	$released = ec_users_release_notification_receipt(
+		$notification_id,
+		$user_id,
+		EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_PRODUCER,
+		$idempotency_key
+	);
+
+	$result['email_failed']      = true;
+	$result['receipt_released']  = $released;
+	$result['retryable_failure'] = $released && $retryable;
+	$result['reason']            = $released ? 'email_enqueue_failed' : 'email_receipt_release_failed';
+	return $result;
+}
+
+/**
+ * Build the branded email's selected event list and scoped footer.
+ *
+ * @param int     $user_id  Recipient user ID.
+ * @param WP_Term $location Canonical location term.
+ * @param array   $events   Selected event rows.
+ * @return array Email subject and body.
+ */
+function extrachill_events_build_local_scene_digest_email( int $user_id, WP_Term $location, array $events ): array {
+	$going = array();
+	$more  = array();
+	$blog  = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'events' ) ) : 0;
+	if ( ! $blog ) {
+		return array(
+			'subject'   => __( "Your Local Scene: This Week's Shows", 'extrachill-events' ),
+			'body_html' => '',
+		);
+	}
+	foreach ( $events as $event ) {
+		$is_going = function_exists( 'ec_users_is_event_marked' ) && ec_users_is_event_marked( $user_id, $event['post_id'], $blog );
+		if ( $is_going ) {
+			$going[] = $event;
+		} else {
+			$more[] = $event;
+		}
+	}
+
+	/* translators: %s: Local Scene name. */
+	$body  = '<p>' . esc_html( sprintf( __( 'Here is what is happening in %s this week.', 'extrachill-events' ), $location->name ) ) . '</p>';
+	$body .= extrachill_events_render_local_scene_digest_section( __( "You're Going", 'extrachill-events' ), $going );
+	$body .= extrachill_events_render_local_scene_digest_section( __( 'More This Week', 'extrachill-events' ), $more );
+	$body .= '<p style="font-size:13px"><a href="' . esc_url( extrachill_events_local_scene_digest_unsubscribe_url( $user_id, $location->slug ) ) . '">' . esc_html__( 'Unsubscribe from this Local Scene digest', 'extrachill-events' ) . '</a></p>';
+
+	return array(
+		'subject'   => __( "Your Local Scene: This Week's Shows", 'extrachill-events' ),
+		'body_html' => $body,
+	);
+}
+
+/**
+ * Render one non-empty digest section.
+ *
+ * @param string $heading Section heading.
+ * @param array  $events  Selected event rows.
+ * @return string Section HTML.
+ */
+function extrachill_events_render_local_scene_digest_section( string $heading, array $events ): string {
+	if ( empty( $events ) ) {
+		return '';
+	}
+	$html = '<h2>' . esc_html( $heading ) . '</h2><ul>';
+	foreach ( $events as $event ) {
+		$price = '';
+		if ( $event['has_price'] ) {
+			$price = in_array( strtolower( $event['price'] ), array( '0', '0.00', '$0', '$0.00', 'free' ), true ) ? __( 'Free', 'extrachill-events' ) : $event['price'];
+		}
+		$details   = $event['datetime']->format( 'D, M j \a\t g:i A' );
+		$event_end = $event['end_datetime'] ?? null;
+		if ( $event_end instanceof DateTimeImmutable ) {
+			$details .= $event['datetime']->format( 'Y-m-d' ) === $event_end->format( 'Y-m-d' )
+				? ' - ' . $event_end->format( 'g:i A' )
+				: ' - ' . $event_end->format( 'D, M j \a\t g:i A' );
+		}
+		$details .= ' · ' . $event['venue_name'];
+		if ( '' !== $price ) {
+			$details .= ' · ' . $price;
+		}
+		$html .= '<li><a href="' . esc_url( extrachill_events_local_scene_digest_tracked_url( $event['url'] ) ) . '"><strong>' . esc_html( $event['title'] ) . '</strong></a><br>' . esc_html( $details ) . '</li>';
+	}
+	return $html . '</ul>';
+}
+
+/**
+ * Add generic campaign tags without embedding location identity.
+ *
+ * @param mixed $url Canonical URL or error.
+ * @return string Tracked URL.
+ */
+function extrachill_events_local_scene_digest_tracked_url( $url ): string {
+	if ( is_wp_error( $url ) || ! is_string( $url ) ) {
+		return '';
+	}
+	return extrachill_events_local_scene_digest_add_query_args(
+		$url,
+		array(
+			'utm_source'   => 'local_scene_digest',
+			'utm_medium'   => 'email',
+			'utm_campaign' => 'weekly_events',
+		)
+	);
+}
+
+/**
+ * Mint a location-specific signed unsubscribe URL valid for 30 days.
+ *
+ * @param int      $user_id Recipient user ID.
+ * @param string   $slug    Canonical location slug.
+ * @param int|null $expires Optional expiry timestamp.
+ * @return string Signed URL.
+ */
+function extrachill_events_local_scene_digest_unsubscribe_url( int $user_id, string $slug, ?int $expires = null ): string {
+	$slug    = sanitize_title( $slug );
+	$expires = $expires ?? ( time() + 30 * DAY_IN_SECONDS );
+	$token   = hash_hmac( 'sha256', $user_id . '|' . $slug . '|' . $expires, wp_salt( 'auth' ) );
+	return extrachill_events_local_scene_digest_add_query_args(
+		rest_url( 'extrachill/v1/local-scene-digest/unsubscribe' ),
+		array(
+			'user'      => $user_id,
+			'location'  => $slug,
+			'expires'   => $expires,
+			'signature' => $token,
+		)
+	);
+}
+
+/**
+ * Add query values one at a time through WordPress' public API.
+ *
+ * @param string $url  Base URL.
+ * @param array  $args Query arguments.
+ * @return string URL with arguments.
+ */
+function extrachill_events_local_scene_digest_add_query_args( string $url, array $args ): string {
+	foreach ( $args as $key => $value ) {
+		$url = add_query_arg( $key, $value, $url );
+	}
+	return $url;
+}
+
+/** Register the public, signature-authenticated one-click route. */
+function extrachill_events_register_local_scene_digest_routes(): void {
+	register_rest_route(
+		'extrachill/v1',
+		'/local-scene-digest/unsubscribe',
+		array(
+			array(
+				'methods'             => 'GET',
+				'callback'            => 'extrachill_events_local_scene_digest_unsubscribe_confirmation',
+				'permission_callback' => '__return_true',
+				'args'                => extrachill_events_local_scene_digest_unsubscribe_args(),
+			),
+			array(
+				'methods'             => 'POST',
+				'callback'            => 'extrachill_events_local_scene_digest_unsubscribe',
+				'permission_callback' => '__return_true',
+				'args'                => extrachill_events_local_scene_digest_unsubscribe_args(),
+			),
+		)
+	);
+}
+
+/** Return the shared signed unsubscribe request schema. */
+function extrachill_events_local_scene_digest_unsubscribe_args(): array {
+	return array(
+		'user'      => array(
+			'required'          => true,
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+		),
+		'location'  => array(
+			'required'          => true,
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_title',
+		),
+		'expires'   => array(
+			'required'          => true,
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+		),
+		'signature' => array(
+			'required'          => true,
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+		),
+	);
+}
+
+/**
+ * Verify and normalize one signed unsubscribe request without mutating consent.
+ *
+ * @param WP_REST_Request $request Unsubscribe request.
+ * @return array|WP_Error
+ */
+function extrachill_events_verify_local_scene_digest_unsubscribe( WP_REST_Request $request ) {
+	$user_id   = absint( $request->get_param( 'user' ) );
+	$slug      = sanitize_title( $request->get_param( 'location' ) );
+	$expires   = absint( $request->get_param( 'expires' ) );
+	$signature = (string) $request->get_param( 'signature' );
+	$expected  = hash_hmac( 'sha256', $user_id . '|' . $slug . '|' . $expires, wp_salt( 'auth' ) );
+	if ( ! $user_id || '' === $slug || $expires < time() || $expires > time() + 30 * DAY_IN_SECONDS || ! hash_equals( $expected, $signature ) ) {
+		return new WP_Error( 'invalid_local_scene_digest_unsubscribe', __( 'This unsubscribe link is invalid or expired.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+
+	return compact( 'user_id', 'slug', 'expires', 'signature' );
+}
+
+/**
+ * Render a scanner-safe confirmation form without changing consent.
+ *
+ * @param WP_REST_Request $request Unsubscribe request.
+ * @param bool            $render  Whether to render the browser handoff page.
+ * @return array|WP_Error
+ */
+function extrachill_events_local_scene_digest_unsubscribe_confirmation( WP_REST_Request $request, bool $render = true ) {
+	$verified = extrachill_events_verify_local_scene_digest_unsubscribe( $request );
+	if ( is_wp_error( $verified ) ) {
+		if ( $render ) {
+			extrachill_events_render_local_scene_digest_unsubscribe_page( __( 'Unsubscribe link invalid', 'extrachill-events' ), __( 'This unsubscribe link is invalid or has expired. You can manage this Local Scene subscription from its events page.', 'extrachill-events' ) );
+		}
+		return $verified;
+	}
+
+	$form = extrachill_events_build_local_scene_digest_unsubscribe_form( $verified );
+	if ( $render ) {
+		extrachill_events_render_local_scene_digest_unsubscribe_page( __( 'Unsubscribe from weekly Local Scene picks?', 'extrachill-events' ), __( 'This stops both the weekly email and its in-app update for this Local Scene only.', 'extrachill-events' ), $form );
+	}
+	return array(
+		'confirmed' => false,
+		'html'      => $form,
+	);
+}
+
+/**
+ * Build the signed POST confirmation form.
+ *
+ * @param array $verified Verified signed payload.
+ * @return string
+ */
+function extrachill_events_build_local_scene_digest_unsubscribe_form( array $verified ): string {
+	$fields = '';
+	foreach (
+		array(
+			'user'      => $verified['user_id'],
+			'location'  => $verified['slug'],
+			'expires'   => $verified['expires'],
+			'signature' => $verified['signature'],
+		) as $name => $value
+	) {
+		$fields .= '<input type="hidden" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '">';
+	}
+	return '<form method="post" action="' . esc_url( rest_url( 'extrachill/v1/local-scene-digest/unsubscribe' ) ) . '">' . $fields . '<button type="submit">' . esc_html__( 'Unsubscribe from this Local Scene', 'extrachill-events' ) . '</button></form>';
+}
+
+/**
+ * Verify a signed POST and remove only its digest-specific location consent.
+ *
+ * @param WP_REST_Request $request Unsubscribe request.
+ * @param bool            $render  Whether to render the browser handoff page.
+ * @return WP_REST_Response|WP_Error
+ */
+function extrachill_events_local_scene_digest_unsubscribe( WP_REST_Request $request, bool $render = true ) {
+	$verified = extrachill_events_verify_local_scene_digest_unsubscribe( $request );
+	if ( is_wp_error( $verified ) ) {
+		if ( $render ) {
+			extrachill_events_render_local_scene_digest_unsubscribe_page( __( 'Unsubscribe link invalid', 'extrachill-events' ), __( 'This unsubscribe request is invalid or has expired. You can manage this Local Scene subscription from its events page.', 'extrachill-events' ) );
+		}
+		return $verified;
+	}
+	$user_id = $verified['user_id'];
+	$slug    = $verified['slug'];
+	if ( ! function_exists( 'extrachill_users_unsubscribe_from_entity' ) ) {
+		if ( $render ) {
+			extrachill_events_render_local_scene_digest_unsubscribe_page( __( 'Unsubscribe unavailable', 'extrachill-events' ), __( 'This subscription could not be updated right now. Please try again later or manage it from the Local Scene events page.', 'extrachill-events' ) );
+		}
+		return new WP_Error( 'local_scene_digest_unsubscribe_unavailable', __( 'Unsubscribe is temporarily unavailable.', 'extrachill-events' ), array( 'status' => 503 ) );
+	}
+
+	$result = extrachill_users_unsubscribe_from_entity( $user_id, EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_ENTITY, EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_TAXONOMY, $slug );
+	if ( is_wp_error( $result ) ) {
+		if ( $render ) {
+			extrachill_events_render_local_scene_digest_unsubscribe_page( __( 'Unsubscribe unavailable', 'extrachill-events' ), __( 'This subscription could not be updated right now. Please try again later or manage it from the Local Scene events page.', 'extrachill-events' ) );
+		}
+		return $result;
+	}
+	if ( $render ) {
+		extrachill_events_render_local_scene_digest_unsubscribe_page( __( "You're unsubscribed", 'extrachill-events' ), __( 'You will no longer receive the weekly email or its in-app update for this Local Scene. Your saved Local Scene and other notification preferences have not changed.', 'extrachill-events' ) );
+	}
+	return rest_ensure_response( array( 'unsubscribed' => true ) );
+}
+
+/**
+ * Render the standalone browser confirmation used by the signed one-click route.
+ *
+ * @param string $title       Page title.
+ * @param string $message     Confirmation message.
+ * @param string $action_html Optional escaped action markup.
+ */
+function extrachill_events_render_local_scene_digest_unsubscribe_page( string $title, string $message, string $action_html = '' ): void {
+	if ( ! headers_sent() ) {
+		status_header( 200 );
+		nocache_headers();
+		header( 'Content-Type: text/html; charset=utf-8' );
+		header( 'X-Robots-Tag: noindex, nofollow', true );
+	}
+
+	echo extrachill_events_build_local_scene_digest_unsubscribe_page( $title, $message, $action_html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by dedicated builders.
+	exit;
+}
+
+/**
+ * Build escaped standalone unsubscribe confirmation markup.
+ *
+ * @param string $title       Page title.
+ * @param string $message     Confirmation message.
+ * @param string $action_html Optional escaped action markup.
+ * @return string
+ */
+function extrachill_events_build_local_scene_digest_unsubscribe_page( string $title, string $message, string $action_html = '' ): string {
+	$html  = '<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>' . esc_html( $title ) . '</title>';
+	$html .= '<style>body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:#f6f6f6;color:#222;margin:0;padding:0}.wrap{max-width:520px;margin:10vh auto;padding:2rem;background:#fff;border-radius:8px;box-shadow:0 1px 4px rgba(0,0,0,.08);text-align:center}h1{font-size:1.4rem;margin:0 0 1rem}p{line-height:1.5;margin:0 0 1.5rem}a,button{display:inline-block;color:#fff;background:#222;text-decoration:none;padding:.65rem 1.25rem;border:0;border-radius:6px;cursor:pointer}form{margin:0 0 1rem}</style>';
+	$html .= '</head><body><div class="wrap"><h1>' . esc_html( $title ) . '</h1><p>' . esc_html( $message ) . '</p>' . $action_html . '<a href="' . esc_url( home_url( '/' ) ) . '">' . esc_html__( 'Back to Extra Chill Events', 'extrachill-events' ) . '</a></div></body></html>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- action markup comes from the escaped form builder.
+	return $html;
+}
+
+/** Render the explicit archive opt-in directly after the Local Scene CTA. */
+function extrachill_events_render_local_scene_digest_opt_in(): void {
+	$term = extrachill_events_get_archive_scene_term();
+	if ( null === $term ) {
+		return;
+	}
+	$archive_url = get_term_link( $term );
+	if ( ! is_user_logged_in() ) {
+		echo '<aside class="events-market-context events-market-context--quiet"><span>' . esc_html__( 'Want a weekly email and in-app update for this Local Scene?', 'extrachill-events' ) . '</span> <a href="' . esc_url( wp_login_url( $archive_url ) ) . '">' . esc_html__( 'Sign in to subscribe', 'extrachill-events' ) . '</a></aside>';
+		return;
+	}
+
+	$current = extrachill_events_get_account_market();
+	if ( ! $current || (int) $current['term_id'] !== (int) $term->term_id ) {
+		echo '<aside class="events-market-context events-market-context--quiet"><span>' . esc_html__( 'Make this archive your Local Scene before subscribing to its weekly email and in-app update.', 'extrachill-events' ) . '</span></aside>';
+		return;
+	}
+	?>
+	<aside class="events-market-context" data-local-scene-digest-control>
+		<div class="events-market-context__copy">
+			<strong><?php esc_html_e( 'Weekly Local Scene email + update', 'extrachill-events' ); ?></strong>
+			<span data-local-scene-digest-status><?php esc_html_e( 'Checking your subscription…', 'extrachill-events' ); ?></span>
+		</div>
+		<button class="button-1 button-small" type="button" disabled aria-pressed="false" data-local-scene-digest data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Subscribe to email + updates', 'extrachill-events' ); ?></button>
+	</aside>
+	<?php
+}
+add_action( 'extrachill_archive_below_description', 'extrachill_events_render_local_scene_digest_opt_in', 5 );
+
+/** Enqueue the progressive toggle only when its current-scene control exists. */
+function extrachill_events_local_scene_digest_scripts(): void {
+	$term = extrachill_events_get_archive_scene_term();
+	if ( null === $term || ! is_user_logged_in() ) {
+		return;
+	}
+	$current = extrachill_events_get_account_market();
+	if ( ! $current || (int) $current['term_id'] !== (int) $term->term_id ) {
+		return;
+	}
+	wp_enqueue_script( 'extrachill-events-local-scene-digest', EXTRACHILL_EVENTS_PLUGIN_URL . 'assets/js/local-scene-digest.js', array(), EXTRACHILL_EVENTS_VERSION, true );
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_events_local_scene_digest_scripts' );

--- a/tests/Unit/Core/LocalSceneDigestSystemTaskTest.php
+++ b/tests/Unit/Core/LocalSceneDigestSystemTaskTest.php
@@ -1,0 +1,75 @@
+<?php
+/** Local Scene digest SystemTask contract tests. */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Stubs/digest-stubs.php';
+require_once __DIR__ . '/Stubs/system-task-base-stub.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Steps/LocalSceneDigest/LocalSceneDigestSystemTask.php';
+
+class LocalSceneDigestSystemTaskTest extends TestCase {
+	public function test_task_is_feature_gated_and_manually_runnable(): void {
+		$task = new \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask();
+		$meta = $task::getTaskMeta();
+		$this->assertSame( 'extrachill_local_scene_digest', $task->getTaskType() );
+		$this->assertSame( 'extrachill_local_scene_digest_enabled', $meta['setting_key'] );
+		$this->assertFalse( $meta['default_enabled'] );
+		$this->assertTrue( $meta['supports_run'] );
+		$this->assertTrue( $meta['mutates'] );
+		$this->assertTrue( $meta['supports_dry_run'] );
+		$this->assertSame( array( 'days', 'limit', 'dry_run' ), $meta['params_schema']['accepted'] );
+		$this->assertSame( 14, $meta['params_schema']['properties']['days']['maximum'] );
+		$this->assertSame( 20, $meta['params_schema']['properties']['limit']['maximum'] );
+		$this->assertFalse( $task->requiresAgentContext(), 'Recurring site-scoped execution must not require an agent envelope.' );
+	}
+
+	public function test_execute_fails_job_for_retryable_runner_evidence(): void {
+		$GLOBALS['ec_test_systemtask_calls']          = array();
+		$GLOBALS['ec_test_plugin_settings_reads']     = array();
+		$GLOBALS['ec_test_plugin_settings']           = array( 'extrachill_local_scene_digest_enabled' => true );
+		$task = new class() extends \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask {
+			protected function runDigest( array $params ): array {
+				return array(
+					'counts'            => array( 'retryable_failures' => 1 ),
+					'failures'          => array( 'candidate_query_failed' => 1 ),
+					'retryable_failure' => true,
+				);
+			}
+		};
+		$task->executeTask( 41, array( 'dry_run' => true ) );
+
+		$this->assertSame( array( 'extrachill_local_scene_digest_enabled', false ), $GLOBALS['ec_test_plugin_settings_reads'][0] );
+		$this->assertSame( 'failJob', $GLOBALS['ec_test_systemtask_calls'][0]['method'] );
+		$this->assertSame( 'Local Scene digest encountered a retryable delivery failure.', $GLOBALS['ec_test_systemtask_calls'][0]['message'] );
+		$this->assertStringNotContainsString( 'location', strtolower( $GLOBALS['ec_test_systemtask_calls'][0]['message'] ) );
+	}
+
+	public function test_execute_completes_nonretryable_evidence(): void {
+		$GLOBALS['ec_test_systemtask_calls'] = array();
+		$GLOBALS['ec_test_plugin_settings']  = array( 'extrachill_local_scene_digest_enabled' => true );
+		$task = new class() extends \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask {
+			protected function runDigest( array $params ): array {
+				return array(
+					'counts'            => array( 'candidate_queries_truncated' => 1, 'retryable_failures' => 0 ),
+					'failures'          => array( 'candidate_query_truncated' => 1 ),
+					'retryable_failure' => false,
+				);
+			}
+		};
+		$task->executeTask( 42, array() );
+
+		$this->assertSame( 'completeJob', $GLOBALS['ec_test_systemtask_calls'][0]['method'] );
+		$this->assertFalse( $GLOBALS['ec_test_systemtask_calls'][0]['data']['retryable_failure'] );
+		$this->assertSame( 1, $GLOBALS['ec_test_systemtask_calls'][0]['data']['counts']['candidate_queries_truncated'] );
+	}
+
+	public function test_recurring_schedule_is_default_disabled_and_explicitly_delivers(): void {
+		$bootstrap = file_get_contents( dirname( __DIR__, 3 ) . '/extrachill-events.php' );
+		$this->assertIsString( $bootstrap );
+		$this->assertMatchesRegularExpression( "/'enabled_setting'\\s*=>\\s*'extrachill_local_scene_digest_enabled'/", $bootstrap );
+		$this->assertMatchesRegularExpression( "/'default_enabled'\\s*=>\\s*false/", $bootstrap );
+		$this->assertMatchesRegularExpression( "/'dry_run'\\s*=>\\s*false/", $bootstrap );
+	}
+}

--- a/tests/Unit/Core/LocalSceneDigestTest.php
+++ b/tests/Unit/Core/LocalSceneDigestTest.php
@@ -1,0 +1,698 @@
+<?php
+/** Tests for the weekly Local Scene digest. */
+
+use PHPUnit\Framework\TestCase;
+
+/** Load global WordPress doubles only inside this class's isolated process. */
+function extrachill_events_load_local_scene_digest_test_environment(): void {
+if ( ! class_exists( 'WP_Term' ) ) {
+	class WP_Term {
+		public $term_id;
+		public $slug;
+		public $name;
+		public function __construct( object $term ) {
+			foreach ( get_object_vars( $term ) as $key => $value ) {
+				$this->{$key} = $value;
+			}
+		}
+	}
+}
+if ( ! class_exists( 'WP_Post' ) ) {
+	class WP_Post {
+		public $ID;
+		public $post_status;
+		public $post_title;
+		public function __construct( array $data ) {
+			foreach ( $data as $key => $value ) {
+				$this->{$key} = $value;
+			}
+		}
+	}
+}
+if ( ! class_exists( 'WP_User' ) ) {
+	class WP_User {
+		public $user_email;
+		public $display_name;
+		public function __construct( string $email, string $name = 'Listener' ) {
+			$this->user_email  = $email;
+			$this->display_name = $name;
+		}
+	}
+}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public $code;
+		public $message;
+		public $data;
+		public function __construct( string $code = '', string $message = '', array $data = array() ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+	}
+}
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request {
+		private $params;
+		public function __construct( array $params ) {
+			$this->params = $params;
+		}
+		public function get_param( string $key ) {
+			return $this->params[ $key ] ?? null;
+		}
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action() {}
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ) { return abs( (int) $value ); }
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $value ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $value ) ); }
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $value ) { return trim( strtolower( preg_replace( '/[^a-z0-9]+/i', '-', (string) $value ) ), '-' ); }
+}
+if ( ! function_exists( '__' ) ) {
+	function __( $value ) { return $value; }
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES ); }
+}
+if ( ! function_exists( 'esc_html__' ) ) {
+	function esc_html__( $value ) { return esc_html( $value ); }
+}
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $value ) { return (string) $value; }
+}
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES ); }
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value ) { return $GLOBALS['local_scene_filters'][ $hook ] ?? $value; }
+}
+if ( ! function_exists( 'wp_timezone' ) ) {
+	function wp_timezone() { return new DateTimeZone( 'America/New_York' ); }
+}
+if ( ! function_exists( 'wp_http_validate_url' ) ) {
+	function wp_http_validate_url( $url ) { return filter_var( $url, FILTER_VALIDATE_URL ) ? $url : false; }
+}
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id() { return 7; }
+}
+if ( ! function_exists( 'get_the_title' ) ) {
+	function get_the_title( $post ) { return $post->post_title; }
+}
+if ( ! function_exists( 'get_permalink' ) ) {
+	function get_permalink( $post ) {
+		return isset( $GLOBALS['festival_notification_meta'] ) ? 'https://events.example/events/' . $post->ID . '/' : 'https://events.example.com/event/' . $post->ID . '/';
+	}
+}
+if ( ! function_exists( 'get_term_link' ) ) {
+	function get_term_link( $term ) { return 'https://events.example.com/location/' . $term->slug . '/'; }
+}
+if ( ! function_exists( 'add_query_arg' ) ) {
+	function add_query_arg( $key, $value, $url ) { return $url . ( false === strpos( $url, '?' ) ? '?' : '&' ) . rawurlencode( $key ) . '=' . rawurlencode( $value ); }
+}
+if ( ! function_exists( 'rest_url' ) ) {
+	function rest_url( $path ) { return 'https://events.example.com/wp-json/' . $path; }
+}
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url() { return 'https://events.example.com/'; }
+}
+if ( ! function_exists( 'wp_salt' ) ) {
+	function wp_salt() { return 'test-secret'; }
+}
+if ( ! function_exists( 'rest_ensure_response' ) ) {
+	function rest_ensure_response( $value ) { return $value; }
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) { return $value instanceof WP_Error; }
+}
+if ( ! function_exists( 'is_email' ) ) {
+	function is_email( $value ) { return false !== filter_var( $value, FILTER_VALIDATE_EMAIL ); }
+}
+if ( ! function_exists( 'data_machine_events_query_events' ) ) {
+	function data_machine_events_query_events( array $params ) {
+		$GLOBALS['local_scene_query_params'][] = $params;
+		if ( array_key_exists( 'local_scene_query_result', $GLOBALS ) ) {
+			return $GLOBALS['local_scene_query_result'];
+		}
+		$posts = $GLOBALS['local_scene_posts'] ?? array();
+		return array( 'posts' => $posts, 'total' => $GLOBALS['local_scene_query_total'] ?? count( $posts ) );
+	}
+}
+if ( ! function_exists( 'data_machine_events_parse_event_data' ) ) {
+	function data_machine_events_parse_event_data( WP_Post $post ): ?array { return $GLOBALS['local_scene_event_data'][ $post->ID ] ?? null; }
+}
+if ( ! function_exists( 'wp_get_post_terms' ) ) {
+	function wp_get_post_terms( $post_id, $taxonomy, $args = array() ) {
+		if ( isset( $GLOBALS['festival_notification_terms'] ) ) {
+			return $GLOBALS['festival_notification_terms'][ $taxonomy ] ?? array();
+		}
+		return $GLOBALS['local_scene_terms'][ $post_id ][ $taxonomy ] ?? array();
+	}
+}
+if ( ! function_exists( 'extrachill_get_priority_event_ids' ) ) {
+	function extrachill_get_priority_event_ids() { return $GLOBALS['local_scene_priority_events'] ?? array(); }
+}
+if ( ! function_exists( 'ec_get_priority_venue_ids' ) ) {
+	function ec_get_priority_venue_ids() { return $GLOBALS['local_scene_priority_venues'] ?? array(); }
+}
+if ( ! function_exists( 'ec_users_is_event_marked' ) ) {
+	function ec_users_is_event_marked( int $user_id, int $event_id, int $blog_id ): bool {
+		$GLOBALS['local_scene_mark_checks'][] = compact( 'user_id', 'event_id', 'blog_id' );
+		return ! empty( $GLOBALS['local_scene_marks'][ $user_id ][ $event_id ] );
+	}
+}
+if ( ! function_exists( 'ec_get_blog_id' ) ) {
+	function ec_get_blog_id( string $site ): int {
+		$GLOBALS['local_scene_blog_requests'][] = $site;
+		return $GLOBALS['local_scene_events_blog_id'] ?? 7;
+	}
+}
+if ( ! function_exists( 'ec_get_network_bot_user_id' ) ) {
+	function ec_get_network_bot_user_id(): int { return 99; }
+}
+if ( ! function_exists( 'get_userdata' ) ) {
+	function get_userdata( $user_id ) {
+		if ( isset( $GLOBALS['ec_test_existing_user_ids'] ) ) {
+			return in_array( (int) $user_id, $GLOBALS['ec_test_existing_user_ids'], true ) ? (object) array( 'ID' => (int) $user_id ) : false;
+		}
+		return $GLOBALS['local_scene_users'][ $user_id ] ?? null;
+	}
+}
+if ( ! function_exists( 'ec_users_notify_with_receipts' ) ) {
+	function ec_users_notify_with_receipts( $ids, array $payload ): array {
+		$GLOBALS['local_scene_notifications'][] = compact( 'ids', 'payload' );
+		$status          = array_shift( $GLOBALS['local_scene_receipt_statuses'] );
+		$notification_id = $GLOBALS['local_scene_notification_id'] ?? 123;
+		return array( 'recipients' => array( $ids[0] => array( 'status' => $status ?: 'inserted', 'notification_id' => $notification_id, 'error' => $GLOBALS['local_scene_receipt_error'] ?? null ) ) );
+	}
+}
+if ( ! function_exists( 'ec_users_release_notification_receipt' ) ) {
+	function ec_users_release_notification_receipt( int $notification_id, int $user_id, string $producer, string $idempotency_key ): bool {
+		$GLOBALS['local_scene_releases'][] = compact( 'notification_id', 'user_id', 'producer', 'idempotency_key' );
+		return $GLOBALS['local_scene_release_result'] ?? true;
+	}
+}
+if ( ! function_exists( 'ec_send_email_queued' ) ) {
+	function ec_send_email_queued( array $args ) {
+		$GLOBALS['local_scene_emails'][] = $args;
+		return $GLOBALS['local_scene_queue_result'] ?? array( 'success' => true );
+	}
+}
+if ( ! function_exists( 'get_terms' ) ) {
+	function get_terms() { return $GLOBALS['local_scene_locations'] ?? array(); }
+}
+if ( ! function_exists( 'get_ancestors' ) ) {
+	function get_ancestors() { return array( 2, 1 ); }
+}
+if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) ) {
+	function extrachill_users_entity_subscription_recipients( $producer, $type, $taxonomy, $slug, $delivery = 'notification' ) {
+		if ( isset( $GLOBALS['festival_notification_recipients'] ) ) {
+			$GLOBALS['festival_notification_resolutions'][] = array(
+				'producer'    => $producer,
+				'entity_type' => $type,
+				'taxonomy'    => $taxonomy,
+				'slug'        => $slug,
+			);
+			return $GLOBALS['festival_notification_recipients'][ $slug ] ?? array();
+		}
+		$GLOBALS['local_scene_recipient_resolutions'][] = compact( 'producer', 'type', 'taxonomy', 'slug', 'delivery' );
+		return $GLOBALS['local_scene_recipients'][ $delivery ] ?? array();
+	}
+}
+if ( ! function_exists( 'extrachill_users_get_local_scene' ) ) {
+	function extrachill_users_get_local_scene( $user_id ) {
+		if ( isset( $GLOBALS['festival_notification_scenes'] ) ) {
+			return $GLOBALS['festival_notification_scenes'][ $user_id ] ?? null;
+		}
+		return $GLOBALS['local_scene_scenes'][ $user_id ] ?? null;
+	}
+}
+if ( ! function_exists( 'extrachill_users_unsubscribe_from_entity' ) ) {
+	function extrachill_users_unsubscribe_from_entity( $user, $type, $taxonomy, $slug ) {
+		$GLOBALS['local_scene_unsubscribes'][] = compact( 'user', 'type', 'taxonomy', 'slug' );
+		return array( 'subscribed' => false );
+	}
+}
+
+require_once dirname( __DIR__, 3 ) . '/inc/core/local-scene-digest.php';
+}
+
+/**
+ * Local Scene digest behavior.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class LocalSceneDigestTest extends TestCase {
+	private WP_Term $location;
+
+	protected function setUp(): void {
+		extrachill_events_load_local_scene_digest_test_environment();
+		$this->location = $this->term( 44, 'austin', 'Austin' );
+		$GLOBALS['local_scene_posts']           = array();
+		$GLOBALS['local_scene_filters']         = array();
+		unset( $GLOBALS['ec_test_filters']['extrachill_local_scene_digest_now'], $GLOBALS['ec_test_filters']['extrachill_local_scene_digest_candidate_cap'] );
+		unset( $GLOBALS['local_scene_query_result'], $GLOBALS['local_scene_query_total'] );
+		$GLOBALS['local_scene_event_data']      = array();
+		$GLOBALS['local_scene_terms']           = array();
+		$GLOBALS['local_scene_priority_events'] = array();
+		$GLOBALS['local_scene_priority_venues'] = array();
+		$GLOBALS['local_scene_marks']           = array();
+		$GLOBALS['local_scene_mark_checks']     = array();
+		$GLOBALS['local_scene_blog_requests']   = array();
+		$GLOBALS['local_scene_events_blog_id']  = 7;
+		$GLOBALS['local_scene_users']           = array( 7 => new WP_User( 'fan@example.com' ), 99 => new WP_User( 'bot@example.com' ) );
+		$GLOBALS['local_scene_notifications']   = array();
+		$GLOBALS['local_scene_receipt_statuses'] = array();
+		$GLOBALS['local_scene_notification_id'] = 123;
+		$GLOBALS['local_scene_receipt_error']   = null;
+		$GLOBALS['local_scene_emails']          = array();
+		$GLOBALS['local_scene_queue_result']    = array( 'success' => true );
+		$GLOBALS['local_scene_releases']        = array();
+		$GLOBALS['local_scene_release_result']  = true;
+		$GLOBALS['local_scene_unsubscribes']    = array();
+		$GLOBALS['local_scene_locations']       = array( $this->location );
+		$GLOBALS['local_scene_recipients']      = array( 'notification' => array(), 'email' => array() );
+		$GLOBALS['local_scene_scenes']          = array();
+		$GLOBALS['local_scene_recipient_resolutions'] = array();
+		$GLOBALS['local_scene_query_params']    = array();
+		$GLOBALS['test_term_ancestors'] = array( 2, 1 );
+	}
+
+	public function test_specific_entity_mapping_and_producer_authorization_are_bounded(): void {
+		$entities = extrachill_events_local_scene_digest_subscription_entities( array( 'location' => 'location' ) );
+		$this->assertSame( 'location', $entities['local_scene_digest'] );
+		$entity = array( 'entity_type' => 'local_scene_digest', 'taxonomy' => 'location' );
+		$this->assertTrue( extrachill_events_authorize_local_scene_digest_producer( false, EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_PRODUCER, $entity, 'email' ) );
+		$this->assertFalse( extrachill_events_authorize_local_scene_digest_producer( false, EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_PRODUCER, array( 'entity_type' => 'location', 'taxonomy' => 'location' ), 'email' ) );
+		$this->assertFalse( extrachill_events_authorize_local_scene_digest_producer( false, EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_PRODUCER, array( 'entity_type' => 'artist', 'taxonomy' => 'artist' ), 'email' ) );
+		$this->assertFalse( extrachill_events_authorize_local_scene_digest_producer( false, 'other', $entity, 'email' ) );
+	}
+
+	public function test_candidates_enforce_venue_local_window_city_status_and_datetime_gates(): void {
+		$austin = new DateTimeZone( 'America/Chicago' );
+		$today  = new DateTimeImmutable( 'tomorrow', $austin );
+		foreach ( range( 1, 13 ) as $id ) {
+			$GLOBALS['local_scene_posts'][] = new WP_Post( array( 'ID' => $id, 'post_status' => 'publish', 'post_title' => $id < 3 ? 'Same Show!' : 'Show ' . $id ) );
+			$GLOBALS['local_scene_terms'][ $id ] = array( 'location' => array( 44 ), 'venue' => array( $this->term( 10, 'club', 'Club' ) ), 'artist' => array( $id ) );
+			$GLOBALS['local_scene_event_data'][ $id ] = array( 'startDate' => $today->format( 'Y-m-d' ), 'startTime' => '20:00:00', 'endTime' => '22:00:00', 'venueTimezone' => 'America/Chicago', 'performer' => 'Band' );
+		}
+		$GLOBALS['local_scene_priority_events']            = array( 2 );
+		$GLOBALS['local_scene_terms'][3]['location']       = array( 55 );
+		$GLOBALS['local_scene_event_data'][4]['eventStatus'] = 'EventCancelled';
+		$GLOBALS['local_scene_event_data'][5]['eventStatus'] = 'EventPostponed';
+		$GLOBALS['local_scene_event_data'][6]['startTime'] = '00:00:00';
+		$GLOBALS['local_scene_terms'][7]['venue'][]        = $this->term( 11, 'other', 'Other' );
+		$GLOBALS['local_scene_event_data'][8]['venueTimezone'] = 'Not/A_Timezone';
+		$GLOBALS['local_scene_event_data'][9]['endTime']       = 'not-a-time';
+		$GLOBALS['local_scene_event_data'][10]['endTime']      = '19:00:00';
+		$GLOBALS['local_scene_event_data'][11]['eventStatus']  = 'EventUnknown';
+		$GLOBALS['local_scene_event_data'][12]['startDate']    = $today->modify( '+8 days' )->format( 'Y-m-d' );
+		unset( $GLOBALS['local_scene_event_data'][13]['venueTimezone'] );
+
+		$result = extrachill_events_local_scene_digest_candidates( $this->location, 7 );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 2, $result[0]['post_id'], 'The priority duplicate should win deterministically.' );
+		$this->assertSame( array( 44 ), $GLOBALS['local_scene_query_params'][0]['tax_filters']['location'] );
+		$this->assertSame( 'publish', $GLOBALS['local_scene_query_params'][0]['status'] );
+		$this->assertSame( 'America/Chicago', $result[0]['datetime']->getTimezone()->getName() );
+		$this->assertSame( '22:00', $result[0]['end_datetime']->format( 'H:i' ) );
+		$this->assertLessThan( $today->format( 'Y-m-d' ), $GLOBALS['local_scene_query_params'][0]['date_start'] );
+	}
+
+	public function test_candidates_use_venue_local_rolling_boundaries_and_bounded_query(): void {
+		$timezone = new DateTimeZone( 'America/Chicago' );
+		$now      = new DateTimeImmutable( '2030-07-15 12:00:00', $timezone );
+		$GLOBALS['local_scene_filters'] = array(
+			'extrachill_local_scene_digest_now'           => $now->getTimestamp(),
+			'extrachill_local_scene_digest_candidate_cap' => 37,
+		);
+		add_filter( 'extrachill_local_scene_digest_now', static fn() => $now->getTimestamp() );
+		add_filter( 'extrachill_local_scene_digest_candidate_cap', static fn() => 37 );
+		$dates = array(
+			1 => $now->modify( '-1 second' ),
+			2 => $now,
+			3 => $now->modify( '+7 days -1 second' ),
+			4 => $now->modify( '+7 days' ),
+		);
+		foreach ( $dates as $id => $date ) {
+			$GLOBALS['local_scene_posts'][] = new WP_Post( array( 'ID' => $id, 'post_status' => 'publish', 'post_title' => 'Boundary ' . $id ) );
+			$GLOBALS['local_scene_terms'][ $id ] = array( 'location' => array( 44 ), 'venue' => array( $this->term( 10 + $id, 'club-' . $id, 'Club ' . $id ) ), 'artist' => array( $id ) );
+			$GLOBALS['local_scene_event_data'][ $id ] = array( 'startDate' => $date->format( 'Y-m-d' ), 'startTime' => $date->format( 'H:i:s' ), 'venueTimezone' => 'America/Chicago' );
+		}
+		$evidence = array();
+
+		$result = extrachill_events_local_scene_digest_candidates( $this->location, 7, $evidence );
+
+		$this->assertSame( array( 2, 3 ), array_column( $result, 'post_id' ) );
+		$this->assertSame( 38, $GLOBALS['local_scene_query_params'][0]['per_page'] );
+		$this->assertFalse( $evidence['truncated'] );
+		$this->assertFalse( $evidence['failed'] );
+	}
+
+	public function test_candidate_truncation_uses_cap_plus_one_contract_and_slices_before_hydration(): void {
+		$now = new DateTimeImmutable( '2030-07-15 12:00:00', new DateTimeZone( 'America/Chicago' ) );
+		add_filter( 'extrachill_local_scene_digest_now', static fn() => $now->getTimestamp() );
+		add_filter( 'extrachill_local_scene_digest_candidate_cap', static fn() => 20 );
+		foreach ( range( 1, 21 ) as $id ) {
+			$GLOBALS['local_scene_posts'][] = new WP_Post( array( 'ID' => $id, 'post_status' => 'publish', 'post_title' => 'Capped ' . $id ) );
+			$GLOBALS['local_scene_terms'][ $id ] = array( 'location' => array( 44 ), 'venue' => array( $this->term( 100 + $id, 'venue-' . $id, 'Venue ' . $id ) ), 'artist' => array( $id ) );
+			$GLOBALS['local_scene_event_data'][ $id ] = array( 'startDate' => '2030-07-16', 'startTime' => '20:00:00', 'venueTimezone' => 'America/Chicago' );
+		}
+		$evidence = array();
+
+		$result = extrachill_events_local_scene_digest_candidates( $this->location, 7, $evidence );
+
+		$this->assertSame( 21, $GLOBALS['local_scene_query_params'][0]['per_page'] );
+		$this->assertTrue( $evidence['truncated'] );
+		$this->assertCount( 20, $result );
+		$this->assertNotContains( 21, array_column( $result, 'post_id' ) );
+	}
+
+	public function test_candidate_query_failure_returns_privacy_safe_evidence(): void {
+		$GLOBALS['local_scene_query_result'] = false;
+		$evidence = array();
+
+		$this->assertSame( array(), extrachill_events_local_scene_digest_candidates( $this->location, 7, $evidence ) );
+		$this->assertSame( array( 'failed' => true, 'truncated' => false ), $evidence );
+
+		$run = extrachill_events_run_local_scene_digest();
+		$this->assertSame( 1, $run['counts']['candidate_query_failures'] );
+		$this->assertSame( 1, $run['counts']['retryable_failures'] );
+		$this->assertTrue( $run['retryable_failure'] );
+		$this->assertSame( 1, $run['failures']['candidate_query_failed'] );
+		$this->assertStringNotContainsString( 'austin', json_encode( $run ) );
+	}
+
+	public function test_priority_ordering_going_partition_and_sparse_behavior(): void {
+		$base = new DateTimeImmutable( 'tomorrow 18:00', wp_timezone() );
+		$events = array(
+			$this->event( 1, $base, false, false, 4, true ),
+			$this->event( 2, $base->modify( '+1 hour' ), true, false, 1, false ),
+			$this->event( 3, $base->modify( '+2 hours' ), false, true, 4, true ),
+		);
+		usort( $events, 'extrachill_events_compare_local_scene_digest_events' );
+		$this->assertSame( array( 2, 3, 1 ), array_column( $events, 'post_id' ) );
+
+		$GLOBALS['local_scene_marks'][7][1] = true;
+		$selected = extrachill_events_select_local_scene_digest_events( $events, 7, 8 );
+		$this->assertSame( array( 1, 2, 3 ), array_column( $selected, 'post_id' ) );
+		$this->assertCount( 3, $selected, 'Sparse scenes send every qualified event.' );
+		$this->assertNotEmpty( $GLOBALS['local_scene_mark_checks'] );
+		$this->assertSame( array( 7 ), array_values( array_unique( array_column( $GLOBALS['local_scene_mark_checks'], 'blog_id' ) ) ) );
+		$this->assertContains( 'events', $GLOBALS['local_scene_blog_requests'] );
+	}
+
+	public function test_attendance_fails_closed_without_canonical_events_blog(): void {
+		$GLOBALS['local_scene_events_blog_id'] = 0;
+		$this->assertSame( array(), extrachill_events_select_local_scene_digest_events( array( $this->event( 1, new DateTimeImmutable( 'tomorrow' ) ) ), 7, 8 ) );
+	}
+
+	public function test_dense_selection_caps_repeated_venues_and_performers_when_alternatives_exist(): void {
+		$base   = new DateTimeImmutable( 'tomorrow 18:00', wp_timezone() );
+		$events = array();
+		foreach ( range( 1, 10 ) as $id ) {
+			$event                   = $this->event( $id, $base->modify( '+' . $id . ' hours' ) );
+			$event['venue_id']       = $id <= 4 ? 1 : $id;
+			$event['performer_keys'] = array( $id <= 4 ? 'term:1' : 'term:' . $id );
+			$events[]                = $event;
+		}
+
+		$selected = extrachill_events_select_local_scene_digest_events( $events, 7, 8 );
+		$this->assertCount( 8, $selected );
+		$this->assertCount( 2, array_filter( $selected, static fn( $event ) => 1 === $event['venue_id'] ) );
+		$this->assertCount( 2, array_filter( $selected, static fn( $event ) => in_array( 'term:1', $event['performer_keys'], true ) ) );
+	}
+
+	public function test_receipt_replay_never_queues_a_second_email(): void {
+		$events = array( $this->event( 1, new DateTimeImmutable( 'tomorrow 20:00', wp_timezone() ) ) );
+		$GLOBALS['local_scene_receipt_statuses'] = array( 'inserted', 'existing' );
+
+		$first  = extrachill_events_deliver_local_scene_digest( 7, $this->location, $events, true );
+		$replay = extrachill_events_deliver_local_scene_digest( 7, $this->location, $events, true );
+
+		$this->assertTrue( $first['email_queued'] );
+		$this->assertSame( 'existing', $replay['status'] );
+		$this->assertFalse( $replay['email_queued'] );
+		$this->assertCount( 1, $GLOBALS['local_scene_emails'] );
+		$this->assertStringContainsString( "More This Week", $GLOBALS['local_scene_emails'][0]['context']['body_html'] );
+		$this->assertTrue( $GLOBALS['local_scene_notifications'][0]['payload']['producer_owns_email'] );
+		$this->assertEmpty( $GLOBALS['local_scene_releases'], 'Successful delivery and replay must retain the receipt.' );
+	}
+
+	public function test_master_suppressed_delivery_retains_suppressed_notification_without_queueing(): void {
+		$events = array( $this->event( 1, new DateTimeImmutable( 'tomorrow 20:00', wp_timezone() ) ) );
+
+		$result = extrachill_events_deliver_local_scene_digest( 7, $this->location, $events, false );
+
+		$this->assertSame( 'inserted', $result['status'] );
+		$this->assertFalse( $result['email_queued'] );
+		$this->assertFalse( $result['email_failed'] );
+		$this->assertEmpty( $GLOBALS['local_scene_emails'] );
+		$this->assertEmpty( $GLOBALS['local_scene_releases'] );
+		$this->assertTrue( $GLOBALS['local_scene_notifications'][0]['payload']['producer_owns_email'] );
+	}
+
+	public function test_queue_errors_and_non_array_results_fail_closed(): void {
+		$events = array( $this->event( 1, new DateTimeImmutable( 'tomorrow 20:00', new DateTimeZone( 'America/Chicago' ) ) ) );
+		$GLOBALS['local_scene_queue_result'] = new WP_Error( 'queue_failed' );
+		$failed = extrachill_events_deliver_local_scene_digest( 7, $this->location, $events, true );
+		$this->assertFalse( $failed['email_queued'] );
+		$this->assertTrue( $failed['email_failed'] );
+		$this->assertTrue( $failed['receipt_released'] );
+		$this->assertTrue( $failed['retryable_failure'] );
+		$this->assertSame( 'inserted', $failed['status'] );
+		$this->assertSame( 'email_enqueue_failed', $failed['reason'] );
+		$this->assertSame(
+			array(
+				'notification_id' => 123,
+				'user_id'         => 7,
+				'producer'        => EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_PRODUCER,
+				'idempotency_key' => $GLOBALS['local_scene_notifications'][0]['payload']['idempotency_key'],
+			),
+			$GLOBALS['local_scene_releases'][0]
+		);
+
+		$GLOBALS['local_scene_receipt_statuses'] = array( 'inserted' );
+		$GLOBALS['local_scene_queue_result'] = false;
+		$non_array = extrachill_events_deliver_local_scene_digest( 7, $this->location, $events, true );
+		$this->assertFalse( $non_array['email_queued'] );
+		$this->assertTrue( $non_array['email_failed'] );
+		$this->assertTrue( $non_array['receipt_released'] );
+		$this->assertTrue( $non_array['retryable_failure'] );
+		$this->assertCount( 2, $GLOBALS['local_scene_releases'] );
+		$this->assertSame( $GLOBALS['local_scene_releases'][0], $GLOBALS['local_scene_releases'][1] );
+	}
+
+	public function test_email_preflight_failures_release_exact_receipt_but_malformed_receipts_do_not_queue(): void {
+		$events = array( $this->event( 1, new DateTimeImmutable( 'tomorrow 20:00', wp_timezone() ) ) );
+		unset( $GLOBALS['local_scene_users'][7] );
+
+		$invalid_user = extrachill_events_deliver_local_scene_digest( 7, $this->location, $events, true );
+		$this->assertTrue( $invalid_user['email_failed'] );
+		$this->assertFalse( $invalid_user['retryable_failure'] );
+		$this->assertSame(
+			array(
+				'notification_id' => 123,
+				'user_id'         => 7,
+				'producer'        => EXTRACHILL_EVENTS_LOCAL_SCENE_DIGEST_PRODUCER,
+				'idempotency_key' => $GLOBALS['local_scene_notifications'][0]['payload']['idempotency_key'],
+			),
+			$GLOBALS['local_scene_releases'][0]
+		);
+		$this->assertEmpty( $GLOBALS['local_scene_emails'] );
+
+		$GLOBALS['local_scene_users'][7]         = new WP_User( 'fan@example.com' );
+		$GLOBALS['local_scene_notification_id'] = 0;
+		$malformed = extrachill_events_deliver_local_scene_digest( 7, $this->location, $events, true );
+		$this->assertSame( 'failed', $malformed['status'] );
+		$this->assertSame( 'invalid_delivery_receipt', $malformed['reason'] );
+		$this->assertFalse( $malformed['email_queued'] );
+		$this->assertCount( 1, $GLOBALS['local_scene_releases'], 'No exact receipt exists to release.' );
+
+		$GLOBALS['local_scene_notification_id'] = 123;
+		$GLOBALS['local_scene_events_blog_id']  = 0;
+		$invalid_email = extrachill_events_deliver_local_scene_digest( 7, $this->location, $events, true );
+		$this->assertTrue( $invalid_email['email_failed'] );
+		$this->assertFalse( $invalid_email['retryable_failure'] );
+		$this->assertSame( 'email_enqueue_failed', $invalid_email['reason'] );
+		$this->assertCount( 2, $GLOBALS['local_scene_releases'] );
+		$this->assertSame( $GLOBALS['local_scene_releases'][0], $GLOBALS['local_scene_releases'][1] );
+	}
+
+	public function test_release_failure_keeps_notification_status_and_reports_email_failure(): void {
+		$GLOBALS['local_scene_queue_result']   = new WP_Error( 'queue_failed' );
+		$GLOBALS['local_scene_release_result'] = false;
+		$result = extrachill_events_deliver_local_scene_digest( 7, $this->location, array( $this->event( 1, new DateTimeImmutable( 'tomorrow 20:00', wp_timezone() ) ) ), true );
+
+		$this->assertSame( 'inserted', $result['status'] );
+		$this->assertTrue( $result['email_failed'] );
+		$this->assertFalse( $result['receipt_released'] );
+		$this->assertFalse( $result['retryable_failure'] );
+		$this->assertSame( 'email_receipt_release_failed', $result['reason'] );
+	}
+
+	public function test_receipt_errors_are_propagated_as_stable_privacy_safe_reasons(): void {
+		$GLOBALS['local_scene_receipt_statuses'] = array( 'failed', 'failed' );
+		$GLOBALS['local_scene_receipt_error']    = 'insert_failed';
+		$known = extrachill_events_deliver_local_scene_digest( 7, $this->location, array( $this->event( 1, new DateTimeImmutable( 'tomorrow' ) ) ), true );
+		$this->assertSame( 'notification_insert_failed', $known['reason'] );
+
+		$GLOBALS['local_scene_receipt_error'] = 'recipient@example.com';
+		$unknown = extrachill_events_deliver_local_scene_digest( 7, $this->location, array( $this->event( 1, new DateTimeImmutable( 'tomorrow' ) ) ), true );
+		$this->assertSame( 'notification_receipt_failed', $unknown['reason'] );
+		$this->assertStringNotContainsString( 'example', $unknown['reason'] );
+	}
+
+	public function test_aggregate_counts_separate_notification_success_from_email_admission_failure(): void {
+		$tomorrow = new DateTimeImmutable( 'tomorrow', wp_timezone() );
+		$GLOBALS['local_scene_posts'] = array( new WP_Post( array( 'ID' => 8, 'post_status' => 'publish', 'post_title' => 'Qualified Show' ) ) );
+		$GLOBALS['local_scene_terms'][8] = array( 'location' => array( 44 ), 'venue' => array( $this->term( 10, 'club', 'Club' ) ), 'artist' => array( 3 ) );
+		$GLOBALS['local_scene_event_data'][8] = array( 'startDate' => $tomorrow->format( 'Y-m-d' ), 'startTime' => '20:00:00', 'venueTimezone' => 'America/New_York' );
+		$GLOBALS['local_scene_recipients'] = array( 'notification' => array( 7 ), 'email' => array( 7 ) );
+		$GLOBALS['local_scene_scenes'][7] = array( 'slug' => 'austin' );
+		$GLOBALS['local_scene_queue_result'] = new WP_Error( 'queue_failed' );
+		add_filter( 'extrachill_local_scene_digest_candidate_cap', static fn() => 20 );
+		foreach ( range( 9, 28 ) as $id ) {
+			$GLOBALS['local_scene_posts'][] = new WP_Post( array( 'ID' => $id, 'post_status' => 'publish', 'post_title' => 'Extra Show ' . $id ) );
+			$GLOBALS['local_scene_terms'][ $id ] = array( 'location' => array( 44 ), 'venue' => array( $this->term( 100 + $id, 'club-' . $id, 'Club ' . $id ) ), 'artist' => array( $id ) );
+			$GLOBALS['local_scene_event_data'][ $id ] = array( 'startDate' => $tomorrow->format( 'Y-m-d' ), 'startTime' => '21:00:00', 'venueTimezone' => 'America/New_York' );
+		}
+
+		$result = extrachill_events_run_local_scene_digest();
+
+		$this->assertSame( 1, $result['counts']['notifications_inserted'] );
+		$this->assertSame( 0, $result['counts']['notification_failures'] );
+		$this->assertSame( 0, $result['counts']['emails_queued'] );
+		$this->assertSame( 1, $result['counts']['email_failures'] );
+		$this->assertSame( 1, $result['counts']['notifications_released'] );
+		$this->assertSame( 1, $result['counts']['retryable_failures'] );
+		$this->assertTrue( $result['retryable_failure'] );
+		$this->assertSame( 1, $result['failures']['email_enqueue_failed'] );
+		$this->assertSame( 1, $result['counts']['candidate_queries_truncated'] );
+		$this->assertSame( 1, $result['failures']['candidate_query_truncated'] );
+		$this->assertCount( 1, $GLOBALS['local_scene_releases'] );
+
+		$GLOBALS['local_scene_posts']                     = array_slice( $GLOBALS['local_scene_posts'], 0, 1 );
+		$GLOBALS['ec_test_filters']['extrachill_local_scene_digest_candidate_cap'] = array();
+		$GLOBALS['local_scene_recipients']['email'] = array();
+		$GLOBALS['local_scene_releases']            = array();
+		$GLOBALS['local_scene_queue_result']        = array( 'success' => true );
+		$master_suppressed = extrachill_events_run_local_scene_digest();
+		$this->assertSame( 1, $master_suppressed['counts']['notifications_inserted'] );
+		$this->assertSame( 0, $master_suppressed['counts']['emails_queued'] );
+		$this->assertSame( 0, $master_suppressed['counts']['email_failures'] );
+		$this->assertSame( 0, $master_suppressed['counts']['notifications_released'] );
+		$this->assertEmpty( $master_suppressed['failures'] );
+		$this->assertFalse( $master_suppressed['retryable_failure'] );
+		$this->assertEmpty( $GLOBALS['local_scene_releases'] );
+
+		$GLOBALS['local_scene_recipients']['email'] = array( 7 );
+		$GLOBALS['local_scene_receipt_statuses']    = array( 'existing' );
+		$replay = extrachill_events_run_local_scene_digest();
+		$this->assertSame( 1, $replay['counts']['notifications_existing'] );
+		$this->assertSame( 0, $replay['counts']['emails_queued'] );
+		$this->assertSame( 0, $replay['counts']['email_failures'] );
+		$this->assertSame( 0, $replay['counts']['notifications_released'] );
+		$this->assertEmpty( $replay['failures'] );
+		$this->assertFalse( $replay['retryable_failure'] );
+		$this->assertEmpty( $GLOBALS['local_scene_releases'] );
+	}
+
+	public function test_runner_marks_location_and_recipient_resolution_failures_retryable(): void {
+		$GLOBALS['local_scene_locations'] = new WP_Error( 'location_query_failed' );
+		$location_failure = extrachill_events_run_local_scene_digest();
+		$this->assertTrue( $location_failure['retryable_failure'] );
+		$this->assertSame( 1, $location_failure['counts']['retryable_failures'] );
+		$this->assertSame( 1, $location_failure['failures']['location_query_failed'] );
+
+		$GLOBALS['local_scene_locations'] = array( $this->location );
+		$tomorrow = new DateTimeImmutable( 'tomorrow', wp_timezone() );
+		$GLOBALS['local_scene_posts'] = array( new WP_Post( array( 'ID' => 8, 'post_status' => 'publish', 'post_title' => 'Qualified Show' ) ) );
+		$GLOBALS['local_scene_terms'][8] = array( 'location' => array( 44 ), 'venue' => array( $this->term( 10, 'club', 'Club' ) ), 'artist' => array( 3 ) );
+		$GLOBALS['local_scene_event_data'][8] = array( 'startDate' => $tomorrow->format( 'Y-m-d' ), 'startTime' => '20:00:00', 'venueTimezone' => 'America/New_York' );
+		$GLOBALS['local_scene_recipients']['notification'] = new WP_Error( 'recipient_query_failed' );
+		$recipient_failure = extrachill_events_run_local_scene_digest();
+		$this->assertTrue( $recipient_failure['retryable_failure'] );
+		$this->assertSame( 1, $recipient_failure['counts']['retryable_failures'] );
+		$this->assertSame( 1, $recipient_failure['failures']['recipient_resolution_failed'] );
+	}
+
+	public function test_austin_times_render_in_venue_timezone_with_explicit_end(): void {
+		$start = new DateTimeImmutable( '2030-07-15 20:00:00', new DateTimeZone( 'America/Chicago' ) );
+		$event = $this->event( 1, $start );
+		$event['end_datetime'] = $start->modify( '+2 hours' );
+		$html = extrachill_events_render_local_scene_digest_section( 'Austin', array( $event ) );
+		$this->assertStringContainsString( 'Mon, Jul 15 at 8:00 PM - 10:00 PM', $html );
+	}
+
+	public function test_scene_mismatch_does_not_deliver_and_empty_scene_does_nothing(): void {
+		$empty = extrachill_events_run_local_scene_digest();
+		$this->assertSame( 0, $empty['counts']['recipients'] );
+		$this->assertEmpty( $GLOBALS['local_scene_recipient_resolutions'], 'Empty scenes do not resolve or deliver to an audience.' );
+
+		$tomorrow = new DateTimeImmutable( 'tomorrow', wp_timezone() );
+		$GLOBALS['local_scene_posts'] = array( new WP_Post( array( 'ID' => 8, 'post_status' => 'publish', 'post_title' => 'Qualified Show' ) ) );
+		$GLOBALS['local_scene_terms'][8] = array( 'location' => array( 44 ), 'venue' => array( $this->term( 10, 'club', 'Club' ) ), 'artist' => array( 3 ) );
+		$GLOBALS['local_scene_event_data'][8] = array( 'startDate' => $tomorrow->format( 'Y-m-d' ), 'startTime' => '20:00:00', 'venueTimezone' => 'America/New_York' );
+		$GLOBALS['local_scene_recipients'] = array( 'notification' => array( 7 ), 'email' => array( 7 ) );
+		$GLOBALS['local_scene_scenes'][7] = array( 'slug' => 'denver' );
+
+		$mismatch = extrachill_events_run_local_scene_digest();
+		$this->assertSame( 1, $mismatch['counts']['scene_mismatches'] );
+		$this->assertSame( 0, $mismatch['counts']['notifications_inserted'] );
+		$this->assertEmpty( $GLOBALS['local_scene_notifications'] );
+		$this->assertSame( array( 'local_scene_digest', 'local_scene_digest' ), array_column( $GLOBALS['local_scene_recipient_resolutions'], 'type' ) );
+		$this->assertSame( array( 'location', 'location' ), array_column( $GLOBALS['local_scene_recipient_resolutions'], 'taxonomy' ) );
+		$evidence = json_encode( $mismatch );
+		$this->assertStringNotContainsString( 'austin', $evidence );
+		$this->assertStringNotContainsString( 'denver', $evidence );
+		$this->assertStringNotContainsString( 'fan@example.com', $evidence );
+	}
+
+	public function test_unsubscribe_get_is_scanner_safe_and_post_is_location_scoped(): void {
+		$expires = time() + 60;
+		$valid   = $this->unsubscribe_request( 7, 'austin', $expires );
+		$confirmation = extrachill_events_local_scene_digest_unsubscribe_confirmation( $valid, false );
+		$this->assertSame( false, $confirmation['confirmed'] );
+		$this->assertStringContainsString( 'method="post"', $confirmation['html'] );
+		$this->assertStringContainsString( 'name="location" value="austin"', $confirmation['html'] );
+		$this->assertEmpty( $GLOBALS['local_scene_unsubscribes'], 'Signed GET must never mutate consent.' );
+
+		$result  = extrachill_events_local_scene_digest_unsubscribe( $valid, false );
+		$this->assertSame( array( 'unsubscribed' => true ), $result );
+		$this->assertSame( array( 'user' => 7, 'type' => 'local_scene_digest', 'taxonomy' => 'location', 'slug' => 'austin' ), $GLOBALS['local_scene_unsubscribes'][0] );
+
+		$tampered = $this->unsubscribe_request( 7, 'denver', $expires, hash_hmac( 'sha256', '7|austin|' . $expires, wp_salt( 'auth' ) ) );
+		$this->assertInstanceOf( WP_Error::class, extrachill_events_local_scene_digest_unsubscribe_confirmation( $tampered, false ) );
+		$this->assertInstanceOf( WP_Error::class, extrachill_events_local_scene_digest_unsubscribe( $tampered, false ) );
+		$this->assertInstanceOf( WP_Error::class, extrachill_events_local_scene_digest_unsubscribe( $this->unsubscribe_request( 7, 'austin', time() - 1 ), false ) );
+		$page = extrachill_events_build_local_scene_digest_unsubscribe_page( "You're unsubscribed", 'Only this scene changed.' );
+		$this->assertStringContainsString( 'noindex,nofollow', $page );
+		$this->assertStringContainsString( 'Only this scene changed.', $page );
+	}
+
+	private function event( int $id, DateTimeImmutable $date, bool $priority_event = false, bool $priority_venue = false, int $completeness = 0, bool $has_price = false ): array {
+		return array(
+			'post_id' => $id, 'title' => 'Show ' . $id, 'url' => 'https://events.example.com/event/' . $id . '/', 'datetime' => $date,
+			'end_datetime' => null,
+			'venue_id' => $id, 'venue_name' => 'Venue ' . $id, 'performer_keys' => array( 'term:' . $id ), 'price' => $has_price ? 'Free' : '',
+			'priority_event' => $priority_event, 'priority_venue' => $priority_venue, 'completeness' => $completeness, 'has_price' => $has_price,
+		);
+	}
+
+	private function unsubscribe_request( int $user, string $slug, int $expires, ?string $signature = null ): WP_REST_Request {
+		$signature = $signature ?? hash_hmac( 'sha256', $user . '|' . $slug . '|' . $expires, wp_salt( 'auth' ) );
+		return new WP_REST_Request( array( 'user' => $user, 'location' => $slug, 'expires' => $expires, 'signature' => $signature ) );
+	}
+
+	private function term( int $id, string $slug, string $name ): WP_Term {
+		return new WP_Term( (object) array( 'term_id' => $id, 'slug' => $slug, 'name' => $name ) );
+	}
+}

--- a/tests/Unit/Core/Stubs/system-task-base-stub.php
+++ b/tests/Unit/Core/Stubs/system-task-base-stub.php
@@ -44,3 +44,14 @@ if ( ! class_exists( __NAMESPACE__ . '\\SystemTask' ) ) {
 		}
 	}
 }
+
+namespace DataMachine\Core;
+
+if ( ! class_exists( __NAMESPACE__ . '\\PluginSettings' ) ) {
+	class PluginSettings {
+		public static function get( string $key, $default = null ) {
+			$GLOBALS['ec_test_plugin_settings_reads'][] = array( $key, $default );
+			return $GLOBALS['ec_test_plugin_settings'][ $key ] ?? $default;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a city-agnostic weekly digest keyed by canonical location terms, with exact scene isolation and venue-local date handling
- add explicit digest-specific opt-in on city archives, personalized Going-first selection, bounded deterministic ranking, branded email, and scanner-safe scoped unsubscribe
- register a dry-run-safe recurring Data Machine task with aggregate privacy-safe evidence and retryable partial-failure handling

## Consent And Delivery
- saving Local Scene does not subscribe
- opt-in uses the Events-owned `local_scene_digest/location/<slug>` identity
- execution rechecks that the subscribed city still matches the user's current Local Scene
- users are told the opt-in creates weekly email and in-app updates
- producer-owned receipts suppress duplicate generic notification email and release on explicit queue-admission failure

## Dependency
Requires Extra-Chill/extrachill-users#298 for producer-owned email receipts and truthful unsubscribe failures.

## Verification
- focused PHP: 23 tests, 158 assertions
- focused JavaScript: 2 tests
- JS lint, production PHPCS, PHP syntax, and `git diff --check`: passed
- combined suite: 260 tests, 734 assertions, with the same 7 errors and 18 failures as refreshed `main`; baseline tracked in #385

## Scope
This ships the broad Local Scene primitive for any canonical city. Genre and venue-format filtering remain out of scope until those classifications exist canonically.

Closes #370