### PR TITLE
test: isolate qualify suite globals and fixtures

### DIFF
--- a/tests/Unit/Abilities/EventsByArtistAbilityTest.php
+++ b/tests/Unit/Abilities/EventsByArtistAbilityTest.php
@@ -141,9 +141,14 @@ require_once dirname( __DIR__, 3 ) . '/inc/abilities/events-by-artist.php';
 
 final class EventsByArtistAbilityTest extends TestCase {
 	private int $starting_blog_id = 4;
+	private $original_ability_resolver;
+	private bool $registered_test_category = false;
 
 	protected function setUp(): void {
-		$GLOBALS['ec_artist_test'] = array(
+		parent::setUp();
+		$this->original_ability_resolver     = $GLOBALS['ec_test_ability_resolver'] ?? null;
+		$GLOBALS['ec_test_ability_resolver'] = static fn() => $GLOBALS['ec_artist_test']['ability'] ?? null;
+		$GLOBALS['ec_artist_test']           = array(
 			'blog_id' => 4,
 			'stack'   => array(),
 			'terms'   => array( 1 => array(), 7 => array() ),
@@ -183,6 +188,7 @@ final class EventsByArtistAbilityTest extends TestCase {
 				wp_unregister_ability( 'data-machine-events/events-by-term' );
 			}
 			if ( ! wp_has_ability_category( 'extrachill-events-tests' ) ) {
+				$this->registered_test_category = true;
 				WP_Ability_Categories_Registry::get_instance()->register(
 					'extrachill-events-tests',
 					array(
@@ -231,6 +237,22 @@ final class EventsByArtistAbilityTest extends TestCase {
 				)
 			);
 		}
+	}
+
+	protected function tearDown(): void {
+		if ( function_exists( 'wp_unregister_ability' ) && wp_has_ability( 'data-machine-events/events-by-term' ) ) {
+			wp_unregister_ability( 'data-machine-events/events-by-term' );
+		}
+		if ( $this->registered_test_category && wp_has_ability_category( 'extrachill-events-tests' ) ) {
+			wp_unregister_ability_category( 'extrachill-events-tests' );
+		}
+		if ( null === $this->original_ability_resolver ) {
+			unset( $GLOBALS['ec_test_ability_resolver'] );
+		} else {
+			$GLOBALS['ec_test_ability_resolver'] = $this->original_ability_resolver;
+		}
+		unset( $GLOBALS['ec_artist_test'] );
+		parent::tearDown();
 	}
 
 	private function resetManagedFixture(): void {

--- a/tests/Unit/ConcertStatsPublicProfileRenderTest.php
+++ b/tests/Unit/ConcertStatsPublicProfileRenderTest.php
@@ -8,10 +8,16 @@
 final class ConcertStatsPublicProfileRenderTest extends WP_UnitTestCase {
 	private int $owner_id;
 	private int $viewer_id;
+	private int $original_user_id;
+	private array $original_get;
+	private bool $registered_test_category = false;
 
 	protected function setUp(): void {
 		parent::setUp();
+		$this->original_user_id = get_current_user_id();
+		$this->original_get     = $_GET;
 		if ( ! wp_has_ability_category( 'extrachill-events-tests' ) ) {
+			$this->registered_test_category = true;
 			WP_Ability_Categories_Registry::get_instance()->register(
 				'extrachill-events-tests',
 				array(
@@ -52,8 +58,14 @@ final class ConcertStatsPublicProfileRenderTest extends WP_UnitTestCase {
 	}
 
 	protected function tearDown(): void {
-		$_GET = array();
-		wp_set_current_user( 0 );
+		if ( wp_has_ability( 'extrachill/get-user-settings' ) ) {
+			wp_unregister_ability( 'extrachill/get-user-settings' );
+		}
+		if ( $this->registered_test_category && wp_has_ability_category( 'extrachill-events-tests' ) ) {
+			wp_unregister_ability_category( 'extrachill-events-tests' );
+		}
+		$_GET = $this->original_get;
+		wp_set_current_user( $this->original_user_id );
 		parent::tearDown();
 	}
 

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -321,9 +321,20 @@ final class AccountMarketTest extends TestCase {
 	private $original_blog_id;
 	private $ancestor_filter;
 	private $term_link_filter;
+	private $original_ability_resolver;
+	private array $original_get;
 
 	protected function setUp(): void {
 		parent::setUp();
+		$this->original_ability_resolver     = $GLOBALS['ec_test_ability_resolver'] ?? null;
+		$this->original_get                  = $_GET;
+		$GLOBALS['ec_test_ability_resolver'] = static function ( string $name ) {
+			if ( 'extrachill/get-user-settings' === $name ) {
+				return $GLOBALS['test_account_market_ability'] ?? null;
+			}
+
+			return 'extrachill/update-user-settings' === $name ? ( $GLOBALS['test_update_scene_ability'] ?? null ) : null;
+		};
 		foreach (
 			array(
 				'test_is_user_logged_in',
@@ -382,6 +393,12 @@ final class AccountMarketTest extends TestCase {
 		$GLOBALS['current_user'] = $this->original_current_user;
 		$GLOBALS['wp_query']     = $this->original_wp_query;
 		$GLOBALS['blog_id']      = $this->original_blog_id;
+		$_GET                    = $this->original_get;
+		if ( null === $this->original_ability_resolver ) {
+			unset( $GLOBALS['ec_test_ability_resolver'] );
+		} else {
+			$GLOBALS['ec_test_ability_resolver'] = $this->original_ability_resolver;
+		}
 		parent::tearDown();
 	}
 

--- a/tests/Unit/Core/QualifyRecheckHandlerTest.php
+++ b/tests/Unit/Core/QualifyRecheckHandlerTest.php
@@ -30,11 +30,26 @@ class QualifyRecheckHandlerTest extends TestCase {
 	private $original_log_hooks;
 	private $schedule_callback;
 	private $enqueue_callback;
+	private $original_ability_resolver;
+	private bool $registered_test_category = false;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->original_wpdb                  = $GLOBALS['wpdb'] ?? null;
 		$this->original_log_hooks             = $GLOBALS['wp_filter']['datamachine_log'] ?? null;
+		$this->original_ability_resolver       = $GLOBALS['ec_test_ability_resolver'] ?? null;
+		$GLOBALS['ec_test_ability_resolver']   = static function ( string $name ) {
+			if ( 'extrachill/qualify-venue' !== $name ) {
+				return null;
+			}
+
+			return new class() {
+				public function execute( array $input ) {
+					unset( $input );
+					return $GLOBALS['ec_test_ability_result'];
+				}
+			};
+		};
 		if ( function_exists( 'remove_all_actions' ) ) {
 			remove_all_actions( 'datamachine_log' );
 		}
@@ -55,7 +70,7 @@ class QualifyRecheckHandlerTest extends TestCase {
 		if ( function_exists( 'wp_unregister_ability' ) && wp_has_ability( 'extrachill/qualify-venue' ) ) {
 			wp_unregister_ability( 'extrachill/qualify-venue' );
 		}
-		if ( function_exists( 'wp_unregister_ability_category' ) && wp_has_ability_category( 'extrachill-events-tests' ) ) {
+		if ( $this->registered_test_category && function_exists( 'wp_unregister_ability_category' ) && wp_has_ability_category( 'extrachill-events-tests' ) ) {
 			wp_unregister_ability_category( 'extrachill-events-tests' );
 		}
 		remove_filter( 'pre_as_schedule_single_action', $this->schedule_callback, 10 );
@@ -66,6 +81,11 @@ class QualifyRecheckHandlerTest extends TestCase {
 			$GLOBALS['wp_filter']['datamachine_log'] = $this->original_log_hooks;
 		}
 		$GLOBALS['wpdb'] = $this->original_wpdb;
+		if ( null === $this->original_ability_resolver ) {
+			unset( $GLOBALS['ec_test_ability_resolver'] );
+		} else {
+			$GLOBALS['ec_test_ability_resolver'] = $this->original_ability_resolver;
+		}
 		unset(
 			$GLOBALS['ec_test_action_scheduler'],
 			$GLOBALS['ec_test_ability_result']
@@ -81,6 +101,7 @@ class QualifyRecheckHandlerTest extends TestCase {
 			wp_unregister_ability( 'extrachill/qualify-venue' );
 		}
 		if ( ! wp_has_ability_category( 'extrachill-events-tests' ) ) {
+			$this->registered_test_category = true;
 			\WP_Ability_Categories_Registry::get_instance()->register(
 				'extrachill-events-tests',
 				array(

--- a/tests/Unit/FestivalNotificationsTest.php
+++ b/tests/Unit/FestivalNotificationsTest.php
@@ -170,7 +170,7 @@ class FestivalNotificationsTest extends WP_UnitTestCase {
 			array(
 				'post_author' => self::factory()->user->create(),
 				'post_type'   => DATA_MACHINE_EVENTS_POST_TYPE,
-				'post_status' => 'publish',
+				'post_status' => 'draft',
 				'post_title'  => 'The Big Show',
 			)
 		);

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -851,6 +851,8 @@ require_once dirname( __DIR__ ) . '/inc/Abilities/VenueProfileAbilities.php';
  */
 final class VenueMembershipAuthorizationTest extends TestCase {
 	private $original_wpdb;
+	private $original_ability_resolver;
+	private $config_updated_callback;
 
 	private function set_current_user( int $user_id ): void {
 		if ( function_exists( 'wp_set_current_user' ) ) {
@@ -859,7 +861,8 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 	}
 
 	protected function setUp(): void {
-		$this->original_wpdb = $GLOBALS['wpdb'] ?? null;
+		$this->original_wpdb            = $GLOBALS['wpdb'] ?? null;
+		$this->original_ability_resolver = $GLOBALS['ec_test_ability_resolver'] ?? null;
 		if ( $this->original_wpdb ) {
 			$user_emails = array(
 				1 => 'admin@example.com',
@@ -1016,10 +1019,21 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 				return new WP_Error( 'unexpected_dme_update' );
 			},
 		);
+		$GLOBALS['ec_test_ability_resolver'] = static fn( string $name ) => $GLOBALS['venue_membership_test']['ability_objects'][ $name ] ?? null;
+		$this->config_updated_callback       = static function ( ...$args ): void {
+			$GLOBALS['venue_membership_test']['fired_actions']['extrachill_events_venue_booking_config_updated'][] = $args;
+		};
+		add_action( 'extrachill_events_venue_booking_config_updated', $this->config_updated_callback, 10, 3 );
 		$GLOBALS['wpdb']                  = new VenueMembershipWpdb( $this->original_wpdb );
 	}
 
 	protected function tearDown(): void {
+		remove_action( 'extrachill_events_venue_booking_config_updated', $this->config_updated_callback, 10 );
+		if ( null === $this->original_ability_resolver ) {
+			unset( $GLOBALS['ec_test_ability_resolver'] );
+		} else {
+			$GLOBALS['ec_test_ability_resolver'] = $this->original_ability_resolver;
+		}
 		$GLOBALS['wpdb'] = $this->original_wpdb;
 		$this->set_current_user( 0 );
 		parent::tearDown();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -94,6 +94,29 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	}
 }
 
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook, ...$args ) {
+		if ( empty( $GLOBALS['ec_test_filters'][ $hook ] ) ) {
+			return;
+		}
+
+		ksort( $GLOBALS['ec_test_filters'][ $hook ] );
+		foreach ( $GLOBALS['ec_test_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				call_user_func_array( $callback[0], array_slice( $args, 0, $callback[1] ) );
+			}
+		}
+	}
+}
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( $name ) {
+		$resolver = $GLOBALS['ec_test_ability_resolver'] ?? null;
+
+		return is_callable( $resolver ) ? $resolver( $name ) : null;
+	}
+}
+
 if ( ! function_exists( 'esc_url_raw' ) ) {
 	function esc_url_raw( $url ) {
 		return is_string( $url ) ? trim( $url ) : '';
@@ -102,7 +125,12 @@ if ( ! function_exists( 'esc_url_raw' ) ) {
 
 if ( ! function_exists( 'sanitize_text_field' ) ) {
 	function sanitize_text_field( $str ) {
-		return is_string( $str ) ? trim( strip_tags( $str ) ) : '';
+		if ( ! is_string( $str ) ) {
+			return '';
+		}
+
+		$str = preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $str );
+		return trim( strip_tags( $str ) );
 	}
 }
 


### PR DESCRIPTION
## Summary

- route plain-unit actions and ability lookups through owner-controlled test fixtures instead of collection-order globals
- restore ability registry, request, current-user, and dispatcher state after each owning test
- preserve the isolated venue harness contract through the shared dispatcher without changing production behavior
- create festival posts as drafts so fixture setup cannot trigger publish notifications before the explicit test call

## Evidence

- Reported issue baseline: **237 tests, 576 assertions, 7 errors, 18 failures**
- Reproduced Core one-process baseline: **206 tests, 590 assertions, 1 error, 7 failures**
- Fixed Core normal order: **206 tests, 609 assertions, 0 errors, 0 failures**
- Fixed Core random order (seed 385): **206 tests, 609 assertions, 0 errors, 0 failures**
- Fixed isolated venue suite: **44 tests, 308 assertions, 0 failures**
- Fixed isolated artist suite: **13 tests, 40 assertions, 0 failures**
- Fixed isolated Local Scene suite: **23 tests, 158 assertions, 0 failures**
- Managed WordPress baseline before this work: **224 tests, 654 assertions, 0 failures**
- Final managed WordPress run 30236689328 after rebasing onto #396: **225 tests, 687 assertions, 0 failures**
- Homeboy review lint and review test: **green**

The managed count gained the focused multisite schema regression and its assertions from prerequisite PR #396; #385 itself does not remove, split, or suppress tests.

## Root Causes By Owner

- `tests/bootstrap.php`: lacked a shared action dispatcher and owner-selectable ability resolver, so file collection order permanently selected incompatible global doubles; its text sanitizer also retained script bodies unlike WordPress
- `AccountMarketTest` and `EventsByArtistAbilityTest`: ability/request fixtures were not restored after each owner
- `QualifyRecheckHandlerTest`: its controlled qualification ability depended on whichever `wp_get_ability()` double loaded first
- `FestivalNotificationsTest`: publishing the factory post invoked the notification hook before the test's explicit transition
- `ConcertStatsPublicProfileRenderTest`: request, current-user, and test ability registry state were reset to assumed defaults rather than restored
- `VenueMembershipAuthorizationTest`: its isolated ability and action stubs needed to register through and restore the shared dispatcher boundary

## Files Changed

- `tests/bootstrap.php`
- `tests/Unit/Core/AccountMarketTest.php`
- `tests/Unit/Core/QualifyRecheckHandlerTest.php`
- `tests/Unit/Abilities/EventsByArtistAbilityTest.php`
- `tests/Unit/FestivalNotificationsTest.php`
- `tests/Unit/ConcertStatsPublicProfileRenderTest.php`
- `tests/VenueMembershipAuthorizationTest.php`

## Commands Run

- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/Unit/Core`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php --order-by=random --random-order-seed=385 tests/Unit/Core`
- `vendor/bin/phpunit --configuration phpunit-venue-unit.xml.dist`
- `vendor/bin/phpunit --configuration phpunit-artist-unit.xml.dist`
- `vendor/bin/phpunit --configuration phpunit-local-scene-unit.xml.dist`
- `DME_CALENDAR_CONTRACT_ROOT=/var/lib/datamachine/workspace/data-machine-events/contracts vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/Unit/Abilities/CanonicalAdapterContractsTest.php`
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php`
- `php -l` for every changed PHP file
- `git diff --check origin/main...HEAD`

## Skips And Risks

- No tests were skipped, split, reordered, suppressed, or process-isolated.
- No production code or behavior changed.
- The repository-declared `phpunit.xml.dist` still requires the managed WordPress bootstrap for its `WP_UnitTestCase` files; a bare local PHAR exits during collection. The one-process plain Core lane and managed WordPress Homeboy lane cover both runtime modes.
- The unrelated validation-dependency lint scope defect remains tracked in #397; PR-scoped Homeboy lint passed for this change.

Closes #385