### PR TITLE
test: isolate booking harness globals

### DIFF
--- a/tests/BookingAttachmentTest.php
+++ b/tests/BookingAttachmentTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
-final class BookingAttachmentTest extends TestCase {
+final class BookingAttachmentTest extends BookingTestCase {
 
 	private $provider;
 

--- a/tests/BookingCommunicationTest.php
+++ b/tests/BookingCommunicationTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
-final class BookingCommunicationTest extends TestCase {
+final class BookingCommunicationTest extends BookingTestCase {
 
 	protected function setUp(): void {
 		$GLOBALS['ec_artist_test'] = array(

--- a/tests/BookingEventConversionTest.php
+++ b/tests/BookingEventConversionTest.php
@@ -28,7 +28,7 @@ final class BookingConversionAbilityFake {
 	}
 }
 
-final class BookingEventConversionTest extends TestCase {
+final class BookingEventConversionTest extends BookingTestCase {
 	protected function setUp(): void {
 		$GLOBALS['ec_test_filters'] = array();
 		$GLOBALS['ec_artist_test'] = array(

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
-final class BookingFoundationTest extends TestCase {
+final class BookingFoundationTest extends BookingTestCase {
 	protected function setUp(): void {
 		$GLOBALS['ec_artist_test'] = array(
 			'blog_id'       => 7,

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
-final class BookingHoldTest extends TestCase {
+final class BookingHoldTest extends BookingTestCase {
 
 	protected function setUp(): void {
 		$GLOBALS['ec_artist_test'] = array(

--- a/tests/BookingInquiryAdmissionTest.php
+++ b/tests/BookingInquiryAdmissionTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
 /** Verifies the hidden inquiry ability's complete attachment saga. */
-final class BookingInquiryAdmissionTest extends TestCase {
+final class BookingInquiryAdmissionTest extends BookingTestCase {
 
 	/**
 	 * Fake private provider.

--- a/tests/BookingMarketingDelegatedSchemaTest.php
+++ b/tests/BookingMarketingDelegatedSchemaTest.php
@@ -40,7 +40,7 @@ namespace {
 	require_once __DIR__ . '/Support/BookingTestHarness.php';
 	require_once dirname( __DIR__, 2 ) . '/data-machine/inc/Abilities/DelegatedOperationAbilities.php';
 
-	final class BookingMarketingDelegatedSchemaTest extends TestCase {
+	final class BookingMarketingDelegatedSchemaTest extends BookingTestCase {
 		protected function setUp(): void {
 			$GLOBALS['ec_artist_test'] = array( 'abilities' => array() );
 		}

--- a/tests/BookingMarketingTest.php
+++ b/tests/BookingMarketingTest.php
@@ -212,7 +212,7 @@ if ( ! class_exists( '\AgentsAPI\AI\Approvals\WP_Agent_Pending_Action' ) ) {
 	class_alias( BookingMarketingPendingActionFake::class, '\AgentsAPI\AI\Approvals\WP_Agent_Pending_Action' );
 }
 
-final class BookingMarketingTest extends TestCase {
+final class BookingMarketingTest extends BookingTestCase {
 	private BookingMarketingDelegatedBackendFake $backend;
 	private $original_wpdb;
 	private array $asset_files = array();
@@ -318,15 +318,19 @@ final class BookingMarketingTest extends TestCase {
 			$GLOBALS['ec_artist_test']['ability_objects'][ 'datamachine/' . $verb . '-delegated-operation' ] = new BookingMarketingDelegatedAbilityFake( $this->backend, $verb );
 		}
 		$GLOBALS['ec_test_ability_resolver'] = static fn( string $name ) => $GLOBALS['ec_artist_test']['ability_objects'][ $name ] ?? null;
-		$this->log_callback                  = static function ( $level, $message, $context ): void {
-			$GLOBALS['ec_artist_test']['fired_actions']['datamachine_log'][] = array( $level, $message, $context );
-		};
-		add_action( 'datamachine_log', $this->log_callback, 10, 3 );
+		if ( ! defined( 'EC_TEST_DO_ACTION_RECORDS_FIXTURES' ) ) {
+			$this->log_callback = static function ( $level, $message, $context ): void {
+				$GLOBALS['ec_artist_test']['fired_actions']['datamachine_log'][] = array( $level, $message, $context );
+			};
+			add_action( 'datamachine_log', $this->log_callback, 10, 3 );
+		}
 	}
 
 	protected function tearDown(): void {
 		$GLOBALS['wpdb'] = $this->original_wpdb;
-		remove_action( 'datamachine_log', $this->log_callback, 10 );
+		if ( $this->log_callback ) {
+			remove_action( 'datamachine_log', $this->log_callback, 10 );
+		}
 		unset( $GLOBALS['ec_test_ability_resolver'] );
 		foreach ( $this->asset_files as $file ) {
 			if ( is_file( $file ) ) {

--- a/tests/BookingMutationTest.php
+++ b/tests/BookingMutationTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
-final class BookingMutationTest extends TestCase {
+final class BookingMutationTest extends BookingTestCase {
 	protected function setUp(): void {
 		$GLOBALS['ec_artist_test'] = array(
 			'blog_id'       => 7,

--- a/tests/BookingNotificationTest.php
+++ b/tests/BookingNotificationTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
 /** Covers recovery, authorization, and structured receipt reconciliation. */
-final class BookingNotificationTest extends TestCase {
+final class BookingNotificationTest extends BookingTestCase {
 	/** Reset booking persistence. */
 	protected function setUp(): void {
 		$GLOBALS['ec_artist_test'] = array(

--- a/tests/BookingPrivateFileProviderTest.php
+++ b/tests/BookingPrivateFileProviderTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
-final class BookingPrivateFileProviderTest extends TestCase {
+final class BookingPrivateFileProviderTest extends BookingTestCase {
 
 	private $base;
 	private $root;

--- a/tests/CanonicalEventPublicationGuardTest.php
+++ b/tests/CanonicalEventPublicationGuardTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
-final class CanonicalEventPublicationGuardTest extends TestCase {
+final class CanonicalEventPublicationGuardTest extends BookingTestCase {
 
 	protected function setUp(): void {
 		$GLOBALS['ec_test_filters'] = array();

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -119,6 +119,11 @@ if ( ! function_exists( 'sanitize_textarea_field' ) ) {
 }
 if ( ! function_exists( 'wp_generate_uuid4' ) ) {
 	function wp_generate_uuid4() {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			static $venue_sequence = 0;
+			++$venue_sequence;
+			return sprintf( '00000000-0000-4000-8000-%012d', $venue_sequence );
+		}
 		++$GLOBALS['ec_artist_test']['uuid'];
 		return sprintf( '123e4567-e89b-42d3-a456-%012d', $GLOBALS['ec_artist_test']['uuid'] );
 	}
@@ -137,6 +142,9 @@ if ( ! function_exists( 'ec_get_blog_id' ) ) {
 }
 if ( ! function_exists( 'get_current_blog_id' ) ) {
 	function get_current_blog_id() {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			return $GLOBALS['venue_membership_test']['current_blog_id'];
+		}
 		return $GLOBALS['ec_artist_test']['blog_id']; }
 }
 if ( ! function_exists( 'switch_to_blog' ) ) {
@@ -151,6 +159,10 @@ if ( ! function_exists( 'restore_current_blog' ) ) {
 }
 if ( ! function_exists( 'get_term' ) ) {
 	function get_term( $term_id, $taxonomy = '' ) {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			$term = $GLOBALS['venue_membership_test']['terms'][ $term_id ] ?? null;
+			return $term && ( '' === $taxonomy || $taxonomy === $term->taxonomy ) ? $term : null;
+		}
 		if ( ! empty( $GLOBALS['ec_artist_test']['throw_get_term'] ) ) {
 			throw new RuntimeException( 'term read failed' );
 		}
@@ -162,12 +174,19 @@ if ( ! function_exists( 'get_term' ) ) {
 if ( ! function_exists( 'get_term_meta' ) ) {
 	function get_term_meta( $term_id, $key, $single = false ) {
 		unset( $single );
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			return $GLOBALS['venue_membership_test']['term_meta'][ $term_id ][ $key ] ?? '';
+		}
 		$state = $GLOBALS['ec_artist_test'];
 		return $state['meta'][ $state['blog_id'] ][ $term_id ][ $key ] ?? '';
 	}
 }
 if ( ! function_exists( 'update_term_meta' ) ) {
 	function update_term_meta( $term_id, $key, $value ) {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			$GLOBALS['venue_membership_test']['term_meta'][ $term_id ][ $key ] = $value;
+			return 1;
+		}
 		$current = get_term_meta( $term_id, $key, true );
 		if ( ! empty( $GLOBALS['ec_artist_test']['fail_term_meta'] ) || $current === $value ) {
 			return false;
@@ -239,6 +258,9 @@ if ( ! function_exists( 'parse_blocks' ) ) {
 }
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( $key, $default = false ) {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			return $GLOBALS['venue_membership_test']['options'][ $key ] ?? $default;
+		}
 		return $GLOBALS['ec_artist_test']['options'][ $key ] ?? $default; }
 }
 if ( ! function_exists( 'update_option' ) ) {
@@ -256,14 +278,26 @@ if ( ! function_exists( 'delete_option' ) ) {
 }
 if ( ! function_exists( 'get_current_user_id' ) ) {
 	function get_current_user_id() {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			return $GLOBALS['venue_membership_test']['current_user_id'];
+		}
 		return $GLOBALS['ec_artist_test']['current_user_id'] ?? 12; }
 }
 if ( ! function_exists( 'get_userdata' ) ) {
 	function get_userdata( $user_id ) {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			return $GLOBALS['venue_membership_test']['users'][ $user_id ] ?? false;
+		}
 		return (int) $user_id > 0 ? (object) array( 'ID' => (int) $user_id ) : false; }
 }
 if ( ! function_exists( 'user_can' ) ) {
 	function user_can( $user_id, $capability ) {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			if ( 'manage_options' === $capability ) {
+				return ! empty( $GLOBALS['venue_membership_test']['administrators'][ $user_id ] );
+			}
+			return VenueAuthorization::ACCESS_CAPABILITY === $capability && ! empty( $GLOBALS['venue_membership_test']['team_access'][ $user_id ] );
+		}
 		if ( isset( $GLOBALS['ec_artist_test']['user_caps'][ (int) $user_id ] ) && array_key_exists( $capability, $GLOBALS['ec_artist_test']['user_caps'][ (int) $user_id ] ) ) {
 			return (bool) $GLOBALS['ec_artist_test']['user_caps'][ (int) $user_id ][ $capability ];
 		}
@@ -271,6 +305,9 @@ if ( ! function_exists( 'user_can' ) ) {
 }
 if ( ! function_exists( 'ec_feature_available' ) ) {
 	function ec_feature_available( $feature, $user_id ) {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			return VenueAuthorization::FEATURE === $feature && ! empty( $GLOBALS['venue_membership_test']['feature_available'] );
+		}
 		return 'venue_booking' === $feature && (int) $user_id > 0; }
 }
 if ( ! function_exists( 'add_action' ) ) {
@@ -280,6 +317,10 @@ if ( ! function_exists( 'add_action' ) ) {
 }
 if ( ! function_exists( 'wp_register_ability' ) ) {
 	function wp_register_ability( $name, $definition ) {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			$GLOBALS['venue_membership_test']['abilities'][ $name ] = $definition;
+			return;
+		}
 		$GLOBALS['ec_artist_test']['abilities'][ $name ] = $definition; }
 }
 if ( ! function_exists( 'wp_get_ability' ) ) {
@@ -311,6 +352,10 @@ if ( ! function_exists( 'ec_users_notify_with_receipts' ) ) {
 }
 if ( ! function_exists( 'wp_cache_delete' ) ) {
 	function wp_cache_delete( $key, $group = '' ) {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			$GLOBALS['venue_membership_test']['cache_deletes'][] = array( $key, $group );
+			return true;
+		}
 		$GLOBALS['ec_artist_test']['cache_deletes'][] = array( $key, $group );
 		return true; }
 }

--- a/tests/TicketSettlementTest.php
+++ b/tests/TicketSettlementTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
-final class TicketSettlementTest extends TestCase {
+final class TicketSettlementTest extends BookingTestCase {
 	/** @var BookingRepository */
 	private $bookings;
 	/** @var BookingTestAuthorization */

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -19,6 +19,8 @@ use ExtraChillEvents\Core\VenueOnboardingService;
 use ExtraChillEvents\Core\VenueProfile;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
 if ( ! defined( 'ARRAY_A' ) ) {
 	define( 'ARRAY_A', 'ARRAY_A' );
 		}
@@ -849,7 +851,7 @@ require_once dirname( __DIR__ ) . '/inc/Abilities/VenueProfileAbilities.php';
  * Venue membership and profile composition coverage uses isolated WP doubles.
  *
  */
-final class VenueMembershipAuthorizationTest extends TestCase {
+final class VenueMembershipAuthorizationTest extends BookingTestCase {
 	private $original_wpdb;
 	private $original_ability_resolver;
 	private $config_updated_callback;
@@ -1020,15 +1022,19 @@ final class VenueMembershipAuthorizationTest extends TestCase {
 			},
 		);
 		$GLOBALS['ec_test_ability_resolver'] = static fn( string $name ) => $GLOBALS['venue_membership_test']['ability_objects'][ $name ] ?? null;
-		$this->config_updated_callback       = static function ( ...$args ): void {
-			$GLOBALS['venue_membership_test']['fired_actions']['extrachill_events_venue_booking_config_updated'][] = $args;
-		};
-		add_action( 'extrachill_events_venue_booking_config_updated', $this->config_updated_callback, 10, 3 );
+		if ( ! defined( 'EC_TEST_DO_ACTION_RECORDS_FIXTURES' ) ) {
+			$this->config_updated_callback = static function ( ...$args ): void {
+				$GLOBALS['venue_membership_test']['fired_actions']['extrachill_events_venue_booking_config_updated'][] = $args;
+			};
+			add_action( 'extrachill_events_venue_booking_config_updated', $this->config_updated_callback, 10, 3 );
+		}
 		$GLOBALS['wpdb']                  = new VenueMembershipWpdb( $this->original_wpdb );
 	}
 
 	protected function tearDown(): void {
-		remove_action( 'extrachill_events_venue_booking_config_updated', $this->config_updated_callback, 10 );
+		if ( $this->config_updated_callback ) {
+			remove_action( 'extrachill_events_venue_booking_config_updated', $this->config_updated_callback, 10 );
+		}
 		if ( null === $this->original_ability_resolver ) {
 			unset( $GLOBALS['ec_test_ability_resolver'] );
 		} else {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -95,7 +95,16 @@ if ( ! function_exists( 'apply_filters' ) ) {
 }
 
 if ( ! function_exists( 'do_action' ) ) {
+	define( 'EC_TEST_DO_ACTION_RECORDS_FIXTURES', true );
+
 	function do_action( $hook, ...$args ) {
+		if ( isset( $GLOBALS['ec_artist_test']['fired_actions'] ) && is_array( $GLOBALS['ec_artist_test']['fired_actions'] ) ) {
+			$GLOBALS['ec_artist_test']['fired_actions'][ $hook ][] = $args;
+		}
+		if ( isset( $GLOBALS['venue_membership_test']['fired_actions'] ) && is_array( $GLOBALS['venue_membership_test']['fired_actions'] ) ) {
+			$GLOBALS['venue_membership_test']['fired_actions'][ $hook ][] = $args;
+		}
+
 		if ( empty( $GLOBALS['ec_test_filters'][ $hook ] ) ) {
 			return;
 		}
@@ -112,8 +121,11 @@ if ( ! function_exists( 'do_action' ) ) {
 if ( ! function_exists( 'wp_get_ability' ) ) {
 	function wp_get_ability( $name ) {
 		$resolver = $GLOBALS['ec_test_ability_resolver'] ?? null;
+		$ability  = is_callable( $resolver ) ? $resolver( $name ) : null;
 
-		return is_callable( $resolver ) ? $resolver( $name ) : null;
+		return $ability
+			?? ( $GLOBALS['ec_artist_test']['ability_objects'][ $name ] ?? null )
+			?? ( $GLOBALS['venue_membership_test']['ability_objects'][ $name ] ?? null );
 	}
 }
 
@@ -150,6 +162,43 @@ if ( ! function_exists( 'mb_substr' ) && function_exists( 'substr' ) ) {
 	// PHP 8.4 with mbstring should always have mb_substr, but guard anyway.
 	function mb_substr( $string, $start, $length = null ) {
 		return null === $length ? substr( $string, $start ) : substr( $string, $start, $length );
+	}
+}
+
+/** Restores mutable plain-test globals after every test. */
+abstract class BookingTestCase extends PHPUnit\Framework\TestCase {
+	private $booking_test_globals;
+	private $booking_test_document_root_exists;
+	private $booking_test_document_root;
+
+	public function runBare(): void {
+		$keys                       = array( 'wpdb', 'ec_artist_test', 'venue_membership_test', 'ec_test_ability_resolver', 'ec_test_filters', 'extrachill_events_booking_reference_lock_uncertainty', 'extrachill_events_booking_database_connection_quarantined' );
+		$this->booking_test_globals = array();
+		foreach ( $keys as $key ) {
+			$this->booking_test_globals[ $key ] = array(
+				'exists' => array_key_exists( $key, $GLOBALS ),
+				'value'  => $GLOBALS[ $key ] ?? null,
+			);
+		}
+		$this->booking_test_document_root_exists = array_key_exists( 'DOCUMENT_ROOT', $_SERVER );
+		$this->booking_test_document_root        = $_SERVER['DOCUMENT_ROOT'] ?? null;
+
+		try {
+			parent::runBare();
+		} finally {
+			foreach ( $this->booking_test_globals as $key => $snapshot ) {
+				if ( $snapshot['exists'] ) {
+					$GLOBALS[ $key ] = $snapshot['value'];
+				} else {
+					unset( $GLOBALS[ $key ] );
+				}
+			}
+			if ( $this->booking_test_document_root_exists ) {
+				$_SERVER['DOCUMENT_ROOT'] = $this->booking_test_document_root;
+			} else {
+				unset( $_SERVER['DOCUMENT_ROOT'] );
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- compose shared ability/action dispatch with both booking and venue-membership fixtures regardless of file load order
- restore database doubles, resolvers, hooks, fixture globals, lock diagnostics, and document-root state around every plain booking test
- preserve explicit action recorders when tests run under real WordPress instead of the plain bootstrap polyfill

## Root cause
`tests/bootstrap.php` won the global `wp_get_ability()` and `do_action()` definitions before `BookingTestHarness.php`, but its implementations did not delegate to booking fixture objects or record booking actions. Booking classes also left global database and fixture state behind, so `BookingWpdb` reached the venue membership class and replaced the expected database boundary.

The fix is test-only: it changes only PHPUnit bootstrap, harness, and test classes. No production authorization, ability, persistence, or fallback behavior changes. Production contracts remain covered by the same assertions, including fail-closed authorization, action evidence, exact venue scoping, lifecycle transitions, and managed-runtime callback support.

## Verification
- baseline: `373 tests, 3722 assertions, 51 errors, 1 failure`
- aggregate: `vendor/bin/phpunit --configuration phpunit-booking.xml.dist` -> `373 tests, 4090 assertions`
- randomized seed 400: `373 tests, 4090 assertions`
- venue membership: `44 tests, 314 assertions`
- event conversion: `43 tests, 294 assertions`
- marketing + delegated schemas: `36 tests, 163 assertions`
- holds: `40 tests, 188 assertions`
- notifications: `11 tests, 48 assertions`
- correspondence: `40 tests, 270 assertions`
- settlement: `9 tests, 1772 assertions`
- changed-file syntax checks, `git diff --check`, Homeboy lint, Homeboy PR audit, and block build pass
- independent exact-diff review completed with all findings resolved

The managed WP Codebox/MySQL profile could not start locally because this host does not expose the configured `WP_CODEBOX_DB_*` service credentials. The repository's managed MySQL workflows will be dispatched for this branch and their check state reported separately.

## Related issues
#395 is the narrower `BookingWpdb`/membership manifestation and should remain for maintainers to close or deduplicate. #349 tracks broader repository-wide procedural-stub isolation beyond this booking-specific boundary.

Closes #400