### PR TITLE
feat: complete venue update subscriptions

### DIFF
--- a/assets/js/venue-update-subscriptions.js
+++ b/assets/js/venue-update-subscriptions.js
@@ -1,0 +1,83 @@
+( function () {
+	'use strict';
+
+	const button = document.querySelector( '[data-venue-update-subscription]' );
+	if ( ! button ) {
+		return;
+	}
+
+	const status = button
+		.closest( '[data-venue-update-control]' )
+		.querySelector( '[data-venue-update-status]' );
+	const input = {
+		entity_type: 'venue',
+		taxonomy: 'venue',
+		slug: button.dataset.slug,
+	};
+
+	function setState( subscribed, message ) {
+		button.setAttribute( 'aria-pressed', subscribed ? 'true' : 'false' );
+		button.textContent = subscribed
+			? 'Subscribed to updates'
+			: 'Subscribe to updates';
+		status.textContent =
+			message ||
+			( subscribed
+				? 'Private venue updates are on.'
+				: 'Private venue updates are off.' );
+	}
+
+	function request( ability, method ) {
+		let url = button.dataset.endpoint + 'extrachill/' + ability + '/run';
+		const options = {
+			method,
+			credentials: 'same-origin',
+			headers: { 'X-WP-Nonce': button.dataset.nonce },
+		};
+		if ( 'GET' === method ) {
+			const query = new URLSearchParams();
+			Object.keys( input ).forEach( ( key ) =>
+				query.set( `input[${ key }]`, input[ key ] )
+			);
+			url += `?${ query.toString() }`;
+		} else {
+			options.headers[ 'Content-Type' ] = 'application/json';
+			options.body = JSON.stringify( { input } );
+		}
+		return window.fetch( url, options ).then( ( response ) =>
+			response.json().then( ( data ) => {
+				if ( ! response.ok ) {
+					throw new Error( data.message || 'Request failed.' );
+				}
+				return data;
+			} )
+		);
+	}
+
+	request( 'entity-subscription-status', 'GET' )
+		.then( ( data ) => setState( Boolean( data.subscribed ) ) )
+		.catch( () => {
+			status.textContent =
+				'Subscription status is unavailable. Please try again.';
+		} )
+		.finally( () => {
+			button.disabled = false;
+		} );
+
+	button.addEventListener( 'click', () => {
+		const subscribed = 'true' === button.getAttribute( 'aria-pressed' );
+		button.disabled = true;
+		request(
+			subscribed ? 'entity-unsubscribe' : 'entity-subscribe',
+			'POST'
+		)
+			.then( ( data ) => setState( Boolean( data.subscribed ) ) )
+			.catch( () => {
+				status.textContent =
+					'Unable to update your subscription. Please try again.';
+			} )
+			.finally( () => {
+				button.disabled = false;
+			} );
+	} );
+} )();

--- a/assets/js/venue-update-subscriptions.test.js
+++ b/assets/js/venue-update-subscriptions.test.js
@@ -1,0 +1,89 @@
+/** Explicit venue update subscription control. */
+/* global beforeEach, describe, expect, it, jest */
+
+async function flushPromises() {
+	await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+}
+
+describe( 'Venue update subscriptions', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		document.body.innerHTML = `
+			<div data-venue-update-control>
+				<span data-venue-update-status></span>
+				<button disabled aria-pressed="false" data-venue-update-subscription
+					data-endpoint="https://example.com/wp-json/wp-abilities/v1/abilities/"
+					data-nonce="nonce" data-slug="the-royal-american"></button>
+			</div>`;
+		global.fetch = jest.fn();
+	} );
+
+	it( 'loads status without mutating consent', async () => {
+		fetch.mockResolvedValue( {
+			ok: true,
+			json: () => Promise.resolve( { subscribed: false } ),
+		} );
+		require( './venue-update-subscriptions' );
+		await flushPromises();
+
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+		expect( fetch.mock.calls[ 0 ][ 1 ].method ).toBe( 'GET' );
+		expect( fetch.mock.calls[ 0 ][ 0 ] ).toContain(
+			'entity-subscription-status'
+		);
+		expect( fetch.mock.calls[ 0 ][ 0 ] ).not.toContain(
+			'entity-subscribe/run'
+		);
+	} );
+
+	it( 'subscribes with the exact venue identity after a click', async () => {
+		fetch
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: () => Promise.resolve( { subscribed: false } ),
+			} )
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: () => Promise.resolve( { subscribed: true } ),
+			} );
+		require( './venue-update-subscriptions' );
+		await flushPromises();
+		document.querySelector( 'button' ).click();
+		await flushPromises();
+
+		expect( fetch.mock.calls[ 1 ][ 0 ] ).toContain(
+			'entity-subscribe/run'
+		);
+		expect( JSON.parse( fetch.mock.calls[ 1 ][ 1 ].body ).input ).toEqual( {
+			entity_type: 'venue',
+			taxonomy: 'venue',
+			slug: 'the-royal-american',
+		} );
+		expect( document.querySelector( 'button' ).textContent ).toBe(
+			'Subscribed to updates'
+		);
+	} );
+
+	it( 'unsubscribes only after an explicit second click', async () => {
+		fetch
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: () => Promise.resolve( { subscribed: true } ),
+			} )
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: () => Promise.resolve( { subscribed: false } ),
+			} );
+		require( './venue-update-subscriptions' );
+		await flushPromises();
+		document.querySelector( 'button' ).click();
+		await flushPromises();
+
+		expect( fetch.mock.calls[ 1 ][ 0 ] ).toContain(
+			'entity-unsubscribe/run'
+		);
+		expect( document.querySelector( 'button' ).textContent ).toBe(
+			'Subscribe to updates'
+		);
+	} );
+} );

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -317,6 +317,8 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/account-market.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/local-scene-digest.php';
 		extrachill_events_init_local_scene_digest();
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/venue-update-subscriptions.php';
+		extrachill_events_init_venue_update_subscriptions();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/near-me.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/discovery-pages.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/router-pages.php';

--- a/inc/core/venue-update-subscriptions.php
+++ b/inc/core/venue-update-subscriptions.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Explicit private venue update subscriptions.
+ *
+ * @package ExtraChillEvents
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EXTRACHILL_EVENTS_VENUE_UPDATE_PRODUCER  = 'extrachill-events-venue-updates';
+const EXTRACHILL_EVENTS_VENUE_UPDATE_SENT_META = '_extrachill_events_venue_update_notification_sent';
+
+/** Register venue archive controls and private notification delivery. */
+function extrachill_events_init_venue_update_subscriptions(): void {
+	add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_events_authorize_venue_update_producer', 10, 4 );
+	add_action( 'transition_post_status', 'extrachill_events_notify_venue_subscribers', 10, 3 );
+	add_action( 'extrachill_archive_below_description', 'extrachill_events_render_venue_update_control', 5 );
+	add_action( 'wp_enqueue_scripts', 'extrachill_events_venue_update_scripts' );
+}
+
+/**
+ * Authorize only private notification delivery for canonical venue updates.
+ *
+ * @param bool   $authorized Existing authorization decision.
+ * @param string $producer   Requesting producer.
+ * @param array  $entity     Normalized entity identity.
+ * @param string $delivery   Delivery channel.
+ * @return bool
+ */
+function extrachill_events_authorize_venue_update_producer( $authorized, $producer, $entity, $delivery ): bool {
+	if ( EXTRACHILL_EVENTS_VENUE_UPDATE_PRODUCER !== $producer ) {
+		return (bool) $authorized;
+	}
+
+	return 'notification' === $delivery
+		&& is_array( $entity )
+		&& 'venue' === ( $entity['entity_type'] ?? '' )
+		&& 'venue' === ( $entity['taxonomy'] ?? '' );
+}
+
+/**
+ * Return the canonical venue represented by the current archive.
+ *
+ * @return WP_Term|null
+ */
+function extrachill_events_get_venue_archive_term(): ?WP_Term {
+	if ( ! is_tax( 'venue' ) ) {
+		return null;
+	}
+
+	$term = get_queried_object();
+	return $term instanceof WP_Term && 'venue' === $term->taxonomy ? $term : null;
+}
+
+/** Render an explicit venue update opt-in on canonical venue archives. */
+function extrachill_events_render_venue_update_control(): void {
+	$term = extrachill_events_get_venue_archive_term();
+	if ( null === $term ) {
+		return;
+	}
+
+	$archive_url = get_term_link( $term );
+	if ( ! is_user_logged_in() ) {
+		echo '<aside class="events-market-context events-market-context--quiet"><span>' . esc_html__( 'Get a private notification when new events are published at this venue.', 'extrachill-events' ) . '</span> <a href="' . esc_url( wp_login_url( $archive_url ) ) . '">' . esc_html__( 'Sign in to subscribe', 'extrachill-events' ) . '</a></aside>';
+		return;
+	}
+
+	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+		define( 'DONOTCACHEPAGE', true );
+	}
+	nocache_headers();
+	?>
+	<aside class="events-market-context" data-venue-update-control>
+		<div class="events-market-context__copy">
+			<strong><?php esc_html_e( 'Venue updates', 'extrachill-events' ); ?></strong>
+			<span data-venue-update-status><?php esc_html_e( 'Checking your subscription...', 'extrachill-events' ); ?></span>
+		</div>
+		<button class="button-1 button-small" type="button" disabled aria-pressed="false" data-venue-update-subscription data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Subscribe to updates', 'extrachill-events' ); ?></button>
+	</aside>
+	<?php
+}
+
+/** Enqueue the progressive control only for authenticated venue archives. */
+function extrachill_events_venue_update_scripts(): void {
+	if ( null === extrachill_events_get_venue_archive_term() || ! is_user_logged_in() ) {
+		return;
+	}
+
+	wp_enqueue_script( 'extrachill-events-venue-update-subscriptions', EXTRACHILL_EVENTS_PLUGIN_URL . 'assets/js/venue-update-subscriptions.js', array(), EXTRACHILL_EVENTS_VERSION, true );
+}
+
+/**
+ * Notify unique subscribers when an event first becomes published.
+ *
+ * @param string  $new_status New post status.
+ * @param string  $old_status Previous post status.
+ * @param WP_Post $post       Post transitioning status.
+ */
+function extrachill_events_notify_venue_subscribers( $new_status, $old_status, $post ): void {
+	if ( 'publish' !== $new_status || 'publish' === $old_status || ! $post instanceof WP_Post ) {
+		return;
+	}
+	if ( ! defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) || DATA_MACHINE_EVENTS_POST_TYPE !== get_post_type( $post ) ) {
+		return;
+	}
+	if ( get_post_meta( $post->ID, EXTRACHILL_EVENTS_VENUE_UPDATE_SENT_META, true ) ) {
+		return;
+	}
+	if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify_with_receipts' ) ) {
+		return;
+	}
+
+	$slugs = wp_get_post_terms( $post->ID, 'venue', array( 'fields' => 'slugs' ) );
+	if ( is_wp_error( $slugs ) || empty( $slugs ) ) {
+		return;
+	}
+
+	$recipient_ids = array();
+	foreach ( array_values( array_unique( array_filter( array_map( 'sanitize_title', $slugs ) ) ) ) as $slug ) {
+		$recipients = extrachill_users_entity_subscription_recipients(
+			EXTRACHILL_EVENTS_VENUE_UPDATE_PRODUCER,
+			'venue',
+			'venue',
+			$slug,
+			'notification'
+		);
+		if ( ! is_wp_error( $recipients ) ) {
+			$recipient_ids = array_merge( $recipient_ids, $recipients );
+		}
+	}
+
+	$recipient_ids = array_values( array_unique( array_filter( array_map( 'absint', $recipient_ids ) ) ) );
+	if ( empty( $recipient_ids ) ) {
+		return;
+	}
+
+	// Claim before delivery so concurrent publication hooks cannot duplicate notices.
+	if ( ! add_post_meta( $post->ID, EXTRACHILL_EVENTS_VENUE_UPDATE_SENT_META, current_time( 'mysql', true ), true ) ) {
+		return;
+	}
+
+	$receipt = ec_users_notify_with_receipts(
+		$recipient_ids,
+		array(
+			'actor_id'        => (int) $post->post_author,
+			'type'            => 'venue_event_published',
+			/* translators: %s: event title. */
+			'title'           => sprintf( __( 'New venue event: %s', 'extrachill-events' ), get_the_title( $post ) ),
+			'link'            => get_permalink( $post ),
+			'item_id'         => (int) $post->ID,
+			'producer'        => EXTRACHILL_EVENTS_VENUE_UPDATE_PRODUCER,
+			'idempotency_key' => 'event:' . (int) $post->ID,
+		)
+	);
+
+	if ( ! is_array( $receipt ) || 0 < absint( $receipt['failed'] ?? count( $recipient_ids ) ) ) {
+		delete_post_meta( $post->ID, EXTRACHILL_EVENTS_VENUE_UPDATE_SENT_META );
+	}
+}

--- a/phpunit-managed.xml.dist
+++ b/phpunit-managed.xml.dist
@@ -16,6 +16,7 @@
 			<file>tests/Unit/Abilities/EventsByTermTaxonomyContextTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalAdapterContractsTest.php</file>
 			<file>tests/Unit/FestivalNotificationsTest.php</file>
+			<file>tests/Unit/VenueUpdateSubscriptionsTest.php</file>
 			<file>tests/Unit/SingleEventNetworkBridgeTest.php</file>
 			<file>tests/Unit/ConcertStatsPublicProfileRenderTest.php</file>
 			<file>tests/MySQLIntegration/BookingSchemaMultisiteTest.php</file>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
 			<file>tests/Unit/Abilities/EventsByArtistAbilityTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalAdapterContractsTest.php</file>
 			<file>tests/Unit/FestivalNotificationsTest.php</file>
+			<file>tests/Unit/VenueUpdateSubscriptionsTest.php</file>
 			<file>tests/Unit/SingleEventNetworkBridgeTest.php</file>
 			<file>tests/Unit/ConcertStatsPublicProfileRenderTest.php</file>
 		</testsuite>

--- a/tests/Support/venue-update-subscription-stubs.php
+++ b/tests/Support/venue-update-subscription-stubs.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Runtime stubs for venue update subscription tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+// phpcs:disable -- This isolated fixture intentionally declares WordPress test doubles.
+
+if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) ) {
+	/** Record private recipient resolution and return configured fixtures. */
+	function extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug, $delivery = 'notification' ) {
+		$GLOBALS['festival_notification_resolutions'][] = compact( 'producer', 'entity_type', 'taxonomy', 'slug', 'delivery' );
+		return $GLOBALS['festival_notification_recipients'][ $slug ] ?? array();
+	}
+}
+
+if ( ! function_exists( 'ec_users_notify_with_receipts' ) ) {
+	/** Record notification delivery and return its configured result. */
+	function ec_users_notify_with_receipts( $user_ids, array $data ) {
+		$GLOBALS['festival_notification_calls'][] = array(
+			'user_ids' => $user_ids,
+			'data'     => $data,
+		);
+		$inserted = array_shift( $GLOBALS['festival_notification_delivery_results'] ) ?? count( $user_ids );
+		return array(
+			'requested'  => count( $user_ids ),
+			'inserted'   => $inserted,
+			'existing'   => 0,
+			'failed'     => count( $user_ids ) - $inserted,
+			'recipients' => array(),
+		);
+	}
+}

--- a/tests/Unit/VenueUpdateSubscriptionsTest.php
+++ b/tests/Unit/VenueUpdateSubscriptionsTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Tests for explicit private venue update subscriptions.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+// phpcs:disable -- This isolated fixture shares WordPress test doubles with the festival notification tests.
+
+require_once dirname( __DIR__ ) . '/Support/venue-update-subscription-stubs.php';
+require_once dirname( __DIR__, 2 ) . '/inc/core/venue-update-subscriptions.php';
+
+/** Verify archive consent UI and first-publication delivery behavior. */
+final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
+
+	/** Prepare venue taxonomy and notification fixtures. */
+	protected function setUp(): void {
+		parent::setUp();
+		register_post_type( DATA_MACHINE_EVENTS_POST_TYPE, array( 'public' => true ) );
+		register_taxonomy( 'venue', DATA_MACHINE_EVENTS_POST_TYPE );
+		$GLOBALS['festival_notification_terms']            = array( 'venue' => array() );
+		$GLOBALS['festival_notification_recipients']       = array();
+		$GLOBALS['festival_notification_resolutions']      = array();
+		$GLOBALS['festival_notification_calls']            = array();
+		$GLOBALS['festival_notification_meta']             = array();
+		$GLOBALS['festival_notification_delivery_results'] = array();
+		$GLOBALS['festival_notification_claim_failure']    = false;
+	}
+
+	/** Create a draft canonical event with configured venue terms. */
+	private function event_post(): WP_Post {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::factory()->user->create(),
+				'post_type'   => DATA_MACHINE_EVENTS_POST_TYPE,
+				'post_status' => 'draft',
+				'post_title'  => 'The Big Show',
+			)
+		);
+		wp_set_object_terms( $post_id, $GLOBALS['festival_notification_terms']['venue'], 'venue' );
+		return get_post( $post_id );
+	}
+
+	/** Navigate the test request to one canonical venue archive. */
+	private function venue_archive(): WP_Term {
+		$term_id = self::factory()->term->create(
+			array(
+				'taxonomy' => 'venue',
+				'name'     => 'The Royal American',
+				'slug'     => 'the-royal-american',
+			)
+		);
+		$term    = get_term( $term_id, 'venue' );
+		$this->go_to( get_term_link( $term ) );
+		return $term;
+	}
+
+	/** The producer may resolve only venue notification recipients. */
+	public function test_authorizes_only_exact_venue_notification_contract(): void {
+		$venue  = array(
+			'entity_type' => 'venue',
+			'taxonomy'    => 'venue',
+		);
+		$artist = array(
+			'entity_type' => 'artist',
+			'taxonomy'    => 'artist',
+		);
+
+		$this->assertTrue( extrachill_events_authorize_venue_update_producer( false, EXTRACHILL_EVENTS_VENUE_UPDATE_PRODUCER, $venue, 'notification' ) );
+		$this->assertFalse( extrachill_events_authorize_venue_update_producer( false, EXTRACHILL_EVENTS_VENUE_UPDATE_PRODUCER, $venue, 'email' ) );
+		$this->assertFalse( extrachill_events_authorize_venue_update_producer( false, EXTRACHILL_EVENTS_VENUE_UPDATE_PRODUCER, $artist, 'notification' ) );
+		$this->assertFalse( extrachill_events_authorize_venue_update_producer( false, 'untrusted', $venue, 'notification' ) );
+	}
+
+	/** Anonymous archives offer sign-in without exposing a mutation control. */
+	public function test_anonymous_archive_renders_sign_in_without_mutation_control(): void {
+		$this->venue_archive();
+		wp_set_current_user( 0 );
+
+		ob_start();
+		extrachill_events_render_venue_update_control();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'Sign in to subscribe', $html );
+		$this->assertStringNotContainsString( 'data-venue-update-subscription', $html );
+	}
+
+	/** Authenticated archives progressively load the exact venue identity. */
+	public function test_authenticated_archive_renders_progressive_status_control(): void {
+		$this->venue_archive();
+		wp_set_current_user( self::factory()->user->create() );
+
+		ob_start();
+		extrachill_events_render_venue_update_control();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'data-venue-update-subscription', $html );
+		$this->assertStringContainsString( 'Checking your subscription...', $html );
+		$this->assertStringContainsString( 'data-slug="the-royal-american"', $html );
+	}
+
+	/** First publication deduplicates subscribers across all assigned venues. */
+	public function test_first_publication_notifies_unique_subscribers_across_venues(): void {
+		$GLOBALS['festival_notification_terms']['venue'] = array( 'the-royal-american', 'music-farm' );
+		$GLOBALS['festival_notification_recipients']     = array(
+			'the-royal-american' => array( 7, 9 ),
+			'music-farm'         => array( 9, 11 ),
+		);
+		$post = $this->event_post();
+
+		extrachill_events_notify_venue_subscribers( 'publish', 'draft', $post );
+
+		$this->assertCount( 2, $GLOBALS['festival_notification_resolutions'] );
+		$this->assertEqualsCanonicalizing( array( 7, 9, 11 ), $GLOBALS['festival_notification_calls'][0]['user_ids'] );
+		$this->assertSame( 'venue_event_published', $GLOBALS['festival_notification_calls'][0]['data']['type'] );
+		$this->assertSame( 'New venue event: The Big Show', $GLOBALS['festival_notification_calls'][0]['data']['title'] );
+		$this->assertSame( EXTRACHILL_EVENTS_VENUE_UPDATE_PRODUCER, $GLOBALS['festival_notification_calls'][0]['data']['producer'] );
+		$this->assertSame( 'event:' . $post->ID, $GLOBALS['festival_notification_calls'][0]['data']['idempotency_key'] );
+	}
+
+	/** Published updates and repeated hooks cannot duplicate delivery. */
+	public function test_published_updates_and_repeated_hooks_do_not_duplicate_delivery(): void {
+		$GLOBALS['festival_notification_terms']['venue']                   = array( 'the-royal-american' );
+		$GLOBALS['festival_notification_recipients']['the-royal-american'] = array( 7 );
+		$post = $this->event_post();
+
+		extrachill_events_notify_venue_subscribers( 'publish', 'publish', $post );
+		extrachill_events_notify_venue_subscribers( 'publish', 'draft', $post );
+		extrachill_events_notify_venue_subscribers( 'publish', 'draft', $post );
+
+		$this->assertCount( 1, $GLOBALS['festival_notification_calls'] );
+		$this->assertCount( 1, $GLOBALS['festival_notification_resolutions'] );
+		$this->assertNotEmpty( get_post_meta( $post->ID, EXTRACHILL_EVENTS_VENUE_UPDATE_SENT_META, true ) );
+	}
+
+	/** A failed delivery releases the claim so publication can retry. */
+	public function test_failed_delivery_releases_claim_for_retry(): void {
+		$GLOBALS['festival_notification_terms']['venue']                   = array( 'the-royal-american' );
+		$GLOBALS['festival_notification_recipients']['the-royal-american'] = array( 7 );
+		$GLOBALS['festival_notification_delivery_results']                 = array( 0, 1 );
+		$post = $this->event_post();
+
+		extrachill_events_notify_venue_subscribers( 'publish', 'draft', $post );
+		$this->assertSame( '', get_post_meta( $post->ID, EXTRACHILL_EVENTS_VENUE_UPDATE_SENT_META, true ) );
+		extrachill_events_notify_venue_subscribers( 'publish', 'draft', $post );
+
+		$this->assertCount( 2, $GLOBALS['festival_notification_calls'] );
+		$this->assertNotEmpty( get_post_meta( $post->ID, EXTRACHILL_EVENTS_VENUE_UPDATE_SENT_META, true ) );
+	}
+}


### PR DESCRIPTION
## Summary
- Render a progressive "Subscribe to updates" control on canonical venue archives, with a sign-in CTA for anonymous visitors and status loading before authenticated mutation is enabled.
- Use the existing Users abilities with exactly `venue/venue/<slug>`; this is a private update subscription, not a follower/following relationship and not a subscriber-list surface.
- Add an Events-owned producer authorized only for canonical venue identities over private notification delivery.

## Delivery And Privacy
- Notify unique subscribers across every canonically assigned venue term only when an event first transitions to published.
- Combine an atomic publication claim with Users notification receipts keyed by producer and event ID, suppressing repeated/concurrent hooks and duplicate notices during partial-delivery retries.
- Do not infer subscriptions from attendance, Local Scene, submissions, booking, or venue page visits.
- Preserve the existing artist/festival notification producer unchanged.
- Venue email sharing remains separate consent tracked in #409 and Extra-Chill/extrachill-users#300; neither choice implies the other.

## Verification
- `homeboy review lint --changed-only --summary` - passed PHPCS, ESLint, and PHPStan with no findings.
- `npm run test:js -- --runInBand` - passed 10 suites, 48 tests.
- `npm run build` - production build passed (existing Sass deprecation warnings only).
- Focused PHP syntax and WordPress coding standards checks passed.
- `homeboy review test --json-summary` - local managed WP Codebox run reached the runner after supplying the configured MySQL environment, but exited without exposing its PHPUnit log; an immediate focused retry was blocked by Homeboy's warm-machine resource policy. The managed suite includes the new PHP tests and will run in CI with the repository's declared MySQL service.

Closes #408