### PR TITLE
fix: install booking schema on switched multisite blogs

### DIFF
--- a/phpunit-managed.xml.dist
+++ b/phpunit-managed.xml.dist
@@ -18,6 +18,7 @@
 			<file>tests/Unit/FestivalNotificationsTest.php</file>
 			<file>tests/Unit/SingleEventNetworkBridgeTest.php</file>
 			<file>tests/Unit/ConcertStatsPublicProfileRenderTest.php</file>
+			<file>tests/MySQLIntegration/BookingSchemaMultisiteTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/MySQLIntegration/BookingSchemaMultisiteTest.php
+++ b/tests/MySQLIntegration/BookingSchemaMultisiteTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Booking schema coverage on the canonical Events multisite blog.
+ *
+ * @package ExtraChillEvents\Tests\MySQLIntegration
+ */
+
+use ExtraChillEvents\Core\BookingSchema;
+
+/** Proves the managed bootstrap installs the site-scoped schema idempotently. */
+final class BookingSchemaMultisiteTest extends WP_UnitTestCase {
+
+	/** Verify every table belongs to blog 7 and survives a repeated install. */
+	public function test_installs_and_verifies_current_prefix_tables_after_switch(): void {
+		global $wpdb;
+
+		$this->assertTrue( is_multisite() );
+		$this->assertSame( 1, get_current_blog_id() );
+
+		switch_to_blog( 7 );
+		try {
+			$prefix = $wpdb->get_blog_prefix( 7 );
+			$tables = array(
+				BookingSchema::bookings_table(),
+				BookingSchema::activity_table(),
+				BookingSchema::communication_state_table(),
+				BookingSchema::attachments_table(),
+				BookingSchema::attachment_deliveries_table(),
+				BookingSchema::memberships_table(),
+				BookingSchema::claims_table(),
+				BookingSchema::invitations_table(),
+				BookingSchema::onboarding_audit_table(),
+				BookingSchema::holds_table(),
+				BookingSchema::sales_reports_table(),
+				BookingSchema::settlements_table(),
+			);
+
+			$this->assertSame( $prefix, $wpdb->prefix );
+			$this->assertTrue( BookingSchema::is_ready() );
+			$this->assertTrue( BookingSchema::health() );
+			$this->assertCount( 12, $tables );
+			foreach ( $tables as $table ) {
+				$this->assertStringStartsWith( $prefix, $table );
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema integration assertion.
+				$this->assertSame( $table, $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) );
+			}
+
+			$this->assertTrue( BookingSchema::install() );
+			$this->assertTrue( BookingSchema::health() );
+		} finally {
+			restore_current_blog();
+		}
+
+		$this->assertSame( 1, get_current_blog_id() );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -134,12 +134,24 @@ require_once dirname( __DIR__ ) . '/inc/Core/QualifyFingerprinter.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueQualificationAbilities.php';
 
 // Managed multisite tests exercise the production network's Events blog ID.
-if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site' ) && function_exists( 'wpmu_create_blog' ) && ! get_site( 7 ) ) {
+if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site' ) && function_exists( 'wpmu_create_blog' ) ) {
 	while ( ! get_site( 7 ) ) {
 		$next_id = get_sites( array( 'count' => true ) ) + 1;
 		$created = wpmu_create_blog( 'site-' . $next_id . '.example.org', '/', 'Test Site ' . $next_id, 1 );
 		if ( is_wp_error( $created ) || (int) $created > 7 ) {
 			throw new RuntimeException( 'Unable to provision the Events multisite test fixture.' );
 		}
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/Core/BookingSchema.php';
+	switch_to_blog( 7 );
+	try {
+		$booking_schema = ExtraChillEvents\Core\BookingSchema::install();
+		if ( true !== $booking_schema ) {
+			$failure = is_wp_error( $booking_schema ) ? $booking_schema->get_error_code() . ': ' . wp_json_encode( $booking_schema->get_error_data() ) : 'unknown error';
+			throw new RuntimeException( 'Unable to provision the Events booking schema: ' . $failure );
+		}
+	} finally {
+		restore_current_blog();
 	}
 }


### PR DESCRIPTION
## Summary
- install and verify the production booking schema after the managed bootstrap provisions canonical Events blog 7
- add a focused MySQL/multisite regression covering all 12 current-prefix tables and a repeated idempotent install
- keep production `BookingSchema` unchanged because WordPress core and the managed MySQL evidence confirm its current-blog behavior is correct

## Root cause
The managed baseline from #355 provisions blog 7 after WordPress and the plugin have already booted, but it did not run the site-scoped booking installer in that newly created blog context. `BookingSchema::install()` already derives every table from the live `$wpdb->prefix`; WordPress core's `switch_to_blog()` calls `$wpdb->set_blog_id()`, which updates that prefix before `dbDelta()` receives the `CREATE TABLE` statements. The missing table was therefore an incomplete managed bootstrap lifecycle, not a production table-name or `dbDelta()` defect.

## Changed contracts
- `tests/bootstrap.php`: after ensuring blog 7 exists, switch to it, run the real production installer, fail bootstrap on any schema error, and always restore the original blog.
- `tests/MySQLIntegration/BookingSchemaMultisiteTest.php`: assert blog-7 prefix selection, readiness, full health, all 12 physical tables, repeated installation, and blog restoration.
- `phpunit-managed.xml.dist`: include the focused regression in the pinned managed WordPress suite.

## Evidence
- Local isolated suites: 80 tests, 506 assertions passing (artist 13/40, venue 44/308, Local Scene 23/158).
- Local Homeboy review lint: PHPCS, ESLint, and PHPStan passing with no findings.
- Faithful managed evidence will be updated here from this PR's pinned MySQL/multisite CI run; local managed execution was not substituted with SQLite.
- Existing consumer confirmation: PR #384 managed MySQL 8.4/multisite run 30234629203 passed its alpha test with 1 test and 186 assertions after preloading equivalent site-scoped provisioning.

## Compatibility and idempotency
The production installer and runtime hooks are unchanged. Existing sites continue using the same version-gated request path. First-install managed environments now execute the production installer only after the canonical site exists and the current blog prefix is active. Existing managed databases safely repeat the same installer; the regression explicitly calls it a second time and requires full schema health afterward.

## Relationship to #384
Draft PR #384 exposed the missing managed lifecycle and currently carries a dedicated alpha preload fixture alongside broader consumer work. This PR does not copy that alpha proof or create tables directly; it fixes the repository's owning managed bootstrap contract and independently proves the production installer.

## Residual risks
The regression depends on the pinned managed WordPress/MySQL CI runtime because the host has no disposable local MySQL service. CI remains the authoritative database evidence.

Closes #387