### PR TITLE
feat: add source-class ramp evidence gates

### DIFF
--- a/docs/source-class-ramp-playbook.md
+++ b/docs/source-class-ramp-playbook.md
@@ -1,0 +1,83 @@
+# Event Source Ramp Playbook
+
+This playbook evaluates source-class throughput changes without changing flows. It consumes one timestamped JSON evidence document, applies the versioned policy in `EventSourceRampEvaluator`, and emits an executable apply and rollback plan owned by Data Machine.
+
+## Stages
+
+| Source class | Handler | Stages |
+| --- | --- | --- |
+| Ticketmaster | `ticketmaster` | `1 -> 3 -> 5` |
+| Dice | `dice_fm` | `1 -> 3 -> 10` |
+| Universal scraper | `universal_web_scraper` | `1 -> 2` |
+
+Every stage requires at least 24 hours of evidence. Evidence must be no more than two hours old and identify its flow-settings, jobs-liveness, job-metrics, Action Scheduler, event-quality, and bundle-wave sources. DME cadence status may be included as `cadence_status`; it is informational until data-machine-events#260 stabilizes a public contract.
+
+## Gates
+
+Common maximums are queue depth `25`, oldest queue age `7200` seconds, jobs without a scheduler path `0`, failed rate `0.05`, deferred rate `0.10`, AI defer budget used `0.80`, exhausted AI defer attempts `0`, and Action Scheduler pending growth `10`.
+
+Source thresholds are:
+
+| Source | Rejection max | Eligible min | Duplicate max | Event yield min |
+| --- | ---: | ---: | ---: | ---: |
+| Ticketmaster | 0.10 | 5 | 0.10 | 0.50 |
+| Dice | 0.15 | 5 | 0.15 | 0.40 |
+| Universal scraper | 0.25 | 2 | 0.20 | 0.25 |
+
+Rates and event yield are ratios from `0` to `1`. Action Scheduler growth is the end pending count minus the start pending count for the same scoped window. Eligible events and event yield come from the same flow/source-class window as the job metrics.
+
+## Evidence
+
+Build the evidence from existing public surfaces rather than adding another scheduler or metrics store:
+
+```sh
+wp datamachine flows get <flow-id> --format=json
+wp datamachine jobs liveness --flow=<flow-id> --format=json
+wp datamachine jobs list --flow=<flow-id> --since='24 hours ago' --format=json
+wp data-machine-events check quality --flow-id=<flow-id> --issue=duplicates --format=json
+```
+
+Record the corresponding Action Scheduler snapshot and event-bundle rollout wave in `provenance`. Persist the resulting artifact in the rollout evidence location owned by the operator or bundle wave; this plugin does not create a second evidence store.
+
+```json
+{
+  "schema_version": "1.0.0",
+  "observed_at": "2026-07-27T15:00:00Z",
+  "window_start": "2026-07-26T15:00:00Z",
+  "window_end": "2026-07-27T15:00:00Z",
+  "provenance": {
+    "flow_settings": "flow-42.json",
+    "jobs_liveness": "liveness-42.json",
+    "job_metrics": "jobs-42.json",
+    "action_scheduler": "action-scheduler-42.json",
+    "event_quality": "quality-42.json",
+    "bundle_wave": "extrachill-event-bundles#10/london"
+  },
+  "metrics": {
+    "queue_depth": 4,
+    "oldest_queue_age_seconds": 600,
+    "jobs_without_scheduler_path": 0,
+    "failed_rate": 0.01,
+    "deferred_rate": 0.04,
+    "ai_defer_budget_used_rate": 0.20,
+    "ai_defer_exhausted": 0,
+    "action_scheduler_pending_growth": 2,
+    "source_rejection_rate": 0.02,
+    "eligible_events": 40,
+    "duplicate_rate": 0.03,
+    "event_yield": 0.70
+  },
+  "cadence_status": null
+}
+```
+
+Run preflight before changing a wave and postflight after the next 24-hour window:
+
+```sh
+wp extrachill events ramp --source-class=ticketmaster --current-max-items=1 --phase=preflight --evidence=preflight.json --scope=pipeline --scope-id=10
+wp extrachill events ramp --source-class=ticketmaster --current-max-items=3 --phase=postflight --evidence=postflight.json --scope=pipeline --scope-id=10
+```
+
+Missing, stale, or failing preflight evidence holds the current stage. A complete postflight with a failed metric emits a reduction to the previous stage, or a pause at stage 1. Rollback never deletes canonical events. Passing final-stage evidence reports `complete` rather than proposing an unbounded increase.
+
+The command never applies its plan. Data Machine's `datamachine/configure-flow-steps` ability remains the mutation owner. Pipeline/flow bulk-config preview is marked unavailable until Extra-Chill/data-machine#3019 restores its dry-run guarantee; only an operator-confirmed `--execute` command appears in the plan.

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -31,6 +31,10 @@ define( 'EXTRACHILL_EVENTS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 // WP-CLI commands.
 if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCommand.php' ) ) {
+	require_once __DIR__ . '/inc/Core/EventSourceRampEvaluator.php';
+	require_once __DIR__ . '/inc/Cli/EventSourceRampCommand.php';
+	\WP_CLI::add_command( 'extrachill events ramp', \ExtraChillEvents\Cli\EventSourceRampCommand::class );
+
 	require_once __DIR__ . '/inc/Cli/AddCityCommand.php';
 	\WP_CLI::add_command( 'extrachill-events add-city', \ExtraChillEvents\Cli\AddCityCommand::class );
 
@@ -259,6 +263,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdictResolver.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/PlatformDetector.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyFingerprinter.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/EventSourceRampEvaluator.php';
 
 		// Artist URL Import subsystem (migrated from data-machine-events in #200).
 		// Moderation-queue table + REST controller/routes. The abilities load in
@@ -439,6 +444,9 @@ class ExtraChillEvents {
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/MarketReportAbilities.php';
 		new \ExtraChillEvents\Abilities\MarketReportAbilities();
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/EventSourceRampAbilities.php';
+		new \ExtraChillEvents\Abilities\EventSourceRampAbilities();
 
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/EventTimeAuditAbilities.php';
 		new \ExtraChillEvents\Abilities\EventTimeAuditAbilities();

--- a/inc/Abilities/EventSourceRampAbilities.php
+++ b/inc/Abilities/EventSourceRampAbilities.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Read-only event source ramp ability.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+use ExtraChillEvents\Core\EventSourceRampEvaluator;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Registers the read-only source ramp evaluation ability. */
+class EventSourceRampAbilities {
+
+	/**
+	 * Whether the registration hook has already been attached.
+	 *
+	 * @var bool
+	 */
+	private static bool $registered = false;
+
+	/** Attach ability registration once. */
+	public function __construct() {
+		if ( ! self::$registered ) {
+			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+			self::$registered = true;
+		}
+	}
+
+	/** Register the source ramp ability. */
+	public function register(): void {
+		wp_register_ability(
+			'extrachill/evaluate-event-source-ramp',
+			array(
+				'label'               => __( 'Evaluate Event Source Ramp', 'extrachill-events' ),
+				'description'         => __( 'Evaluate timestamped source-class ramp evidence and return a reversible, non-executed plan.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => self::input_schema(),
+				'output_schema'       => self::output_schema(),
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static fn(): bool => current_user_can( 'manage_options' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => true,
+						'idempotent'  => true,
+						'destructive' => false,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Return the ability input schema.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function input_schema(): array {
+		return array(
+			'$schema'              => 'https://json-schema.org/draft/2020-12/schema',
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => array( 'source_class', 'current_max_items', 'phase', 'scope', 'scope_id', 'evidence' ),
+			'properties'           => array(
+				'source_class'      => array(
+					'type' => 'string',
+					'enum' => array( 'ticketmaster', 'dice', 'universal_scraper' ),
+				),
+				'current_max_items' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'phase'             => array(
+					'type' => 'string',
+					'enum' => array( 'preflight', 'postflight' ),
+				),
+				'scope'             => array(
+					'type' => 'string',
+					'enum' => array( 'pipeline', 'flow' ),
+				),
+				'scope_id'          => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'evidence'          => self::evidence_schema(),
+			),
+		);
+	}
+
+	/**
+	 * Return the ability output schema.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function output_schema(): array {
+		return array(
+			'$schema'              => 'https://json-schema.org/draft/2020-12/schema',
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => array( 'schema_version', 'generated_at', 'phase', 'source_class', 'profile', 'scope', 'current_stage', 'proposed_stage', 'decision', 'can_advance', 'failed_gates', 'gates', 'evidence', 'apply_plan' ),
+			'properties'           => array(
+				'schema_version' => array(
+					'type'  => 'string',
+					'const' => EventSourceRampEvaluator::SCHEMA_VERSION,
+				),
+				'generated_at'   => array(
+					'type'   => 'string',
+					'format' => 'date-time',
+				),
+				'phase'          => array(
+					'type' => 'string',
+					'enum' => array( 'preflight', 'postflight' ),
+				),
+				'source_class'   => array( 'type' => 'string' ),
+				'profile'        => array( 'type' => 'object' ),
+				'scope'          => array( 'type' => 'object' ),
+				'current_stage'  => array( 'type' => 'integer' ),
+				'proposed_stage' => array( 'type' => array( 'integer', 'null' ) ),
+				'decision'       => array(
+					'type' => 'string',
+					'enum' => array( 'advance', 'hold', 'rollback', 'complete' ),
+				),
+				'can_advance'    => array( 'type' => 'boolean' ),
+				'failed_gates'   => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'string' ),
+				),
+				'gates'          => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'object' ),
+				),
+				'evidence'       => array( 'type' => 'object' ),
+				'apply_plan'     => array( 'type' => 'object' ),
+			),
+		);
+	}
+
+	/**
+	 * Return the submitted evidence schema.
+	 *
+	 * Individual metrics are optional at schema validation so the evaluator can
+	 * return machine-readable missing-gate decisions instead of transport errors.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function evidence_schema(): array {
+		$metric_names = array_keys( EventSourceRampEvaluator::profiles()['ticketmaster']['thresholds'] );
+		$metrics      = array();
+		foreach ( $metric_names as $name ) {
+			$metrics[ $name ] = array( 'type' => 'number' );
+		}
+
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => array( 'schema_version', 'observed_at', 'window_start', 'window_end', 'provenance', 'metrics' ),
+			'properties'           => array(
+				'schema_version' => array(
+					'type'  => 'string',
+					'const' => EventSourceRampEvaluator::SCHEMA_VERSION,
+				),
+				'observed_at'    => array(
+					'type'   => 'string',
+					'format' => 'date-time',
+				),
+				'window_start'   => array(
+					'type'   => 'string',
+					'format' => 'date-time',
+				),
+				'window_end'     => array(
+					'type'   => 'string',
+					'format' => 'date-time',
+				),
+				'provenance'     => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
+				'metrics'        => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => $metrics,
+				),
+				'cadence_status' => array( 'type' => array( 'object', 'null' ) ),
+			),
+		);
+	}
+
+	/**
+	 * Evaluate supplied evidence without runtime mutation.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input ): array {
+		return ( new EventSourceRampEvaluator() )->evaluate( $input );
+	}
+}

--- a/inc/Cli/EventSourceRampCommand.php
+++ b/inc/Cli/EventSourceRampCommand.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * JSON CLI adapter for event source ramp evidence.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+use ExtraChillEvents\Core\EventSourceRampEvaluator;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Adapts local JSON evidence to the pure ramp evaluator. */
+class EventSourceRampCommand {
+
+	/**
+	 * Evaluate machine-readable preflight or postflight evidence.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --source-class=<class>
+	 * : ticketmaster, dice, or universal_scraper.
+	 *
+	 * --current-max-items=<number>
+	 * : Current declared ramp stage.
+	 *
+	 * --phase=<phase>
+	 * : preflight or postflight.
+	 *
+	 * --evidence=<path>
+	 * : JSON evidence file. Use - to read standard input.
+	 *
+	 * --scope=<scope>
+	 * : Reversible target scope: pipeline or flow.
+	 *
+	 * --scope-id=<id>
+	 * : Pipeline or flow ID.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill events ramp --source-class=ticketmaster --current-max-items=1 --phase=preflight --evidence=preflight.json --scope=pipeline --scope-id=10
+	 *
+	 *     wp extrachill events ramp --source-class=dice --current-max-items=3 --phase=postflight --evidence=- --scope=flow --scope-id=42
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		unset( $args );
+		$required = array( 'source-class', 'current-max-items', 'phase', 'evidence', 'scope', 'scope-id' );
+		foreach ( $required as $name ) {
+			if ( ! isset( $assoc_args[ $name ] ) || '' === (string) $assoc_args[ $name ] ) {
+				\WP_CLI::error( sprintf( '--%s is required.', $name ) );
+			}
+		}
+
+		$path = (string) $assoc_args['evidence'];
+		$json = '-' === $path ? stream_get_contents( STDIN ) : file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Operator-supplied local CLI evidence file.
+		if ( false === $json ) {
+			\WP_CLI::error( 'Unable to read evidence JSON.' );
+		}
+
+		$evidence = json_decode( $json, true );
+		if ( ! is_array( $evidence ) ) {
+			\WP_CLI::error( 'Evidence must be a JSON object.' );
+		}
+
+		$result = ( new EventSourceRampEvaluator() )->evaluate(
+			array(
+				'source_class'      => (string) $assoc_args['source-class'],
+				'current_max_items' => (int) $assoc_args['current-max-items'],
+				'phase'             => (string) $assoc_args['phase'],
+				'scope'             => (string) $assoc_args['scope'],
+				'scope_id'          => (int) $assoc_args['scope-id'],
+				'evidence'          => $evidence,
+			)
+		);
+
+		\WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+	}
+}

--- a/inc/Core/EventSourceRampEvaluator.php
+++ b/inc/Core/EventSourceRampEvaluator.php
@@ -1,0 +1,407 @@
+<?php
+/**
+ * Deterministic source-class ramp gate evaluation.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Evaluates supplied operational evidence without reading or mutating runtime state. */
+class EventSourceRampEvaluator {
+
+	public const SCHEMA_VERSION               = '1.0.0';
+	public const MINIMUM_WINDOW_HOURS         = 24;
+	public const MAXIMUM_EVIDENCE_AGE_SECONDS = 7200;
+
+	/**
+	 * Required evidence provenance keys.
+	 *
+	 * @var string[]
+	 */
+	private const REQUIRED_PROVENANCE = array(
+		'flow_settings',
+		'jobs_liveness',
+		'job_metrics',
+		'action_scheduler',
+		'event_quality',
+		'bundle_wave',
+	);
+
+	/**
+	 * Return the policy profiles used by both the evaluator and operator output.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public static function profiles(): array {
+		$common = array(
+			'queue_depth'                     => array(
+				'operator' => 'max',
+				'value'    => 25,
+			),
+			'oldest_queue_age_seconds'        => array(
+				'operator' => 'max',
+				'value'    => 7200,
+			),
+			'jobs_without_scheduler_path'     => array(
+				'operator' => 'max',
+				'value'    => 0,
+			),
+			'failed_rate'                     => array(
+				'operator' => 'max',
+				'value'    => 0.05,
+			),
+			'deferred_rate'                   => array(
+				'operator' => 'max',
+				'value'    => 0.10,
+			),
+			'ai_defer_budget_used_rate'       => array(
+				'operator' => 'max',
+				'value'    => 0.80,
+			),
+			'ai_defer_exhausted'              => array(
+				'operator' => 'max',
+				'value'    => 0,
+			),
+			'action_scheduler_pending_growth' => array(
+				'operator' => 'max',
+				'value'    => 10,
+			),
+		);
+
+		return array(
+			'ticketmaster'      => array(
+				'handler'    => 'ticketmaster',
+				'stages'     => array( 1, 3, 5 ),
+				'thresholds' => array_merge(
+					$common,
+					array(
+						'source_rejection_rate' => array(
+							'operator' => 'max',
+							'value'    => 0.10,
+						),
+						'eligible_events'       => array(
+							'operator' => 'min',
+							'value'    => 5,
+						),
+						'duplicate_rate'        => array(
+							'operator' => 'max',
+							'value'    => 0.10,
+						),
+						'event_yield'           => array(
+							'operator' => 'min',
+							'value'    => 0.50,
+						),
+					)
+				),
+			),
+			'dice'              => array(
+				'handler'    => 'dice_fm',
+				'stages'     => array( 1, 3, 10 ),
+				'thresholds' => array_merge(
+					$common,
+					array(
+						'source_rejection_rate' => array(
+							'operator' => 'max',
+							'value'    => 0.15,
+						),
+						'eligible_events'       => array(
+							'operator' => 'min',
+							'value'    => 5,
+						),
+						'duplicate_rate'        => array(
+							'operator' => 'max',
+							'value'    => 0.15,
+						),
+						'event_yield'           => array(
+							'operator' => 'min',
+							'value'    => 0.40,
+						),
+					)
+				),
+			),
+			'universal_scraper' => array(
+				'handler'    => 'universal_web_scraper',
+				'stages'     => array( 1, 2 ),
+				'thresholds' => array_merge(
+					$common,
+					array(
+						'source_rejection_rate' => array(
+							'operator' => 'max',
+							'value'    => 0.25,
+						),
+						'eligible_events'       => array(
+							'operator' => 'min',
+							'value'    => 2,
+						),
+						'duplicate_rate'        => array(
+							'operator' => 'max',
+							'value'    => 0.20,
+						),
+						'event_yield'           => array(
+							'operator' => 'min',
+							'value'    => 0.25,
+						),
+					)
+				),
+			),
+		);
+	}
+
+	/**
+	 * Evaluate a preflight or postflight evidence document.
+	 *
+	 * @param array<string,mixed> $input Evaluation input.
+	 * @param int|null            $now   Stable clock for tests; defaults to time().
+	 * @return array<string,mixed>
+	 */
+	public function evaluate( array $input, ?int $now = null ): array {
+		$now          = $now ?? time();
+		$source_class = (string) ( $input['source_class'] ?? '' );
+		$phase        = (string) ( $input['phase'] ?? 'preflight' );
+		$current      = (int) ( $input['current_max_items'] ?? 0 );
+		$scope        = (string) ( $input['scope'] ?? 'pipeline' );
+		$scope_id     = (int) ( $input['scope_id'] ?? 0 );
+		$evidence     = is_array( $input['evidence'] ?? null ) ? $input['evidence'] : array();
+		$profiles     = self::profiles();
+
+		$validation_errors = array();
+		if ( ! isset( $profiles[ $source_class ] ) ) {
+			$validation_errors[] = 'Unknown source_class.';
+		}
+		if ( ! in_array( $phase, array( 'preflight', 'postflight' ), true ) ) {
+			$validation_errors[] = 'phase must be preflight or postflight.';
+		}
+		if ( ! in_array( $scope, array( 'pipeline', 'flow' ), true ) || $scope_id < 1 ) {
+			$validation_errors[] = 'A reversible pipeline or flow scope with a positive scope_id is required.';
+		}
+
+		$profile     = $profiles[ $source_class ] ?? array(
+			'handler'    => '',
+			'stages'     => array(),
+			'thresholds' => array(),
+		);
+		$stage_index = array_search( $current, $profile['stages'], true );
+		if ( false === $stage_index ) {
+			$validation_errors[] = 'current_max_items must match a declared source stage.';
+		}
+
+		$gates = $this->evaluate_evidence( $evidence, $profile['thresholds'], $now );
+		if ( ! empty( $validation_errors ) ) {
+			$gates[] = array(
+				'name'      => 'input_validation',
+				'status'    => 'fail',
+				'observed'  => $validation_errors,
+				'threshold' => 'valid evaluation input',
+			);
+		}
+
+		$failed_names      = array_values(
+			array_map(
+				static fn( array $gate ): string => (string) $gate['name'],
+				array_filter( $gates, static fn( array $gate ): bool => 'pass' !== $gate['status'] )
+			)
+		);
+		$blocking_evidence = array_intersect( $failed_names, array( 'schema_version', 'observation_window', 'freshness', 'provenance', 'input_validation' ) );
+		$metric_failures   = array_diff( $failed_names, $blocking_evidence );
+		$last_stage        = false !== $stage_index && count( $profile['stages'] ) - 1 === $stage_index;
+		$next_stage        = ( false !== $stage_index && ! $last_stage ) ? $profile['stages'][ $stage_index + 1 ] : null;
+
+		if ( ! empty( $blocking_evidence ) ) {
+			$decision = 'hold';
+		} elseif ( ! empty( $metric_failures ) ) {
+			$decision = 'postflight' === $phase ? 'rollback' : 'hold';
+		} elseif ( $last_stage ) {
+			$decision = 'complete';
+		} else {
+			$decision = 'advance';
+		}
+
+		return array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'generated_at'   => gmdate( 'c', $now ),
+			'phase'          => $phase,
+			'source_class'   => $source_class,
+			'profile'        => $profile,
+			'scope'          => array(
+				'type' => $scope,
+				'id'   => $scope_id,
+			),
+			'current_stage'  => $current,
+			'proposed_stage' => 'advance' === $decision ? $next_stage : null,
+			'decision'       => $decision,
+			'can_advance'    => 'advance' === $decision,
+			'failed_gates'   => $failed_names,
+			'gates'          => $gates,
+			'evidence'       => $evidence,
+			'apply_plan'     => $this->build_plan( $decision, $profile, $current, $next_stage, $scope, $scope_id, $stage_index ),
+		);
+	}
+
+	/**
+	 * Evaluate evidence metadata and policy metrics.
+	 *
+	 * @param array<string,mixed> $evidence   Submitted evidence document.
+	 * @param array<string,mixed> $thresholds Source-class thresholds.
+	 * @param int                 $now        Evaluation clock.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function evaluate_evidence( array $evidence, array $thresholds, int $now ): array {
+		$gates   = array();
+		$gates[] = $this->exact_gate( 'schema_version', $evidence['schema_version'] ?? null, self::SCHEMA_VERSION );
+
+		$start   = $this->timestamp( $evidence['window_start'] ?? null );
+		$end     = $this->timestamp( $evidence['window_end'] ?? null );
+		$hours   = ( null !== $start && null !== $end && $end >= $start ) ? ( $end - $start ) / HOUR_IN_SECONDS : null;
+		$gates[] = $this->numeric_gate( 'observation_window', $hours, 'min', self::MINIMUM_WINDOW_HOURS );
+
+		$observed_at = $this->timestamp( $evidence['observed_at'] ?? null );
+		$age         = null === $observed_at ? null : $now - $observed_at;
+		$gates[]     = $this->numeric_gate( 'freshness', $age, 'range', array( -300, self::MAXIMUM_EVIDENCE_AGE_SECONDS ) );
+
+		$provenance         = is_array( $evidence['provenance'] ?? null ) ? $evidence['provenance'] : array();
+		$missing_provenance = array_values( array_diff( self::REQUIRED_PROVENANCE, array_keys( array_filter( $provenance ) ) ) );
+		$gates[]            = array(
+			'name'      => 'provenance',
+			'status'    => empty( $missing_provenance ) ? 'pass' : 'missing',
+			'observed'  => empty( $missing_provenance ) ? array_keys( $provenance ) : $missing_provenance,
+			'threshold' => self::REQUIRED_PROVENANCE,
+		);
+
+		$metrics = is_array( $evidence['metrics'] ?? null ) ? $evidence['metrics'] : array();
+		foreach ( $thresholds as $name => $threshold ) {
+			$gates[] = $this->numeric_gate( $name, $metrics[ $name ] ?? null, $threshold['operator'], $threshold['value'] );
+		}
+
+		return $gates;
+	}
+
+	/**
+	 * Compare a scalar value for exact equality.
+	 *
+	 * @param string $name      Gate name.
+	 * @param mixed  $observed  Observed value.
+	 * @param mixed  $threshold Required value.
+	 * @return array<string,mixed>
+	 */
+	private function exact_gate( string $name, $observed, $threshold ): array {
+		return array(
+			'name'      => $name,
+			'status'    => null === $observed ? 'missing' : ( $observed === $threshold ? 'pass' : 'fail' ),
+			'observed'  => $observed,
+			'threshold' => $threshold,
+		);
+	}
+
+	/**
+	 * Compare a numeric observation against a threshold.
+	 *
+	 * @param string          $name      Gate name.
+	 * @param mixed           $observed  Observed value.
+	 * @param string          $operator  min, max, or range.
+	 * @param int|float|int[] $threshold Threshold value.
+	 * @return array<string,mixed>
+	 */
+	private function numeric_gate( string $name, $observed, string $operator, $threshold ): array {
+		if ( ! is_int( $observed ) && ! is_float( $observed ) ) {
+			$status = 'missing';
+		} elseif ( 'min' === $operator ) {
+			$status = $observed >= $threshold ? 'pass' : 'fail';
+		} elseif ( 'range' === $operator ) {
+			$status = $observed >= $threshold[0] && $observed <= $threshold[1] ? 'pass' : 'fail';
+		} else {
+			$status = $observed <= $threshold ? 'pass' : 'fail';
+		}
+
+		return array(
+			'name'      => $name,
+			'status'    => $status,
+			'observed'  => $observed,
+			'operator'  => $operator,
+			'threshold' => $threshold,
+		);
+	}
+
+	/**
+	 * Parse an evidence timestamp.
+	 *
+	 * @param mixed $value Candidate timestamp.
+	 * @return int|null
+	 */
+	private function timestamp( $value ): ?int {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return null;
+		}
+		$timestamp = strtotime( $value );
+		return false === $timestamp ? null : $timestamp;
+	}
+
+	/**
+	 * Build an operator-confirmed apply and reversal plan.
+	 *
+	 * @param string              $decision    Evaluated decision.
+	 * @param array<string,mixed> $profile     Source profile.
+	 * @param int                 $current     Current max_items stage.
+	 * @param int|null            $next        Proposed max_items stage.
+	 * @param string              $scope       Pipeline or flow scope.
+	 * @param int                 $scope_id    Pipeline or flow ID.
+	 * @param int|false           $stage_index Current profile index.
+	 * @return array<string,mixed>
+	 */
+	private function build_plan( string $decision, array $profile, int $current, ?int $next, string $scope, int $scope_id, $stage_index ): array {
+		$plan = array(
+			'observational'              => true,
+			'mutation_owner'             => 'datamachine/configure-flow-steps',
+			'canonical_events_preserved' => true,
+			'preview_available'          => false,
+			'preview_blocker'            => 'Extra-Chill/data-machine#3019',
+			'apply_command'              => null,
+			'rollback_command'           => null,
+		);
+
+		if ( 'advance' === $decision && null !== $next ) {
+			$plan['apply_command']    = $this->bulk_config_command( $profile['handler'], $next, $scope, $scope_id );
+			$plan['rollback_command'] = $this->bulk_config_command( $profile['handler'], $current, $scope, $scope_id );
+		} elseif ( 'rollback' === $decision ) {
+			$previous = is_int( $stage_index ) && $stage_index > 0 ? $profile['stages'][ $stage_index - 1 ] : null;
+			if ( null !== $previous ) {
+				$plan['apply_command']    = $this->bulk_config_command( $profile['handler'], $previous, $scope, $scope_id );
+				$plan['rollback_command'] = $this->bulk_config_command( $profile['handler'], $current, $scope, $scope_id );
+			} else {
+				$plan['apply_command']    = 'pipeline' === $scope
+					? sprintf( 'wp datamachine flows pause --pipeline=%d', $scope_id )
+					: sprintf( 'wp datamachine flows pause %d', $scope_id );
+				$plan['rollback_command'] = 'pipeline' === $scope
+					? sprintf( 'wp datamachine flows resume --pipeline=%d', $scope_id )
+					: sprintf( 'wp datamachine flows resume %d', $scope_id );
+			}
+		}
+
+		return $plan;
+	}
+
+	/**
+	 * Render an executable command owned by Data Machine.
+	 *
+	 * @param string $handler   Handler slug.
+	 * @param int    $max_items Target max_items value.
+	 * @param string $scope     Pipeline or flow scope.
+	 * @param int    $scope_id  Pipeline or flow ID.
+	 * @return string
+	 */
+	private function bulk_config_command( string $handler, int $max_items, string $scope, int $scope_id ): string {
+		$id_flag = 'pipeline' === $scope ? 'pipeline_id' : 'flow_id';
+		return sprintf(
+			'wp datamachine flows bulk-config --handler=%s --config=\'{"max_items":%d}\' --scope=%s --%s=%d --execute --format=json',
+			$handler,
+			$max_items,
+			$scope,
+			$id_flag,
+			$scope_id
+		);
+	}
+}

--- a/tests/Unit/Core/EventSourceRampEvaluatorTest.php
+++ b/tests/Unit/Core/EventSourceRampEvaluatorTest.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Event source ramp policy tests.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use ExtraChillEvents\Abilities\EventSourceRampAbilities;
+use ExtraChillEvents\Core\EventSourceRampEvaluator;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__, 3 ) . '/inc/Core/EventSourceRampEvaluator.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Abilities/EventSourceRampAbilities.php';
+
+/** Covers source profiles, gate decisions, schema, and mutation safety. */
+class EventSourceRampEvaluatorTest extends TestCase {
+
+	private const NOW = 1785164400; // 2026-07-27T15:00:00Z.
+
+	/** Confirm each source uses the policy stages and owning handler. */
+	public function test_source_profiles_are_explicit(): void {
+		$profiles = EventSourceRampEvaluator::profiles();
+
+		$this->assertSame( array( 1, 3, 5 ), $profiles['ticketmaster']['stages'] );
+		$this->assertSame( 'ticketmaster', $profiles['ticketmaster']['handler'] );
+		$this->assertSame( array( 1, 3, 10 ), $profiles['dice']['stages'] );
+		$this->assertSame( 'dice_fm', $profiles['dice']['handler'] );
+		$this->assertSame( array( 1, 2 ), $profiles['universal_scraper']['stages'] );
+		$this->assertSame( 'universal_web_scraper', $profiles['universal_scraper']['handler'] );
+	}
+
+	/**
+	 * Confirm passing evidence proposes each source's next stage.
+	 *
+	 * @dataProvider advancement_provider
+	 * @param string $source  Source class.
+	 * @param int    $current Current stage.
+	 * @param int    $next    Expected stage.
+	 */
+	public function test_passing_evidence_proposes_each_source_next_stage( string $source, int $current, int $next ): void {
+		$result = $this->evaluate( $source, $current, 'preflight', $this->passing_evidence() );
+
+		$this->assertSame( 'advance', $result['decision'] );
+		$this->assertTrue( $result['can_advance'] );
+		$this->assertSame( $next, $result['proposed_stage'] );
+		$this->assertStringContainsString( '"max_items":' . $next, $result['apply_plan']['apply_command'] );
+	}
+
+	/**
+	 * Provide each source's first advancement.
+	 *
+	 * @return array<string,array{string,int,int}>
+	 */
+	public function advancement_provider(): array {
+		return array(
+			'ticketmaster'      => array( 'ticketmaster', 1, 3 ),
+			'dice'              => array( 'dice', 1, 3 ),
+			'universal scraper' => array( 'universal_scraper', 1, 2 ),
+		);
+	}
+
+	/** Confirm a missing required metric produces a hold. */
+	public function test_missing_evidence_refuses_advancement(): void {
+		$evidence = $this->passing_evidence();
+		unset( $evidence['metrics']['failed_rate'] );
+
+		$result = $this->evaluate( 'ticketmaster', 1, 'preflight', $evidence );
+
+		$this->assertSame( 'hold', $result['decision'] );
+		$this->assertContains( 'failed_rate', $result['failed_gates'] );
+		$this->assertNull( $result['apply_plan']['apply_command'] );
+	}
+
+	/** Confirm stale postflight evidence cannot cause advancement or rollback. */
+	public function test_stale_evidence_refuses_advancement_without_rollback(): void {
+		$evidence                = $this->passing_evidence();
+		$evidence['observed_at'] = gmdate( 'c', self::NOW - EventSourceRampEvaluator::MAXIMUM_EVIDENCE_AGE_SECONDS - 1 );
+
+		$result = $this->evaluate( 'dice', 3, 'postflight', $evidence );
+
+		$this->assertSame( 'hold', $result['decision'] );
+		$this->assertContains( 'freshness', $result['failed_gates'] );
+		$this->assertNull( $result['apply_plan']['apply_command'] );
+	}
+
+	/** Confirm a failed preflight metric holds the current stage. */
+	public function test_failed_preflight_gate_holds_current_stage(): void {
+		$evidence                           = $this->passing_evidence();
+		$evidence['metrics']['queue_depth'] = 26;
+
+		$result = $this->evaluate( 'ticketmaster', 1, 'preflight', $evidence );
+
+		$this->assertSame( 'hold', $result['decision'] );
+		$this->assertContains( 'queue_depth', $result['failed_gates'] );
+	}
+
+	/** Confirm a passing final stage cannot advance beyond policy. */
+	public function test_passing_final_stage_is_complete(): void {
+		$result = $this->evaluate( 'dice', 10, 'postflight', $this->passing_evidence() );
+
+		$this->assertSame( 'complete', $result['decision'] );
+		$this->assertFalse( $result['can_advance'] );
+		$this->assertNull( $result['proposed_stage'] );
+		$this->assertNull( $result['apply_plan']['apply_command'] );
+	}
+
+	/** Confirm a trustworthy failed postflight reduces one stage reversibly. */
+	public function test_failed_postflight_emits_reversible_reduction(): void {
+		$evidence                           = $this->passing_evidence();
+		$evidence['metrics']['failed_rate'] = 0.06;
+
+		$result = $this->evaluate( 'ticketmaster', 3, 'postflight', $evidence );
+
+		$this->assertSame( 'rollback', $result['decision'] );
+		$this->assertStringContainsString( '"max_items":1', $result['apply_plan']['apply_command'] );
+		$this->assertStringContainsString( '"max_items":3', $result['apply_plan']['rollback_command'] );
+		$this->assertTrue( $result['apply_plan']['canonical_events_preserved'] );
+	}
+
+	/** Confirm a failed first stage pauses instead of deleting events. */
+	public function test_failed_first_stage_postflight_pauses_reversibly(): void {
+		$evidence                                  = $this->passing_evidence();
+		$evidence['metrics']['ai_defer_exhausted'] = 1;
+
+		$result = $this->evaluate( 'universal_scraper', 1, 'postflight', $evidence );
+
+		$this->assertSame( 'rollback', $result['decision'] );
+		$this->assertSame( 'wp datamachine flows pause --pipeline=10', $result['apply_plan']['apply_command'] );
+		$this->assertSame( 'wp datamachine flows resume --pipeline=10', $result['apply_plan']['rollback_command'] );
+	}
+
+	/** Confirm evaluator output matches the declared top-level JSON schema. */
+	public function test_output_matches_declared_json_schema(): void {
+		$result = $this->evaluate( 'ticketmaster', 1, 'preflight', $this->passing_evidence() );
+		$schema = EventSourceRampAbilities::output_schema();
+
+		$this->assertSame( array(), array_diff( $schema['required'], array_keys( $result ) ) );
+		$this->assertSame( array(), array_diff( array_keys( $result ), array_keys( $schema['properties'] ) ) );
+		$this->assertSame( EventSourceRampEvaluator::SCHEMA_VERSION, $result['schema_version'] );
+		$this->assertJson( wp_json_encode( $result ) );
+
+		$input_schema = EventSourceRampAbilities::input_schema();
+		$this->assertFalse( $input_schema['additionalProperties'] );
+		$this->assertSame(
+			array_keys( EventSourceRampEvaluator::profiles()['ticketmaster']['thresholds'] ),
+			array_keys( $input_schema['properties']['evidence']['properties']['metrics']['properties'] )
+		);
+	}
+
+	/** Confirm evaluation emits a plan but never calls a mutation hook. */
+	public function test_evaluation_is_observational_and_does_not_call_mutation_owner(): void {
+		$GLOBALS['ec_ramp_mutations'] = 0;
+		add_filter(
+			'extrachill_events_ramp_mutation',
+			static function (): bool {
+				++$GLOBALS['ec_ramp_mutations'];
+				return true;
+			}
+		);
+
+		$result = $this->evaluate( 'ticketmaster', 1, 'preflight', $this->passing_evidence() );
+
+		$this->assertSame( 0, $GLOBALS['ec_ramp_mutations'] );
+		$this->assertTrue( $result['apply_plan']['observational'] );
+		$this->assertFalse( $result['apply_plan']['preview_available'] );
+		$this->assertSame( 'Extra-Chill/data-machine#3019', $result['apply_plan']['preview_blocker'] );
+		unset( $GLOBALS['ec_ramp_mutations'] );
+	}
+
+	/**
+	 * Build passing evidence at a stable time.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function passing_evidence(): array {
+		return array(
+			'schema_version' => EventSourceRampEvaluator::SCHEMA_VERSION,
+			'observed_at'    => gmdate( 'c', self::NOW - 60 ),
+			'window_start'   => gmdate( 'c', self::NOW - DAY_IN_SECONDS ),
+			'window_end'     => gmdate( 'c', self::NOW ),
+			'provenance'     => array(
+				'flow_settings'    => 'flow.json',
+				'jobs_liveness'    => 'liveness.json',
+				'job_metrics'      => 'jobs.json',
+				'action_scheduler' => 'actions.json',
+				'event_quality'    => 'quality.json',
+				'bundle_wave'      => 'extrachill-event-bundles#10/london',
+			),
+			'metrics'        => array(
+				'queue_depth'                     => 5,
+				'oldest_queue_age_seconds'        => 600,
+				'jobs_without_scheduler_path'     => 0,
+				'failed_rate'                     => 0.01,
+				'deferred_rate'                   => 0.04,
+				'ai_defer_budget_used_rate'       => 0.20,
+				'ai_defer_exhausted'              => 0,
+				'action_scheduler_pending_growth' => 2,
+				'source_rejection_rate'           => 0.02,
+				'eligible_events'                 => 40,
+				'duplicate_rate'                  => 0.03,
+				'event_yield'                     => 0.70,
+			),
+			'cadence_status' => null,
+		);
+	}
+
+	/**
+	 * Evaluate one source with a stable clock and scope.
+	 *
+	 * @param string              $source   Source class.
+	 * @param int                 $current  Current stage.
+	 * @param string              $phase    Evidence phase.
+	 * @param array<string,mixed> $evidence Evidence document.
+	 * @return array<string,mixed>
+	 */
+	private function evaluate( string $source, int $current, string $phase, array $evidence ): array {
+		return ( new EventSourceRampEvaluator() )->evaluate(
+			array(
+				'source_class'      => $source,
+				'current_max_items' => $current,
+				'phase'             => $phase,
+				'scope'             => 'pipeline',
+				'scope_id'          => 10,
+				'evidence'          => $evidence,
+			),
+			self::NOW
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- add a read-only ability and JSON CLI evaluator for Ticketmaster, Dice, and universal-scraper ramp evidence
- refuse advancement on missing, stale, or failing evidence and emit reversible Data Machine-owned advance/rollback plans
- document source stages, exact SLO thresholds, evidence provenance, bundle-wave usage, and the upstream dry-run blocker

## Primitives Checked And Reused

- Data Machine `datamachine/configure-flow-steps` remains the sole flow-config mutation owner; generated commands use `wp datamachine flows bulk-config`
- `wp datamachine jobs liveness --format=json` supplies scheduler-path and queue-age evidence
- `wp datamachine jobs list --since=... --format=json` plus persisted RunMetrics outcome classes supply failed, deferred, source-rejection, eligible, and yield inputs
- `wp data-machine-events check quality --issue=duplicates --format=json` supplies event-quality evidence
- existing Action Scheduler snapshots supply pending-growth evidence; no scheduler or metrics store was added
- event-bundles rollout-wave identity is required in provenance; DME cadence status is optional until data-machine-events#260 stabilizes its public contract
- Extra Chill market-report/analytics surfaces were inspected but intentionally not used as operational queue-health gates

## Policy Defaults

- observation window: minimum 24 hours; evidence freshness: maximum 2 hours
- Ticketmaster stages: `1 -> 3 -> 5`; rejection <= 0.10, eligible >= 5, duplicates <= 0.10, yield >= 0.50
- Dice stages: `1 -> 3 -> 10`; rejection <= 0.15, eligible >= 5, duplicates <= 0.15, yield >= 0.40
- universal scraper stages: `1 -> 2`; rejection <= 0.25, eligible >= 2, duplicates <= 0.20, yield >= 0.25
- common gates: queue depth <= 25, oldest queue age <= 7200s, no-scheduler-path jobs = 0, failed rate <= 0.05, deferred rate <= 0.10, AI defer budget used <= 0.80, exhausted AI defers = 0, Action Scheduler pending growth <= 10

## Commands

```sh
wp extrachill events ramp --source-class=ticketmaster --current-max-items=1 --phase=preflight --evidence=preflight.json --scope=pipeline --scope-id=10
wp extrachill events ramp --source-class=ticketmaster --current-max-items=3 --phase=postflight --evidence=postflight.json --scope=pipeline --scope-id=10
```

The evaluator never executes its plan. Passing stages emit operator-confirmed `bulk-config --execute` commands and exact reversal commands. Failed stage-1 postflights emit pause/resume plans, preserving canonical events.

Pipeline/flow `bulk-config --dry-run` currently mutates through its owner path. This PR marks preview unavailable and links Extra-Chill/data-machine#3019 rather than presenting that unsafe command as observational.

## Event Bundles Compatibility

Each preflight/postflight document requires `bundle_wave` provenance, so London and later waves from Extra-Chill/extrachill-event-bundles#10 can persist reviewed evidence with their declarative changes. The evaluator scopes plans to one pipeline or flow, never global state, and does not activate, pause, or rewrite a bundle itself.

## Verification

- `./vendor/bin/phpunit tests/Unit/Core/EventSourceRampEvaluatorTest.php`: 12 tests, 47 assertions passed
- focused WordPress PHPCS: passed (repository filename convention excluded)
- PHP syntax checks: passed for all added PHP files
- `git diff --check`: passed
- Homeboy review `ca41195a-ca68-49ff-8b6a-be4630ef724e`: audit passed, lint passed with PHPCS/ESLint/PHPStan and zero findings
- Homeboy selected test could not start because the WP Codebox adapter lacks `WP_CODEBOX_DB_HOST`; it reported 0 executed tests. The same selected test passes in the local PHPUnit command above.
- the repository-wide plain PHPUnit suite remains blocked by its documented `WP_UnitTestCase` bootstrap mismatch

Closes #39