### PR TITLE
test: provision canonical multisite booking fixture

### DIFF
--- a/tests/MySQLIntegration/booking-schema-multisite-bootstrap.php
+++ b/tests/MySQLIntegration/booking-schema-multisite-bootstrap.php
@@ -1,5 +1,9 @@
 <?php
-/** Provision the canonical Events site and its site-scoped booking schema. */
+/**
+ * Provision the canonical Events site and its site-scoped booking schema.
+ *
+ * @package ExtraChillEvents\Tests\MySQLIntegration
+ */
 
 if ( ! is_multisite() ) {
 	throw new RuntimeException( 'The booking schema integration test requires multisite.' );
@@ -10,12 +14,35 @@ if ( ! class_exists( 'DataMachineEvents\\Core\\EventDatesTable' ) ) {
 }
 DataMachineEvents\Core\EventDatesTable::create_table();
 
+$factory          = new WP_UnitTest_Factory();
+$fixture_site_ids = array();
+register_shutdown_function(
+	static function () use ( &$fixture_site_ids ): void {
+		global $wpdb;
+
+		foreach ( array_reverse( $fixture_site_ids ) as $site_id ) {
+			$prefix = $wpdb->get_blog_prefix( $site_id );
+			wp_delete_site( $site_id );
+
+			// Core deletes its own site tables; remove site-scoped plugin tables too.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Test fixture cleanup must discover plugin tables.
+			$tables = $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $prefix ) . '%' ) );
+			foreach ( $tables as $table ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture cleanup for database-returned table names.
+				$wpdb->query( "DROP TABLE IF EXISTS `{$table}`" );
+			}
+		}
+	}
+);
 while ( ! get_site( 7 ) ) {
-	$next_id = get_sites( array( 'count' => true ) ) + 1;
-	$created = wpmu_create_blog( 'site-' . $next_id . '.example.org', '/', 'Test Site ' . $next_id, 1 );
+	$created = $factory->blog->create();
 	if ( is_wp_error( $created ) || (int) $created > 7 ) {
 		throw new RuntimeException( 'Unable to provision the Events multisite test fixture.' );
 	}
+	$fixture_site_ids[] = (int) $created;
+}
+if ( ! wp_is_site_initialized( 7 ) ) {
+	throw new RuntimeException( 'The Events multisite test fixture was not initialized.' );
 }
 
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingSchema.php';


### PR DESCRIPTION
## Summary
- provision missing multisite blogs through the canonical WordPress test factory so blog 7 receives core tables, options, and roles before booking schema setup
- verify the canonical Events test site is initialized and clean up only fixture-created sites plus site-scoped plugin tables
- keep the change isolated to the managed MySQL test bootstrap with no production behavior changes

Closes #399

## Verification
- `php -l tests/MySQLIntegration/booking-schema-multisite-bootstrap.php`
- `vendor/bin/phpcs --standard=WordPress tests/MySQLIntegration/booking-schema-multisite-bootstrap.php`
- `homeboy review lint --placement local --changed-only`
- `homeboy review audit --placement local --changed-since origin/main`
- `git diff --check`
- `vendor/bin/phpunit --configuration phpunit-booking.xml.dist` (same existing 50 errors and 1 failure on clean `origin/main`; no differential regression)
- managed MySQL tests deferred to CI because this host has no configured `WP_CODEBOX_DB_*` external test service