### PR TITLE
fix: accept MariaDB integer display widths

### DIFF
--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -1311,7 +1311,11 @@ class BookingSchema {
 
 	/** Normalize one SHOW COLUMNS row to the declared contract shape. */
 	private static function normalize_column( array $column ): array {
-		$type = preg_replace( '/\(\d+\)(?=\s+unsigned)/', '', strtolower( trim( (string) ( $column['Type'] ?? '' ) ) ) );
+		$type = preg_replace(
+			'/\A(tinyint|smallint|mediumint|int|integer|bigint)\(\d+\)(\s+unsigned)?\z/',
+			'$1$2',
+			strtolower( trim( (string) ( $column['Type'] ?? '' ) ) )
+		);
 		return array(
 			'type'     => preg_replace( '/\s+/', ' ', $type ),
 			'nullable' => 'YES' === strtoupper( (string) ( $column['Null'] ?? '' ) ),

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -219,6 +219,15 @@ final class BookingFoundationTest extends TestCase {
 		$this->assertSame( '', get_option( BookingSchema::VERSION_OPTION, '' ) );
 	}
 
+	public function test_mariadb_integer_display_widths_are_ignored(): void {
+		$this->assertTrue( BookingSchema::install() );
+		$table = BookingSchema::sales_reports_table();
+		$GLOBALS['wpdb']->schemas[ $table ]['columns']['id']['Type']           = 'bigint(20) unsigned';
+		$GLOBALS['wpdb']->schemas[ $table ]['columns']['tickets_sold']['Type'] = 'bigint(20)';
+
+		$this->assertTrue( BookingSchema::health() );
+	}
+
 	public function test_partial_schema_is_not_stamped_and_repeat_install_repairs_it(): void {
 		$GLOBALS['wpdb']->schema_omit['wp_7_ec_bookings']['columns'] = array( 'event_id' );
 		$result = BookingSchema::install();


### PR DESCRIPTION
## Summary
- normalize deprecated integer display widths from MariaDB for signed and unsigned integer families
- preserve meaningful parameters on non-integer column types
- prove valid `bigint(20)` and `bigint(20) unsigned` schemas remain healthy

## Production impact
This restores booking schema readiness on the Events site, where MariaDB reports `tickets_sold` as `bigint(20)`. Booking abilities remain fail-closed until this patch is deployed and the plugin-owned installer succeeds.

## Evidence
- focused PHPUnit: 2 tests, 6 assertions
- branch-scoped Homeboy PHPCS/PHPStan: green (`56810a49-f7df-4bcb-b72f-9e6254636d4a`)
- `git diff --check`: green

Closes #406.