### PR TITLE
feat: add local support request domain

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -270,8 +270,10 @@ class ExtraChillEvents {
 		// init_abilities(); the admin screen instantiates in init_admin().
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ArtistUrlSubmissionsTable.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingSchema.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportSchema.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueAuthorization.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportAuthorization.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueInvitationToken.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueOnboardingRepository.php';
@@ -279,6 +281,8 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueInvitationDeliveryWorker.php';
 		\ExtraChillEvents\Core\VenueInvitationDeliveryWorker::register();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingNotificationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingCommunicationService.php';
@@ -428,6 +432,11 @@ class ExtraChillEvents {
 			new \ExtraChillEvents\Abilities\TicketSettlementAbilities();
 		}
 
+		if ( \ExtraChillEvents\Core\LocalSupportSchema::is_ready() ) {
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/LocalSupportAbilities.php';
+			new \ExtraChillEvents\Abilities\LocalSupportAbilities();
+		}
+
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/PriorityVenueAbilities.php';
 		new \ExtraChillEvents\Abilities\PriorityVenueAbilities();
 
@@ -521,6 +530,10 @@ class ExtraChillEvents {
 
 		if ( class_exists( '\\ExtraChillEvents\\Core\\BookingSchema' ) ) {
 			\ExtraChillEvents\Core\BookingSchema::maybe_install();
+		}
+
+		if ( class_exists( '\\ExtraChillEvents\\Core\\LocalSupportSchema' ) ) {
+			\ExtraChillEvents\Core\LocalSupportSchema::maybe_install();
 		}
 	}
 

--- a/inc/Abilities/LocalSupportAbilities.php
+++ b/inc/Abilities/LocalSupportAbilities.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Private local support abilities.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+use ExtraChillEvents\Core\LocalSupportService;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Registers authenticated, non-REST local support contracts. */
+class LocalSupportAbilities {
+
+	/** @var LocalSupportService */
+	private $service;
+
+	public function __construct( ?LocalSupportService $service = null ) {
+		$this->service = $service ? $service : new LocalSupportService();
+		add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+	}
+
+	/** Register the private domain surface. */
+	public function register(): void {
+		$this->register_ability( 'open-local-support-request', __( 'Open Local Support Request', 'extrachill-events' ), $this->open_schema(), array( $this, 'open_request' ), false, true );
+		$this->register_ability( 'get-local-support-request', __( 'Get Local Support Request', 'extrachill-events' ), $this->id_schema( 'request_id' ), array( $this, 'get_request' ), true, true );
+		$this->register_ability( 'transition-local-support-request', __( 'Transition Local Support Request', 'extrachill-events' ), $this->transition_request_schema(), array( $this, 'transition_request' ), false, true );
+		$this->register_ability( 'express-local-support-interest', __( 'Express Local Support Interest', 'extrachill-events' ), $this->express_schema(), array( $this, 'express_interest' ), false, true );
+		$this->register_ability( 'transition-local-support-interest', __( 'Transition Local Support Interest', 'extrachill-events' ), $this->transition_interest_schema(), array( $this, 'transition_interest' ), false, true );
+		$this->register_ability( 'set-local-support-contact-consent', __( 'Set Local Support Contact Consent', 'extrachill-events' ), $this->consent_schema(), array( $this, 'set_contact_consent' ), false, true );
+		$this->register_ability(
+			'list-local-support-interests',
+			__( 'List Local Support Interests', 'extrachill-events' ),
+			$this->list_schema(),
+			array( $this, 'list_interests' ),
+			true,
+			true,
+			array(
+				'type'  => 'array',
+				'items' => $this->interest_schema(),
+			)
+		);
+	}
+
+	/** Execute request creation. */
+	public function open_request( array $input ) {
+		return $this->service->open_request( $input, get_current_user_id() );
+	}
+
+	/** Execute organizer request read. */
+	public function get_request( array $input ) {
+		return $this->service->get_request( (int) $input['request_id'], get_current_user_id() );
+	}
+
+	/** Execute request transition. */
+	public function transition_request( array $input ) {
+		return $this->service->transition_request( (int) $input['request_id'], (string) $input['to_status'], (int) $input['expected_version'], (string) $input['idempotency_key'], get_current_user_id() );
+	}
+
+	/** Execute interest creation. */
+	public function express_interest( array $input ) {
+		return $this->service->express_interest( (int) $input['request_id'], (int) $input['artist_term_id'], (string) $input['idempotency_key'], get_current_user_id() );
+	}
+
+	/** Execute interest transition. */
+	public function transition_interest( array $input ) {
+		return $this->service->transition_interest( (int) $input['interest_id'], (string) $input['to_status'], (int) $input['expected_version'], (string) $input['idempotency_key'], get_current_user_id() );
+	}
+
+	/** Execute request-scoped contact consent. */
+	public function set_contact_consent( array $input ) {
+		return $this->service->set_contact_consent( (int) $input['interest_id'], (bool) $input['granted'], (array) ( $input['contact'] ?? array() ), (array) ( $input['fields'] ?? array() ), (int) $input['expected_version'], (string) $input['idempotency_key'], get_current_user_id() );
+	}
+
+	/** Execute organizer shortlist read. */
+	public function list_interests( array $input ) {
+		return $this->service->list_interests( (int) $input['request_id'], get_current_user_id(), (int) ( $input['limit'] ?? 100 ) );
+	}
+
+	/** Require an authenticated actor; domain authorization remains in the service. */
+	public function authenticated(): bool {
+		return get_current_user_id() > 0;
+	}
+
+	/** Register one consistently private ability. */
+	private function register_ability( string $slug, string $label, array $input, callable $callback, bool $read_only, bool $idempotent, ?array $output = null ): void {
+		wp_register_ability(
+			'extrachill-events/' . $slug,
+			array(
+				'label'               => $label,
+				'description'         => __( 'Private event-scoped local support operation.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => $input,
+				'output_schema'       => $output ? $output : $this->record_schema(),
+				'execute_callback'    => $callback,
+				'permission_callback' => array( $this, 'authenticated' ),
+				'meta'                => array(
+					'show_in_rest' => false,
+					'annotations'  => array(
+						'readonly'    => $read_only,
+						'idempotent'  => $idempotent,
+						'destructive' => ! $read_only,
+					),
+				),
+			)
+		);
+	}
+
+	private function open_schema(): array {
+		return $this->object_schema(
+			array(
+				'event_id'        => $this->integer(),
+				'booking_id'      => array(
+					'type'    => array( 'integer', 'null' ),
+					'minimum' => 1,
+				),
+				'organizer_type'  => array(
+					'type' => 'string',
+					'enum' => array( 'venue', 'artist' ),
+				),
+				'organizer_id'    => $this->integer(),
+				'idempotency_key' => $this->key_schema(),
+			),
+			array( 'event_id', 'organizer_type', 'organizer_id', 'idempotency_key' )
+		);
+	}
+
+	private function express_schema(): array {
+		return $this->object_schema(
+			array(
+				'request_id'      => $this->integer(),
+				'artist_term_id'  => $this->integer(),
+				'idempotency_key' => $this->key_schema(),
+			),
+			array( 'request_id', 'artist_term_id', 'idempotency_key' )
+		);
+	}
+
+	private function transition_request_schema(): array {
+		return $this->object_schema(
+			array(
+				'request_id'       => $this->integer(),
+				'to_status'        => array(
+					'type' => 'string',
+					'enum' => LocalSupportService::REQUEST_STATUSES,
+				),
+				'expected_version' => $this->integer(),
+				'idempotency_key'  => $this->key_schema(),
+			),
+			array( 'request_id', 'to_status', 'expected_version', 'idempotency_key' )
+		);
+	}
+
+	private function transition_interest_schema(): array {
+		return $this->object_schema(
+			array(
+				'interest_id'      => $this->integer(),
+				'to_status'        => array(
+					'type' => 'string',
+					'enum' => LocalSupportService::INTEREST_STATUSES,
+				),
+				'expected_version' => $this->integer(),
+				'idempotency_key'  => $this->key_schema(),
+			),
+			array( 'interest_id', 'to_status', 'expected_version', 'idempotency_key' )
+		);
+	}
+
+	private function consent_schema(): array {
+		return $this->object_schema(
+			array(
+				'interest_id'      => $this->integer(),
+				'granted'          => array( 'type' => 'boolean' ),
+				'fields'           => array(
+					'type'        => 'array',
+					'items'       => array(
+						'type' => 'string',
+						'enum' => array( 'name', 'email', 'phone' ),
+					),
+					'uniqueItems' => true,
+				),
+				'contact'          => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'name'  => array(
+							'type'      => 'string',
+							'maxLength' => 255,
+						),
+						'email' => array(
+							'type'      => 'string',
+							'format'    => 'email',
+							'maxLength' => 255,
+						),
+						'phone' => array(
+							'type'      => 'string',
+							'maxLength' => 64,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'expected_version' => $this->integer(),
+				'idempotency_key'  => $this->key_schema(),
+			),
+			array( 'interest_id', 'granted', 'expected_version', 'idempotency_key' )
+		);
+	}
+
+	private function list_schema(): array {
+		return $this->object_schema(
+			array(
+				'request_id' => $this->integer(),
+				'limit'      => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+					'maximum' => 100,
+					'default' => 100,
+				),
+			),
+			array( 'request_id' )
+		);
+	}
+
+	private function id_schema( string $field ): array {
+		return $this->object_schema( array( $field => $this->integer() ), array( $field ) );
+	}
+
+	private function object_schema( array $properties, array $required ): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => $properties,
+			'required'             => $required,
+			'additionalProperties' => false,
+		);
+	}
+
+	private function integer(): array {
+		return array(
+			'type'    => 'integer',
+			'minimum' => 1,
+		);
+	}
+
+	private function key_schema(): array {
+		return array(
+			'type'      => 'string',
+			'minLength' => 1,
+			'maxLength' => 191,
+		);
+	}
+
+	private function record_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(),
+			'additionalProperties' => true,
+		);
+	}
+
+	private function interest_schema(): array {
+		return $this->record_schema();
+	}
+}

--- a/inc/Core/LocalSupportAuthorization.php
+++ b/inc/Core/LocalSupportAuthorization.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Local support identity and authorization policy.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Validates canonical event bindings and exact organizer/artist authority. */
+class LocalSupportAuthorization {
+
+	/** @var VenueAuthorization */
+	private $venues;
+
+	public function __construct( ?VenueAuthorization $venues = null ) {
+		$this->venues = $venues ? $venues : new VenueAuthorization();
+	}
+
+	/** Resolve a valid canonical event and its one exact venue. */
+	public function event_context( int $event_id ) {
+		$post = get_post( $event_id );
+		if ( ! $post || 'data_machine_events' !== $post->post_type || 'trash' === $post->post_status ) {
+			return new \WP_Error( 'invalid_local_support_event', __( 'A valid canonical event is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$venues = wp_get_object_terms( $event_id, 'venue', array( 'fields' => 'ids' ) );
+		if ( is_wp_error( $venues ) || 1 !== count( (array) $venues ) ) {
+			return new \WP_Error( 'invalid_local_support_event_venue', __( 'The event must have one canonical venue.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$venue_id = (int) reset( $venues );
+		$venue    = get_term( $venue_id, 'venue' );
+		if ( ! $venue || is_wp_error( $venue ) || 'venue' !== $venue->taxonomy ) {
+			return new \WP_Error( 'invalid_local_support_event_venue', __( 'The event venue binding is invalid.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return array(
+			'event_id'      => $event_id,
+			'venue_term_id' => $venue_id,
+		);
+	}
+
+	/** Authorize and validate the organizer identity against the exact event. */
+	public function authorize_organizer( array $request, int $user_id ) {
+		$context = $this->event_context( (int) $request['event_id'] );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+		if ( (int) $request['venue_term_id'] !== $context['venue_term_id'] ) {
+			return $this->denied();
+		}
+		if ( 'venue' === $request['organizer_type'] ) {
+			if ( (int) $request['organizer_id'] !== $context['venue_term_id'] ) {
+				return $this->denied();
+			}
+			return $this->venues->authorize( $user_id, $context['venue_term_id'], VenueAuthorization::ACTION_ACCESS_VENUE );
+		}
+		if ( 'artist' !== $request['organizer_type'] ) {
+			return $this->denied();
+		}
+		$artist_id = (int) $request['organizer_id'];
+		$attached  = $this->artist_attached_to_event( $context['event_id'], $artist_id );
+		if ( true !== $attached ) {
+			return is_wp_error( $attached ) ? $attached : $this->denied();
+		}
+		return $this->authorize_artist( $artist_id, $user_id );
+	}
+
+	/** Authorize one canonical artist manager through its bound profile. */
+	public function authorize_artist( int $artist_term_id, int $user_id ) {
+		$profile_id = $this->artist_profile_id( $artist_term_id );
+		if ( is_wp_error( $profile_id ) ) {
+			return $profile_id;
+		}
+		if ( ! function_exists( 'ec_user_can' ) || ! ec_user_can(
+			'manage_artist',
+			array(
+				'artist_id' => $profile_id,
+				'user_id'   => $user_id,
+			)
+		) ) {
+			return $this->denied();
+		}
+		return true;
+	}
+
+	/** Determine whether a canonical artist is explicitly attached to the event. */
+	public function artist_attached_to_event( int $event_id, int $artist_term_id ) {
+		if ( ! function_exists( 'extrachill_events_resolve_artist_term' ) ) {
+			return new \WP_Error( 'local_support_artist_mapping_unavailable', __( 'Canonical artist mapping is unavailable.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+		$mapped = extrachill_events_resolve_artist_term( $artist_term_id );
+		if ( is_wp_error( $mapped ) ) {
+			return $mapped;
+		}
+		$artists = wp_get_object_terms( $event_id, 'artist', array( 'fields' => 'ids' ) );
+		if ( is_wp_error( $artists ) ) {
+			return new \WP_Error( 'local_support_event_artists_unavailable', __( 'Event artist bindings could not be validated.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+		return in_array( (int) $mapped['term_id'], array_map( 'intval', (array) $artists ), true );
+	}
+
+	/** Resolve and verify a canonical term's bidirectional Artist Platform profile. */
+	private function artist_profile_id( int $artist_term_id ) {
+		$main_blog_id   = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'main' ) : 0;
+		$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : 0;
+		if ( $main_blog_id < 1 || $artist_blog_id < 1 || $artist_term_id < 1 ) {
+			return new \WP_Error( 'invalid_local_support_artist', __( 'A valid canonical artist is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		switch_to_blog( $main_blog_id );
+		try {
+			$term       = get_term( $artist_term_id, 'artist' );
+			$profile_id = $term && ! is_wp_error( $term ) ? absint( get_term_meta( $artist_term_id, '_artist_profile_id', true ) ) : 0;
+		} finally {
+			restore_current_blog();
+		}
+		if ( $profile_id < 1 ) {
+			return new \WP_Error( 'invalid_local_support_artist', __( 'The canonical artist has no bound profile.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		switch_to_blog( $artist_blog_id );
+		try {
+			$profile = get_post( $profile_id );
+			$bound   = absint( get_post_meta( $profile_id, '_artist_term_id', true ) );
+		} finally {
+			restore_current_blog();
+		}
+		if ( ! $profile || 'artist_profile' !== $profile->post_type || 'publish' !== $profile->post_status || $bound !== $artist_term_id ) {
+			return new \WP_Error( 'invalid_local_support_artist', __( 'The artist profile binding is invalid.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return $profile_id;
+	}
+
+	/** Return a non-enumerating denial. */
+	private function denied(): \WP_Error {
+		return new \WP_Error( 'local_support_forbidden', __( 'You are not authorized for this local support request.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+}

--- a/inc/Core/LocalSupportRepository.php
+++ b/inc/Core/LocalSupportRepository.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Private local support persistence.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Provides bounded persistence for local support aggregates. */
+class LocalSupportRepository {
+
+	/** Create one request. Database uniqueness owns concurrent event admission. */
+	public function create_request( array $data ) {
+		global $wpdb;
+		$now = gmdate( 'Y-m-d H:i:s' );
+		$row = array(
+			'public_id'          => wp_generate_uuid4(),
+			'event_id'           => (int) $data['event_id'],
+			'venue_term_id'      => (int) $data['venue_term_id'],
+			'booking_id'         => empty( $data['booking_id'] ) ? null : (int) $data['booking_id'],
+			'organizer_type'     => (string) $data['organizer_type'],
+			'organizer_id'       => (int) $data['organizer_id'],
+			'status'             => 'open',
+			'version'            => 1,
+			'created_by_user_id' => (int) $data['actor_id'],
+			'created_at'         => $now,
+			'updated_at'         => $now,
+		);
+		if ( false === $wpdb->insert( LocalSupportSchema::requests_table(), $row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private operational write.
+			return new \WP_Error( 'local_support_request_create_failed', __( 'The support request could not be created.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return $this->get_request( (int) $wpdb->insert_id );
+	}
+
+	/** Get one request by numeric ID. */
+	public function get_request( int $id, bool $for_update = false ) {
+		global $wpdb;
+		$table = LocalSupportSchema::requests_table();
+		$lock  = $for_update ? ' FOR UPDATE' : '';
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1{$lock}", $id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted table and fixed lock clause.
+		return $this->row_result( $row, 'local_support_request_read_failed', array( $this, 'hydrate_request' ) );
+	}
+
+	/** Get the sole request for a canonical event. */
+	public function get_request_by_event( int $event_id ) {
+		global $wpdb;
+		$table = LocalSupportSchema::requests_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE event_id = %d LIMIT 1", $event_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact indexed read.
+		return $this->row_result( $row, 'local_support_request_read_failed', array( $this, 'hydrate_request' ) );
+	}
+
+	/** Create one artist interest. */
+	public function create_interest( int $request_id, int $artist_term_id, int $actor_id ) {
+		global $wpdb;
+		$now = gmdate( 'Y-m-d H:i:s' );
+		$row = array(
+			'public_id'            => wp_generate_uuid4(),
+			'request_id'           => $request_id,
+			'artist_term_id'       => $artist_term_id,
+			'status'               => 'interested',
+			'version'              => 1,
+			'contact_payload'      => null,
+			'consent_fields'       => null,
+			'consent_version'      => 0,
+			'consented_by_user_id' => null,
+			'consented_at'         => null,
+			'revoked_by_user_id'   => null,
+			'revoked_at'           => null,
+			'created_by_user_id'   => $actor_id,
+			'created_at'           => $now,
+			'updated_at'           => $now,
+		);
+		if ( false === $wpdb->insert( LocalSupportSchema::interests_table(), $row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private operational write.
+			return new \WP_Error( 'local_support_interest_create_failed', __( 'Artist interest could not be recorded.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return $this->get_interest( (int) $wpdb->insert_id );
+	}
+
+	/** Get one interest. */
+	public function get_interest( int $id, bool $for_update = false ) {
+		global $wpdb;
+		$table = LocalSupportSchema::interests_table();
+		$lock  = $for_update ? ' FOR UPDATE' : '';
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1{$lock}", $id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted table and fixed lock clause.
+		return $this->row_result( $row, 'local_support_interest_read_failed', array( $this, 'hydrate_interest' ) );
+	}
+
+	/** Get one artist's interest in one request. */
+	public function get_interest_for_artist( int $request_id, int $artist_term_id ) {
+		global $wpdb;
+		$table = LocalSupportSchema::interests_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE request_id = %d AND artist_term_id = %d LIMIT 1", $request_id, $artist_term_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact unique read.
+		return $this->row_result( $row, 'local_support_interest_read_failed', array( $this, 'hydrate_interest' ) );
+	}
+
+	/** List bounded interests for an organizer shortlist. */
+	public function list_interests( int $request_id, int $limit = 100 ) {
+		global $wpdb;
+		$table = LocalSupportSchema::interests_table();
+		$limit = max( 1, min( 100, $limit ) );
+		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE request_id = %d ORDER BY created_at ASC, id ASC LIMIT %d", $request_id, $limit ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded private read.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'local_support_interest_list_failed', __( 'Local support interests could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return array_map( array( $this, 'hydrate_interest' ), (array) $rows );
+	}
+
+	/** Apply a versioned request update. */
+	public function update_request( int $id, int $expected_version, array $changes ) {
+		return $this->conditional_update( LocalSupportSchema::requests_table(), $id, $expected_version, $changes, 'request' );
+	}
+
+	/** Apply a versioned interest update. */
+	public function update_interest( int $id, int $expected_version, array $changes ) {
+		return $this->conditional_update( LocalSupportSchema::interests_table(), $id, $expected_version, $changes, 'interest' );
+	}
+
+	/** Append one immutable activity marker. */
+	public function append_activity( array $data ) {
+		global $wpdb;
+		$payload = wp_json_encode(
+			array(
+				'version' => 1,
+				'data'    => $data['payload'] ?? array(),
+			)
+		);
+		if ( false === $payload ) {
+			return new \WP_Error( 'local_support_activity_encode_failed', __( 'Local support activity could not be encoded.', 'extrachill-events' ) );
+		}
+		$row = array(
+			'request_id'      => (int) $data['request_id'],
+			'interest_id'     => empty( $data['interest_id'] ) ? null : (int) $data['interest_id'],
+			'kind'            => sanitize_key( (string) $data['kind'] ),
+			'actor_user_id'   => (int) $data['actor_user_id'],
+			'idempotency_key' => (string) $data['idempotency_key'],
+			'request_hash'    => (string) $data['request_hash'],
+			'result_version'  => (int) $data['result_version'],
+			'payload'         => $payload,
+			'created_at'      => gmdate( 'Y-m-d H:i:s' ),
+		);
+		if ( false === $wpdb->insert( LocalSupportSchema::activity_table(), $row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Append-only private audit write.
+			return new \WP_Error( 'local_support_activity_write_failed', __( 'Local support activity could not be recorded.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		$row['id'] = (int) $wpdb->insert_id;
+		return $row;
+	}
+
+	/** Find a prior mutation receipt. */
+	public function find_activity( int $request_id, string $idempotency_key ) {
+		global $wpdb;
+		$table = LocalSupportSchema::activity_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE request_id = %d AND idempotency_key = %s LIMIT 1", $request_id, $idempotency_key ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact idempotency receipt read.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'local_support_activity_read_failed', __( 'Local support activity could not be read.', 'extrachill-events' ) );
+		}
+		return is_array( $row ) ? $row : null;
+	}
+
+	/** Hydrate request scalar types. */
+	public function hydrate_request( array $row ): array {
+		foreach ( array( 'id', 'event_id', 'venue_term_id', 'organizer_id', 'version', 'created_by_user_id' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		$row['booking_id'] = null === $row['booking_id'] ? null : (int) $row['booking_id'];
+		return $row;
+	}
+
+	/** Hydrate interest and reveal contact only while consent is active. */
+	public function hydrate_interest( array $row ): array {
+		$stored_fields = $row['consent_fields'];
+		foreach ( array( 'id', 'request_id', 'artist_term_id', 'version', 'consent_version', 'created_by_user_id' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		foreach ( array( 'consented_by_user_id', 'revoked_by_user_id' ) as $field ) {
+			$row[ $field ] = null === $row[ $field ] ? null : (int) $row[ $field ];
+		}
+		$row['contact']        = null;
+		$row['consent_fields'] = null;
+		if ( null !== $row['contact_payload'] && null === $row['revoked_at'] ) {
+			$row['contact']        = json_decode( $row['contact_payload'], true );
+			$row['consent_fields'] = json_decode( (string) $stored_fields, true );
+		}
+		unset( $row['contact_payload'] );
+		return $row;
+	}
+
+	/** Execute one optimistic update. */
+	private function conditional_update( string $table, int $id, int $expected_version, array $changes, string $kind ) {
+		global $wpdb;
+		$changes['version']    = $expected_version + 1;
+		$changes['updated_at'] = gmdate( 'Y-m-d H:i:s' );
+		$updated               = $wpdb->update(
+			$table,
+			$changes,
+			array(
+				'id'      => $id,
+				'version' => $expected_version,
+			)
+		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Optimistic private aggregate write.
+		if ( 1 !== $updated ) {
+			return new \WP_Error( 'local_support_version_conflict', __( 'The local support record changed since it was read.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return 'request' === $kind ? $this->get_request( $id ) : $this->get_interest( $id );
+	}
+
+	/** Normalize a single-row read. */
+	private function row_result( $row, string $error_code, callable $hydrate ) {
+		global $wpdb;
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( $error_code, __( 'The local support record could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return is_array( $row ) ? call_user_func( $hydrate, $row ) : null;
+	}
+}

--- a/inc/Core/LocalSupportSchema.php
+++ b/inc/Core/LocalSupportSchema.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Private event-scoped local support storage.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Owns the site-scoped local support schema. */
+class LocalSupportSchema {
+
+	public const SCHEMA_VERSION = '1';
+	public const VERSION_OPTION = 'extrachill_events_local_support_schema_version';
+
+	/** Get the support requests table. */
+	public static function requests_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_local_support_requests';
+	}
+
+	/** Get the artist interests table. */
+	public static function interests_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_local_support_interests';
+	}
+
+	/** Get the append-only activity table. */
+	public static function activity_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_local_support_activity';
+	}
+
+	/** Install all local support tables. */
+	public static function install() {
+		global $wpdb;
+
+		$requests  = self::requests_table();
+		$interests = self::interests_table();
+		$activity  = self::activity_table();
+		$charset   = $wpdb->get_charset_collate();
+
+		$requests_sql = "CREATE TABLE {$requests} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			public_id CHAR(36) NOT NULL,
+			event_id BIGINT UNSIGNED NOT NULL,
+			venue_term_id BIGINT UNSIGNED NOT NULL,
+			booking_id BIGINT UNSIGNED NULL,
+			organizer_type VARCHAR(16) NOT NULL,
+			organizer_id BIGINT UNSIGNED NOT NULL,
+			status VARCHAR(16) NOT NULL DEFAULT 'open',
+			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
+			created_by_user_id BIGINT UNSIGNED NOT NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY public_id (public_id),
+			UNIQUE KEY event_id (event_id),
+			KEY organizer_status (organizer_type, organizer_id, status),
+			KEY venue_status_created (venue_term_id, status, created_at)
+		) ENGINE=InnoDB {$charset};";
+
+		$interests_sql = "CREATE TABLE {$interests} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			public_id CHAR(36) NOT NULL,
+			request_id BIGINT UNSIGNED NOT NULL,
+			artist_term_id BIGINT UNSIGNED NOT NULL,
+			status VARCHAR(16) NOT NULL DEFAULT 'interested',
+			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
+			contact_payload LONGTEXT NULL,
+			consent_fields LONGTEXT NULL,
+			consent_version BIGINT UNSIGNED NOT NULL DEFAULT '0',
+			consented_by_user_id BIGINT UNSIGNED NULL,
+			consented_at DATETIME NULL,
+			revoked_by_user_id BIGINT UNSIGNED NULL,
+			revoked_at DATETIME NULL,
+			created_by_user_id BIGINT UNSIGNED NOT NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY public_id (public_id),
+			UNIQUE KEY request_artist (request_id, artist_term_id),
+			KEY request_status_created (request_id, status, created_at),
+			KEY artist_status_created (artist_term_id, status, created_at)
+		) ENGINE=InnoDB {$charset};";
+
+		$activity_sql = "CREATE TABLE {$activity} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			request_id BIGINT UNSIGNED NOT NULL,
+			interest_id BIGINT UNSIGNED NULL,
+			kind VARCHAR(64) NOT NULL,
+			actor_user_id BIGINT UNSIGNED NOT NULL,
+			idempotency_key VARCHAR(191) NOT NULL,
+			request_hash CHAR(64) NOT NULL,
+			result_version BIGINT UNSIGNED NOT NULL,
+			payload LONGTEXT NOT NULL,
+			created_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY request_idempotency (request_id, idempotency_key),
+			KEY request_created (request_id, created_at, id),
+			KEY interest_created (interest_id, created_at, id),
+			KEY kind_created (kind, created_at)
+		) ENGINE=InnoDB {$charset};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $requests_sql );
+		$requests_error = (string) $wpdb->last_error;
+		dbDelta( $interests_sql );
+		$interests_error = (string) $wpdb->last_error;
+		dbDelta( $activity_sql );
+		$activity_error = (string) $wpdb->last_error;
+		if ( '' !== $requests_error || '' !== $interests_error || '' !== $activity_error ) {
+			return new \WP_Error(
+				'local_support_schema_install_failed',
+				__( 'The local support schema could not be installed.', 'extrachill-events' ),
+				compact( 'requests_error', 'interests_error', 'activity_error' )
+			);
+		}
+		$health = self::health();
+		if ( is_wp_error( $health ) ) {
+			return $health;
+		}
+		update_option( self::VERSION_OPTION, self::SCHEMA_VERSION, false );
+		return true;
+	}
+
+	/** Install only when stale. */
+	public static function maybe_install() {
+		return self::is_ready() ? true : self::install();
+	}
+
+	/** Return the cheap readiness signal. */
+	public static function is_ready(): bool {
+		return self::SCHEMA_VERSION === (string) get_option( self::VERSION_OPTION, '' );
+	}
+
+	/** Verify required tables and uniqueness contracts. */
+	public static function health() {
+		global $wpdb;
+		$contracts = array(
+			self::requests_table()  => array( 'public_id', 'event_id' ),
+			self::interests_table() => array( 'public_id', 'request_artist' ),
+			self::activity_table()  => array( 'request_idempotency' ),
+		);
+		foreach ( $contracts as $table => $unique_indexes ) {
+			$found = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema health cannot use cached data.
+			if ( $found !== $table || '' !== (string) $wpdb->last_error ) {
+				return new \WP_Error( 'local_support_schema_table_missing', __( 'A local support table is missing.', 'extrachill-events' ), array( 'table' => $table ) );
+			}
+			$status = $wpdb->get_row( $wpdb->prepare( 'SHOW TABLE STATUS WHERE Name = %s', $table ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema health cannot use cached data.
+			if ( 'innodb' !== strtolower( (string) ( $status['Engine'] ?? '' ) ) ) {
+				return new \WP_Error( 'local_support_schema_engine_invalid', __( 'Local support storage must be transactional.', 'extrachill-events' ), array( 'table' => $table ) );
+			}
+			$indexes      = $wpdb->get_results( "SHOW INDEX FROM `{$table}`", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted current-prefix table.
+			$found_unique = array();
+			foreach ( (array) $indexes as $index ) {
+				if ( 0 === (int) $index['Non_unique'] ) {
+					$found_unique[] = (string) $index['Key_name'];
+				}
+			}
+			foreach ( $unique_indexes as $index ) {
+				if ( ! in_array( $index, $found_unique, true ) ) {
+					return new \WP_Error(
+						'local_support_schema_index_missing',
+						__( 'A local support uniqueness contract is missing.', 'extrachill-events' ),
+						array(
+							'table' => $table,
+							'index' => $index,
+						)
+					);
+				}
+			}
+		}
+		return true;
+	}
+}

--- a/inc/Core/LocalSupportService.php
+++ b/inc/Core/LocalSupportService.php
@@ -1,0 +1,600 @@
+<?php
+/**
+ * Event-scoped local support aggregate service.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Owns local support lifecycle, privacy, idempotency, and transaction boundaries. */
+class LocalSupportService {
+
+	public const REQUEST_STATUSES  = array( 'open', 'paused', 'filled', 'closed', 'cancelled' );
+	public const INTEREST_STATUSES = array( 'interested', 'withdrawn', 'shortlisted', 'selected', 'declined' );
+
+	private const REQUEST_TRANSITIONS = array(
+		'open'      => array( 'paused', 'filled', 'closed', 'cancelled' ),
+		'paused'    => array( 'open', 'closed', 'cancelled' ),
+		'filled'    => array( 'closed' ),
+		'closed'    => array(),
+		'cancelled' => array(),
+	);
+
+	private const INTEREST_TRANSITIONS = array(
+		'interested'  => array( 'withdrawn', 'shortlisted', 'declined' ),
+		'shortlisted' => array( 'withdrawn', 'selected', 'declined' ),
+		'selected'    => array( 'withdrawn' ),
+		'withdrawn'   => array(),
+		'declined'    => array(),
+	);
+
+	/** @var LocalSupportRepository */
+	private $repository;
+
+	/** @var LocalSupportAuthorization */
+	private $authorization;
+
+	public function __construct( ?LocalSupportRepository $repository = null, ?LocalSupportAuthorization $authorization = null ) {
+		$this->repository    = $repository ? $repository : new LocalSupportRepository();
+		$this->authorization = $authorization ? $authorization : new LocalSupportAuthorization();
+	}
+
+	/** Open one request per canonical event. */
+	public function open_request( array $input, int $actor_id ) {
+		$key = $this->idempotency_key( $input['idempotency_key'] ?? '' );
+		if ( is_wp_error( $key ) ) {
+			return $key;
+		}
+		$event_id      = absint( $input['event_id'] ?? 0 );
+		$organizer     = sanitize_key( (string) ( $input['organizer_type'] ?? '' ) );
+		$organizer_id  = absint( $input['organizer_id'] ?? 0 );
+		$booking_id    = empty( $input['booking_id'] ) ? null : absint( $input['booking_id'] );
+		$event_context = $this->authorization->event_context( $event_id );
+		if ( is_wp_error( $event_context ) ) {
+			return $event_context;
+		}
+		$request = array(
+			'event_id'       => $event_id,
+			'venue_term_id'  => $event_context['venue_term_id'],
+			'booking_id'     => $booking_id,
+			'organizer_type' => $organizer,
+			'organizer_id'   => $organizer_id,
+		);
+		$allowed = $this->authorization->authorize_organizer( $request, $actor_id );
+		if ( true !== $allowed ) {
+			return $allowed;
+		}
+		if ( null !== $booking_id ) {
+			$booking = ( new BookingRepository() )->get( $booking_id );
+			if ( ! is_array( $booking ) || (int) $booking['event_id'] !== $event_id || (int) $booking['venue_term_id'] !== $event_context['venue_term_id'] ) {
+				return new \WP_Error( 'invalid_local_support_booking', __( 'The optional booking must belong to this exact event and venue.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+		}
+		$hash     = $this->request_hash( 'open_request', $request, $actor_id );
+		$existing = $this->repository->get_request_by_event( $event_id );
+		if ( is_wp_error( $existing ) ) {
+			return $existing;
+		}
+		if ( is_array( $existing ) ) {
+			return $this->replay( $existing, $key, $hash );
+		}
+
+		$started = $this->begin();
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$allowed = $this->authorization->authorize_organizer( $request, $actor_id );
+		if ( true !== $allowed ) {
+			return $this->rollback( $allowed );
+		}
+		$created = $this->repository->create_request( array_merge( $request, array( 'actor_id' => $actor_id ) ) );
+		if ( is_wp_error( $created ) ) {
+			$rolled = $this->rollback( $created );
+			if ( 'local_support_request_create_failed' !== $rolled->get_error_code() ) {
+				return $rolled;
+			}
+			$winner = $this->repository->get_request_by_event( $event_id );
+			return is_array( $winner ) ? $this->replay( $winner, $key, $hash ) : $rolled;
+		}
+		$activity = $this->record( $created['id'], null, 'request_opened', $actor_id, $key, $hash, 1, array( 'status' => 'open' ) );
+		if ( is_wp_error( $activity ) ) {
+			return $this->rollback( $activity );
+		}
+		$committed = $this->commit();
+		if ( is_wp_error( $committed ) ) {
+			return $committed;
+		}
+		$this->emit( 'request_opened', $created['id'], null, 1 );
+		return $created;
+	}
+
+	/** Read one request as its organizer. */
+	public function get_request( int $request_id, int $actor_id ) {
+		$request = $this->repository->get_request( $request_id );
+		if ( ! is_array( $request ) ) {
+			return is_wp_error( $request ) ? $request : $this->not_found();
+		}
+		$allowed = $this->authorization->authorize_organizer( $request, $actor_id );
+		return true === $allowed ? $request : $allowed;
+	}
+
+	/** Apply one organizer-owned request transition. */
+	public function transition_request( int $request_id, string $to_status, int $expected_version, string $idempotency_key, int $actor_id ) {
+		$request = $this->repository->get_request( $request_id );
+		if ( ! is_array( $request ) ) {
+			return is_wp_error( $request ) ? $request : $this->not_found();
+		}
+		$allowed = $this->authorization->authorize_organizer( $request, $actor_id );
+		if ( true !== $allowed ) {
+			return $allowed;
+		}
+		$to_status = sanitize_key( $to_status );
+		if ( ! in_array( $to_status, self::REQUEST_TRANSITIONS[ $request['status'] ] ?? array(), true ) ) {
+			return new \WP_Error( 'local_support_request_transition_forbidden', __( 'The requested support-request transition is not allowed.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return $this->mutate_request(
+			$request,
+			$expected_version,
+			$idempotency_key,
+			$actor_id,
+			'request_status_changed',
+			array( 'status' => $to_status ),
+			array(
+				'from_status' => $request['status'],
+				'to_status'   => $to_status,
+			)
+		);
+	}
+
+	/** Create or replay one artist interest. */
+	public function express_interest( int $request_id, int $artist_term_id, string $idempotency_key, int $actor_id ) {
+		$request = $this->repository->get_request( $request_id );
+		if ( ! is_array( $request ) ) {
+			return is_wp_error( $request ) ? $request : $this->not_found();
+		}
+		if ( 'open' !== $request['status'] ) {
+			return new \WP_Error( 'local_support_request_not_open', __( 'This support request is not accepting interest.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$allowed = $this->authorization->authorize_artist( $artist_term_id, $actor_id );
+		if ( true !== $allowed ) {
+			return $allowed;
+		}
+		$attached = $this->authorization->artist_attached_to_event( $request['event_id'], $artist_term_id );
+		if ( is_wp_error( $attached ) ) {
+			return $attached;
+		}
+		if ( $attached ) {
+			return new \WP_Error( 'local_support_artist_already_attached', __( 'Artists already attached to the event cannot express local-support interest.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$key  = $this->idempotency_key( $idempotency_key );
+		$hash = $this->request_hash(
+			'express_interest',
+			array(
+				'request_id'     => $request_id,
+				'artist_term_id' => $artist_term_id,
+			),
+			$actor_id
+		);
+		if ( is_wp_error( $key ) ) {
+			return $key;
+		}
+		$existing = $this->repository->get_interest_for_artist( $request_id, $artist_term_id );
+		if ( is_wp_error( $existing ) ) {
+			return $existing;
+		}
+		if ( is_array( $existing ) ) {
+			$replayed = $this->replay( $request, $key, $hash );
+			return is_wp_error( $replayed ) ? $replayed : $existing;
+		}
+		$started = $this->begin();
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$allowed = $this->authorization->authorize_artist( $artist_term_id, $actor_id );
+		if ( true !== $allowed ) {
+			return $this->rollback( $allowed );
+		}
+		$interest = $this->repository->create_interest( $request_id, $artist_term_id, $actor_id );
+		if ( is_wp_error( $interest ) ) {
+			$rolled = $this->rollback( $interest );
+			if ( 'local_support_interest_create_failed' !== $rolled->get_error_code() ) {
+				return $rolled;
+			}
+			$winner = $this->repository->get_interest_for_artist( $request_id, $artist_term_id );
+			if ( ! is_array( $winner ) ) {
+				return $rolled;
+			}
+			$replayed = $this->replay( $request, $key, $hash );
+			return is_wp_error( $replayed ) ? $replayed : $winner;
+		}
+		$activity = $this->record(
+			$request_id,
+			$interest['id'],
+			'interest_expressed',
+			$actor_id,
+			$key,
+			$hash,
+			1,
+			array(
+				'artist_term_id' => $artist_term_id,
+				'status'         => 'interested',
+			)
+		);
+		if ( is_wp_error( $activity ) ) {
+			return $this->rollback( $activity );
+		}
+		$committed = $this->commit();
+		if ( is_wp_error( $committed ) ) {
+			return $committed;
+		}
+		$this->emit( 'interest_expressed', $request_id, $interest['id'], 1 );
+		return $interest;
+	}
+
+	/** Transition an interest as the artist or organizer, depending on target state. */
+	public function transition_interest( int $interest_id, string $to_status, int $expected_version, string $idempotency_key, int $actor_id ) {
+		$interest = $this->repository->get_interest( $interest_id );
+		if ( ! is_array( $interest ) ) {
+			return is_wp_error( $interest ) ? $interest : $this->not_found();
+		}
+		$request = $this->repository->get_request( $interest['request_id'] );
+		if ( ! is_array( $request ) ) {
+			return is_wp_error( $request ) ? $request : $this->not_found();
+		}
+		$to_status = sanitize_key( $to_status );
+		if ( ! in_array( $to_status, self::INTEREST_TRANSITIONS[ $interest['status'] ] ?? array(), true ) ) {
+			return new \WP_Error( 'local_support_interest_transition_forbidden', __( 'The requested interest transition is not allowed.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$artist_owned = 'withdrawn' === $to_status;
+		$allowed      = $artist_owned
+			? $this->authorization->authorize_artist( $interest['artist_term_id'], $actor_id )
+			: $this->authorization->authorize_organizer( $request, $actor_id );
+		if ( true !== $allowed ) {
+			return $allowed;
+		}
+		if ( ! $artist_owned && ! in_array( $to_status, array( 'shortlisted', 'selected', 'declined' ), true ) ) {
+			return new \WP_Error( 'local_support_interest_transition_forbidden', __( 'Only the artist may withdraw interest.', 'extrachill-events' ), array( 'status' => 403 ) );
+		}
+		return $this->mutate_interest(
+			$request,
+			$interest,
+			$expected_version,
+			$idempotency_key,
+			$actor_id,
+			'interest_status_changed',
+			array( 'status' => $to_status ),
+			array(
+				'from_status' => $interest['status'],
+				'to_status'   => $to_status,
+			),
+			$artist_owned
+		);
+	}
+
+	/** Grant or revoke request-scoped contact disclosure. */
+	public function set_contact_consent( int $interest_id, bool $granted, array $contact, array $fields, int $expected_version, string $idempotency_key, int $actor_id ) {
+		$interest = $this->repository->get_interest( $interest_id );
+		if ( ! is_array( $interest ) ) {
+			return is_wp_error( $interest ) ? $interest : $this->not_found();
+		}
+		$request = $this->repository->get_request( $interest['request_id'] );
+		if ( ! is_array( $request ) ) {
+			return is_wp_error( $request ) ? $request : $this->not_found();
+		}
+		$allowed = $this->authorization->authorize_artist( $interest['artist_term_id'], $actor_id );
+		if ( true !== $allowed ) {
+			return $allowed;
+		}
+		$consent_version = $interest['consent_version'] + 1;
+		$now             = gmdate( 'Y-m-d H:i:s' );
+		if ( $granted ) {
+			$normalized = $this->normalize_contact( $contact, $fields );
+			if ( is_wp_error( $normalized ) ) {
+				return $normalized;
+			}
+			$changes = array(
+				'contact_payload'      => wp_json_encode( $normalized['contact'] ),
+				'consent_fields'       => wp_json_encode( $normalized['fields'] ),
+				'consent_version'      => $consent_version,
+				'consented_by_user_id' => $actor_id,
+				'consented_at'         => $now,
+				'revoked_by_user_id'   => null,
+				'revoked_at'           => null,
+			);
+			$payload = array(
+				'granted'         => true,
+				'fields'          => $normalized['fields'],
+				'consent_version' => $consent_version,
+				'consented_at'    => $now,
+			);
+			$kind    = 'contact_consent_granted';
+		} else {
+			$changes = array(
+				'contact_payload'    => null,
+				'consent_fields'     => null,
+				'consent_version'    => $consent_version,
+				'revoked_by_user_id' => $actor_id,
+				'revoked_at'         => $now,
+			);
+			$payload = array(
+				'granted'         => false,
+				'fields'          => (array) ( $interest['consent_fields'] ?? array() ),
+				'consent_version' => $consent_version,
+				'revoked_at'      => $now,
+			);
+			$kind    = 'contact_consent_revoked';
+		}
+		return $this->mutate_interest( $request, $interest, $expected_version, $idempotency_key, $actor_id, $kind, $changes, $payload, true );
+	}
+
+	/** Return the private organizer shortlist; no uninterested candidates exist here. */
+	public function list_interests( int $request_id, int $actor_id, int $limit = 100 ) {
+		$request = $this->repository->get_request( $request_id );
+		if ( ! is_array( $request ) ) {
+			return is_wp_error( $request ) ? $request : $this->not_found();
+		}
+		$allowed = $this->authorization->authorize_organizer( $request, $actor_id );
+		return true === $allowed ? $this->repository->list_interests( $request_id, $limit ) : $allowed;
+	}
+
+	/** Public lifecycle validator used by focused domain tests. */
+	public static function can_transition_request( string $from, string $to ): bool {
+		return in_array( $to, self::REQUEST_TRANSITIONS[ $from ] ?? array(), true );
+	}
+
+	/** Public lifecycle validator used by focused domain tests. */
+	public static function can_transition_interest( string $from, string $to ): bool {
+		return in_array( $to, self::INTEREST_TRANSITIONS[ $from ] ?? array(), true );
+	}
+
+	/** Run one request mutation transaction. */
+	private function mutate_request( array $request, int $expected_version, string $key, int $actor_id, string $kind, array $changes, array $payload ) {
+		$key  = $this->idempotency_key( $key );
+		$hash = $this->request_hash( $kind, $changes, $actor_id );
+		if ( is_wp_error( $key ) ) {
+			return $key;
+		}
+		$replay = $this->replay( $request, $key, $hash, false );
+		if ( null !== $replay ) {
+			return $replay;
+		}
+		if ( $request['version'] !== $expected_version ) {
+			return $this->conflict( $request['version'] );
+		}
+		$started = $this->begin();
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$locked = $this->repository->get_request( $request['id'], true );
+		if ( ! is_array( $locked ) || $locked['version'] !== $expected_version ) {
+			$rolled = $this->rollback( is_array( $locked ) ? $this->conflict( $locked['version'] ) : $this->not_found() );
+			return is_array( $locked ) ? $this->concurrent_replay( $request['id'], $key, $hash, $rolled, 'request', $request['id'] ) : $rolled;
+		}
+		$allowed = $this->authorization->authorize_organizer( $locked, $actor_id );
+		if ( true !== $allowed ) {
+			return $this->rollback( $allowed );
+		}
+		$updated = $this->repository->update_request( $locked['id'], $expected_version, $changes );
+		$event   = is_wp_error( $updated ) ? $updated : $this->record( $locked['id'], null, $kind, $actor_id, $key, $hash, $updated['version'], $payload );
+		if ( is_wp_error( $event ) ) {
+			return $this->rollback( $event );
+		}
+		$committed = $this->commit();
+		if ( is_wp_error( $committed ) ) {
+			return $committed;
+		}
+		$this->emit( $kind, $locked['id'], null, $updated['version'] );
+		return $updated;
+	}
+
+	/** Run one interest mutation transaction. */
+	private function mutate_interest( array $request, array $interest, int $expected_version, string $key, int $actor_id, string $kind, array $changes, array $payload, bool $artist_owned ) {
+		$key  = $this->idempotency_key( $key );
+		$hash = $this->request_hash(
+			$kind,
+			array(
+				'interest_id' => $interest['id'],
+				'changes'     => $changes,
+			),
+			$actor_id
+		);
+		if ( is_wp_error( $key ) ) {
+			return $key;
+		}
+		$receipt = $this->repository->find_activity( $request['id'], $key );
+		if ( is_wp_error( $receipt ) ) {
+			return $receipt;
+		}
+		if ( is_array( $receipt ) ) {
+			return hash_equals( (string) $receipt['request_hash'], $hash ) ? $interest : $this->idempotency_conflict();
+		}
+		if ( $interest['version'] !== $expected_version ) {
+			return $this->conflict( $interest['version'] );
+		}
+		$started = $this->begin();
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$locked = $this->repository->get_interest( $interest['id'], true );
+		if ( ! is_array( $locked ) || $locked['version'] !== $expected_version ) {
+			$rolled = $this->rollback( is_array( $locked ) ? $this->conflict( $locked['version'] ) : $this->not_found() );
+			return is_array( $locked ) ? $this->concurrent_replay( $request['id'], $key, $hash, $rolled, 'interest', $interest['id'] ) : $rolled;
+		}
+		$allowed = $artist_owned
+			? $this->authorization->authorize_artist( $locked['artist_term_id'], $actor_id )
+			: $this->authorization->authorize_organizer( $request, $actor_id );
+		if ( true !== $allowed ) {
+			return $this->rollback( $allowed );
+		}
+		$updated = $this->repository->update_interest( $locked['id'], $expected_version, $changes );
+		$event   = is_wp_error( $updated ) ? $updated : $this->record( $request['id'], $locked['id'], $kind, $actor_id, $key, $hash, $updated['version'], $payload );
+		if ( is_wp_error( $event ) ) {
+			return $this->rollback( $event );
+		}
+		$committed = $this->commit();
+		if ( is_wp_error( $committed ) ) {
+			return $committed;
+		}
+		$this->emit( $kind, $request['id'], $locked['id'], $updated['version'] );
+		return $updated;
+	}
+
+	/** Normalize disclosed fields without retaining undisclosed contact data. */
+	private function normalize_contact( array $contact, array $fields ) {
+		$fields = array_values( array_unique( array_map( 'sanitize_key', $fields ) ) );
+		if ( empty( $fields ) || array_diff( $fields, array( 'name', 'email', 'phone' ) ) ) {
+			return new \WP_Error( 'invalid_local_support_consent_fields', __( 'Consent must name supported contact fields.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$normalized = array();
+		foreach ( $fields as $field ) {
+			$value = 'email' === $field ? sanitize_email( (string) ( $contact[ $field ] ?? '' ) ) : sanitize_text_field( (string) ( $contact[ $field ] ?? '' ) );
+			if ( '' === $value ) {
+				return new \WP_Error(
+					'invalid_local_support_contact',
+					__( 'Every consented contact field requires a value.', 'extrachill-events' ),
+					array(
+						'status' => 400,
+						'field'  => $field,
+					)
+				);
+			}
+			$normalized[ $field ] = mb_substr( $value, 0, 'phone' === $field ? 64 : 255 );
+		}
+		return array(
+			'contact' => $normalized,
+			'fields'  => $fields,
+		);
+	}
+
+	/** Return a prior receipt, null when no receipt exists. */
+	private function replay( array $request, string $key, string $hash, bool $required = true ) {
+		$receipt = $this->repository->find_activity( $request['id'], $key );
+		if ( is_wp_error( $receipt ) ) {
+			return $receipt;
+		}
+		if ( ! is_array( $receipt ) ) {
+			return $required ? $this->idempotency_conflict() : null;
+		}
+		return hash_equals( (string) $receipt['request_hash'], $hash ) ? $request : $this->idempotency_conflict();
+	}
+
+	/** Resolve a mutation that lost its row-version race to the same idempotent call. */
+	private function concurrent_replay( int $request_id, string $key, string $hash, \WP_Error $fallback, string $aggregate, int $aggregate_id ) {
+		$receipt = $this->repository->find_activity( $request_id, $key );
+		if ( ! is_array( $receipt ) || ! hash_equals( (string) $receipt['request_hash'], $hash ) ) {
+			return is_wp_error( $receipt ) ? $receipt : $fallback;
+		}
+		return 'request' === $aggregate ? $this->repository->get_request( $aggregate_id ) : $this->repository->get_interest( $aggregate_id );
+	}
+
+	/** Append one mutation receipt. */
+	private function record( int $request_id, ?int $interest_id, string $kind, int $actor_id, string $key, string $hash, int $version, array $payload ) {
+		return $this->repository->append_activity(
+			array(
+				'request_id'      => $request_id,
+				'interest_id'     => $interest_id,
+				'kind'            => $kind,
+				'actor_user_id'   => $actor_id,
+				'idempotency_key' => $key,
+				'request_hash'    => $hash,
+				'result_version'  => $version,
+				'payload'         => array_merge( $payload, array( 'version' => $version ) ),
+			)
+		);
+	}
+
+	/** Emit a privacy-safe internal contract after commit for #422. */
+	private function emit( string $kind, int $request_id, ?int $interest_id, int $version ): void {
+		do_action(
+			'extrachill_events_local_support_changed',
+			array(
+				'kind'        => $kind,
+				'request_id'  => $request_id,
+				'interest_id' => $interest_id,
+				'version'     => $version,
+			)
+		);
+	}
+
+	/** Normalize bounded idempotency keys. */
+	private function idempotency_key( $key ) {
+		$key = trim( sanitize_text_field( (string) $key ) );
+		return '' === $key || strlen( $key ) > 191
+			? new \WP_Error( 'local_support_idempotency_key_required', __( 'A bounded idempotency key is required.', 'extrachill-events' ), array( 'status' => 400 ) )
+			: $key;
+	}
+
+	/** Fingerprint one actor-bound mutation. */
+	private function request_hash( string $operation, array $data, int $actor_id ): string {
+		$this->canonicalize( $data );
+		return hash_hmac(
+			'sha256',
+			wp_json_encode(
+				array(
+					'operation' => $operation,
+					'actor_id'  => $actor_id,
+					'data'      => $data,
+				)
+			),
+			wp_salt( 'auth' )
+		);
+	}
+
+	/** Sort associative data recursively for stable hashes. */
+	private function canonicalize( array &$value ): void {
+		if ( array() !== $value && array_keys( $value ) !== range( 0, count( $value ) - 1 ) ) {
+			ksort( $value, SORT_STRING );
+		}
+		foreach ( $value as &$item ) {
+			if ( is_array( $item ) ) {
+				$this->canonicalize( $item );
+			}
+		}
+	}
+
+	private function begin() {
+		global $wpdb;
+		return false === $wpdb->query( 'START TRANSACTION' ) // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate transaction boundary.
+			? new \WP_Error( 'local_support_transaction_start_failed', __( 'The local support transaction could not start.', 'extrachill-events' ) )
+			: true;
+	}
+
+	private function commit() {
+		global $wpdb;
+		return false === $wpdb->query( 'COMMIT' ) // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate transaction boundary.
+			? new \WP_Error( 'local_support_transaction_commit_uncertain', __( 'The local support transaction outcome is uncertain.', 'extrachill-events' ) )
+			: true;
+	}
+
+	private function rollback( \WP_Error $cause ): \WP_Error {
+		global $wpdb;
+		if ( false === $wpdb->query( 'ROLLBACK' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate transaction boundary.
+			return new \WP_Error( 'local_support_transaction_rollback_failed', __( 'The local support transaction could not roll back.', 'extrachill-events' ), array( 'cause' => $cause->get_error_code() ) );
+		}
+		return $cause;
+	}
+
+	private function conflict( int $version ): \WP_Error {
+		return new \WP_Error(
+			'local_support_version_conflict',
+			__( 'The local support record changed since it was read.', 'extrachill-events' ),
+			array(
+				'status'          => 409,
+				'current_version' => $version,
+			)
+		);
+	}
+
+	private function idempotency_conflict(): \WP_Error {
+		return new \WP_Error( 'local_support_idempotency_conflict', __( 'The idempotency key was already used for a different mutation.', 'extrachill-events' ), array( 'status' => 409 ) );
+	}
+
+	private function not_found(): \WP_Error {
+		return new \WP_Error( 'local_support_not_found', __( 'The local support record was not found.', 'extrachill-events' ), array( 'status' => 404 ) );
+	}
+}

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -9,6 +9,7 @@
 	<testsuites>
 		<testsuite name="booking-foundation">
 			<file>tests/BookingFoundationTest.php</file>
+			<file>tests/LocalSupportDomainTest.php</file>
 			<file>tests/BookingAttachmentTest.php</file>
 			<file>tests/BookingInquiryAdmissionTest.php</file>
 			<file>tests/BookingPrivateFileProviderTest.php</file>

--- a/tests/LocalSupportDomainTest.php
+++ b/tests/LocalSupportDomainTest.php
@@ -1,0 +1,361 @@
+<?php
+/**
+ * Event-scoped local support domain tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Abilities\LocalSupportAbilities;
+use ExtraChillEvents\Core\LocalSupportAuthorization;
+use ExtraChillEvents\Core\LocalSupportRepository;
+use ExtraChillEvents\Core\LocalSupportSchema;
+use ExtraChillEvents\Core\LocalSupportService;
+use ExtraChillEvents\Core\VenueAuthorization;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
+final class LocalSupportDomainTest extends TestCase {
+
+	/** @var LocalSupportMemoryRepository */
+	private $repository;
+
+	/** @var LocalSupportTestAuthorization */
+	private $authorization;
+
+	/** @var LocalSupportService */
+	private $service;
+
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id'       => 7,
+			'uuid'          => 0,
+			'options'       => array(),
+			'dbdelta'       => array(),
+			'abilities'     => array(),
+			'actions'       => array(),
+			'fired_actions' => array(),
+		);
+		$GLOBALS['wpdb']           = new BookingWpdb();
+		$this->repository          = new LocalSupportMemoryRepository();
+		$this->authorization       = new LocalSupportTestAuthorization();
+		$this->service             = new LocalSupportService( $this->repository, $this->authorization );
+	}
+
+	public function test_schema_owns_separate_unique_transactional_tables(): void {
+		$this->assertTrue( LocalSupportSchema::install() );
+		$this->assertTrue( LocalSupportSchema::health() );
+		$this->assertSame( 'wp_7_ec_local_support_requests', LocalSupportSchema::requests_table() );
+		$this->assertSame( array( 'event_id' ), $GLOBALS['wpdb']->schemas[ LocalSupportSchema::requests_table() ]['indexes']['event_id']['columns'] );
+		$this->assertTrue( $GLOBALS['wpdb']->schemas[ LocalSupportSchema::requests_table() ]['indexes']['event_id']['unique'] );
+		$this->assertSame( array( 'request_id', 'artist_term_id' ), $GLOBALS['wpdb']->schemas[ LocalSupportSchema::interests_table() ]['indexes']['request_artist']['columns'] );
+		$this->assertTrue( $GLOBALS['wpdb']->schemas[ LocalSupportSchema::activity_table() ]['indexes']['request_idempotency']['unique'] );
+	}
+
+	public function test_request_and_interest_lifecycles_are_separate_and_explicit(): void {
+		$this->assertTrue( LocalSupportService::can_transition_request( 'open', 'paused' ) );
+		$this->assertTrue( LocalSupportService::can_transition_request( 'open', 'filled' ) );
+		$this->assertFalse( LocalSupportService::can_transition_request( 'closed', 'open' ) );
+		$this->assertTrue( LocalSupportService::can_transition_interest( 'interested', 'shortlisted' ) );
+		$this->assertTrue( LocalSupportService::can_transition_interest( 'shortlisted', 'selected' ) );
+		$this->assertFalse( LocalSupportService::can_transition_interest( 'declined', 'interested' ) );
+	}
+
+	/** Prove exact venue and bound canonical artist organizer authorization. */
+	public function test_real_authorization_requires_exact_event_bindings_and_current_authority(): void {
+		$GLOBALS['ec_artist_test'] = array_merge(
+			$GLOBALS['ec_artist_test'],
+			array(
+				'blog_id'          => 7,
+				'stack'            => array(),
+				'terms'            => array(
+					1 => array( 101 => (object) array( 'term_id' => 101, 'taxonomy' => 'artist' ) ),
+					7 => array( 55 => (object) array( 'term_id' => 55, 'taxonomy' => 'venue' ) ),
+				),
+				'meta'             => array( 1 => array( 101 => array( '_artist_profile_id' => 501 ) ) ),
+				'posts'            => array(
+					4 => array( 501 => (object) array( 'ID' => 501, 'post_type' => 'artist_profile', 'post_status' => 'publish' ) ),
+					7 => array( 900 => (object) array( 'ID' => 900, 'post_type' => 'data_machine_events', 'post_status' => 'publish' ) ),
+				),
+				'post_meta'        => array( 4 => array( 501 => array( '_artist_term_id' => 101 ) ) ),
+				'event_venues'     => array( 7 => array( 900 => array( 55 ) ) ),
+				'event_artists'    => array( 7 => array( 900 => array( 1001 ) ) ),
+				'artist_mappings'  => array( 101 => 1001 ),
+				'artist_managers'  => array( 501 => array( 30 => true ) ),
+			)
+		);
+		$authorization = new LocalSupportAuthorization( new LocalSupportVenueAuthorization() );
+		$venue_request = array( 'event_id' => 900, 'venue_term_id' => 55, 'organizer_type' => 'venue', 'organizer_id' => 55 );
+		$this->assertTrue( $authorization->authorize_organizer( $venue_request, 12 ) );
+		$venue_request['organizer_id'] = 56;
+		$this->assertSame( 'local_support_forbidden', $authorization->authorize_organizer( $venue_request, 12 )->get_error_code() );
+
+		$artist_request = array( 'event_id' => 900, 'venue_term_id' => 55, 'organizer_type' => 'artist', 'organizer_id' => 101 );
+		$this->assertTrue( $authorization->authorize_organizer( $artist_request, 30 ) );
+		$this->assertSame( 'local_support_forbidden', $authorization->authorize_organizer( $artist_request, 31 )->get_error_code() );
+		$GLOBALS['ec_artist_test']['event_artists'][7][900] = array();
+		$this->assertSame( 'local_support_forbidden', $authorization->authorize_organizer( $artist_request, 30 )->get_error_code() );
+	}
+
+	public function test_one_request_and_interest_are_idempotent_and_hash_bound(): void {
+		$request = $this->open_request();
+		$retry   = $this->open_request();
+		$this->assertSame( $request['id'], $retry['id'] );
+		$this->assertCount( 1, $this->repository->requests );
+
+		$conflict = $this->service->open_request(
+			array(
+				'event_id'        => 900,
+				'organizer_type'  => 'artist',
+				'organizer_id'    => 101,
+				'idempotency_key' => 'open-900',
+			),
+			12
+		);
+		$this->assertSame( 'local_support_idempotency_conflict', $conflict->get_error_code() );
+
+		$interest = $this->service->express_interest( $request['id'], 202, 'interest-202', 20 );
+		$retry    = $this->service->express_interest( $request['id'], 202, 'interest-202', 20 );
+		$this->assertSame( $interest['id'], $retry['id'] );
+		$this->assertCount( 1, $this->repository->interests );
+		$this->assertNull( $interest['contact'] );
+	}
+
+	public function test_optimistic_conflicts_and_authority_fail_closed(): void {
+		$request = $this->open_request();
+		$paused  = $this->service->transition_request( $request['id'], 'paused', 1, 'pause-1', 12 );
+		$this->assertSame( 2, $paused['version'] );
+		$this->assertSame( 'local_support_version_conflict', $this->service->transition_request( $request['id'], 'closed', 1, 'close-stale', 12 )->get_error_code() );
+
+		$this->authorization->organizer_allowed = false;
+		$this->assertSame( 'local_support_forbidden', $this->service->get_request( $request['id'], 12 )->get_error_code() );
+		$this->authorization->organizer_allowed = true;
+		$this->service->transition_request( $request['id'], 'open', 2, 'resume-1', 12 );
+		$this->authorization->artist_allowed    = false;
+		$this->assertSame( 'local_support_forbidden', $this->service->express_interest( $request['id'], 202, 'denied-interest', 20 )->get_error_code() );
+	}
+
+	public function test_contact_is_absent_until_explicit_consent_and_revocation_is_audited(): void {
+		$request  = $this->open_request();
+		$interest = $this->service->express_interest( $request['id'], 202, 'interest-202', 20 );
+		$this->assertNull( $interest['contact'] );
+
+		$granted = $this->service->set_contact_consent(
+			$interest['id'],
+			true,
+			array(
+				'name'  => 'Artist Manager',
+				'email' => 'artist@example.com',
+				'phone' => 'not disclosed',
+			),
+			array( 'name', 'email' ),
+			1,
+			'consent-1',
+			20
+		);
+		$this->assertSame(
+			array(
+				'name'  => 'Artist Manager',
+				'email' => 'artist@example.com',
+			),
+			$granted['contact']
+		);
+		$this->assertSame( array( 'name', 'email' ), $granted['consent_fields'] );
+		$this->assertSame( 1, $granted['consent_version'] );
+		$this->assertNull( $granted['revoked_at'] );
+
+		$revoked = $this->service->set_contact_consent( $interest['id'], false, array(), array(), 2, 'revoke-1', 20 );
+		$this->assertNull( $revoked['contact'] );
+		$this->assertNull( $revoked['consent_fields'] );
+		$this->assertSame( 2, $revoked['consent_version'] );
+		$this->assertSame( 20, $revoked['revoked_by_user_id'] );
+		$this->assertSame( array( 'contact_consent_granted', 'contact_consent_revoked' ), array_slice( array_column( $this->repository->activity, 'kind' ), -2 ) );
+		$this->assertStringNotContainsString( 'artist@example.com', wp_json_encode( $this->repository->activity ) );
+	}
+
+	public function test_only_organizer_can_shortlist_and_private_abilities_are_not_rest_exposed(): void {
+		$request  = $this->open_request();
+		$interest = $this->service->express_interest( $request['id'], 202, 'interest-202', 20 );
+		$selected = $this->service->transition_interest( $interest['id'], 'shortlisted', 1, 'shortlist-202', 12 );
+		$this->assertSame( 'shortlisted', $selected['status'] );
+		$this->assertSame( array( 202 ), array_column( $this->service->list_interests( $request['id'], 12 ), 'artist_term_id' ) );
+
+		$abilities = new LocalSupportAbilities( $this->service );
+		$abilities->register();
+		$this->assertArrayHasKey( 'extrachill-events/open-local-support-request', $GLOBALS['ec_artist_test']['abilities'] );
+		foreach ( $GLOBALS['ec_artist_test']['abilities'] as $name => $definition ) {
+			if ( 0 === strpos( $name, 'extrachill-events/' ) && false !== strpos( $name, 'local-support' ) ) {
+				$this->assertFalse( $definition['meta']['show_in_rest'], $name );
+			}
+		}
+	}
+
+	private function open_request(): array {
+		return $this->service->open_request(
+			array(
+				'event_id'        => 900,
+				'organizer_type'  => 'venue',
+				'organizer_id'    => 55,
+				'idempotency_key' => 'open-900',
+			),
+			12
+		);
+	}
+}
+
+/** In-memory persistence double that exercises service behavior without SQL parsing. */
+final class LocalSupportMemoryRepository extends LocalSupportRepository {
+	public $requests  = array();
+	public $interests = array();
+	public $activity  = array();
+
+	public function create_request( array $data ) {
+		$id                    = count( $this->requests ) + 1;
+		$this->requests[ $id ] = array_merge(
+			$data,
+			array(
+				'id'                 => $id,
+				'public_id'          => 'request-' . $id,
+				'status'             => 'open',
+				'version'            => 1,
+				'created_by_user_id' => $data['actor_id'],
+				'created_at'         => '2026-07-27 00:00:00',
+				'updated_at'         => '2026-07-27 00:00:00',
+			)
+		);
+		unset( $this->requests[ $id ]['actor_id'] );
+		return $this->requests[ $id ];
+	}
+
+	public function get_request( int $id, bool $for_update = false ) {
+		unset( $for_update );
+		return $this->requests[ $id ] ?? null;
+	}
+
+	public function get_request_by_event( int $event_id ) {
+		foreach ( $this->requests as $request ) {
+			if ( $request['event_id'] === $event_id ) {
+				return $request;
+			}
+		}
+		return null;
+	}
+
+	public function create_interest( int $request_id, int $artist_term_id, int $actor_id ) {
+		$id                     = count( $this->interests ) + 1;
+		$row                    = array(
+			'id'                   => $id,
+			'public_id'            => 'interest-' . $id,
+			'request_id'           => $request_id,
+			'artist_term_id'       => $artist_term_id,
+			'status'               => 'interested',
+			'version'              => 1,
+			'contact_payload'      => null,
+			'consent_fields'       => null,
+			'consent_version'      => 0,
+			'consented_by_user_id' => null,
+			'consented_at'         => null,
+			'revoked_by_user_id'   => null,
+			'revoked_at'           => null,
+			'created_by_user_id'   => $actor_id,
+			'created_at'           => '2026-07-27 00:00:00',
+			'updated_at'           => '2026-07-27 00:00:00',
+		);
+		$this->interests[ $id ] = $row;
+		return $this->hydrate_interest( $row );
+	}
+
+	public function get_interest( int $id, bool $for_update = false ) {
+		unset( $for_update );
+		return isset( $this->interests[ $id ] ) ? $this->hydrate_interest( $this->interests[ $id ] ) : null;
+	}
+
+	public function get_interest_for_artist( int $request_id, int $artist_term_id ) {
+		foreach ( $this->interests as $row ) {
+			if ( $row['request_id'] === $request_id && $row['artist_term_id'] === $artist_term_id ) {
+				return $this->hydrate_interest( $row );
+			}
+		}
+		return null;
+	}
+
+	public function list_interests( int $request_id, int $limit = 100 ): array {
+		$rows = array_filter(
+			$this->interests,
+			static function ( $row ) use ( $request_id ) {
+				return $row['request_id'] === $request_id;
+			}
+		);
+		return array_map( array( $this, 'hydrate_interest' ), array_slice( array_values( $rows ), 0, $limit ) );
+	}
+
+	public function update_request( int $id, int $expected_version, array $changes ) {
+		if ( ! isset( $this->requests[ $id ] ) || $this->requests[ $id ]['version'] !== $expected_version ) {
+			return new WP_Error( 'local_support_version_conflict' );
+		}
+		$this->requests[ $id ] = array_merge( $this->requests[ $id ], $changes, array( 'version' => $expected_version + 1 ) );
+		return $this->requests[ $id ];
+	}
+
+	public function update_interest( int $id, int $expected_version, array $changes ) {
+		if ( ! isset( $this->interests[ $id ] ) || $this->interests[ $id ]['version'] !== $expected_version ) {
+			return new WP_Error( 'local_support_version_conflict' );
+		}
+		$this->interests[ $id ] = array_merge( $this->interests[ $id ], $changes, array( 'version' => $expected_version + 1 ) );
+		return $this->hydrate_interest( $this->interests[ $id ] );
+	}
+
+	public function append_activity( array $data ) {
+		$data['id']       = count( $this->activity ) + 1;
+		$this->activity[] = $data;
+		return $data;
+	}
+
+	public function find_activity( int $request_id, string $idempotency_key ) {
+		foreach ( $this->activity as $activity ) {
+			if ( $activity['request_id'] === $request_id && $activity['idempotency_key'] === $idempotency_key ) {
+				return $activity;
+			}
+		}
+		return null;
+	}
+}
+
+/** Authorization double with explicit fail-closed controls. */
+final class LocalSupportTestAuthorization extends LocalSupportAuthorization {
+	public $organizer_allowed = true;
+	public $artist_allowed    = true;
+	public $attached_artists  = array( 101 );
+
+	public function event_context( int $event_id ) {
+		return 900 === $event_id ? array(
+			'event_id'      => 900,
+			'venue_term_id' => 55,
+		) : new WP_Error( 'invalid_local_support_event' );
+	}
+
+	public function authorize_organizer( array $request, int $user_id ) {
+		unset( $user_id );
+		if ( ! $this->organizer_allowed || 900 !== $request['event_id'] || 55 !== $request['venue_term_id'] || ( 'venue' === $request['organizer_type'] && 55 !== $request['organizer_id'] ) || ( 'artist' === $request['organizer_type'] && ! in_array( $request['organizer_id'], $this->attached_artists, true ) ) ) {
+			return new WP_Error( 'local_support_forbidden' );
+		}
+		return true;
+	}
+
+	public function authorize_artist( int $artist_term_id, int $user_id ) {
+		unset( $artist_term_id, $user_id );
+		return $this->artist_allowed ? true : new WP_Error( 'local_support_forbidden' );
+	}
+
+	public function artist_attached_to_event( int $event_id, int $artist_term_id ) {
+		return 900 === $event_id && in_array( $artist_term_id, $this->attached_artists, true );
+	}
+}
+
+/** Exact venue policy double used while exercising the real support authorization. */
+final class LocalSupportVenueAuthorization extends VenueAuthorization {
+	/** Accept only the fixture's exact venue member relationship. */
+	public function authorize( int $user_id, int $venue_term_id, string $action ) {
+		return 12 === $user_id && 55 === $venue_term_id && VenueAuthorization::ACTION_ACCESS_VENUE === $action ? true : new WP_Error( 'venue_action_forbidden' );
+	}
+}

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -25,6 +25,7 @@ use ExtraChillEvents\Abilities\VenueBookingMutationAbilities;
 use ExtraChillEvents\Abilities\VenueBookingEventAbilities;
 use ExtraChillEvents\Abilities\VenueBookingCommunicationAbilities;
 use ExtraChillEvents\Core\VenueAuthorization;
+use ExtraChillEvents\Core\LocalSupportSchema;
 
 if ( ! defined( 'ARRAY_A' ) ) {
 	define( 'ARRAY_A', 'ARRAY_A' );
@@ -225,11 +226,26 @@ if ( ! function_exists( 'wp_get_object_terms' ) ) {
 		if ( ! empty( $GLOBALS['ec_artist_test']['venue_terms_error'] ) ) {
 			return new WP_Error( 'venue_terms_read_failed', 'simulated venue taxonomy read failure' );
 		}
+		if ( 'artist' === $taxonomy ) {
+			$ids = $GLOBALS['ec_artist_test']['event_artists'][ get_current_blog_id() ][ $post_id ] ?? array();
+			return ( $args['fields'] ?? '' ) === 'ids' ? $ids : array();
+		}
 		if ( 'venue' !== $taxonomy ) {
 			return array();
 		}
 		$ids = $GLOBALS['ec_artist_test']['event_venues'][ get_current_blog_id() ][ $post_id ] ?? array();
 		return ( $args['fields'] ?? '' ) === 'ids' ? $ids : array();
+	}
+}
+if ( ! function_exists( 'extrachill_events_resolve_artist_term' ) ) {
+	function extrachill_events_resolve_artist_term( $artist_term_id ) {
+		$mapped = $GLOBALS['ec_artist_test']['artist_mappings'][ (int) $artist_term_id ] ?? 0;
+		return $mapped > 0 ? array( 'term_id' => $mapped, 'term_slug' => 'artist-' . $mapped ) : new WP_Error( 'artist_mapping_missing' );
+	}
+}
+if ( ! function_exists( 'ec_user_can' ) ) {
+	function ec_user_can( $capability, array $context = array() ) {
+		return 'manage_artist' === $capability && ! empty( $GLOBALS['ec_artist_test']['artist_managers'][ (int) ( $context['artist_id'] ?? 0 ) ][ (int) ( $context['user_id'] ?? 0 ) ] );
 	}
 }
 if ( ! function_exists( 'parse_blocks' ) ) {
@@ -1615,9 +1631,13 @@ final class BookingWpdb {
 }
 
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingSchema.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/LocalSupportSchema.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueMembershipRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueAuthorization.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingRepository.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/LocalSupportRepository.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/LocalSupportAuthorization.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/LocalSupportService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingActivityRepository.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingNotificationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingCommunicationService.php';
@@ -1639,6 +1659,7 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueBookingConfig.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/TicketSettlementService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/CanonicalEventPublicationGuard.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingAbilities.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Abilities/LocalSupportAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/BookingAttachmentAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingHoldAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingMutationAbilities.php';


### PR DESCRIPTION
## Summary

- add separate private InnoDB aggregates for one support request per canonical event and one interest per request/artist, with independent explicit lifecycles and optimistic versions
- enforce exact event venue or attached canonical artist organizer authority, recheck artist-manager authority for interest and consent mutations, and fail closed on invalid identity bindings
- keep contact values absent until request-scoped consent, erase active disclosure on revocation, and retain actor/fields/version/timestamp audit without copying contact values into append-only activity
- expose authenticated, non-REST abilities plus the privacy-safe `extrachill_events_local_support_changed` event contract for follow-up integration

## Boundaries

This PR is the private domain foundation only. It does not resolve candidates or deliver notifications; those remain in #422. It does not add UI; that remains in #421. It does not infer billing/headliner roles or publish selected artists.

## Tests

- `vendor/bin/phpunit -c phpunit-booking.xml.dist --filter LocalSupportDomainTest` (`7 tests`, `49 assertions`)
- `npm run lint:js`
- `homeboy review --changed-since origin/main --summary --placement local`: audit passed with no introduced findings; PHPCS, ESLint, and PHPStan level 7 passed with zero findings
- Homeboy test execution blocked before PHPUnit by missing `WP_CODEBOX_DB_HOST`; repository-wide PHPUnit bootstrap/isolation failures and this adapter configuration are tracked in #424

Closes #420