### PR TITLE
feat: add local support matching notifications

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -285,6 +285,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingNotificationService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportNotificationAdapter.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportNotificationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingCommunicationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingHoldRepository.php';

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -281,6 +281,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingNotificationService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportNotificationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingCommunicationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingHoldRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingMutationService.php';
@@ -304,6 +305,7 @@ class ExtraChillEvents {
 		\ExtraChillEvents\Core\BookingHoldRepository::register();
 		\ExtraChillEvents\Core\BookingCommunicationService::register();
 		\ExtraChillEvents\Core\BookingNotificationService::register();
+		\ExtraChillEvents\Core\LocalSupportNotificationService::register();
 		new \ExtraChillEvents\Core\CanonicalEventPublicationGuard();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/ArtistUrlImport.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/ArtistUrlImportRoutes.php';

--- a/inc/Core/LocalSupportNotificationAdapter.php
+++ b/inc/Core/LocalSupportNotificationAdapter.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * Production local-support notification domain adapter.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Persists notification state in the local-support activity ledger. */
+class LocalSupportNotificationAdapter {
+
+	public const WORKSPACE_URL_FILTER = 'extrachill_events_local_support_workspace_url';
+
+	/** @var LocalSupportRepository */
+	private $repository;
+	/** @var LocalSupportAuthorization */
+	private $authorization;
+	/** @var VenueMembershipRepository */
+	private $memberships;
+	/** @var callable|null Authorized workspace resolver test seam. */
+	private $workspace;
+
+	public function __construct( ?LocalSupportRepository $repository = null, ?LocalSupportAuthorization $authorization = null, ?VenueMembershipRepository $memberships = null, $workspace = null ) {
+		$this->repository    = $repository ? $repository : new LocalSupportRepository();
+		$this->authorization = $authorization ? $authorization : new LocalSupportAuthorization();
+		$this->memberships   = $memberships ? $memberships : new VenueMembershipRepository();
+		$this->workspace     = $workspace;
+	}
+
+	/** Hydrate the exact committed domain records represented by one change event. */
+	public function notification_source( array $change ) {
+		$kind        = sanitize_key( (string) ( $change['kind'] ?? '' ) );
+		$request_id  = absint( $change['request_id'] ?? 0 );
+		$interest_id = empty( $change['interest_id'] ) ? null : absint( $change['interest_id'] );
+		$version     = absint( $change['version'] ?? 0 );
+		if ( '' === $kind || $request_id < 1 || $version < 1 ) {
+			return new \WP_Error( 'local_support_change_invalid', __( 'The emitted local-support change is invalid.', 'extrachill-events' ) );
+		}
+		$request  = $this->repository->get_request( $request_id );
+		$activity = $this->repository->find_activity_for_change( $request_id, $interest_id, $kind, $version );
+		if ( ! is_array( $request ) || ! is_array( $activity ) ) {
+			if ( is_wp_error( $request ) || is_wp_error( $activity ) ) {
+				return is_wp_error( $request ) ? $request : $activity;
+			}
+			return new \WP_Error( 'local_support_change_source_missing', __( 'The emitted local-support change has no durable source activity.', 'extrachill-events' ) );
+		}
+		$interest = null;
+		if ( null !== $interest_id ) {
+			$interest = $this->repository->get_interest( $interest_id );
+			if ( ! is_array( $interest ) || (int) $interest['request_id'] !== $request_id ) {
+				return is_wp_error( $interest ) ? $interest : new \WP_Error( 'local_support_change_interest_missing', __( 'The emitted local-support interest could not be resolved.', 'extrachill-events' ) );
+			}
+		}
+		return compact( 'request', 'interest', 'activity' );
+	}
+
+	/** Append one idempotent, privacy-safe notification intent. */
+	public function append_notification_intent( array $intent ) {
+		$existing = $this->repository->find_activity( (int) $intent['request_id'], (string) $intent['idempotency_key'] );
+		if ( is_wp_error( $existing ) ) {
+			return $existing;
+		}
+		if ( is_array( $existing ) ) {
+			return $this->intent_from_activity( $this->repository->hydrate_activity( $existing ) );
+		}
+		$source = $this->source_activity_by_id( (int) $intent['source_activity_id'], (int) $intent['request_id'] );
+		if ( ! is_array( $source ) ) {
+			return is_wp_error( $source ) ? $source : new \WP_Error( 'local_support_notification_source_missing', __( 'The notification intent source activity is unavailable.', 'extrachill-events' ) );
+		}
+		$hash   = hash( 'sha256', (string) $intent['idempotency_key'] );
+		$record = $this->repository->append_activity(
+			array(
+				'request_id'      => (int) $intent['request_id'],
+				'interest_id'     => null,
+				'kind'            => 'notification_intent',
+				'actor_user_id'   => (int) $source['actor_user_id'],
+				'idempotency_key' => (string) $intent['idempotency_key'],
+				'request_hash'    => $hash,
+				'result_version'  => (int) $source['result_version'],
+				'payload'         => $intent,
+			)
+		);
+		if ( is_wp_error( $record ) ) {
+			$winner = $this->repository->find_activity( (int) $intent['request_id'], (string) $intent['idempotency_key'] );
+			return is_array( $winner ) ? $this->intent_from_activity( $this->repository->hydrate_activity( $winner ) ) : $record;
+		}
+		return $this->intent_from_activity( $this->repository->hydrate_activity( $record ) );
+	}
+
+	/** Return a bounded page of due durable intents. */
+	public function pending_notification_intents( int $limit ) {
+		$rows = $this->repository->pending_notification_intents( $limit );
+		return is_wp_error( $rows ) ? $rows : array_map( array( $this, 'intent_from_activity' ), $rows );
+	}
+
+	/** Return a bounded page of committed changes missing a processed marker. */
+	public function pending_notification_sources( int $limit ) {
+		return $this->repository->pending_notification_sources( $limit );
+	}
+
+	/** Mark one source as fully translated into zero or more durable intents. */
+	public function mark_notification_source_processed( array $activity ) {
+		$key      = 'local-support-notification-source:' . hash_hmac( 'sha256', (string) $activity['id'], wp_salt( 'auth' ) );
+		$existing = $this->repository->find_activity( (int) $activity['request_id'], $key );
+		if ( is_wp_error( $existing ) || is_array( $existing ) ) {
+			return $existing;
+		}
+		$record = $this->repository->append_activity(
+			array(
+				'request_id'      => (int) $activity['request_id'],
+				'interest_id'     => empty( $activity['interest_id'] ) ? null : (int) $activity['interest_id'],
+				'kind'            => 'notification_source_processed',
+				'actor_user_id'   => (int) $activity['actor_user_id'],
+				'idempotency_key' => $key,
+				'request_hash'    => (string) $activity['request_hash'],
+				'result_version'  => (int) $activity['result_version'],
+				'payload'         => array( 'source_activity_id' => (int) $activity['id'] ),
+			)
+		);
+		if ( is_wp_error( $record ) ) {
+			$winner = $this->repository->find_activity( (int) $activity['request_id'], $key );
+			return is_array( $winner ) ? $winner : $record;
+		}
+		return $record;
+	}
+
+	/** Return terminal delivery state for one intent. */
+	public function notification_terminal( array $intent ) {
+		$row = $this->repository->notification_terminal( (int) $intent['request_id'], (string) $intent['_request_hash'] );
+		return is_wp_error( $row ) || ! is_array( $row ) ? $row : $row['payload'];
+	}
+
+	/** Count prior delivery attempts for one intent. */
+	public function notification_attempt_count( array $intent ) {
+		return $this->repository->notification_attempt_count( (int) $intent['request_id'], (string) $intent['_request_hash'] );
+	}
+
+	/** Append one deferred retry marker. */
+	public function record_notification_attempt( array $intent, int $attempt, string $due_at, string $error_code ) {
+		$record = $this->repository->append_activity(
+			array(
+				'request_id'      => (int) $intent['request_id'],
+				'interest_id'     => null,
+				'kind'            => 'notification_attempt',
+				'actor_user_id'   => (int) $intent['_actor_user_id'],
+				'idempotency_key' => sprintf( 'local-support-notification-attempt:%s:%d', $intent['_request_hash'], $attempt ),
+				'request_hash'    => (string) $intent['_request_hash'],
+				'result_version'  => (int) $intent['_result_version'],
+				'payload'         => array(
+					'status'     => 'retrying',
+					'attempt'    => $attempt,
+					'due_at'     => $due_at,
+					'error_code' => sanitize_key( $error_code ),
+				),
+				'created_at'      => $due_at,
+			)
+		);
+		return is_wp_error( $record ) ? $record : $this->repository->hydrate_activity( $record )['payload'];
+	}
+
+	/** Append one terminal receipt marker. */
+	public function record_notification_terminal( array $intent, string $status, array $details ) {
+		$record = $this->repository->append_activity(
+			array(
+				'request_id'      => (int) $intent['request_id'],
+				'interest_id'     => null,
+				'kind'            => 'notification_terminal',
+				'actor_user_id'   => (int) $intent['_actor_user_id'],
+				'idempotency_key' => 'local-support-notification-terminal:' . $intent['_request_hash'],
+				'request_hash'    => (string) $intent['_request_hash'],
+				'result_version'  => (int) $intent['_result_version'],
+				'payload'         => array(
+					'status'  => sanitize_key( $status ),
+					'details' => $details,
+				),
+			)
+		);
+		if ( is_wp_error( $record ) ) {
+			$existing = $this->repository->notification_terminal( (int) $intent['request_id'], (string) $intent['_request_hash'] );
+			return is_array( $existing ) ? $existing['payload'] : $record;
+		}
+		return $this->repository->hydrate_activity( $record )['payload'];
+	}
+
+	/** Resolve currently authorized users for the stored organizer identity. */
+	public function organizer_recipient_ids( int $request_id ) {
+		$request = $this->repository->get_request( $request_id );
+		if ( ! is_array( $request ) ) {
+			return is_wp_error( $request ) ? $request : new \WP_Error( 'local_support_request_missing', __( 'The local-support request could not be resolved.', 'extrachill-events' ) );
+		}
+		if ( 'venue' === $request['organizer_type'] ) {
+			$members = $this->memberships->list_for_venue(
+				(int) $request['venue_term_id'],
+				array(
+					'status' => VenueAuthorization::STATUS_ACTIVE,
+					'limit'  => 100,
+				)
+			);
+			if ( is_wp_error( $members ) ) {
+				return $members;
+			}
+			$candidates = array_column( $members, 'user_id' );
+		} elseif ( 'artist' === $request['organizer_type'] ) {
+			$candidates = $this->artist_manager_ids( (int) $request['organizer_id'] );
+			if ( is_wp_error( $candidates ) ) {
+				return $candidates;
+			}
+		} else {
+			return new \WP_Error( 'local_support_organizer_invalid', __( 'The local-support organizer identity is invalid.', 'extrachill-events' ) );
+		}
+
+		$recipients = array();
+		foreach ( array_unique( array_map( 'absint', $candidates ) ) as $user_id ) {
+			if ( $user_id > 0 && get_userdata( $user_id ) && true === $this->authorization->authorize_organizer( $request, $user_id ) ) {
+				$recipients[] = $user_id;
+			}
+		}
+		return $recipients;
+	}
+
+	/** Resolve a future private workspace route only after current authorization. */
+	public function workspace_url( int $request_id, int $recipient_id, array $intent ) {
+		$request = $this->repository->get_request( $request_id );
+		if ( ! is_array( $request ) ) {
+			return is_wp_error( $request ) ? $request : new \WP_Error( 'local_support_request_missing', __( 'The local-support request could not be resolved.', 'extrachill-events' ) );
+		}
+		$allowed = 'organizer_interest_changed' === ( $intent['kind'] ?? '' )
+			? $this->authorization->authorize_organizer( $request, $recipient_id )
+			: ( get_userdata( $recipient_id ) ? true : new \WP_Error( 'local_support_workspace_forbidden', __( 'The local-support workspace is not authorized.', 'extrachill-events' ) ) );
+		if ( true !== $allowed ) {
+			return is_wp_error( $allowed ) ? $allowed : new \WP_Error( 'local_support_workspace_forbidden', __( 'The local-support workspace is not authorized.', 'extrachill-events' ) );
+		}
+		$url = $this->workspace
+			? call_user_func( $this->workspace, $request, $recipient_id )
+			: apply_filters( self::WORKSPACE_URL_FILTER, null, $request, $recipient_id );
+		return is_string( $url ) && '' !== $url
+			? $url
+			: new \WP_Error( 'local_support_workspace_unavailable', __( 'A private local-support workspace route is not available yet.', 'extrachill-events' ) );
+	}
+
+	/** Convert one activity row back to the service's strict intent shape. */
+	private function intent_from_activity( array $activity ): array {
+		$intent                        = (array) $activity['payload'];
+		$intent['_request_hash']       = (string) $activity['request_hash'];
+		$intent['_actor_user_id']      = (int) $activity['actor_user_id'];
+		$intent['_result_version']     = (int) $activity['result_version'];
+		$intent['_intent_activity_id'] = (int) $activity['id'];
+		return $intent;
+	}
+
+	/** Read one source activity by immutable ID and request. */
+	private function source_activity_by_id( int $activity_id, int $request_id ) {
+		return $this->repository->get_activity( $activity_id, $request_id );
+	}
+
+	/** Resolve reciprocal Artist Platform managers for a canonical artist term. */
+	private function artist_manager_ids( int $artist_term_id ) {
+		$main_blog_id   = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'main' ) ) : 0;
+		$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'artist' ) ) : 0;
+		if ( $main_blog_id < 1 || $artist_blog_id < 1 || ! function_exists( 'extrachill_artist_platform_get_local_support_manager_ids' ) ) {
+			return new \WP_Error( 'local_support_artist_managers_unavailable', __( 'Validated Artist Platform manager recipients are unavailable.', 'extrachill-events' ) );
+		}
+		switch_to_blog( $main_blog_id );
+		try {
+			$profile_id = absint( get_term_meta( $artist_term_id, '_artist_profile_id', true ) );
+		} finally {
+			restore_current_blog();
+		}
+		if ( $profile_id < 1 ) {
+			return new \WP_Error( 'local_support_artist_binding_invalid', __( 'The organizer artist profile binding is invalid.', 'extrachill-events' ) );
+		}
+		switch_to_blog( $artist_blog_id );
+		try {
+			return extrachill_artist_platform_get_local_support_manager_ids( $profile_id );
+		} finally {
+			restore_current_blog();
+		}
+	}
+}

--- a/inc/Core/LocalSupportNotificationService.php
+++ b/inc/Core/LocalSupportNotificationService.php
@@ -14,15 +14,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Coordinates Events-owned matching with dependency-owned storage and eligibility. */
 class LocalSupportNotificationService {
 
-	public const REQUEST_OPENED_HOOK   = 'extrachill_events_local_support_request_opened';
-	public const INTEREST_CHANGED_HOOK = 'extrachill_events_local_support_interest_changed';
-	public const RECONCILE_HOOK        = 'extrachill_events_reconcile_local_support_notifications';
-	public const ADAPTER_FILTER        = 'extrachill_events_local_support_notification_adapter';
-	public const ERROR_HOOK            = 'extrachill_events_local_support_notification_error';
-	public const ELIGIBILITY_ABILITY   = 'extrachill/resolve-local-support-candidates';
-	public const PRODUCER              = 'extrachill-events-local-support';
-	public const SCHEDULER_GROUP       = 'extrachill-events-local-support';
-	public const MAX_ATTEMPTS          = 5;
+	public const CHANGE_HOOK         = 'extrachill_events_local_support_changed';
+	public const RECONCILE_HOOK      = 'extrachill_events_reconcile_local_support_notifications';
+	public const ERROR_HOOK          = 'extrachill_events_local_support_notification_error';
+	public const ELIGIBILITY_ABILITY = 'extrachill/artist-query-local-support-candidates';
+	public const PRODUCER            = 'extrachill-events-local-support';
+	public const SCHEDULER_GROUP     = 'extrachill-events-local-support';
+	public const MAX_ATTEMPTS        = 5;
 
 	/** @var object|null #420-owned durable adapter. */
 	private $adapter;
@@ -54,10 +52,10 @@ class LocalSupportNotificationService {
 
 	/** Register domain event consumers and bounded reconciliation. */
 	public static function register(): void {
-		add_action( self::REQUEST_OPENED_HOOK, array( self::class, 'handle_request_opened' ), 10, 2 );
-		add_action( self::INTEREST_CHANGED_HOOK, array( self::class, 'handle_interest_changed' ), 10, 3 );
+		add_action( self::CHANGE_HOOK, array( self::class, 'handle_change' ) );
 		add_action( self::RECONCILE_HOOK, array( self::class, 'reconcile_scheduled' ) );
 		add_action( 'init', array( self::class, 'ensure_reconciliation_schedule' ) );
+		add_filter( 'extrachill_artist_platform_local_support_producer_authorized', array( self::class, 'authorize_producer' ), 10, 2 );
 	}
 
 	/** Ensure ambiguous outcomes remain recoverable after a process interruption. */
@@ -68,22 +66,18 @@ class LocalSupportNotificationService {
 		as_schedule_recurring_action( time() + MINUTE_IN_SECONDS, 5 * MINUTE_IN_SECONDS, self::RECONCILE_HOOK, array(), self::SCHEDULER_GROUP, true );
 	}
 
-	/** Consume the stable #420 request-opened event contract. */
-	public static function handle_request_opened( array $request, array $activity ): void {
+	/** Consume the landed privacy-safe #420 change event. */
+	public static function handle_change( array $change ): void {
 		$service = self::runtime();
-		$result  = is_wp_error( $service ) ? $service : $service->queue_request_opened( $request, $activity );
+		$result  = $service->queue_change( $change );
 		if ( is_wp_error( $result ) ) {
-			do_action( self::ERROR_HOOK, $result, 'request_opened', $activity );
+			do_action( self::ERROR_HOOK, $result, $change );
 		}
 	}
 
-	/** Consume the stable #420 interest-changed event contract. */
-	public static function handle_interest_changed( array $request, array $interest, array $activity ): void {
-		$service = self::runtime();
-		$result  = is_wp_error( $service ) ? $service : $service->queue_interest_changed( $request, $interest, $activity );
-		if ( is_wp_error( $result ) ) {
-			do_action( self::ERROR_HOOK, $result, 'interest_changed', $activity );
-		}
+	/** Authorize only this Events-owned producer at the Artist Platform boundary. */
+	public static function authorize_producer( bool $authorized, string $producer ): bool {
+		return $authorized || self::PRODUCER === $producer;
 	}
 
 	/** Run one scheduler reconciliation page. */
@@ -95,13 +89,32 @@ class LocalSupportNotificationService {
 		}
 	}
 
-	/** Resolve the #420 adapter only at runtime so either dependency may load later. */
-	private static function runtime() {
-		$adapter = apply_filters( self::ADAPTER_FILTER, null );
-		if ( ! is_object( $adapter ) ) {
-			return new \WP_Error( 'local_support_domain_adapter_unavailable', __( 'Local-support notification storage is unavailable; activate the request domain integration.', 'extrachill-events' ) );
+	/** Build the production service against the landed Events domain. */
+	private static function runtime(): self {
+		return new self( new LocalSupportNotificationAdapter() );
+	}
+
+	/** Map one committed domain change to its notification behavior. */
+	public function queue_change( array $change ) {
+		$source = $this->call_adapter( 'notification_source', array( $change ) );
+		if ( is_wp_error( $source ) ) {
+			return $source;
 		}
-		return new self( $adapter );
+		$kind = (string) ( $change['kind'] ?? '' );
+		if ( 'request_opened' === $kind ) {
+			$result = $this->queue_request_opened( $source['request'], $source['activity'] );
+		} elseif ( 0 === strpos( $kind, 'interest_' ) || 0 === strpos( $kind, 'contact_consent_' ) ) {
+			$result = is_array( $source['interest'] )
+				? $this->queue_interest_changed( $source['request'], $source['interest'], $source['activity'] )
+				: new \WP_Error( 'local_support_change_interest_missing', __( 'The interest change has no durable interest record.', 'extrachill-events' ) );
+		} else {
+			return array();
+		}
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		$marked = $this->call_adapter( 'mark_notification_source_processed', array( $source['activity'] ) );
+		return is_wp_error( $marked ) ? $marked : $result;
 	}
 
 	/** Queue one deterministic candidate intent per eligible artist manager. */
@@ -125,7 +138,7 @@ class LocalSupportNotificationService {
 		$queued = array();
 		foreach ( $candidates as $candidate ) {
 			foreach ( $candidate['manager_user_ids'] as $recipient_id ) {
-				$key    = sprintf( 'local-support:request-opened:%d:%d:%d', $activity['id'], $candidate['artist_term_id'], $recipient_id );
+				$key    = $this->intent_key( 'request-opened', array( $activity['id'], $candidate['artist_term_id'], $recipient_id ) );
 				$intent = $this->append_intent(
 					array(
 						'idempotency_key'    => $key,
@@ -156,9 +169,12 @@ class LocalSupportNotificationService {
 
 	/** Queue deterministic organizer intents after an artist interest mutation. */
 	public function queue_interest_changed( array $request, array $interest, array $activity ) {
-		$valid = $this->validate_source( $request, $activity, 'interest_changed' );
+		$valid = $this->validate_source( $request, $activity, (string) ( $activity['kind'] ?? '' ) );
 		if ( true !== $valid ) {
 			return $valid;
+		}
+		if ( 0 !== strpos( (string) $activity['kind'], 'interest_' ) && 0 !== strpos( (string) $activity['kind'], 'contact_consent_' ) ) {
+			return new \WP_Error( 'local_support_source_invalid', __( 'The local-support interest notification source is invalid.', 'extrachill-events' ) );
 		}
 		$artist_term_id = absint( $interest['artist_term_id'] ?? 0 );
 		if ( $artist_term_id < 1 ) {
@@ -171,7 +187,7 @@ class LocalSupportNotificationService {
 		}
 		$queued = array();
 		foreach ( $recipients as $recipient_id ) {
-			$key    = sprintf( 'local-support:interest-changed:%d:%d', $activity['id'], $recipient_id );
+			$key    = $this->intent_key( 'interest-changed', array( $activity['id'], $recipient_id ) );
 			$intent = $this->append_intent(
 				array(
 					'idempotency_key'    => $key,
@@ -200,11 +216,30 @@ class LocalSupportNotificationService {
 
 	/** Reconcile a bounded page supplied by #420's durable activity store. */
 	public function reconcile_pending( int $limit = 50 ) {
+		$limit   = max( 1, min( 100, $limit ) );
+		$sources = $this->call_adapter( 'pending_notification_sources', array( $limit ) );
+		if ( is_wp_error( $sources ) || ! is_array( $sources ) ) {
+			return is_wp_error( $sources ) ? $sources : new \WP_Error( 'local_support_pending_sources_invalid', __( 'Local-support pending notification sources returned an invalid result.', 'extrachill-events' ) );
+		}
+		$recovered = 0;
+		foreach ( $sources as $source ) {
+			$result = $this->queue_change(
+				array(
+					'kind'        => $source['kind'],
+					'request_id'  => $source['request_id'],
+					'interest_id' => $source['interest_id'],
+					'version'     => $source['result_version'],
+				)
+			);
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			++$recovered;
+		}
 		$method = $this->adapter_method( 'pending_notification_intents' );
 		if ( is_wp_error( $method ) ) {
 			return $method;
 		}
-		$limit   = max( 1, min( 100, $limit ) );
 		$intents = $this->adapter->pending_notification_intents( $limit );
 		if ( is_wp_error( $intents ) || ! is_array( $intents ) ) {
 			return is_wp_error( $intents ) ? $intents : new \WP_Error( 'local_support_pending_intents_invalid', __( 'Local-support pending notification storage returned an invalid result.', 'extrachill-events' ) );
@@ -219,10 +254,10 @@ class LocalSupportNotificationService {
 				++$completed;
 			}
 		}
-		if ( count( $intents ) >= $limit ) {
+		if ( count( $sources ) >= $limit || count( $intents ) >= $limit ) {
 			$this->schedule_reconciliation();
 		}
-		return compact( 'completed' );
+		return compact( 'recovered', 'completed' );
 	}
 
 	/** Revalidate authorization and reconcile one idempotent Users receipt. */
@@ -231,7 +266,7 @@ class LocalSupportNotificationService {
 		if ( true !== $valid ) {
 			return $valid;
 		}
-		$terminal = $this->call_adapter( 'notification_terminal', array( $intent['idempotency_key'] ) );
+		$terminal = $this->call_adapter( 'notification_terminal', array( $intent ) );
 		if ( is_wp_error( $terminal ) || is_array( $terminal ) ) {
 			return $terminal;
 		}
@@ -242,7 +277,7 @@ class LocalSupportNotificationService {
 		if ( ! $authorized ) {
 			return $this->record_terminal( $intent, 'suppressed', array( 'reason' => 'recipient_no_longer_authorized' ) );
 		}
-		$link = $this->call_adapter( 'workspace_url', array( (int) $intent['request_id'], (int) $intent['recipient_id'] ) );
+		$link = $this->call_adapter( 'workspace_url', array( (int) $intent['request_id'], (int) $intent['recipient_id'], $intent ) );
 		if ( is_wp_error( $link ) || ! is_string( $link ) || ! $this->valid_url( $link ) ) {
 			$error = is_wp_error( $link ) ? $link : new \WP_Error( 'local_support_workspace_url_invalid', __( 'The authorized local-support workspace URL is unavailable.', 'extrachill-events' ) );
 			return $this->record_failure( $intent, $error );
@@ -286,10 +321,9 @@ class LocalSupportNotificationService {
 	/** Resolve and strictly normalize Artist Platform candidates. */
 	private function resolve_candidates( array $context, string $genre ) {
 		$input = array(
-			'producer'                => self::PRODUCER,
-			'location_term_id'        => $context['location_term_id'],
-			'location_slug'           => $context['location_slug'],
-			'exclude_artist_term_ids' => $context['artist_term_ids'],
+			'producer'           => self::PRODUCER,
+			'scene_slug'         => $context['location_slug'],
+			'exclude_artist_ids' => $context['artist_profile_ids'],
 		);
 		if ( '' !== $genre ) {
 			$input['genre'] = sanitize_text_field( $genre );
@@ -405,18 +439,62 @@ class LocalSupportNotificationService {
 			if ( is_wp_error( $artists ) ) {
 				return new \WP_Error( 'local_support_event_artists_unavailable', __( 'The event artist bindings could not be resolved.', 'extrachill-events' ) );
 			}
-			return array(
+			$context = array(
 				'title'            => get_the_title( $post ),
 				'location_term_id' => (int) $locations[0]->term_id,
 				'location_slug'    => (string) $locations[0]->slug,
 				'venue_term_id'    => (int) $venues[0],
-				'artist_term_ids'  => array_values( array_unique( array_map( 'absint', $artists ) ) ),
+				'local_artist_ids' => array_values( array_unique( array_map( 'absint', $artists ) ) ),
 			);
 		} finally {
 			if ( $switched ) {
 				restore_current_blog();
 			}
 		}
+		$bindings = $this->resolve_attached_artist_bindings( $context['local_artist_ids'] );
+		if ( is_wp_error( $bindings ) ) {
+			return $bindings;
+		}
+		unset( $context['local_artist_ids'] );
+		return array_merge( $context, $bindings );
+	}
+
+	/** Resolve Events artist terms to canonical terms and Artist Platform profiles. */
+	private function resolve_attached_artist_bindings( array $local_artist_ids ) {
+		if ( empty( $local_artist_ids ) ) {
+			return array(
+				'artist_term_ids'    => array(),
+				'artist_profile_ids' => array(),
+			);
+		}
+		$main_blog_id = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'main' ) ) : 0;
+		if ( $main_blog_id < 1 || ! function_exists( 'extrachill_events_find_artist_mapping_claims' ) ) {
+			return new \WP_Error( 'local_support_artist_mapping_unavailable', __( 'Canonical artist mapping is unavailable.', 'extrachill-events' ) );
+		}
+		$term_ids    = array();
+		$profile_ids = array();
+		switch_to_blog( $main_blog_id );
+		try {
+			foreach ( $local_artist_ids as $local_artist_id ) {
+				$claims = extrachill_events_find_artist_mapping_claims( (int) $local_artist_id );
+				if ( 1 !== count( $claims ) ) {
+					return new \WP_Error( 'local_support_artist_binding_invalid', __( 'Every attached event artist requires one canonical artist binding.', 'extrachill-events' ) );
+				}
+				$term_id    = (int) reset( $claims );
+				$profile_id = absint( get_term_meta( $term_id, '_artist_profile_id', true ) );
+				if ( $term_id < 1 || $profile_id < 1 ) {
+					return new \WP_Error( 'local_support_artist_binding_invalid', __( 'Every attached event artist requires one Artist Platform profile binding.', 'extrachill-events' ) );
+				}
+				$term_ids[]    = $term_id;
+				$profile_ids[] = $profile_id;
+			}
+		} finally {
+			restore_current_blog();
+		}
+		return array(
+			'artist_term_ids'    => array_values( array_unique( $term_ids ) ),
+			'artist_profile_ids' => array_values( array_unique( $profile_ids ) ),
+		);
 	}
 
 	/** Validate the private, contact-free durable intent shape. */
@@ -437,7 +515,7 @@ class LocalSupportNotificationService {
 
 	/** Record retry metadata or poison after the bounded attempt count. */
 	private function record_failure( array $intent, \WP_Error $error ) {
-		$count = $this->call_adapter( 'notification_attempt_count', array( $intent['idempotency_key'] ) );
+		$count = $this->call_adapter( 'notification_attempt_count', array( $intent ) );
 		if ( is_wp_error( $count ) ) {
 			return $count;
 		}
@@ -454,14 +532,14 @@ class LocalSupportNotificationService {
 			);
 		}
 		$due_at = gmdate( 'Y-m-d H:i:s', time() + min( HOUR_IN_SECONDS, MINUTE_IN_SECONDS * ( 2 ** max( 0, $attempt - 1 ) ) ) );
-		$result = $this->call_adapter( 'record_notification_attempt', array( $intent['idempotency_key'], $attempt, $due_at, $error->get_error_code() ) );
+		$result = $this->call_adapter( 'record_notification_attempt', array( $intent, $attempt, $due_at, $error->get_error_code() ) );
 		$this->schedule_reconciliation( strtotime( $due_at . ' UTC' ) );
 		return $result;
 	}
 
 	/** Record one idempotent terminal activity through #420's adapter. */
 	private function record_terminal( array $intent, string $status, array $details ) {
-		return $this->call_adapter( 'record_notification_terminal', array( $intent['idempotency_key'], $status, $details ) );
+		return $this->call_adapter( 'record_notification_terminal', array( $intent, $status, $details ) );
 	}
 
 	/** Call one required adapter method with an actionable dependency error. */
@@ -477,6 +555,11 @@ class LocalSupportNotificationService {
 		}
 		/* translators: %s: required local-support domain adapter method. */
 		return new \WP_Error( 'local_support_domain_contract_unavailable', sprintf( __( 'The local-support request domain must provide %s().', 'extrachill-events' ), $method ) );
+	}
+
+	/** Build an internal deterministic key outside user-controlled idempotency space. */
+	private function intent_key( string $kind, array $parts ): string {
+		return 'local-support-notification:' . hash_hmac( 'sha256', $kind . ':' . implode( ':', array_map( 'strval', $parts ) ), wp_salt( 'auth' ) );
 	}
 
 	/** Delegate to Extra Chill Users without producer-specific generic changes. */

--- a/inc/Core/LocalSupportNotificationService.php
+++ b/inc/Core/LocalSupportNotificationService.php
@@ -1,0 +1,517 @@
+<?php
+/**
+ * Local-support candidate matching and durable notification delivery.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Coordinates Events-owned matching with dependency-owned storage and eligibility. */
+class LocalSupportNotificationService {
+
+	public const REQUEST_OPENED_HOOK   = 'extrachill_events_local_support_request_opened';
+	public const INTEREST_CHANGED_HOOK = 'extrachill_events_local_support_interest_changed';
+	public const RECONCILE_HOOK        = 'extrachill_events_reconcile_local_support_notifications';
+	public const ADAPTER_FILTER        = 'extrachill_events_local_support_notification_adapter';
+	public const ERROR_HOOK            = 'extrachill_events_local_support_notification_error';
+	public const ELIGIBILITY_ABILITY   = 'extrachill/resolve-local-support-candidates';
+	public const PRODUCER              = 'extrachill-events-local-support';
+	public const SCHEDULER_GROUP       = 'extrachill-events-local-support';
+	public const MAX_ATTEMPTS          = 5;
+
+	/** @var object|null #420-owned durable adapter. */
+	private $adapter;
+	/** @var callable|null Artist Platform eligibility resolver. */
+	private $eligibility;
+	/** @var callable|null Canonical event context resolver. */
+	private $event_context;
+	/** @var callable|null Structured Users receipt adapter. */
+	private $delivery;
+	/** @var callable|null Bounded actor resolver. */
+	private $actor_resolver;
+
+	/**
+	 * Build the integration service.
+	 *
+	 * The durable adapter owns request/activity persistence and must expose:
+	 * append_notification_intent(), pending_notification_intents(),
+	 * notification_terminal(), notification_attempt_count(),
+	 * record_notification_attempt(), record_notification_terminal(),
+	 * organizer_recipient_ids(), and workspace_url().
+	 */
+	public function __construct( $adapter = null, $eligibility = null, $event_context = null, $delivery = null, $actor_resolver = null ) {
+		$this->adapter        = $adapter;
+		$this->eligibility    = $eligibility;
+		$this->event_context  = $event_context;
+		$this->delivery       = $delivery;
+		$this->actor_resolver = $actor_resolver;
+	}
+
+	/** Register domain event consumers and bounded reconciliation. */
+	public static function register(): void {
+		add_action( self::REQUEST_OPENED_HOOK, array( self::class, 'handle_request_opened' ), 10, 2 );
+		add_action( self::INTEREST_CHANGED_HOOK, array( self::class, 'handle_interest_changed' ), 10, 3 );
+		add_action( self::RECONCILE_HOOK, array( self::class, 'reconcile_scheduled' ) );
+		add_action( 'init', array( self::class, 'ensure_reconciliation_schedule' ) );
+	}
+
+	/** Ensure ambiguous outcomes remain recoverable after a process interruption. */
+	public static function ensure_reconciliation_schedule(): void {
+		if ( ! function_exists( 'as_schedule_recurring_action' ) || ! function_exists( 'as_next_scheduled_action' ) || as_next_scheduled_action( self::RECONCILE_HOOK, array(), self::SCHEDULER_GROUP ) ) {
+			return;
+		}
+		as_schedule_recurring_action( time() + MINUTE_IN_SECONDS, 5 * MINUTE_IN_SECONDS, self::RECONCILE_HOOK, array(), self::SCHEDULER_GROUP, true );
+	}
+
+	/** Consume the stable #420 request-opened event contract. */
+	public static function handle_request_opened( array $request, array $activity ): void {
+		$service = self::runtime();
+		$result  = is_wp_error( $service ) ? $service : $service->queue_request_opened( $request, $activity );
+		if ( is_wp_error( $result ) ) {
+			do_action( self::ERROR_HOOK, $result, 'request_opened', $activity );
+		}
+	}
+
+	/** Consume the stable #420 interest-changed event contract. */
+	public static function handle_interest_changed( array $request, array $interest, array $activity ): void {
+		$service = self::runtime();
+		$result  = is_wp_error( $service ) ? $service : $service->queue_interest_changed( $request, $interest, $activity );
+		if ( is_wp_error( $result ) ) {
+			do_action( self::ERROR_HOOK, $result, 'interest_changed', $activity );
+		}
+	}
+
+	/** Run one scheduler reconciliation page. */
+	public static function reconcile_scheduled(): void {
+		$service = self::runtime();
+		$result  = is_wp_error( $service ) ? $service : $service->reconcile_pending();
+		if ( is_wp_error( $result ) ) {
+			throw new \RuntimeException( $result->get_error_message() ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Scheduler diagnostic.
+		}
+	}
+
+	/** Resolve the #420 adapter only at runtime so either dependency may load later. */
+	private static function runtime() {
+		$adapter = apply_filters( self::ADAPTER_FILTER, null );
+		if ( ! is_object( $adapter ) ) {
+			return new \WP_Error( 'local_support_domain_adapter_unavailable', __( 'Local-support notification storage is unavailable; activate the request domain integration.', 'extrachill-events' ) );
+		}
+		return new self( $adapter );
+	}
+
+	/** Queue one deterministic candidate intent per eligible artist manager. */
+	public function queue_request_opened( array $request, array $activity ) {
+		$valid = $this->validate_source( $request, $activity, 'request_opened' );
+		if ( true !== $valid ) {
+			return $valid;
+		}
+		if ( 'open' !== ( $request['status'] ?? '' ) ) {
+			return new \WP_Error( 'local_support_request_not_open', __( 'Candidate notifications require an open local-support request.', 'extrachill-events' ) );
+		}
+		$context = $this->resolve_event_context( (int) $request['event_id'] );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+		$candidates = $this->resolve_candidates( $context, (string) ( $request['genre'] ?? '' ) );
+		if ( is_wp_error( $candidates ) ) {
+			return $candidates;
+		}
+
+		$queued = array();
+		foreach ( $candidates as $candidate ) {
+			foreach ( $candidate['manager_user_ids'] as $recipient_id ) {
+				$key    = sprintf( 'local-support:request-opened:%d:%d:%d', $activity['id'], $candidate['artist_term_id'], $recipient_id );
+				$intent = $this->append_intent(
+					array(
+						'idempotency_key'    => $key,
+						'kind'               => 'candidate_request_opened',
+						'source_activity_id' => (int) $activity['id'],
+						'request_id'         => (int) $request['id'],
+						'event_id'           => (int) $request['event_id'],
+						'genre'              => sanitize_text_field( (string) ( $request['genre'] ?? '' ) ),
+						'artist_term_id'     => $candidate['artist_term_id'],
+						'recipient_id'       => $recipient_id,
+						'payload'            => array(
+							'type'    => 'local_support_request_opened',
+							/* translators: %s: public event title. */
+							'title'   => sprintf( __( 'Local support wanted for %s', 'extrachill-events' ), $context['title'] ),
+							'item_id' => (int) $request['event_id'],
+						),
+					)
+				);
+				if ( is_wp_error( $intent ) ) {
+					return $intent;
+				}
+				$queued[] = $intent;
+			}
+		}
+		$this->schedule_reconciliation();
+		return $queued;
+	}
+
+	/** Queue deterministic organizer intents after an artist interest mutation. */
+	public function queue_interest_changed( array $request, array $interest, array $activity ) {
+		$valid = $this->validate_source( $request, $activity, 'interest_changed' );
+		if ( true !== $valid ) {
+			return $valid;
+		}
+		$artist_term_id = absint( $interest['artist_term_id'] ?? 0 );
+		if ( $artist_term_id < 1 ) {
+			return new \WP_Error( 'local_support_artist_binding_invalid', __( 'The local-support interest requires a canonical artist binding.', 'extrachill-events' ) );
+		}
+		$context    = $this->resolve_event_context( (int) $request['event_id'] );
+		$recipients = $this->organizer_recipients( $request );
+		if ( is_wp_error( $context ) || is_wp_error( $recipients ) ) {
+			return is_wp_error( $context ) ? $context : $recipients;
+		}
+		$queued = array();
+		foreach ( $recipients as $recipient_id ) {
+			$key    = sprintf( 'local-support:interest-changed:%d:%d', $activity['id'], $recipient_id );
+			$intent = $this->append_intent(
+				array(
+					'idempotency_key'    => $key,
+					'kind'               => 'organizer_interest_changed',
+					'source_activity_id' => (int) $activity['id'],
+					'request_id'         => (int) $request['id'],
+					'event_id'           => (int) $request['event_id'],
+					'artist_term_id'     => $artist_term_id,
+					'recipient_id'       => $recipient_id,
+					'payload'            => array(
+						'type'    => 'local_support_interest_changed',
+						/* translators: %s: public event title. */
+						'title'   => sprintf( __( 'Artist interest updated for %s', 'extrachill-events' ), $context['title'] ),
+						'item_id' => (int) $request['event_id'],
+					),
+				)
+			);
+			if ( is_wp_error( $intent ) ) {
+				return $intent;
+			}
+			$queued[] = $intent;
+		}
+		$this->schedule_reconciliation();
+		return $queued;
+	}
+
+	/** Reconcile a bounded page supplied by #420's durable activity store. */
+	public function reconcile_pending( int $limit = 50 ) {
+		$method = $this->adapter_method( 'pending_notification_intents' );
+		if ( is_wp_error( $method ) ) {
+			return $method;
+		}
+		$limit   = max( 1, min( 100, $limit ) );
+		$intents = $this->adapter->pending_notification_intents( $limit );
+		if ( is_wp_error( $intents ) || ! is_array( $intents ) ) {
+			return is_wp_error( $intents ) ? $intents : new \WP_Error( 'local_support_pending_intents_invalid', __( 'Local-support pending notification storage returned an invalid result.', 'extrachill-events' ) );
+		}
+		$completed = 0;
+		foreach ( array_slice( $intents, 0, $limit ) as $intent ) {
+			$result = $this->reconcile_intent( $intent );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			if ( in_array( $result['status'] ?? '', array( 'delivered', 'suppressed' ), true ) ) {
+				++$completed;
+			}
+		}
+		if ( count( $intents ) >= $limit ) {
+			$this->schedule_reconciliation();
+		}
+		return compact( 'completed' );
+	}
+
+	/** Revalidate authorization and reconcile one idempotent Users receipt. */
+	public function reconcile_intent( array $intent ) {
+		$valid = $this->validate_intent( $intent );
+		if ( true !== $valid ) {
+			return $valid;
+		}
+		$terminal = $this->call_adapter( 'notification_terminal', array( $intent['idempotency_key'] ) );
+		if ( is_wp_error( $terminal ) || is_array( $terminal ) ) {
+			return $terminal;
+		}
+		$authorized = $this->recipient_is_authorized( $intent );
+		if ( is_wp_error( $authorized ) ) {
+			return $this->record_failure( $intent, $authorized );
+		}
+		if ( ! $authorized ) {
+			return $this->record_terminal( $intent, 'suppressed', array( 'reason' => 'recipient_no_longer_authorized' ) );
+		}
+		$link = $this->call_adapter( 'workspace_url', array( (int) $intent['request_id'], (int) $intent['recipient_id'] ) );
+		if ( is_wp_error( $link ) || ! is_string( $link ) || ! $this->valid_url( $link ) ) {
+			$error = is_wp_error( $link ) ? $link : new \WP_Error( 'local_support_workspace_url_invalid', __( 'The authorized local-support workspace URL is unavailable.', 'extrachill-events' ) );
+			return $this->record_failure( $intent, $error );
+		}
+		$actor_id = $this->actor_id( $intent );
+		if ( $actor_id < 1 ) {
+			return $this->record_failure( $intent, new \WP_Error( 'local_support_notification_actor_unavailable', __( 'A bounded notification actor is unavailable.', 'extrachill-events' ) ) );
+		}
+		$payload = array(
+			'actor_id'        => $actor_id,
+			'type'            => $intent['payload']['type'],
+			'title'           => $intent['payload']['title'],
+			'link'            => $link,
+			'item_id'         => (int) $intent['payload']['item_id'],
+			'producer'        => self::PRODUCER,
+			'idempotency_key' => (string) $intent['idempotency_key'],
+		);
+		try {
+			$receipt = $this->deliver( array( (int) $intent['recipient_id'] ), $payload );
+		} catch ( \Throwable $throwable ) {
+			unset( $throwable );
+			return $this->record_failure( $intent, new \WP_Error( 'local_support_delivery_uncertain', __( 'The idempotent notification delivery outcome is uncertain.', 'extrachill-events' ) ) );
+		}
+		if ( is_wp_error( $receipt ) ) {
+			return $this->record_failure( $intent, $receipt );
+		}
+		$status = $receipt['recipients'][ (int) $intent['recipient_id'] ]['status'] ?? 'failed';
+		return in_array( $status, array( 'inserted', 'existing' ), true )
+			? $this->record_terminal( $intent, 'delivered', array( 'receipt_status' => $status ) )
+			: $this->record_failure( $intent, new \WP_Error( 'local_support_delivery_failed', __( 'The notification recipient receipt failed.', 'extrachill-events' ) ) );
+	}
+
+	/** Validate a request-domain source without reading dependency storage. */
+	private function validate_source( array $request, array $activity, string $kind ) {
+		if ( absint( $request['id'] ?? 0 ) < 1 || absint( $request['event_id'] ?? 0 ) < 1 || absint( $activity['id'] ?? 0 ) < 1 || ( $activity['kind'] ?? '' ) !== $kind || absint( $activity['request_id'] ?? 0 ) !== absint( $request['id'] ?? 0 ) ) {
+			return new \WP_Error( 'local_support_source_invalid', __( 'The local-support notification source contract is invalid.', 'extrachill-events' ) );
+		}
+		return true;
+	}
+
+	/** Resolve and strictly normalize Artist Platform candidates. */
+	private function resolve_candidates( array $context, string $genre ) {
+		$input = array(
+			'producer'                => self::PRODUCER,
+			'location_term_id'        => $context['location_term_id'],
+			'location_slug'           => $context['location_slug'],
+			'exclude_artist_term_ids' => $context['artist_term_ids'],
+		);
+		if ( '' !== $genre ) {
+			$input['genre'] = sanitize_text_field( $genre );
+		}
+		if ( $this->eligibility ) {
+			$result = call_user_func( $this->eligibility, $input );
+		} else {
+			$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( self::ELIGIBILITY_ABILITY ) : null;
+			if ( ! $ability || ! is_callable( array( $ability, 'execute' ) ) ) {
+				return new \WP_Error( 'local_support_eligibility_unavailable', __( 'The private Artist Platform local-support eligibility contract is unavailable.', 'extrachill-events' ) );
+			}
+			$result = $ability->execute( $input );
+		}
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		$rows = is_array( $result['candidates'] ?? null ) ? $result['candidates'] : null;
+		if ( null === $rows ) {
+			return new \WP_Error( 'local_support_eligibility_invalid', __( 'The Artist Platform eligibility response is invalid.', 'extrachill-events' ) );
+		}
+		$candidates = array();
+		foreach ( $rows as $row ) {
+			$term_id  = absint( $row['artist_term_id'] ?? 0 );
+			$profile  = absint( $row['artist_profile_id'] ?? 0 );
+			$managers = array_values( array_unique( array_filter( array_map( 'absint', (array) ( $row['manager_user_ids'] ?? array() ) ) ) ) );
+			if ( $term_id < 1 || $profile < 1 || in_array( $term_id, $context['artist_term_ids'], true ) ) {
+				if ( in_array( $term_id, $context['artist_term_ids'], true ) ) {
+					continue;
+				}
+				return new \WP_Error( 'local_support_artist_binding_invalid', __( 'Artist Platform returned a candidate without a canonical artist binding.', 'extrachill-events' ) );
+			}
+			foreach ( $managers as $manager_id ) {
+				if ( ! get_userdata( $manager_id ) ) {
+					return new \WP_Error( 'local_support_manager_invalid', __( 'Artist Platform returned an invalid manager recipient.', 'extrachill-events' ) );
+				}
+			}
+			if ( empty( $managers ) ) {
+				continue;
+			}
+			$candidates[] = array(
+				'artist_profile_id' => $profile,
+				'artist_term_id'    => $term_id,
+				'manager_user_ids'  => $managers,
+			);
+		}
+		return $candidates;
+	}
+
+	/** Recheck current candidate eligibility or organizer authority before delivery. */
+	private function recipient_is_authorized( array $intent ) {
+		if ( 'candidate_request_opened' === $intent['kind'] ) {
+			$context    = $this->resolve_event_context( (int) $intent['event_id'] );
+			$candidates = is_wp_error( $context ) ? $context : $this->resolve_candidates( $context, (string) ( $intent['genre'] ?? '' ) );
+			if ( is_wp_error( $candidates ) ) {
+				return $candidates;
+			}
+			foreach ( $candidates as $candidate ) {
+				if ( (int) $candidate['artist_term_id'] === (int) $intent['artist_term_id'] && in_array( (int) $intent['recipient_id'], $candidate['manager_user_ids'], true ) ) {
+					return true;
+				}
+			}
+			return false;
+		}
+		$recipients = $this->call_adapter( 'organizer_recipient_ids', array( (int) $intent['request_id'] ) );
+		if ( is_wp_error( $recipients ) ) {
+			return $recipients;
+		}
+		return in_array( (int) $intent['recipient_id'], array_map( 'absint', (array) $recipients ), true );
+	}
+
+	/** Resolve currently authorized organizers for the source request. */
+	private function organizer_recipients( array $request ) {
+		$recipients = $this->call_adapter( 'organizer_recipient_ids', array( (int) $request['id'] ) );
+		if ( is_wp_error( $recipients ) ) {
+			return $recipients;
+		}
+		$ids = array_values( array_unique( array_filter( array_map( 'absint', (array) $recipients ) ) ) );
+		if ( empty( $ids ) ) {
+			return new \WP_Error( 'local_support_organizer_unavailable', __( 'The request has no currently authorized organizer notification recipients.', 'extrachill-events' ) );
+		}
+		foreach ( $ids as $user_id ) {
+			if ( ! get_userdata( $user_id ) ) {
+				return new \WP_Error( 'local_support_organizer_invalid', __( 'The request domain returned an invalid organizer recipient.', 'extrachill-events' ) );
+			}
+		}
+		return $ids;
+	}
+
+	/** Resolve canonical event, venue, location, and attached artist terms. */
+	private function resolve_event_context( int $event_id ) {
+		if ( $this->event_context ) {
+			return call_user_func( $this->event_context, $event_id );
+		}
+		$events_blog_id = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'events' ) ) : 0;
+		if ( $events_blog_id < 1 ) {
+			return new \WP_Error( 'local_support_events_site_unavailable', __( 'The canonical Events site is unavailable.', 'extrachill-events' ) );
+		}
+		$switched = get_current_blog_id() !== $events_blog_id;
+		if ( $switched ) {
+			switch_to_blog( $events_blog_id );
+		}
+		try {
+			$post      = get_post( $event_id );
+			$locations = $post ? wp_get_object_terms( $event_id, 'location' ) : array();
+			$venues    = $post ? wp_get_object_terms( $event_id, 'venue', array( 'fields' => 'ids' ) ) : array();
+			$artists   = $post ? wp_get_object_terms( $event_id, 'artist', array( 'fields' => 'ids' ) ) : array();
+			if ( ! $post || 'data_machine_events' !== $post->post_type || is_wp_error( $locations ) || 1 !== count( $locations ) ) {
+				return new \WP_Error( 'local_support_event_location_invalid', __( 'The event requires one canonical Events location.', 'extrachill-events' ) );
+			}
+			if ( is_wp_error( $venues ) || 1 !== count( $venues ) ) {
+				return new \WP_Error( 'local_support_event_venue_invalid', __( 'The event requires one canonical Events venue.', 'extrachill-events' ) );
+			}
+			if ( is_wp_error( $artists ) ) {
+				return new \WP_Error( 'local_support_event_artists_unavailable', __( 'The event artist bindings could not be resolved.', 'extrachill-events' ) );
+			}
+			return array(
+				'title'            => get_the_title( $post ),
+				'location_term_id' => (int) $locations[0]->term_id,
+				'location_slug'    => (string) $locations[0]->slug,
+				'venue_term_id'    => (int) $venues[0],
+				'artist_term_ids'  => array_values( array_unique( array_map( 'absint', $artists ) ) ),
+			);
+		} finally {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+		}
+	}
+
+	/** Validate the private, contact-free durable intent shape. */
+	private function validate_intent( array $intent ) {
+		$required = array( 'idempotency_key', 'kind', 'request_id', 'event_id', 'artist_term_id', 'recipient_id', 'payload' );
+		foreach ( $required as $key ) {
+			if ( empty( $intent[ $key ] ) ) {
+				return new \WP_Error( 'local_support_notification_intent_invalid', __( 'The durable local-support notification intent is invalid.', 'extrachill-events' ) );
+			}
+		}
+		return true;
+	}
+
+	/** Append through #420's idempotent activity contract. */
+	private function append_intent( array $intent ) {
+		return $this->call_adapter( 'append_notification_intent', array( $intent ) );
+	}
+
+	/** Record retry metadata or poison after the bounded attempt count. */
+	private function record_failure( array $intent, \WP_Error $error ) {
+		$count = $this->call_adapter( 'notification_attempt_count', array( $intent['idempotency_key'] ) );
+		if ( is_wp_error( $count ) ) {
+			return $count;
+		}
+		$attempt = absint( $count ) + 1;
+		if ( $attempt >= self::MAX_ATTEMPTS ) {
+			return $this->record_terminal(
+				$intent,
+				'suppressed',
+				array(
+					'reason'     => 'delivery_poisoned',
+					'attempt'    => $attempt,
+					'error_code' => $error->get_error_code(),
+				)
+			);
+		}
+		$due_at = gmdate( 'Y-m-d H:i:s', time() + min( HOUR_IN_SECONDS, MINUTE_IN_SECONDS * ( 2 ** max( 0, $attempt - 1 ) ) ) );
+		$result = $this->call_adapter( 'record_notification_attempt', array( $intent['idempotency_key'], $attempt, $due_at, $error->get_error_code() ) );
+		$this->schedule_reconciliation( strtotime( $due_at . ' UTC' ) );
+		return $result;
+	}
+
+	/** Record one idempotent terminal activity through #420's adapter. */
+	private function record_terminal( array $intent, string $status, array $details ) {
+		return $this->call_adapter( 'record_notification_terminal', array( $intent['idempotency_key'], $status, $details ) );
+	}
+
+	/** Call one required adapter method with an actionable dependency error. */
+	private function call_adapter( string $method, array $args ) {
+		$valid = $this->adapter_method( $method );
+		return is_wp_error( $valid ) ? $valid : call_user_func_array( array( $this->adapter, $method ), $args );
+	}
+
+	/** Ensure a #420 adapter method is callable. */
+	private function adapter_method( string $method ) {
+		if ( is_object( $this->adapter ) && is_callable( array( $this->adapter, $method ) ) ) {
+			return true;
+		}
+		/* translators: %s: required local-support domain adapter method. */
+		return new \WP_Error( 'local_support_domain_contract_unavailable', sprintf( __( 'The local-support request domain must provide %s().', 'extrachill-events' ), $method ) );
+	}
+
+	/** Delegate to Extra Chill Users without producer-specific generic changes. */
+	private function deliver( array $recipient_ids, array $payload ) {
+		if ( $this->delivery ) {
+			return call_user_func( $this->delivery, $recipient_ids, $payload );
+		}
+		return function_exists( 'ec_users_notify_with_receipts' )
+			? ec_users_notify_with_receipts( $recipient_ids, $payload )
+			: new \WP_Error( 'local_support_notification_receipts_unavailable', __( 'Idempotent Users notification receipts are unavailable.', 'extrachill-events' ) );
+	}
+
+	/** Resolve a valid notification actor without exposing a contact identity. */
+	private function actor_id( array $intent ): int {
+		$actor_id = $this->actor_resolver ? absint( call_user_func( $this->actor_resolver, $intent ) ) : 0;
+		if ( $actor_id < 1 && function_exists( 'ec_get_network_bot_user_id' ) ) {
+			$actor_id = absint( ec_get_network_bot_user_id() );
+		}
+		return $actor_id > 0 && get_userdata( $actor_id ) ? $actor_id : 0;
+	}
+
+	/** Validate an absolute HTTP(S) workspace URL. */
+	private function valid_url( string $url ): bool {
+		return function_exists( 'wp_http_validate_url' ) ? (bool) wp_http_validate_url( $url ) : 1 === preg_match( '#^https?://#i', $url );
+	}
+
+	/** Best-effort unique Action Scheduler wakeup. */
+	private function schedule_reconciliation( ?int $timestamp = null ): void {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			return;
+		}
+		try {
+			as_schedule_single_action( $timestamp ? max( time() + 1, $timestamp ) : time() + MINUTE_IN_SECONDS, self::RECONCILE_HOOK, array(), self::SCHEDULER_GROUP, true );
+		} catch ( \Throwable $throwable ) {
+			unset( $throwable );
+		}
+	}
+}

--- a/inc/Core/LocalSupportRepository.php
+++ b/inc/Core/LocalSupportRepository.php
@@ -182,7 +182,7 @@ class LocalSupportRepository {
 		$values = null === $interest_id
 			? array( $request_id, $kind, $version )
 			: array( $request_id, $interest_id, $kind, $version );
-		$row    = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE request_id = %d AND {$where} AND kind = %s AND result_version = %d ORDER BY id DESC LIMIT 1", $values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fixed clause with prepared change identity.
+		$row    = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE request_id = %d AND {$where} AND kind = %s AND result_version = %d ORDER BY id DESC LIMIT 1", $values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fixed clause with prepared change identity; the optional interest placeholder determines the runtime count.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'local_support_activity_read_failed', __( 'Local support activity could not be read.', 'extrachill-events' ) );
 		}
@@ -194,7 +194,8 @@ class LocalSupportRepository {
 		global $wpdb;
 		$table = LocalSupportSchema::activity_table();
 		$limit = max( 1, min( 100, $limit ) );
-		$rows  = $wpdb->get_results(
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reuses the trusted current-prefix activity table in the bounded subquery.
+		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT source.* FROM {$table} source
 				WHERE source.kind IN ('request_opened', 'interest_expressed', 'interest_status_changed', 'contact_consent_granted', 'contact_consent_revoked')
@@ -208,7 +209,8 @@ class LocalSupportRepository {
 				$limit
 			),
 			ARRAY_A
-		); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded recovery query over immutable source activity.
+		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded recovery query over immutable source activity.
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'local_support_notification_sources_read_failed', __( 'Local support notification source activities could not be read.', 'extrachill-events' ) );
 		}
@@ -220,7 +222,8 @@ class LocalSupportRepository {
 		global $wpdb;
 		$table = LocalSupportSchema::activity_table();
 		$limit = max( 1, min( 100, $limit ) );
-		$rows  = $wpdb->get_results(
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reuses the trusted current-prefix activity table in bounded subqueries.
+		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT intent.* FROM {$table} intent
 				WHERE intent.kind = 'notification_intent'
@@ -241,7 +244,8 @@ class LocalSupportRepository {
 				$limit
 			),
 			ARRAY_A
-		); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded due outbox query over private activity.
+		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded due outbox query over private activity.
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'local_support_notification_intents_read_failed', __( 'Local support notification intents could not be read.', 'extrachill-events' ) );
 		}

--- a/inc/Core/LocalSupportRepository.php
+++ b/inc/Core/LocalSupportRepository.php
@@ -141,7 +141,7 @@ class LocalSupportRepository {
 			'request_hash'    => (string) $data['request_hash'],
 			'result_version'  => (int) $data['result_version'],
 			'payload'         => $payload,
-			'created_at'      => gmdate( 'Y-m-d H:i:s' ),
+			'created_at'      => isset( $data['created_at'] ) ? (string) $data['created_at'] : gmdate( 'Y-m-d H:i:s' ),
 		);
 		if ( false === $wpdb->insert( LocalSupportSchema::activity_table(), $row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Append-only private audit write.
 			return new \WP_Error( 'local_support_activity_write_failed', __( 'Local support activity could not be recorded.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
@@ -159,6 +159,114 @@ class LocalSupportRepository {
 			return new \WP_Error( 'local_support_activity_read_failed', __( 'Local support activity could not be read.', 'extrachill-events' ) );
 		}
 		return is_array( $row ) ? $row : null;
+	}
+
+	/** Read one immutable activity by ID and optional request owner. */
+	public function get_activity( int $activity_id, ?int $request_id = null ) {
+		global $wpdb;
+		$table  = LocalSupportSchema::activity_table();
+		$where  = null === $request_id ? '' : ' AND request_id = %d';
+		$values = null === $request_id ? array( $activity_id ) : array( $activity_id, $request_id );
+		$row    = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d{$where} LIMIT 1", $values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fixed optional owner clause with prepared IDs.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'local_support_activity_read_failed', __( 'Local support activity could not be read.', 'extrachill-events' ) );
+		}
+		return is_array( $row ) ? $this->hydrate_activity( $row ) : null;
+	}
+
+	/** Resolve the exact durable activity represented by an emitted change. */
+	public function find_activity_for_change( int $request_id, ?int $interest_id, string $kind, int $version ) {
+		global $wpdb;
+		$table  = LocalSupportSchema::activity_table();
+		$where  = null === $interest_id ? 'interest_id IS NULL' : 'interest_id = %d';
+		$values = null === $interest_id
+			? array( $request_id, $kind, $version )
+			: array( $request_id, $interest_id, $kind, $version );
+		$row    = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE request_id = %d AND {$where} AND kind = %s AND result_version = %d ORDER BY id DESC LIMIT 1", $values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fixed clause with prepared change identity.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'local_support_activity_read_failed', __( 'Local support activity could not be read.', 'extrachill-events' ) );
+		}
+		return is_array( $row ) ? $this->hydrate_activity( $row ) : null;
+	}
+
+	/** List committed notification source activities not yet durably processed. */
+	public function pending_notification_sources( int $limit = 50 ) {
+		global $wpdb;
+		$table = LocalSupportSchema::activity_table();
+		$limit = max( 1, min( 100, $limit ) );
+		$rows  = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT source.* FROM {$table} source
+				WHERE source.kind IN ('request_opened', 'interest_expressed', 'interest_status_changed', 'contact_consent_granted', 'contact_consent_revoked')
+				AND NOT EXISTS (
+					SELECT 1 FROM {$table} marker
+					WHERE marker.request_id = source.request_id
+					AND marker.kind = 'notification_source_processed'
+					AND marker.request_hash = source.request_hash
+				)
+				ORDER BY source.id ASC LIMIT %d",
+				$limit
+			),
+			ARRAY_A
+		); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded recovery query over immutable source activity.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'local_support_notification_sources_read_failed', __( 'Local support notification source activities could not be read.', 'extrachill-events' ) );
+		}
+		return array_map( array( $this, 'hydrate_activity' ), (array) $rows );
+	}
+
+	/** List bounded due notification intents with no terminal activity. */
+	public function pending_notification_intents( int $limit = 50 ) {
+		global $wpdb;
+		$table = LocalSupportSchema::activity_table();
+		$limit = max( 1, min( 100, $limit ) );
+		$rows  = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT intent.* FROM {$table} intent
+				WHERE intent.kind = 'notification_intent'
+				AND NOT EXISTS (
+					SELECT 1 FROM {$table} terminal
+					WHERE terminal.request_id = intent.request_id
+					AND terminal.request_hash = intent.request_hash
+					AND terminal.kind = 'notification_terminal'
+				)
+				AND NOT EXISTS (
+					SELECT 1 FROM {$table} deferred
+					WHERE deferred.request_id = intent.request_id
+					AND deferred.request_hash = intent.request_hash
+					AND deferred.kind = 'notification_attempt'
+					AND deferred.created_at > UTC_TIMESTAMP()
+				)
+				ORDER BY intent.id ASC LIMIT %d",
+				$limit
+			),
+			ARRAY_A
+		); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded due outbox query over private activity.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'local_support_notification_intents_read_failed', __( 'Local support notification intents could not be read.', 'extrachill-events' ) );
+		}
+		return array_map( array( $this, 'hydrate_activity' ), (array) $rows );
+	}
+
+	/** Return one terminal notification activity by its intent correlation hash. */
+	public function notification_terminal( int $request_id, string $request_hash ) {
+		global $wpdb;
+		$table = LocalSupportSchema::activity_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE request_id = %d AND request_hash = %s AND kind = 'notification_terminal' ORDER BY id DESC LIMIT 1", $request_id, $request_hash ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact terminal correlation read.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'local_support_notification_terminal_read_failed', __( 'Local support notification terminal state could not be read.', 'extrachill-events' ) );
+		}
+		return is_array( $row ) ? $this->hydrate_activity( $row ) : null;
+	}
+
+	/** Count delivery attempts for one durable notification intent. */
+	public function notification_attempt_count( int $request_id, string $request_hash ) {
+		global $wpdb;
+		$table = LocalSupportSchema::activity_table();
+		$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE request_id = %d AND request_hash = %s AND kind = 'notification_attempt'", $request_id, $request_hash ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact attempt count.
+		return '' === (string) $wpdb->last_error
+			? (int) $count
+			: new \WP_Error( 'local_support_notification_attempts_read_failed', __( 'Local support notification attempts could not be read.', 'extrachill-events' ) );
 	}
 
 	/** Hydrate request scalar types. */
@@ -186,6 +294,17 @@ class LocalSupportRepository {
 			$row['consent_fields'] = json_decode( (string) $stored_fields, true );
 		}
 		unset( $row['contact_payload'] );
+		return $row;
+	}
+
+	/** Hydrate activity scalar and versioned payload fields. */
+	public function hydrate_activity( array $row ): array {
+		foreach ( array( 'id', 'request_id', 'actor_user_id', 'result_version' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		$row['interest_id'] = null === $row['interest_id'] ? null : (int) $row['interest_id'];
+		$payload            = json_decode( (string) $row['payload'], true );
+		$row['payload']     = is_array( $payload ) && is_array( $payload['data'] ?? null ) ? $payload['data'] : array();
 		return $row;
 	}
 

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -20,6 +20,7 @@
 			<file>tests/BookingMarketingDelegatedSchemaTest.php</file>
 			<file>tests/TicketSettlementTest.php</file>
 			<file>tests/BookingNotificationTest.php</file>
+			<file>tests/LocalSupportNotificationTest.php</file>
 			<file>tests/CanonicalEventPublicationGuardTest.php</file>
 			<file>tests/VenueMembershipAuthorizationTest.php</file>
 		</testsuite>

--- a/tests/LocalSupportNotificationTest.php
+++ b/tests/LocalSupportNotificationTest.php
@@ -5,7 +5,11 @@
  * @package ExtraChillEvents\Tests
  */
 
+use ExtraChillEvents\Core\LocalSupportNotificationAdapter;
 use ExtraChillEvents\Core\LocalSupportNotificationService;
+use ExtraChillEvents\Core\LocalSupportAuthorization;
+use ExtraChillEvents\Core\LocalSupportRepository;
+use ExtraChillEvents\Core\VenueMembershipRepository;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
@@ -17,6 +21,13 @@ final class LocalSupportNotificationAdapterStub {
 	public $terminals  = array();
 	public $organizers = array( 77 );
 	public $workspace  = 'https://events.example/local-support/15';
+	public $source;
+	public $processed = array();
+
+	public function notification_source( array $change ) {
+		unset( $change );
+		return $this->source;
+	}
 
 	public function append_notification_intent( array $intent ) {
 		if ( isset( $this->intents[ $intent['idempotency_key'] ] ) ) {
@@ -28,20 +39,31 @@ final class LocalSupportNotificationAdapterStub {
 	public function pending_notification_intents( int $limit ): array {
 		return array_slice( array_values( $this->intents ), 0, $limit );
 	}
-	public function notification_terminal( string $key ) {
+	public function pending_notification_sources(): array {
+		return array();
+	}
+	public function mark_notification_source_processed( array $activity ): array {
+		$this->processed[] = $activity['id'];
+		return array( 'source_activity_id' => $activity['id'] );
+	}
+	public function notification_terminal( array $intent ) {
+		$key = $intent['idempotency_key'];
 		return $this->terminals[ $key ] ?? null;
 	}
-	public function notification_attempt_count( string $key ): int {
+	public function notification_attempt_count( array $intent ): int {
+		$key = $intent['idempotency_key'];
 		return count( $this->attempts[ $key ] ?? array() );
 	}
-	public function record_notification_attempt( string $key, int $attempt, string $due_at, string $error ): array {
+	public function record_notification_attempt( array $intent, int $attempt, string $due_at, string $error ): array {
+		$key                      = $intent['idempotency_key'];
 		$this->attempts[ $key ][] = compact( 'attempt', 'due_at', 'error' );
 		return array(
 			'status'  => 'retrying',
 			'attempt' => $attempt,
 		);
 	}
-	public function record_notification_terminal( string $key, string $status, array $details ): array {
+	public function record_notification_terminal( array $intent, string $status, array $details ): array {
+		$key                     = $intent['idempotency_key'];
 		$this->terminals[ $key ] = compact( 'status', 'details' );
 		return $this->terminals[ $key ];
 	}
@@ -50,6 +72,128 @@ final class LocalSupportNotificationAdapterStub {
 	}
 	public function workspace_url(): string {
 		return $this->workspace;
+	}
+}
+
+/** Activity-backed repository double for the production adapter. */
+final class LocalSupportNotificationRepositoryStub extends LocalSupportRepository {
+	public $request;
+	public $interest;
+	public $activity = array();
+
+	public function get_request( int $id, bool $for_update = false ) {
+		unset( $for_update );
+		return $id === (int) $this->request['id'] ? $this->request : null;
+	}
+
+	public function get_interest( int $id, bool $for_update = false ) {
+		unset( $for_update );
+		return $id === (int) $this->interest['id'] ? $this->interest : null;
+	}
+
+	public function find_activity_for_change( int $request_id, ?int $interest_id, string $kind, int $version ) {
+		foreach ( $this->activity as $row ) {
+			if ( $row['request_id'] === $request_id && $row['interest_id'] === $interest_id && $row['kind'] === $kind && $row['result_version'] === $version ) {
+				return $row;
+			}
+		}
+		return null;
+	}
+
+	public function get_activity( int $activity_id, ?int $request_id = null ) {
+		foreach ( $this->activity as $row ) {
+			if ( $row['id'] === $activity_id && ( null === $request_id || $row['request_id'] === $request_id ) ) {
+				return $row;
+			}
+		}
+		return null;
+	}
+
+	public function find_activity( int $request_id, string $idempotency_key ) {
+		foreach ( $this->activity as $row ) {
+			if ( $row['request_id'] === $request_id && $row['idempotency_key'] === $idempotency_key ) {
+				return $row;
+			}
+		}
+		return null;
+	}
+
+	public function append_activity( array $data ) {
+		$data['id']         = count( $this->activity ) + 1;
+		$data['created_at'] = $data['created_at'] ?? '2026-07-27 00:00:00';
+		$this->activity[]   = $data;
+		return $data;
+	}
+
+	public function hydrate_activity( array $row ): array {
+		return $row;
+	}
+
+	public function pending_notification_intents( int $limit = 50 ): array {
+		$terminal_hashes = array_column(
+			array_filter(
+				$this->activity,
+				static function ( $row ) {
+					return 'notification_terminal' === $row['kind'];
+				}
+			),
+			'request_hash'
+		);
+		$rows            = array_filter(
+			$this->activity,
+			static function ( $row ) use ( $terminal_hashes ) {
+				return 'notification_intent' === $row['kind'] && ! in_array( $row['request_hash'], $terminal_hashes, true );
+			}
+		);
+		return array_slice( array_values( $rows ), 0, $limit );
+	}
+
+	public function pending_notification_sources( int $limit = 50 ): array {
+		$processed = array_column( array_filter( $this->activity, static function ( $row ) { return 'notification_source_processed' === $row['kind']; } ), 'payload' );
+		$ids       = array_map( static function ( $payload ) { return $payload['source_activity_id']; }, $processed );
+		$rows      = array_filter(
+			$this->activity,
+			static function ( $row ) use ( $ids ) {
+				return in_array( $row['kind'], array( 'request_opened', 'interest_expressed', 'interest_status_changed', 'contact_consent_granted', 'contact_consent_revoked' ), true ) && ! in_array( $row['id'], $ids, true );
+			}
+		);
+		return array_slice( array_values( $rows ), 0, $limit );
+	}
+
+	public function notification_terminal( int $request_id, string $request_hash ) {
+		foreach ( array_reverse( $this->activity ) as $row ) {
+			if ( $row['request_id'] === $request_id && $row['request_hash'] === $request_hash && 'notification_terminal' === $row['kind'] ) {
+				return $row;
+			}
+		}
+		return null;
+	}
+
+	public function notification_attempt_count( int $request_id, string $request_hash ) {
+		return count(
+			array_filter(
+				$this->activity,
+				static function ( $row ) use ( $request_id, $request_hash ) {
+					return $row['request_id'] === $request_id && $row['request_hash'] === $request_hash && 'notification_attempt' === $row['kind'];
+				}
+			)
+		);
+	}
+}
+
+/** Organizer authorization double for production-adapter tests. */
+final class LocalSupportNotificationAuthorizationStub extends LocalSupportAuthorization {
+	public function authorize_organizer( array $request, int $user_id ) {
+		unset( $request );
+		return 77 === $user_id ? true : new WP_Error( 'local_support_forbidden' );
+	}
+}
+
+/** Active venue member resolver double for production-adapter tests. */
+final class LocalSupportNotificationMembershipsStub extends VenueMembershipRepository {
+	public function list_for_venue( int $venue_term_id, array $filters = array(), int $actor_user_id = 0 ) {
+		unset( $venue_term_id, $filters, $actor_user_id );
+		return array( array( 'user_id' => 77 ) );
 	}
 }
 
@@ -82,6 +226,15 @@ final class LocalSupportNotificationTest extends TestCase {
 				'manager_user_ids'  => array( 43 ),
 			),
 		);
+		$this->adapter->source     = array(
+			'request'  => $this->request(),
+			'interest' => array( 'artist_term_id' => 91 ),
+			'activity' => array(
+				'id'         => 301,
+				'kind'       => 'request_opened',
+				'request_id' => 15,
+			),
+		);
 	}
 
 	private function service( ?callable $delivery = null ): LocalSupportNotificationService {
@@ -93,11 +246,12 @@ final class LocalSupportNotificationTest extends TestCase {
 			},
 			static function (): array {
 				return array(
-					'title'            => 'Touring Band at The Room',
-					'location_term_id' => 12,
-					'location_slug'    => 'charleston-sc',
-					'venue_term_id'    => 55,
-					'artist_term_ids'  => array( 88 ),
+					'title'              => 'Touring Band at The Room',
+					'location_term_id'   => 12,
+					'location_slug'      => 'charleston-sc',
+					'venue_term_id'      => 55,
+					'artist_term_ids'    => array( 88 ),
+					'artist_profile_ids' => array( 502 ),
 				);
 			},
 			$delivery ? $delivery : function ( array $recipients, array $payload ): array {
@@ -133,9 +287,8 @@ final class LocalSupportNotificationTest extends TestCase {
 		$this->assertCount( 2, $first );
 		$this->assertCount( 2, $second );
 		$this->assertCount( 2, $this->adapter->intents );
-		$this->assertSame( 12, $this->eligibility_calls[0]['location_term_id'] );
-		$this->assertSame( 'charleston-sc', $this->eligibility_calls[0]['location_slug'] );
-		$this->assertSame( array( 88 ), $this->eligibility_calls[0]['exclude_artist_term_ids'] );
+		$this->assertSame( 'charleston-sc', $this->eligibility_calls[0]['scene_slug'] );
+		$this->assertSame( array( 502 ), $this->eligibility_calls[0]['exclude_artist_ids'] );
 		$this->assertSame( 'Indie Rock', $this->eligibility_calls[0]['genre'] );
 		$this->assertSame( array( 41, 42 ), array_column( array_values( $this->adapter->intents ), 'recipient_id' ) );
 	}
@@ -170,7 +323,7 @@ final class LocalSupportNotificationTest extends TestCase {
 			),
 			array(
 				'id'         => 401,
-				'kind'       => 'interest_changed',
+				'kind'       => 'interest_expressed',
 				'request_id' => 15,
 			)
 		);
@@ -208,17 +361,127 @@ final class LocalSupportNotificationTest extends TestCase {
 		$this->assertSame( $result, $replay );
 	}
 
+	public function test_landed_change_hook_uses_a_production_adapter_and_maps_domain_payloads(): void {
+		LocalSupportNotificationService::register();
+		$callbacks = array_column( $GLOBALS['ec_test_filters'][ LocalSupportNotificationService::CHANGE_HOOK ][10], 0 );
+		$this->assertContains(
+			array( LocalSupportNotificationService::class, 'handle_change' ),
+			$callbacks
+		);
+		$this->assertTrue( LocalSupportNotificationService::authorize_producer( false, LocalSupportNotificationService::PRODUCER ) );
+		$this->assertFalse( LocalSupportNotificationService::authorize_producer( false, 'other-producer' ) );
+
+		$runtime = new ReflectionMethod( LocalSupportNotificationService::class, 'runtime' );
+		$runtime->setAccessible( true );
+		$service = $runtime->invoke( null );
+		$adapter = new ReflectionProperty( LocalSupportNotificationService::class, 'adapter' );
+		$adapter->setAccessible( true );
+		$this->assertInstanceOf( LocalSupportNotificationAdapter::class, $adapter->getValue( $service ) );
+
+		$queued = $this->service()->queue_change(
+			array(
+				'kind'        => 'request_opened',
+				'request_id'  => 15,
+				'interest_id' => null,
+				'version'     => 1,
+			)
+		);
+		$this->assertCount( 2, $queued );
+	}
+
+	public function test_production_adapter_uses_domain_activity_and_workspace_fails_closed(): void {
+		$repository             = new LocalSupportNotificationRepositoryStub();
+		$repository->request    = array(
+			'id'             => 15,
+			'event_id'       => 700,
+			'venue_term_id'  => 55,
+			'organizer_type' => 'venue',
+			'organizer_id'   => 55,
+			'status'         => 'open',
+			'contact_email'  => 'private@example.com',
+		);
+		$repository->interest   = array(
+			'id'             => 8,
+			'request_id'     => 15,
+			'artist_term_id' => 91,
+		);
+		$repository->activity[] = array(
+			'id'              => 1,
+			'request_id'      => 15,
+			'interest_id'     => null,
+			'kind'            => 'request_opened',
+			'actor_user_id'   => 12,
+			'idempotency_key' => 'open-15',
+			'request_hash'    => hash( 'sha256', 'open-15' ),
+			'result_version'  => 1,
+			'payload'         => array( 'status' => 'open' ),
+		);
+		$adapter                = new LocalSupportNotificationAdapter(
+			$repository,
+			new LocalSupportNotificationAuthorizationStub(),
+			new LocalSupportNotificationMembershipsStub()
+		);
+		$service                = new LocalSupportNotificationService(
+			$adapter,
+			static function (): array {
+				return array(
+					'candidates' => array(
+						array(
+							'artist_profile_id' => 501,
+							'artist_term_id'    => 91,
+							'manager_user_ids'  => array( 41 ),
+						),
+					),
+				);
+			},
+			static function (): array {
+				return array(
+					'title'              => 'Touring Band at The Room',
+					'location_term_id'   => 12,
+					'location_slug'      => 'charleston-sc',
+					'venue_term_id'      => 55,
+					'artist_term_ids'    => array(),
+					'artist_profile_ids' => array(),
+				);
+			},
+			null,
+			static function (): int {
+				return 99; }
+		);
+		$queued                 = $service->queue_change(
+			array(
+				'kind'        => 'request_opened',
+				'request_id'  => 15,
+				'interest_id' => null,
+				'version'     => 1,
+			)
+		);
+		$repository->activity   = array_values( array_filter( $repository->activity, static function ( $row ) { return 'notification_source_processed' !== $row['kind']; } ) );
+		$summary                = $service->reconcile_pending();
+		$last                   = end( $repository->activity );
+		$retry                  = $last['payload'];
+
+		$this->assertSame( array( 'request_opened', 'notification_intent', 'notification_source_processed', 'notification_attempt' ), array_column( $repository->activity, 'kind' ) );
+		$this->assertSame( 1, $summary['recovered'] );
+		$this->assertCount( 1, array_filter( $repository->activity, static function ( $row ) { return 'notification_intent' === $row['kind']; } ) );
+		$this->assertSame( 'retrying', $retry['status'] );
+		$this->assertSame( 'local_support_workspace_unavailable', $retry['error_code'] );
+		$this->assertStringNotContainsString( 'private@example.com', wp_json_encode( $repository->activity[1]['payload'] ) );
+		$this->assertSame( array( 77 ), $adapter->organizer_recipient_ids( 15 ) );
+	}
+
 	public function test_missing_dependency_contracts_fail_closed_with_actionable_errors(): void {
 		$missing_domain = ( new LocalSupportNotificationService(
 			null,
 			null,
 			static function (): array {
 				return array(
-					'title'            => 'Show',
-					'location_term_id' => 12,
-					'location_slug'    => 'charleston-sc',
-					'venue_term_id'    => 55,
-					'artist_term_ids'  => array(),
+					'title'              => 'Show',
+					'location_term_id'   => 12,
+					'location_slug'      => 'charleston-sc',
+					'venue_term_id'      => 55,
+					'artist_term_ids'    => array(),
+					'artist_profile_ids' => array(),
 				);
 			}
 		) )->queue_interest_changed(
@@ -226,7 +489,7 @@ final class LocalSupportNotificationTest extends TestCase {
 			array( 'artist_term_id' => 91 ),
 			array(
 				'id'         => 401,
-				'kind'       => 'interest_changed',
+				'kind'       => 'interest_expressed',
 				'request_id' => 15,
 			)
 		);
@@ -235,11 +498,12 @@ final class LocalSupportNotificationTest extends TestCase {
 			null,
 			static function (): array {
 				return array(
-					'title'            => 'Show',
-					'location_term_id' => 12,
-					'location_slug'    => 'charleston-sc',
-					'venue_term_id'    => 55,
-					'artist_term_ids'  => array(),
+					'title'              => 'Show',
+					'location_term_id'   => 12,
+					'location_slug'      => 'charleston-sc',
+					'venue_term_id'      => 55,
+					'artist_term_ids'    => array(),
+					'artist_profile_ids' => array(),
 				);
 			}
 		) )->queue_request_opened(

--- a/tests/LocalSupportNotificationTest.php
+++ b/tests/LocalSupportNotificationTest.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Local-support matching notification tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Core\LocalSupportNotificationService;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
+/** In-memory implementation of the #420 durable notification adapter contract. */
+final class LocalSupportNotificationAdapterStub {
+	public $intents    = array();
+	public $attempts   = array();
+	public $terminals  = array();
+	public $organizers = array( 77 );
+	public $workspace  = 'https://events.example/local-support/15';
+
+	public function append_notification_intent( array $intent ) {
+		if ( isset( $this->intents[ $intent['idempotency_key'] ] ) ) {
+			return $this->intents[ $intent['idempotency_key'] ];
+		}
+		$this->intents[ $intent['idempotency_key'] ] = $intent;
+		return $intent;
+	}
+	public function pending_notification_intents( int $limit ): array {
+		return array_slice( array_values( $this->intents ), 0, $limit );
+	}
+	public function notification_terminal( string $key ) {
+		return $this->terminals[ $key ] ?? null;
+	}
+	public function notification_attempt_count( string $key ): int {
+		return count( $this->attempts[ $key ] ?? array() );
+	}
+	public function record_notification_attempt( string $key, int $attempt, string $due_at, string $error ): array {
+		$this->attempts[ $key ][] = compact( 'attempt', 'due_at', 'error' );
+		return array(
+			'status'  => 'retrying',
+			'attempt' => $attempt,
+		);
+	}
+	public function record_notification_terminal( string $key, string $status, array $details ): array {
+		$this->terminals[ $key ] = compact( 'status', 'details' );
+		return $this->terminals[ $key ];
+	}
+	public function organizer_recipient_ids(): array {
+		return $this->organizers;
+	}
+	public function workspace_url(): string {
+		return $this->workspace;
+	}
+}
+
+/** Covers matching, exclusions, authorization, privacy, replay, and dependency failures. */
+final class LocalSupportNotificationTest extends TestCase {
+	private $adapter;
+	private $eligibility_calls;
+	private $candidates;
+	private $deliveries;
+
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id' => 7,
+			'stack'   => array(),
+			'uuid'    => 0,
+		);
+		$this->adapter             = new LocalSupportNotificationAdapterStub();
+		$this->eligibility_calls   = array();
+		$this->deliveries          = array();
+		$this->candidates          = array(
+			array(
+				'artist_profile_id' => 501,
+				'artist_term_id'    => 91,
+				'manager_user_ids'  => array( 41, 42 ),
+				'email'             => 'must-not-leak@example.com',
+			),
+			array(
+				'artist_profile_id' => 502,
+				'artist_term_id'    => 88,
+				'manager_user_ids'  => array( 43 ),
+			),
+		);
+	}
+
+	private function service( ?callable $delivery = null ): LocalSupportNotificationService {
+		return new LocalSupportNotificationService(
+			$this->adapter,
+			function ( array $input ): array {
+				$this->eligibility_calls[] = $input;
+				return array( 'candidates' => $this->candidates );
+			},
+			static function (): array {
+				return array(
+					'title'            => 'Touring Band at The Room',
+					'location_term_id' => 12,
+					'location_slug'    => 'charleston-sc',
+					'venue_term_id'    => 55,
+					'artist_term_ids'  => array( 88 ),
+				);
+			},
+			$delivery ? $delivery : function ( array $recipients, array $payload ): array {
+				$this->deliveries[] = compact( 'recipients', 'payload' );
+				return array( 'recipients' => array( $recipients[0] => array( 'status' => 'inserted' ) ) );
+			},
+			static function (): int {
+				return 99;
+			}
+		);
+	}
+
+	private function request(): array {
+		return array(
+			'id'            => 15,
+			'event_id'      => 700,
+			'status'        => 'open',
+			'genre'         => 'Indie Rock',
+			'contact_email' => 'private@example.com',
+		);
+	}
+
+	public function test_open_request_matches_canonical_scene_excludes_attached_artist_and_is_idempotent(): void {
+		$service  = $this->service();
+		$activity = array(
+			'id'         => 301,
+			'kind'       => 'request_opened',
+			'request_id' => 15,
+		);
+		$first    = $service->queue_request_opened( $this->request(), $activity );
+		$second   = $service->queue_request_opened( $this->request(), $activity );
+
+		$this->assertCount( 2, $first );
+		$this->assertCount( 2, $second );
+		$this->assertCount( 2, $this->adapter->intents );
+		$this->assertSame( 12, $this->eligibility_calls[0]['location_term_id'] );
+		$this->assertSame( 'charleston-sc', $this->eligibility_calls[0]['location_slug'] );
+		$this->assertSame( array( 88 ), $this->eligibility_calls[0]['exclude_artist_term_ids'] );
+		$this->assertSame( 'Indie Rock', $this->eligibility_calls[0]['genre'] );
+		$this->assertSame( array( 41, 42 ), array_column( array_values( $this->adapter->intents ), 'recipient_id' ) );
+	}
+
+	public function test_candidate_delivery_revalidates_manager_and_discloses_no_private_fields(): void {
+		$intent = $this->service()->queue_request_opened(
+			$this->request(),
+			array(
+				'id'         => 301,
+				'kind'       => 'request_opened',
+				'request_id' => 15,
+			)
+		)[0];
+		$result = $this->service()->reconcile_intent( $intent );
+
+		$this->assertSame( 'delivered', $result['status'] );
+		$this->assertCount( 2, $this->eligibility_calls );
+		$payload = $this->deliveries[0]['payload'];
+		$this->assertSame( 'extrachill-events-local-support', $payload['producer'] );
+		$this->assertSame( 'https://events.example/local-support/15', $payload['link'] );
+		$this->assertStringNotContainsString( 'private@example.com', wp_json_encode( $payload ) );
+		$this->assertStringNotContainsString( 'must-not-leak@example.com', wp_json_encode( $payload ) );
+	}
+
+	public function test_interest_change_notifies_only_current_organizers_and_rechecks_on_delivery(): void {
+		$service = $this->service();
+		$queued  = $service->queue_interest_changed(
+			$this->request(),
+			array(
+				'artist_term_id' => 91,
+				'contact_phone'  => '555-0100',
+			),
+			array(
+				'id'         => 401,
+				'kind'       => 'interest_changed',
+				'request_id' => 15,
+			)
+		);
+
+		$this->assertSame( array( 77 ), array_column( $queued, 'recipient_id' ) );
+		$this->adapter->organizers = array();
+		$result                    = $service->reconcile_intent( $queued[0] );
+		$this->assertSame( 'suppressed', $result['status'] );
+		$this->assertSame( 'recipient_no_longer_authorized', $result['details']['reason'] );
+		$this->assertEmpty( $this->deliveries );
+	}
+
+	public function test_failed_receipts_retry_boundedly_and_replay_terminal_result(): void {
+		$service = $this->service(
+			static function ( array $recipients ): array {
+				return array( 'recipients' => array( $recipients[0] => array( 'status' => 'failed' ) ) );
+			}
+		);
+		$intent  = $service->queue_request_opened(
+			$this->request(),
+			array(
+				'id'         => 301,
+				'kind'       => 'request_opened',
+				'request_id' => 15,
+			)
+		)[0];
+		for ( $attempt = 1; $attempt <= LocalSupportNotificationService::MAX_ATTEMPTS; ++$attempt ) {
+			$result = $service->reconcile_intent( $intent );
+		}
+		$replay = $service->reconcile_intent( $intent );
+
+		$this->assertSame( 'suppressed', $result['status'] );
+		$this->assertSame( 'delivery_poisoned', $result['details']['reason'] );
+		$this->assertSame( LocalSupportNotificationService::MAX_ATTEMPTS, $result['details']['attempt'] );
+		$this->assertSame( $result, $replay );
+	}
+
+	public function test_missing_dependency_contracts_fail_closed_with_actionable_errors(): void {
+		$missing_domain = ( new LocalSupportNotificationService(
+			null,
+			null,
+			static function (): array {
+				return array(
+					'title'            => 'Show',
+					'location_term_id' => 12,
+					'location_slug'    => 'charleston-sc',
+					'venue_term_id'    => 55,
+					'artist_term_ids'  => array(),
+				);
+			}
+		) )->queue_interest_changed(
+			$this->request(),
+			array( 'artist_term_id' => 91 ),
+			array(
+				'id'         => 401,
+				'kind'       => 'interest_changed',
+				'request_id' => 15,
+			)
+		);
+		$missing_artist = ( new LocalSupportNotificationService(
+			$this->adapter,
+			null,
+			static function (): array {
+				return array(
+					'title'            => 'Show',
+					'location_term_id' => 12,
+					'location_slug'    => 'charleston-sc',
+					'venue_term_id'    => 55,
+					'artist_term_ids'  => array(),
+				);
+			}
+		) )->queue_request_opened(
+			$this->request(),
+			array(
+				'id'         => 301,
+				'kind'       => 'request_opened',
+				'request_id' => 15,
+			)
+		);
+
+		$this->assertSame( 'local_support_domain_contract_unavailable', $missing_domain->get_error_code() );
+		$this->assertStringContainsString( 'organizer_recipient_ids', $missing_domain->get_error_message() );
+		$this->assertSame( 'local_support_eligibility_unavailable', $missing_artist->get_error_code() );
+	}
+}

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -1620,6 +1620,7 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueAuthorization.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingActivityRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingNotificationService.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/LocalSupportNotificationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingCommunicationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingHoldRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingMutationService.php';

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -1640,6 +1640,7 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/LocalSupportAuthorization.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/LocalSupportService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingActivityRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingNotificationService.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/LocalSupportNotificationAdapter.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/LocalSupportNotificationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingCommunicationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingHoldRepository.php';


### PR DESCRIPTION
## Summary
- consume the landed `extrachill_events_local_support_changed` domain event and resolve each emitted payload back to its exact committed request, interest, and activity records
- query the landed private Artist Platform candidate ability using canonical Local Scene and profile exclusions, then create deterministic manager notification intents
- persist source markers, intents, deferred attempts, and terminal receipts in the existing local-support activity ledger with bounded recovery
- reauthorize current venue members or reciprocal artist managers before organizer delivery; workspace resolution fails closed until #421 supplies a private route

## Landed Contracts
- #425 provides `LocalSupportService`, `LocalSupportRepository`, `LocalSupportAuthorization`, the append-only activity table, and `extrachill_events_local_support_changed`
- Extra-Chill/extrachill-artist-platform#160 provides private ability `extrachill/artist-query-local-support-candidates` with `scene_slug`, `exclude_artist_ids`, canonical artist/profile IDs, and validated manager user IDs
- Events authorizes only producer `extrachill-events-local-support` through `extrachill_artist_platform_local_support_producer_authorized`
- no production runtime depends on test adapters, speculative hooks, Artist Platform post meta queries, or changes to Extra Chill Users

## Durability And Privacy
- source activities remain recoverable until an idempotent `notification_source_processed` marker lands, including failures before intent creation
- HMAC-derived internal keys remain deterministic without colliding with user-controlled domain idempotency keys
- pending intent reconciliation excludes future-due attempts and terminal receipts; partial, failed, or ambiguous Users receipts retry up to five times
- candidate eligibility and organizer authority are rechecked immediately before delivery
- durable and delivered payloads contain canonical IDs and public show context only; request contact, consent payloads, email, phone, invitation, and subscriber fields are never copied
- `extrachill_events_local_support_workspace_url` defaults to an actionable `local_support_workspace_unavailable` error until the private UI route exists

## Tests
- `./vendor/bin/phpunit -c phpunit-booking.xml.dist --filter '/(LocalSupportDomainTest|LocalSupportNotificationTest|BookingNotificationTest)/'` (passes: 25 tests, 133 assertions)
- `./vendor/bin/phpunit -c phpunit-booking.xml.dist --filter LocalSupportNotificationTest` (passes: 7 tests, 36 assertions)
- `homeboy --placement local review lint extrachill-events --path <worktree> --changed-since origin/main --summary` (passes PHPCS and PHPStan with zero findings; run `799e44c9-7eac-48d5-97db-01fc0b09da11`)
- Homeboy audit reports no introduced findings; one existing informational finding remains for the shared booking harness size
- Homeboy managed tests could not start because this runtime does not expose `WP_CODEBOX_DB_HOST`; the adapter aborted before PHPUnit and reported zero executed tests
- PHP syntax checks and `git diff --check` pass

Closes #422