### PR TITLE
feat: reconcile booking ticket sales evidence

### DIFF
--- a/docs/ticket-settlements.md
+++ b/docs/ticket-settlements.md
@@ -2,42 +2,73 @@
 
 ## Storage
 
+`ec_booking_ticket_sources` stores immutable provider-neutral source identities.
+Each identity binds a booking/event/venue, provider, provider-owned source key,
+and canonical trackable ticket URL. API projections expose only the URL origin;
+paths, query parameters, URL hashes, request hashes, and credentials are never
+returned.
+
 `ec_booking_sales_reports` is append-only evidence scoped to a booking, event,
-venue, provider, and provider report ID. Provider/report identity is globally
-unique within the Events site. An exact retry returns the prior observation;
+venue, provider, and provider report ID. Provider/report identity is scoped to
+the booking so account-local IDs can recur at other venues. An exact retry returns the prior observation;
 reuse with different immutable content is a conflict. Corrections are new
 signed observations and may identify the same-booking, same-currency report
-they correct. Money and counts are signed integers in minor units.
+they correct. Money and counts are signed integers in minor units. Reports may
+bind a ticket-source identity and, for CSV imports, the approved private booking
+attachment containing the exact evidence bytes. Arbitrary source provenance
+remains private; ability projections expose only a redaction marker plus
+server-owned attachment identity and CSV row when present.
+
+`ec_booking_sales_resolutions` is an append-only optimistic decision history.
+Every admit/exclude decision records a per-report version, optional corrected
+source attribution, reason, actor, superseded resolution, and immutable request
+hash. A stale expected version conflicts rather than overwriting history. Once
+a settlement is finalized, further resolutions are rejected so frozen report
+hashes cannot be reinterpreted by a later operator decision.
 
 `ec_booking_settlements` stores at most one frozen settlement per booking. It
 captures basis, basis-point rate, currency, formula version, ordered evidence
-IDs and canonical `(id, request_hash)` content hash, frozen booking version,
+IDs and canonical report/reconciliation content hash, frozen booking version,
 basis amount, signed adjustment, amount due, finalizer, and a second integrity
 hash over the complete immutable financial snapshot. The snapshot hash binds
 booking/event/venue identity, frozen booking revision, basis, rate, currency,
-formula, evidence IDs/hash, and every calculated minor-unit amount. The row also
+formula, evidence IDs/hash, and every calculated minor-unit amount. Formula
+version 2 binds each included report's immutable hash and latest reconciliation
+decision; version 1 settlements retain their legacy report-only verification.
+The row also
 retains the terminal paid or void audit. Finalized evidence and terms are never
 rewritten.
 
-Schema version 12 creates or repairs both InnoDB tables through the existing
-`dbDelta` installer, verifies exact columns/indexes/engines, and stamps the
-version only after health checks pass.
+Schema version 13 preserves the version 12 report and settlement tables, adds
+nullable provenance references to existing observations, and creates the source
+and resolution tables. The existing `dbDelta` installer verifies exact
+columns/indexes/engines and stamps each multisite site only after health checks
+pass. Existing reports remain immutable and become explicitly unattributed
+until an operator resolves them.
 
 ## Abilities
 
+- `extrachill/register-booking-ticket-source`
+- `extrachill/list-booking-ticket-sources`
 - `extrachill/record-booking-ticket-sales`
+- `extrachill/import-booking-ticket-sales-csv`
 - `extrachill/list-booking-ticket-sales`
+- `extrachill/diagnose-booking-ticket-sales`
+- `extrachill/resolve-booking-ticket-sales`
 - `extrachill/calculate-booking-settlement`
 - `extrachill/finalize-booking-settlement`
 - `extrachill/mark-booking-settlement-paid`
 - `extrachill/void-booking-settlement`
 
 All operations authorize internally. Read/evidence operations require exact
-venue access. Finalize, paid, and void require active venue ownership through
-`manage_finances`; transport permission callbacks repeat the same policy.
-Transactions lock venue membership before booking, evidence, and settlement
-rows. Finalization requires both the calculated booking version and ordered
-evidence IDs, so stale and concurrent writes fail with a conflict.
+venue access. Source registration, reconciliation resolution, finalize, paid,
+and void require active venue ownership through `manage_finances`; transport
+permission callbacks repeat the same policy.
+Transactions lock venue membership before booking, settlement, report, and
+resolution rows. Finalization requires the calculated booking version, ordered
+evidence IDs, and formula-2 evidence hash, so stale reconciliation decisions and
+concurrent writes fail with a conflict. Legacy formula-1 settlements retain
+exact retry and terminal-transition compatibility.
 An exact lost-response retry is resolved against the already-frozen booking
 version, terms, formula, and evidence before current mutable booking/evidence
 is considered, so later reports or booking revisions do not break idempotency.
@@ -60,6 +91,26 @@ is `basis_amount_minor * basis_points / 10000`, rounded to the nearest minor
 unit with exact halves away from zero. The signed adjustment is then added.
 Integer overflow is rejected rather than converted to floating point.
 
-Manual and CSV-certified observations are supported. Provider adapters,
-attribution/import/reconciliation from #316, and full show expenses or artist
-payouts from #318 are explicitly outside this foundation.
+## Import And Reconciliation
+
+Manual and CSV-certified paths both call the same immutable report recorder.
+CSV import accepts only an active `text/csv` booking attachment admitted under
+the existing `other_private_evidence` policy. It obtains bytes through the
+opaque one-time private stream handoff, re-hashes and counts every streamed byte
+against immutable attachment metadata before parsing, requires an exact fixed
+header, forbids multiline records, limits rows and physical line lengths,
+rejects non-canonical integers, and never exposes bytes or storage references.
+Exact report IDs make a crash/retry replay deterministic.
+
+Diagnostics are bounded to 1,000 observations and derive unattributed, missing
+file, currency mismatch, duplicate, overlapping, and contradictory evidence.
+Clean attributed evidence is admitted deterministically. Any issue remains
+unresolved until a finance operator appends an admit/exclude resolution. Both
+calculation and finalization run this admission boundary across every currency
+before selecting the requested settlement currency; unresolved evidence cannot
+silently contribute to commission, and excluded evidence remains visible
+in diagnostics and immutable history.
+
+Provider adapters and provider-specific parsing remain outside this generic
+booking domain. Full show expenses or artist payouts from #318 are also outside
+this contract.

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -302,6 +302,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingAttachmentService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingInquiryAdmissionService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingConfig.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/TicketReconciliationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/TicketSettlementService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueProfile.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/CanonicalEventPublicationGuard.php';

--- a/inc/Abilities/TicketSettlementAbilities.php
+++ b/inc/Abilities/TicketSettlementAbilities.php
@@ -11,6 +11,7 @@ namespace ExtraChillEvents\Abilities;
 // phpcs:disable Generic.Commenting.DocComment.MissingShort,Squiz.Commenting.FunctionComment.Missing,Squiz.Commenting.VariableComment.Missing
 
 use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\TicketReconciliationService;
 use ExtraChillEvents\Core\TicketSettlementService;
 use ExtraChillEvents\Core\VenueAuthorization;
 
@@ -27,20 +28,52 @@ class TicketSettlementAbilities {
 	private $bookings;
 	/** @var VenueAuthorization */
 	private $authorization;
+	/** @var TicketReconciliationService */
+	private $reconciliation;
 
-	public function __construct( ?TicketSettlementService $service = null, ?BookingRepository $bookings = null, ?VenueAuthorization $authorization = null ) {
-		$this->bookings      = $bookings ? $bookings : new BookingRepository();
-		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
-		$this->service       = $service ? $service : new TicketSettlementService( $this->bookings, null, $this->authorization );
+	public function __construct( ?TicketSettlementService $service = null, ?BookingRepository $bookings = null, ?VenueAuthorization $authorization = null, ?TicketReconciliationService $reconciliation = null ) {
+		$this->bookings       = $bookings ? $bookings : new BookingRepository();
+		$this->authorization  = $authorization ? $authorization : new VenueAuthorization();
+		$this->reconciliation = $reconciliation ? $reconciliation : new TicketReconciliationService( $this->bookings, null, $this->authorization );
+		$this->service        = $service ? $service : new TicketSettlementService( $this->bookings, null, $this->authorization, null, $this->reconciliation );
 		if ( ! self::$registered ) {
 			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
 			self::$registered = true;
 		}
 	}
 
-	/** Register the six issue-owned operations. */
+	/** Register settlement and reconciliation operations. */
 	public function register(): void {
+		$this->register_ability( 'extrachill/register-booking-ticket-source', __( 'Register Booking Ticket Source', 'extrachill-events' ), $this->source_input_schema(), $this->source_schema(), 'register_source', 'can_manage_booking_finances', false, true );
+		$this->register_ability(
+			'extrachill/list-booking-ticket-sources',
+			__( 'List Booking Ticket Sources', 'extrachill-events' ),
+			$this->booking_page_schema(),
+			array(
+				'type'     => 'array',
+				'maxItems' => 200,
+				'items'    => $this->source_schema(),
+			),
+			'list_sources',
+			'can_access_booking',
+			true,
+			true
+		);
 		$this->register_ability( 'extrachill/record-booking-ticket-sales', __( 'Record Booking Ticket Sales', 'extrachill-events' ), $this->report_input_schema(), $this->report_schema(), 'record_sales', 'can_access_booking', false, true );
+		$this->register_ability(
+			'extrachill/import-booking-ticket-sales-csv',
+			__( 'Import Booking Ticket Sales CSV', 'extrachill-events' ),
+			$this->csv_import_schema(),
+			array(
+				'type'     => 'array',
+				'maxItems' => 1000,
+				'items'    => $this->report_schema(),
+			),
+			'import_csv',
+			'can_access_booking',
+			false,
+			true
+		);
 		$this->register_ability(
 			'extrachill/list-booking-ticket-sales',
 			__( 'List Booking Ticket Sales', 'extrachill-events' ),
@@ -56,6 +89,8 @@ class TicketSettlementAbilities {
 			true
 		);
 		$this->register_ability( 'extrachill/calculate-booking-settlement', __( 'Calculate Booking Settlement', 'extrachill-events' ), $this->calculation_input_schema(), $this->calculation_schema(), 'calculate', 'can_access_booking', true, true );
+		$this->register_ability( 'extrachill/diagnose-booking-ticket-sales', __( 'Diagnose Booking Ticket Sales', 'extrachill-events' ), $this->booking_page_schema(), $this->diagnostics_schema(), 'diagnostics', 'can_access_booking', true, true );
+		$this->register_ability( 'extrachill/resolve-booking-ticket-sales', __( 'Resolve Booking Ticket Sales', 'extrachill-events' ), $this->resolution_input_schema(), $this->resolution_schema(), 'resolve', 'can_manage_booking_finances', false, true );
 		$this->register_ability( 'extrachill/finalize-booking-settlement', __( 'Finalize Booking Settlement', 'extrachill-events' ), $this->finalize_input_schema(), $this->settlement_schema(), 'finalize', 'can_manage_booking_finances', false, true );
 		$this->register_ability( 'extrachill/mark-booking-settlement-paid', __( 'Mark Booking Settlement Paid', 'extrachill-events' ), $this->terminal_input_schema( 'payment_reference' ), $this->settlement_schema(), 'mark_paid', 'can_manage_booking_finances', false, false );
 		$this->register_ability( 'extrachill/void-booking-settlement', __( 'Void Booking Settlement', 'extrachill-events' ), $this->terminal_input_schema( 'reason' ), $this->settlement_schema(), 'void_settlement', 'can_manage_booking_finances', false, false );
@@ -86,6 +121,55 @@ class TicketSettlementAbilities {
 
 	public function record_sales( array $input ) {
 		return $this->service->record_sales( $input, get_current_user_id() );
+	}
+
+	public function register_source( array $input ) {
+		return $this->reconciliation->register_source( $input, get_current_user_id() );
+	}
+
+	public function list_sources( array $input ) {
+		$result = $this->reconciliation->list_sources( (int) $input['booking_id'], get_current_user_id() );
+		return is_array( $result ) ? array_values( $result ) : $result;
+	}
+
+	public function import_csv( array $input ) {
+		$rows = $this->reconciliation->csv_report_inputs( $input, get_current_user_id() );
+		if ( is_wp_error( $rows ) ) {
+			return $rows;
+		}
+		$reports  = array();
+		$failures = array();
+		foreach ( $rows as $index => $row ) {
+			$report = $this->service->record_sales( $row, get_current_user_id() );
+			if ( is_wp_error( $report ) ) {
+				$failures[] = array(
+					'row'  => $index + 2,
+					'code' => $report->get_error_code(),
+				);
+				continue;
+			}
+			$reports[] = $report;
+		}
+		if ( ! empty( $failures ) ) {
+			return new \WP_Error(
+				'sales_csv_import_partial',
+				__( 'Some ticket-sales rows could not be imported.', 'extrachill-events' ),
+				array(
+					'status'              => 409,
+					'imported_report_ids' => array_column( $reports, 'id' ),
+					'failures'            => $failures,
+				)
+			);
+		}
+		return $reports;
+	}
+
+	public function diagnostics( array $input ) {
+		return $this->reconciliation->diagnostics( (int) $input['booking_id'], get_current_user_id() );
+	}
+
+	public function resolve( array $input ) {
+		return $this->reconciliation->resolve( $input, get_current_user_id() );
 	}
 
 	public function list_sales( array $input ) {
@@ -125,39 +209,48 @@ class TicketSettlementAbilities {
 
 	private function report_input_schema(): array {
 		$properties = array(
-			'booking_id'         => $this->positive_id_schema(),
-			'provider'           => array(
+			'booking_id'             => $this->positive_id_schema(),
+			'ticket_source_id'       => array(
+				'type'    => array( 'integer', 'null' ),
+				'minimum' => 1,
+			),
+			'evidence_attachment_id' => array(
+				'type'    => array( 'integer', 'null' ),
+				'minimum' => 1,
+			),
+			'provider'               => array(
 				'type'      => 'string',
 				'minLength' => 1,
 				'maxLength' => 64,
 				'pattern'   => '^[a-z0-9_-]+$',
 			),
-			'external_report_id' => array(
+			'external_report_id'     => array(
 				'type'      => 'string',
 				'minLength' => 1,
 				'maxLength' => 191,
 			),
-			'source_type'        => array(
+			'source_type'            => array(
 				'type' => 'string',
 				'enum' => TicketSettlementService::SOURCE_TYPES,
 			),
-			'period_start'       => $this->datetime_schema(),
-			'period_end'         => $this->datetime_schema(),
-			'tickets_sold'       => array( 'type' => 'integer' ),
-			'tickets_refunded'   => array( 'type' => 'integer' ),
-			'gross_minor'        => array( 'type' => 'integer' ),
-			'fees_minor'         => array( 'type' => 'integer' ),
-			'tax_minor'          => array( 'type' => 'integer' ),
-			'refunds_minor'      => array( 'type' => 'integer' ),
-			'net_minor'          => array( 'type' => 'integer' ),
-			'currency'           => $this->currency_schema(),
-			'corrects_report_id' => array(
+			'period_start'           => $this->datetime_schema(),
+			'period_end'             => $this->datetime_schema(),
+			'tickets_sold'           => array( 'type' => 'integer' ),
+			'tickets_refunded'       => array( 'type' => 'integer' ),
+			'gross_minor'            => array( 'type' => 'integer' ),
+			'fees_minor'             => array( 'type' => 'integer' ),
+			'tax_minor'              => array( 'type' => 'integer' ),
+			'refunds_minor'          => array( 'type' => 'integer' ),
+			'net_minor'              => array( 'type' => 'integer' ),
+			'currency'               => $this->currency_schema(),
+			'corrects_report_id'     => array(
 				'type'    => array( 'integer', 'null' ),
 				'minimum' => 1,
 			),
-			'source'             => array(
+			'source'                 => array(
 				'type'                 => 'object',
 				'minProperties'        => 1,
+				'maxProperties'        => 32,
 				'additionalProperties' => true,
 			),
 		);
@@ -225,6 +318,10 @@ class TicketSettlementAbilities {
 					'uniqueItems' => true,
 					'items'       => $this->positive_id_schema(),
 				),
+				'expected_evidence_hash'   => array(
+					'type'    => 'string',
+					'pattern' => '^[a-f0-9]{64}$',
+				),
 				'basis'                    => array(
 					'type' => 'string',
 					'enum' => TicketSettlementService::BASES,
@@ -237,11 +334,19 @@ class TicketSettlementAbilities {
 				'currency'                 => $this->currency_schema(),
 				'formula_version'          => array(
 					'type' => 'integer',
-					'enum' => array( TicketSettlementService::FORMULA_VERSION ),
+					'enum' => array( 1, TicketSettlementService::FORMULA_VERSION ),
 				),
 				'adjustment_minor'         => array( 'type' => 'integer' ),
 			),
 			'required'             => array( 'booking_id', 'expected_booking_version', 'expected_report_ids', 'basis', 'basis_points', 'currency', 'formula_version', 'adjustment_minor' ),
+			'anyOf'                => array(
+				array( 'required' => array( 'expected_evidence_hash' ) ),
+				array(
+					'properties' => array(
+						'formula_version' => array( 'enum' => array( 1 ) ),
+					),
+				),
+			),
 			'additionalProperties' => false,
 		);
 	}
@@ -272,39 +377,54 @@ class TicketSettlementAbilities {
 		return array(
 			'type'                 => 'object',
 			'properties'           => array(
-				'id'                 => $this->positive_id_schema(),
-				'booking_id'         => $this->positive_id_schema(),
-				'event_id'           => $this->positive_id_schema(),
-				'venue_term_id'      => $this->positive_id_schema(),
-				'provider'           => array( 'type' => 'string' ),
-				'external_report_id' => array( 'type' => 'string' ),
-				'source_type'        => array(
+				'id'                     => $this->positive_id_schema(),
+				'booking_id'             => $this->positive_id_schema(),
+				'event_id'               => $this->positive_id_schema(),
+				'venue_term_id'          => $this->positive_id_schema(),
+				'ticket_source_id'       => $nullable_id,
+				'evidence_attachment_id' => $nullable_id,
+				'provider'               => array( 'type' => 'string' ),
+				'external_report_id'     => array( 'type' => 'string' ),
+				'source_type'            => array(
 					'type' => 'string',
 					'enum' => TicketSettlementService::SOURCE_TYPES,
 				),
-				'period_start'       => $this->datetime_schema(),
-				'period_end'         => $this->datetime_schema(),
-				'tickets_sold'       => array( 'type' => 'integer' ),
-				'tickets_refunded'   => array( 'type' => 'integer' ),
-				'gross_minor'        => array( 'type' => 'integer' ),
-				'fees_minor'         => array( 'type' => 'integer' ),
-				'tax_minor'          => array( 'type' => 'integer' ),
-				'refunds_minor'      => array( 'type' => 'integer' ),
-				'net_minor'          => array( 'type' => 'integer' ),
-				'currency'           => $this->currency_schema(),
-				'corrects_report_id' => $nullable_id,
-				'source'             => array(
+				'period_start'           => $this->datetime_schema(),
+				'period_end'             => $this->datetime_schema(),
+				'tickets_sold'           => array( 'type' => 'integer' ),
+				'tickets_refunded'       => array( 'type' => 'integer' ),
+				'gross_minor'            => array( 'type' => 'integer' ),
+				'fees_minor'             => array( 'type' => 'integer' ),
+				'tax_minor'              => array( 'type' => 'integer' ),
+				'refunds_minor'          => array( 'type' => 'integer' ),
+				'net_minor'              => array( 'type' => 'integer' ),
+				'currency'               => $this->currency_schema(),
+				'corrects_report_id'     => $nullable_id,
+				'source'                 => array(
 					'type'                 => 'object',
-					'additionalProperties' => true,
+					'properties'           => array(
+						'redacted'      => array( 'type' => 'boolean' ),
+						'attachment_id' => array(
+							'type'    => 'string',
+							'pattern' => '^[a-fA-F0-9-]{36}$',
+						),
+						'row'           => array(
+							'type'    => 'integer',
+							'minimum' => 2,
+							'maximum' => 1002,
+						),
+					),
+					'required'             => array( 'redacted' ),
+					'additionalProperties' => false,
 				),
-				'request_hash'       => array(
+				'request_hash'           => array(
 					'type'    => 'string',
 					'pattern' => '^[a-f0-9]{64}$',
 				),
-				'created_by_user_id' => $this->positive_id_schema(),
-				'created_at'         => $this->datetime_schema(),
+				'created_by_user_id'     => $this->positive_id_schema(),
+				'created_at'             => $this->datetime_schema(),
 			),
-			'required'             => array( 'id', 'booking_id', 'event_id', 'venue_term_id', 'provider', 'external_report_id', 'source_type', 'period_start', 'period_end', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'currency', 'corrects_report_id', 'source', 'request_hash', 'created_by_user_id', 'created_at' ),
+			'required'             => array( 'id', 'booking_id', 'event_id', 'venue_term_id', 'ticket_source_id', 'evidence_attachment_id', 'provider', 'external_report_id', 'source_type', 'period_start', 'period_end', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'currency', 'corrects_report_id', 'source', 'request_hash', 'created_by_user_id', 'created_at' ),
 			'additionalProperties' => false,
 		);
 	}
@@ -381,7 +501,7 @@ class TicketSettlementAbilities {
 				'currency'             => $this->currency_schema(),
 				'formula_version'      => array(
 					'type' => 'integer',
-					'enum' => array( TicketSettlementService::FORMULA_VERSION ),
+					'enum' => array( 1, TicketSettlementService::FORMULA_VERSION ),
 				),
 				'included_report_ids'  => array(
 					'type'     => 'array',
@@ -411,6 +531,208 @@ class TicketSettlementAbilities {
 				'updated_at'           => $this->datetime_schema(),
 			),
 			'required'             => array( 'id', 'booking_id', 'event_id', 'venue_term_id', 'status', 'version', 'booking_version', 'basis', 'basis_points', 'currency', 'formula_version', 'included_report_ids', 'evidence_hash', 'integrity_hash', 'basis_amount_minor', 'adjustment_minor', 'amount_due_minor', 'finalized_by_user_id', 'finalized_at', 'paid_by_user_id', 'paid_at', 'payment_reference', 'voided_by_user_id', 'voided_at', 'void_reason', 'created_at', 'updated_at' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function source_input_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'booking_id' => $this->positive_id_schema(),
+				'provider'   => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 64,
+					'pattern'   => '^[a-z0-9_-]+$',
+				),
+				'source_key' => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 191,
+				),
+				'ticket_url' => array(
+					'type'      => 'string',
+					'minLength' => 8,
+					'maxLength' => 2048,
+					'pattern'   => '^https?://',
+				),
+			),
+			'required'             => array( 'booking_id', 'provider', 'source_key', 'ticket_url' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function source_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'id'            => $this->positive_id_schema(),
+				'public_id'     => array(
+					'type'    => 'string',
+					'pattern' => '^[a-fA-F0-9-]{36}$',
+				),
+				'booking_id'    => $this->positive_id_schema(),
+				'event_id'      => $this->positive_id_schema(),
+				'venue_term_id' => $this->positive_id_schema(),
+				'provider'      => array( 'type' => 'string' ),
+				'source_key'    => array( 'type' => 'string' ),
+				'display_url'   => array(
+					'type'    => 'string',
+					'pattern' => '^https?://',
+				),
+				'created_at'    => $this->datetime_schema(),
+			),
+			'required'             => array( 'id', 'public_id', 'booking_id', 'event_id', 'venue_term_id', 'provider', 'source_key', 'display_url', 'created_at' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function csv_import_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'booking_id'       => $this->positive_id_schema(),
+				'attachment_id'    => $this->positive_id_schema(),
+				'ticket_source_id' => $this->positive_id_schema(),
+			),
+			'required'             => array( 'booking_id', 'attachment_id', 'ticket_source_id' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function resolution_input_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'booking_id'       => $this->positive_id_schema(),
+				'report_id'        => $this->positive_id_schema(),
+				'expected_version' => array(
+					'type'    => 'integer',
+					'minimum' => 0,
+				),
+				'decision'         => array(
+					'type' => 'string',
+					'enum' => TicketReconciliationService::DECISIONS,
+				),
+				'ticket_source_id' => array(
+					'type'    => array( 'integer', 'null' ),
+					'minimum' => 1,
+				),
+				'reason'           => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 1000,
+				),
+			),
+			'required'             => array( 'booking_id', 'report_id', 'expected_version', 'decision', 'reason' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function resolution_schema(): array {
+		$nullable_id = array(
+			'type'    => array( 'integer', 'null' ),
+			'minimum' => 1,
+		);
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'id'                       => $this->positive_id_schema(),
+				'public_id'                => array(
+					'type'    => 'string',
+					'pattern' => '^[a-fA-F0-9-]{36}$',
+				),
+				'booking_id'               => $this->positive_id_schema(),
+				'report_id'                => $this->positive_id_schema(),
+				'venue_term_id'            => $this->positive_id_schema(),
+				'version'                  => $this->positive_id_schema(),
+				'decision'                 => array(
+					'type' => 'string',
+					'enum' => TicketReconciliationService::DECISIONS,
+				),
+				'ticket_source_id'         => $nullable_id,
+				'supersedes_resolution_id' => $nullable_id,
+				'reason'                   => array( 'type' => 'string' ),
+				'request_hash'             => array(
+					'type'    => 'string',
+					'pattern' => '^[a-f0-9]{64}$',
+				),
+				'created_by_user_id'       => $this->positive_id_schema(),
+				'created_at'               => $this->datetime_schema(),
+			),
+			'required'             => array( 'id', 'public_id', 'booking_id', 'report_id', 'venue_term_id', 'version', 'decision', 'ticket_source_id', 'supersedes_resolution_id', 'reason', 'request_hash', 'created_by_user_id', 'created_at' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function diagnostics_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'booking_id'           => $this->positive_id_schema(),
+				'reports'              => array(
+					'type'     => 'array',
+					'maxItems' => 1000,
+					'items'    => array(
+						'type'                 => 'object',
+						'properties'           => array(
+							'report_id'              => $this->positive_id_schema(),
+							'report_index'           => array(
+								'type'    => 'integer',
+								'minimum' => 0,
+							),
+							'ticket_source_id'       => array(
+								'type'    => array( 'integer', 'null' ),
+								'minimum' => 1,
+							),
+							'reconciliation_version' => array(
+								'type'    => 'integer',
+								'minimum' => 0,
+							),
+							'decision'               => array(
+								'type' => array( 'string', 'null' ),
+								'enum' => array( 'admit', 'exclude', null ),
+							),
+							'issues'                 => array(
+								'type'        => 'array',
+								'uniqueItems' => true,
+								'items'       => array(
+									'type' => 'string',
+									'enum' => array( 'unattributed', 'file_missing', 'currency_mismatch', 'duplicate', 'contradictory', 'overlap' ),
+								),
+							),
+							'state'                  => array(
+								'type' => 'string',
+								'enum' => array( 'admitted', 'excluded', 'unresolved' ),
+							),
+						),
+						'required'             => array( 'report_id', 'report_index', 'ticket_source_id', 'reconciliation_version', 'decision', 'issues', 'state' ),
+						'additionalProperties' => false,
+					),
+				),
+				'counts'               => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'admitted'   => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'excluded'   => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'unresolved' => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+					),
+					'required'             => array( 'admitted', 'excluded', 'unresolved' ),
+					'additionalProperties' => false,
+				),
+				'ready_for_settlement' => array( 'type' => 'boolean' ),
+			),
+			'required'             => array( 'booking_id', 'reports', 'counts', 'ready_for_settlement' ),
 			'additionalProperties' => false,
 		);
 	}

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Owns and verifies the site-scoped private booking schema. */
 class BookingSchema {
 
-	public const SCHEMA_VERSION = '12';
+	public const SCHEMA_VERSION = '13';
 	public const VERSION_OPTION = 'extrachill_events_booking_schema_version';
 	public const FAILURE_OPTION = 'extrachill_events_booking_schema_error';
 
@@ -88,6 +88,18 @@ class BookingSchema {
 		return $wpdb->prefix . 'ec_booking_sales_reports';
 	}
 
+	/** Get the immutable provider-neutral ticket source identities table. */
+	public static function ticket_sources_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_booking_ticket_sources';
+	}
+
+	/** Get the append-only ticket reconciliation resolutions table. */
+	public static function sales_resolutions_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_booking_sales_resolutions';
+	}
+
 	/** Get the frozen booking settlements table. */
 	public static function settlements_table(): string {
 		global $wpdb;
@@ -108,7 +120,9 @@ class BookingSchema {
 		$invites             = self::invitations_table();
 		$audit               = self::onboarding_audit_table();
 		$holds               = self::holds_table();
+		$ticket_sources      = self::ticket_sources_table();
 		$sales_reports       = self::sales_reports_table();
+		$sales_resolutions   = self::sales_resolutions_table();
 		$settlements         = self::settlements_table();
 		$charset             = $wpdb->get_charset_collate();
 
@@ -353,11 +367,33 @@ class BookingSchema {
 			KEY status_expiration (status, expires_at)
 		) ENGINE=InnoDB {$charset};";
 
+		$ticket_sources_sql = "CREATE TABLE {$ticket_sources} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			public_id CHAR(36) NOT NULL,
+			booking_id BIGINT UNSIGNED NOT NULL,
+			event_id BIGINT UNSIGNED NOT NULL,
+			venue_term_id BIGINT UNSIGNED NOT NULL,
+			provider VARCHAR(64) NOT NULL,
+			source_key VARCHAR(191) NOT NULL,
+			canonical_url LONGTEXT NOT NULL,
+			url_hash CHAR(64) NOT NULL,
+			request_hash CHAR(64) NOT NULL,
+			created_by_user_id BIGINT UNSIGNED NOT NULL,
+			created_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY public_id (public_id),
+			UNIQUE KEY booking_provider_source (booking_id, provider, source_key),
+			KEY event_provider (event_id, provider),
+			KEY venue_created (venue_term_id, created_at, id)
+		) ENGINE=InnoDB {$charset};";
+
 		$sales_reports_sql = "CREATE TABLE {$sales_reports} (
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 			booking_id BIGINT UNSIGNED NOT NULL,
 			event_id BIGINT UNSIGNED NOT NULL,
 			venue_term_id BIGINT UNSIGNED NOT NULL,
+			ticket_source_id BIGINT UNSIGNED NULL,
+			evidence_attachment_id BIGINT UNSIGNED NULL,
 			provider VARCHAR(64) NOT NULL,
 			external_report_id VARCHAR(191) NOT NULL,
 			source_type VARCHAR(32) NOT NULL,
@@ -377,11 +413,36 @@ class BookingSchema {
 			created_by_user_id BIGINT UNSIGNED NOT NULL,
 			created_at DATETIME NOT NULL,
 			PRIMARY KEY (id),
-			UNIQUE KEY provider_external_report (provider, external_report_id),
+			UNIQUE KEY provider_external_report (booking_id, provider, external_report_id),
 			KEY booking_created (booking_id, created_at, id),
 			KEY booking_currency_id (booking_id, currency, id),
+			KEY ticket_source_id (ticket_source_id),
+			KEY evidence_attachment_id (evidence_attachment_id),
 			KEY event_provider_period (event_id, provider, period_start, period_end),
 			KEY corrects_report (corrects_report_id)
+		) ENGINE=InnoDB {$charset};";
+
+		$sales_resolutions_sql = "CREATE TABLE {$sales_resolutions} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			public_id CHAR(36) NOT NULL,
+			booking_id BIGINT UNSIGNED NOT NULL,
+			report_id BIGINT UNSIGNED NOT NULL,
+			venue_term_id BIGINT UNSIGNED NOT NULL,
+			version BIGINT UNSIGNED NOT NULL,
+			decision VARCHAR(16) NOT NULL,
+			ticket_source_id BIGINT UNSIGNED NULL,
+			supersedes_resolution_id BIGINT UNSIGNED NULL,
+			reason VARCHAR(1000) NOT NULL,
+			request_hash CHAR(64) NOT NULL,
+			created_by_user_id BIGINT UNSIGNED NOT NULL,
+			created_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY public_id (public_id),
+			UNIQUE KEY report_version (report_id, version),
+			KEY booking_report_version (booking_id, report_id, version),
+			KEY venue_created (venue_term_id, created_at, id),
+			KEY ticket_source_id (ticket_source_id),
+			KEY supersedes_resolution (supersedes_resolution_id)
 		) ENGINE=InnoDB {$charset};";
 
 		$settlements_sql = "CREATE TABLE {$settlements} (
@@ -446,11 +507,15 @@ class BookingSchema {
 		$audit_error = (string) $wpdb->last_error;
 		dbDelta( $holds_sql );
 		$holds_error = (string) $wpdb->last_error;
+		dbDelta( $ticket_sources_sql );
+		$ticket_sources_error = (string) $wpdb->last_error;
 		dbDelta( $sales_reports_sql );
 		$sales_reports_error = (string) $wpdb->last_error;
+		dbDelta( $sales_resolutions_sql );
+		$sales_resolutions_error = (string) $wpdb->last_error;
 		dbDelta( $settlements_sql );
 		$settlements_error = (string) $wpdb->last_error;
-		if ( '' !== $bookings_error || '' !== $activity_error || '' !== $communication_state_error || '' !== $attachments_error || '' !== $deliveries_error || '' !== $members_error || '' !== $claims_error || '' !== $invites_error || '' !== $audit_error || '' !== $holds_error || '' !== $sales_reports_error || '' !== $settlements_error ) {
+		if ( '' !== $bookings_error || '' !== $activity_error || '' !== $communication_state_error || '' !== $attachments_error || '' !== $deliveries_error || '' !== $members_error || '' !== $claims_error || '' !== $invites_error || '' !== $audit_error || '' !== $holds_error || '' !== $ticket_sources_error || '' !== $sales_reports_error || '' !== $sales_resolutions_error || '' !== $settlements_error ) {
 			$error = new \WP_Error(
 				'booking_schema_dbdelta_failed',
 				__( 'The booking schema could not be reconciled.', 'extrachill-events' ),
@@ -465,7 +530,9 @@ class BookingSchema {
 					'invites_error'             => $invites_error,
 					'audit_error'               => $audit_error,
 					'holds_error'               => $holds_error,
+					'ticket_sources_error'      => $ticket_sources_error,
 					'sales_reports_error'       => $sales_reports_error,
+					'sales_resolutions_error'   => $sales_resolutions_error,
 					'settlements_error'         => $settlements_error,
 				)
 			);
@@ -738,6 +805,12 @@ class BookingSchema {
 					'nullable' => $nullable,
 				),
 				$attributes
+			);
+		};
+		$index    = static function ( bool $unique, string ...$columns ): array {
+			return array(
+				'unique'  => $unique,
+				'columns' => $columns,
 			);
 		};
 		return array(
@@ -1199,31 +1272,57 @@ class BookingSchema {
 					),
 				),
 			),
-			self::sales_reports_table()         => array(
+			self::ticket_sources_table()        => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                 => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'public_id'          => $required( 'char(36)', false ),
 					'booking_id'         => $required( 'bigint unsigned', false ),
 					'event_id'           => $required( 'bigint unsigned', false ),
 					'venue_term_id'      => $required( 'bigint unsigned', false ),
 					'provider'           => $required( 'varchar(64)', false ),
-					'external_report_id' => $required( 'varchar(191)', false ),
-					'source_type'        => $required( 'varchar(32)', false ),
-					'period_start'       => $required( 'datetime', false ),
-					'period_end'         => $required( 'datetime', false ),
-					'tickets_sold'       => $required( 'bigint', false ),
-					'tickets_refunded'   => $required( 'bigint', false ),
-					'gross_minor'        => $required( 'bigint', false ),
-					'fees_minor'         => $required( 'bigint', false ),
-					'tax_minor'          => $required( 'bigint', false ),
-					'refunds_minor'      => $required( 'bigint', false ),
-					'net_minor'          => $required( 'bigint', false ),
-					'currency'           => $required( 'char(3)', false ),
-					'corrects_report_id' => $required( 'bigint unsigned', true ),
-					'source_payload'     => $required( 'longtext', false ),
+					'source_key'         => $required( 'varchar(191)', false ),
+					'canonical_url'      => $required( 'longtext', false ),
+					'url_hash'           => $required( 'char(64)', false ),
 					'request_hash'       => $required( 'char(64)', false ),
 					'created_by_user_id' => $required( 'bigint unsigned', false ),
 					'created_at'         => $required( 'datetime', false ),
+				),
+				'indexes' => array(
+					'PRIMARY'                 => $index( true, 'id' ),
+					'public_id'               => $index( true, 'public_id' ),
+					'booking_provider_source' => $index( true, 'booking_id', 'provider', 'source_key' ),
+					'event_provider'          => $index( false, 'event_id', 'provider' ),
+					'venue_created'           => $index( false, 'venue_term_id', 'created_at', 'id' ),
+				),
+			),
+			self::sales_reports_table()         => array(
+				'engine'  => 'innodb',
+				'columns' => array(
+					'id'                     => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'booking_id'             => $required( 'bigint unsigned', false ),
+					'event_id'               => $required( 'bigint unsigned', false ),
+					'venue_term_id'          => $required( 'bigint unsigned', false ),
+					'ticket_source_id'       => $required( 'bigint unsigned', true ),
+					'evidence_attachment_id' => $required( 'bigint unsigned', true ),
+					'provider'               => $required( 'varchar(64)', false ),
+					'external_report_id'     => $required( 'varchar(191)', false ),
+					'source_type'            => $required( 'varchar(32)', false ),
+					'period_start'           => $required( 'datetime', false ),
+					'period_end'             => $required( 'datetime', false ),
+					'tickets_sold'           => $required( 'bigint', false ),
+					'tickets_refunded'       => $required( 'bigint', false ),
+					'gross_minor'            => $required( 'bigint', false ),
+					'fees_minor'             => $required( 'bigint', false ),
+					'tax_minor'              => $required( 'bigint', false ),
+					'refunds_minor'          => $required( 'bigint', false ),
+					'net_minor'              => $required( 'bigint', false ),
+					'currency'               => $required( 'char(3)', false ),
+					'corrects_report_id'     => $required( 'bigint unsigned', true ),
+					'source_payload'         => $required( 'longtext', false ),
+					'request_hash'           => $required( 'char(64)', false ),
+					'created_by_user_id'     => $required( 'bigint unsigned', false ),
+					'created_at'             => $required( 'datetime', false ),
 				),
 				'indexes' => array(
 					'PRIMARY'                  => array(
@@ -1232,7 +1331,7 @@ class BookingSchema {
 					),
 					'provider_external_report' => array(
 						'unique'  => true,
-						'columns' => array( 'provider', 'external_report_id' ),
+						'columns' => array( 'booking_id', 'provider', 'external_report_id' ),
 					),
 					'booking_created'          => array(
 						'unique'  => false,
@@ -1242,6 +1341,8 @@ class BookingSchema {
 						'unique'  => false,
 						'columns' => array( 'booking_id', 'currency', 'id' ),
 					),
+					'ticket_source_id'         => $index( false, 'ticket_source_id' ),
+					'evidence_attachment_id'   => $index( false, 'evidence_attachment_id' ),
 					'event_provider_period'    => array(
 						'unique'  => false,
 						'columns' => array( 'event_id', 'provider', 'period_start', 'period_end' ),
@@ -1250,6 +1351,33 @@ class BookingSchema {
 						'unique'  => false,
 						'columns' => array( 'corrects_report_id' ),
 					),
+				),
+			),
+			self::sales_resolutions_table()     => array(
+				'engine'  => 'innodb',
+				'columns' => array(
+					'id'                       => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'public_id'                => $required( 'char(36)', false ),
+					'booking_id'               => $required( 'bigint unsigned', false ),
+					'report_id'                => $required( 'bigint unsigned', false ),
+					'venue_term_id'            => $required( 'bigint unsigned', false ),
+					'version'                  => $required( 'bigint unsigned', false ),
+					'decision'                 => $required( 'varchar(16)', false ),
+					'ticket_source_id'         => $required( 'bigint unsigned', true ),
+					'supersedes_resolution_id' => $required( 'bigint unsigned', true ),
+					'reason'                   => $required( 'varchar(1000)', false ),
+					'request_hash'             => $required( 'char(64)', false ),
+					'created_by_user_id'       => $required( 'bigint unsigned', false ),
+					'created_at'               => $required( 'datetime', false ),
+				),
+				'indexes' => array(
+					'PRIMARY'                => $index( true, 'id' ),
+					'public_id'              => $index( true, 'public_id' ),
+					'report_version'         => $index( true, 'report_id', 'version' ),
+					'booking_report_version' => $index( false, 'booking_id', 'report_id', 'version' ),
+					'venue_created'          => $index( false, 'venue_term_id', 'created_at', 'id' ),
+					'ticket_source_id'       => $index( false, 'ticket_source_id' ),
+					'supersedes_resolution'  => $index( false, 'supersedes_resolution_id' ),
 				),
 			),
 			self::settlements_table()           => array(

--- a/inc/Core/TicketReconciliationService.php
+++ b/inc/Core/TicketReconciliationService.php
@@ -1,0 +1,855 @@
+<?php
+/**
+ * Provider-neutral ticket source, import, and reconciliation contracts.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+// Repository convention uses concise method comments.
+// phpcs:disable Generic.Commenting.DocComment.MissingShort,Squiz.Commenting.FunctionComment.Missing,Squiz.Commenting.FunctionComment.MissingParamTag
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Keeps attribution and reconciliation policy beside immutable settlement evidence. */
+class TicketReconciliationService {
+	public const DECISIONS           = array( 'admit', 'exclude' );
+	private const CSV_HEADER         = array( 'external_report_id', 'period_start', 'period_end', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'currency' );
+	private const MAX_CSV_ROWS       = 1000;
+	private const MAX_CSV_LINE_BYTES = 16384;
+
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var BookingActivityRepository */
+	private $activity;
+	/** @var VenueAuthorization */
+	private $authorization;
+	/** @var BookingAttachmentRepository */
+	private $attachments;
+	/** @var BookingAttachmentService */
+	private $attachment_service;
+	/** @var bool */
+	private $transaction_active = false;
+
+	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, ?BookingAttachmentRepository $attachments = null, ?BookingAttachmentService $attachment_service = null ) {
+		$this->bookings           = $bookings ? $bookings : new BookingRepository();
+		$this->activity           = $activity ? $activity : new BookingActivityRepository();
+		$this->authorization      = $authorization ? $authorization : new VenueAuthorization();
+		$this->attachments        = $attachments ? $attachments : new BookingAttachmentRepository();
+		$this->attachment_service = $attachment_service ? $attachment_service : new BookingAttachmentService( $this->attachments, $this->bookings, $this->activity, null, null, $this->authorization );
+	}
+
+	/** Register one immutable ticket URL/source identity. */
+	public function register_source( array $input, int $actor_id ) {
+		$booking = $this->booking( $input['booking_id'] ?? 0 );
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+		$provider = mb_substr( sanitize_key( (string) ( $input['provider'] ?? '' ) ), 0, 64 );
+		$key      = mb_substr( sanitize_text_field( (string) ( $input['source_key'] ?? '' ) ), 0, 191 );
+		$url      = $this->canonical_url( $input['ticket_url'] ?? null );
+		if ( '' === $provider || '' === $key || is_wp_error( $url ) || null === $booking['event_id'] ) {
+			return is_wp_error( $url ) ? $url : new \WP_Error( 'invalid_ticket_source_identity', __( 'A linked event and valid provider source identity are required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$row                 = array(
+			'public_id'          => wp_generate_uuid4(),
+			'booking_id'         => $booking['id'],
+			'event_id'           => $booking['event_id'],
+			'venue_term_id'      => $booking['venue_term_id'],
+			'provider'           => $provider,
+			'source_key'         => $key,
+			'canonical_url'      => $url,
+			'url_hash'           => hash( 'sha256', $url ),
+			'created_by_user_id' => $actor_id,
+			'created_at'         => gmdate( 'Y-m-d H:i:s' ),
+		);
+		$row['request_hash'] = $this->hash( $row, array( 'booking_id', 'event_id', 'venue_term_id', 'provider', 'source_key', 'canonical_url' ) );
+
+		$started = $this->begin_authorized( $booking, $actor_id, VenueAuthorization::ACTION_MANAGE_FINANCES );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$booking = $this->bookings->get_for_update( $booking['id'] );
+		if ( ! is_array( $booking ) || $row['event_id'] !== $booking['event_id'] || $row['venue_term_id'] !== $booking['venue_term_id'] ) {
+			return $this->rollback( new \WP_Error( 'ticket_source_booking_changed', __( 'The booking identity changed before the ticket source was recorded.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+		}
+		$existing = $this->find_source_identity( $booking['id'], $provider, $key, true );
+		if ( is_wp_error( $existing ) ) {
+			return $this->rollback( $existing );
+		}
+		if ( is_array( $existing ) ) {
+			if ( hash_equals( $existing['request_hash'], $row['request_hash'] ) ) {
+				$committed = $this->commit();
+				return is_wp_error( $committed ) ? $committed : $this->present_source( $existing );
+			}
+			return $this->rollback( new \WP_Error( 'ticket_source_idempotency_conflict', __( 'This source identity is already bound to a different ticket URL.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+		}
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Append-only private source identity.
+		if ( false === $wpdb->insert( BookingSchema::ticket_sources_table(), $row ) ) {
+			$winner = $this->find_source_identity( $booking['id'], $provider, $key, true );
+			if ( is_array( $winner ) && hash_equals( $winner['request_hash'], $row['request_hash'] ) ) {
+				$committed = $this->commit();
+				return is_wp_error( $committed ) ? $committed : $this->present_source( $winner );
+			}
+			return $this->rollback( new \WP_Error( 'ticket_source_write_failed', __( 'The ticket source could not be recorded.', 'extrachill-events' ) ) );
+		}
+		$source = $this->get_source( (int) $wpdb->insert_id, true );
+		if ( ! is_array( $source ) ) {
+			return $this->rollback( is_wp_error( $source ) ? $source : new \WP_Error( 'ticket_source_write_failed', __( 'The recorded ticket source could not be verified.', 'extrachill-events' ) ) );
+		}
+		$audit = $this->activity->append(
+			array(
+				'booking_id'      => $booking['id'],
+				'kind'            => 'ticket_source_recorded',
+				'actor_type'      => 'user',
+				'actor_id'        => $actor_id,
+				'external_id'     => (string) $source['id'],
+				'idempotency_key' => 'ticket-source:' . $source['id'],
+				'payload'         => array(
+					'source_id'  => $source['public_id'],
+					'provider'   => $source['provider'],
+					'source_key' => $source['source_key'],
+				),
+			)
+		);
+		if ( is_wp_error( $audit ) ) {
+			return $this->rollback( $audit );
+		}
+		$committed = $this->commit();
+		return is_wp_error( $committed ) ? $committed : $this->present_source( $source );
+	}
+
+	/** Return a bounded redacted source list. */
+	public function list_sources( int $booking_id, int $actor_id ) {
+		$booking = $this->authorized_booking( $booking_id, $actor_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+		global $wpdb;
+		$table = BookingSchema::ticket_sources_table();
+		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d ORDER BY id ASC LIMIT 200", $booking['id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded immutable identities.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'ticket_source_list_failed', __( 'Ticket sources could not be listed.', 'extrachill-events' ) );
+		}
+		$presented = array();
+		foreach ( (array) $rows as $row ) {
+			$source = $this->hydrate_source( $row );
+			if ( is_wp_error( $source ) ) {
+				return $source;
+			}
+			if ( $source['booking_id'] !== $booking['id'] || $source['event_id'] !== $booking['event_id'] || $source['venue_term_id'] !== $booking['venue_term_id'] ) {
+				return new \WP_Error(
+					'ticket_source_booking_changed',
+					__( 'A ticket source no longer matches the booking event and venue identity.', 'extrachill-events' ),
+					array(
+						'status'    => 409,
+						'source_id' => $source['id'],
+					)
+				);
+			}
+			$presented[] = $this->present_source( $source );
+		}
+		return $presented;
+	}
+
+	/** Parse one approved private CSV attachment into canonical report inputs. */
+	public function csv_report_inputs( array $input, int $actor_id ) {
+		$booking = $this->authorized_booking( $input['booking_id'] ?? 0, $actor_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+		$attachment_id = $this->positive_integer( $input['attachment_id'] ?? null, 'attachment_id' );
+		$source_id     = $this->positive_integer( $input['ticket_source_id'] ?? null, 'ticket_source_id' );
+		if ( is_wp_error( $attachment_id ) || is_wp_error( $source_id ) ) {
+			return is_wp_error( $attachment_id ) ? $attachment_id : $source_id;
+		}
+		$source = $this->get_source( $source_id );
+		if ( ! is_array( $source ) || $source['booking_id'] !== $booking['id'] || $source['event_id'] !== $booking['event_id'] || $source['venue_term_id'] !== $booking['venue_term_id'] ) {
+			return new \WP_Error( 'ticket_source_not_found', __( 'The ticket source was not found for this booking.', 'extrachill-events' ), array( 'status' => 404 ) );
+		}
+		$attachment = $this->attachments->get_for_booking( $booking['id'], $attachment_id );
+		if ( is_wp_error( $attachment ) ) {
+			return $attachment;
+		}
+		if ( 'active' !== $attachment['state'] || 'text/csv' !== $attachment['mime_type'] || 'other_private_evidence' !== $attachment['purpose'] ) {
+			return new \WP_Error( 'sales_csv_attachment_invalid', __( 'CSV sales import requires an active approved private evidence attachment.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$descriptor = $this->attachment_service->download_descriptor( $booking['id'], $attachment_id, $actor_id );
+		if ( is_wp_error( $descriptor ) ) {
+			return $descriptor;
+		}
+		$stream = $this->attachment_service->open_download_stream( $booking['id'], $attachment_id, $descriptor['stream_token'], $actor_id, $descriptor['correlation_id'] );
+		if ( is_wp_error( $stream ) ) {
+			return $stream;
+		}
+		if ( ! is_resource( $stream ) ) {
+			return new \WP_Error( 'sales_csv_stream_invalid', __( 'The private CSV stream could not be opened.', 'extrachill-events' ), array( 'status' => 502 ) );
+		}
+		$verified = $this->verified_csv_stream( $stream, $attachment );
+		fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes the approved private stream after bounded parsing.
+		$result = $verified;
+		if ( is_resource( $verified ) ) {
+			$result = $this->parse_csv_stream( $verified, $booking, $source, $attachment );
+			fclose( $verified ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes the verified bounded copy.
+		}
+		$outcome = is_wp_error( $result ) ? 'failed' : 'completed';
+		$logged  = $this->attachment_service->record_delivery_outcome( $booking['id'], $attachment_id, $descriptor['correlation_id'], $outcome, 'completed' === $outcome ? $attachment['byte_size'] : 0, $actor_id );
+		return is_wp_error( $logged ) ? $logged : $result;
+	}
+
+	/** Derive deterministic diagnostics and current admission state. */
+	public function diagnostics( int $booking_id, int $actor_id ) {
+		$booking = $this->authorized_booking( $booking_id, $actor_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+		return is_wp_error( $booking ) ? $booking : $this->diagnostics_for_booking( $booking );
+	}
+
+	/** Append an optimistic operator decision; prior decisions remain immutable. */
+	public function resolve( array $input, int $actor_id ) {
+		$booking = $this->booking( $input['booking_id'] ?? 0 );
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+		$report_id = $this->positive_integer( $input['report_id'] ?? null, 'report_id' );
+		$expected  = $input['expected_version'] ?? null;
+		$decision  = sanitize_key( (string) ( $input['decision'] ?? '' ) );
+		$reason    = mb_substr( sanitize_text_field( (string) ( $input['reason'] ?? '' ) ), 0, 1000 );
+		$source_id = null;
+		if ( array_key_exists( 'ticket_source_id', $input ) && null !== $input['ticket_source_id'] ) {
+			$source_id = $this->positive_integer( $input['ticket_source_id'], 'ticket_source_id' );
+		}
+		if ( is_wp_error( $report_id ) || is_wp_error( $source_id ) || ! is_int( $expected ) || $expected < 0 || ! in_array( $decision, self::DECISIONS, true ) || '' === $reason ) {
+			return is_wp_error( $report_id ) ? $report_id : ( is_wp_error( $source_id ) ? $source_id : new \WP_Error( 'invalid_sales_resolution', __( 'A valid versioned reconciliation decision and reason are required.', 'extrachill-events' ), array( 'status' => 400 ) ) );
+		}
+		$started = $this->begin_authorized( $booking, $actor_id, VenueAuthorization::ACTION_MANAGE_FINANCES );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$booking    = $this->bookings->get_for_update( $booking['id'] );
+		$settlement = is_array( $booking ) ? $this->get_settlement_for_booking( $booking['id'], true ) : null;
+		if ( is_wp_error( $settlement ) ) {
+			return $this->rollback( $settlement );
+		}
+		if ( is_array( $settlement ) ) {
+			return $this->rollback(
+				new \WP_Error(
+					'sales_resolution_settlement_frozen',
+					__( 'Ticket-sales reconciliation cannot change after settlement is finalized.', 'extrachill-events' ),
+					array(
+						'status'        => 409,
+						'settlement_id' => (int) $settlement['id'],
+					)
+				)
+			);
+		}
+		$report = $this->get_report_row( $report_id, true );
+		if ( ! is_array( $booking ) || ! is_array( $report ) || (int) $report['booking_id'] !== (int) $booking['id'] ) {
+			return $this->rollback( new \WP_Error( 'sales_report_not_found', __( 'The sales report was not found for this booking.', 'extrachill-events' ), array( 'status' => 404 ) ) );
+		}
+		if ( (int) $report['event_id'] !== (int) $booking['event_id'] || (int) $report['venue_term_id'] !== (int) $booking['venue_term_id'] ) {
+			return $this->rollback(
+				new \WP_Error(
+					'sales_report_booking_changed',
+					__( 'Ticket-sales evidence no longer matches the booking event and venue identity.', 'extrachill-events' ),
+					array(
+						'status'    => 409,
+						'report_id' => $report_id,
+					)
+				)
+			);
+		}
+		$latest = $this->latest_resolution( $report_id, true );
+		if ( is_wp_error( $latest ) ) {
+			return $this->rollback( $latest );
+		}
+		$current_version = is_array( $latest ) ? $latest['version'] : 0;
+		if ( is_array( $latest ) && $current_version === $expected + 1 ) {
+			$retry      = array(
+				'booking_id'               => $booking['id'],
+				'report_id'                => $report_id,
+				'venue_term_id'            => $booking['venue_term_id'],
+				'version'                  => $expected + 1,
+				'decision'                 => $decision,
+				'ticket_source_id'         => $source_id,
+				'supersedes_resolution_id' => $latest['supersedes_resolution_id'],
+				'reason'                   => $reason,
+				'created_by_user_id'       => $latest['created_by_user_id'],
+				'created_at'               => $latest['created_at'],
+			);
+			$retry_hash = $this->hash( $retry, array( 'booking_id', 'report_id', 'venue_term_id', 'version', 'decision', 'ticket_source_id', 'supersedes_resolution_id', 'reason', 'created_by_user_id', 'created_at' ) );
+			if ( hash_equals( $latest['request_hash'], $retry_hash ) ) {
+				$committed = $this->commit();
+				return is_wp_error( $committed ) ? $committed : $latest;
+			}
+		}
+		if ( $expected !== $current_version ) {
+			return $this->rollback(
+				new \WP_Error(
+					'sales_resolution_version_conflict',
+					__( 'The reconciliation decision changed since it was read.', 'extrachill-events' ),
+					array(
+						'status'          => 409,
+						'current_version' => $current_version,
+					)
+				)
+			);
+		}
+		if ( null !== $source_id ) {
+			$source = $this->get_source( $source_id, true );
+			if ( ! is_array( $source ) || $source['booking_id'] !== $booking['id'] || $source['event_id'] !== $booking['event_id'] || $source['venue_term_id'] !== $booking['venue_term_id'] || $source['provider'] !== $report['provider'] ) {
+				return $this->rollback( new \WP_Error( 'ticket_source_not_found', __( 'The ticket source was not found for this booking.', 'extrachill-events' ), array( 'status' => 404 ) ) );
+			}
+		}
+		$row                 = array(
+			'public_id'                => wp_generate_uuid4(),
+			'booking_id'               => $booking['id'],
+			'report_id'                => $report_id,
+			'venue_term_id'            => $booking['venue_term_id'],
+			'version'                  => $current_version + 1,
+			'decision'                 => $decision,
+			'ticket_source_id'         => $source_id,
+			'supersedes_resolution_id' => is_array( $latest ) ? $latest['id'] : null,
+			'reason'                   => $reason,
+			'created_by_user_id'       => $actor_id,
+			'created_at'               => gmdate( 'Y-m-d H:i:s' ),
+		);
+		$row['request_hash'] = $this->hash( $row, array( 'booking_id', 'report_id', 'venue_term_id', 'version', 'decision', 'ticket_source_id', 'supersedes_resolution_id', 'reason', 'created_by_user_id', 'created_at' ) );
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Append-only operator resolution.
+		if ( false === $wpdb->insert( BookingSchema::sales_resolutions_table(), $row ) ) {
+			$winner = $this->resolution_version( $report_id, $row['version'], true );
+			if ( is_array( $winner ) && hash_equals( $winner['request_hash'], $row['request_hash'] ) ) {
+				$committed = $this->commit();
+				return is_wp_error( $committed ) ? $committed : $winner;
+			}
+			return $this->rollback( new \WP_Error( 'sales_resolution_version_conflict', __( 'A different reconciliation decision won this version.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+		}
+		$resolution = $this->resolution_version( $report_id, $row['version'], true );
+		$audit      = is_array( $resolution )
+			? $this->activity->append(
+				array(
+					'booking_id'      => $booking['id'],
+					'kind'            => 'ticket_sales_reconciled',
+					'actor_type'      => 'user',
+					'actor_id'        => $actor_id,
+					'external_id'     => (string) $report_id,
+					'idempotency_key' => 'sales-resolution:' . $resolution['id'],
+					'payload'         => array(
+						'report_id' => $report_id,
+						'version'   => $resolution['version'],
+						'decision'  => $decision,
+					),
+				)
+			)
+			: $resolution;
+		if ( is_wp_error( $audit ) || ! is_array( $resolution ) ) {
+			return $this->rollback( is_wp_error( $audit ) ? $audit : new \WP_Error( 'sales_resolution_write_failed', __( 'The reconciliation decision could not be verified.', 'extrachill-events' ) ) );
+		}
+		$committed = $this->commit();
+		return is_wp_error( $committed ) ? $committed : $resolution;
+	}
+
+	/** Internal settlement boundary: reject unresolved evidence and return admitted reports. */
+	public function admitted_reports( array $booking, array $reports ) {
+		$diagnostics = $this->derive_diagnostics( $booking, $reports );
+		if ( is_wp_error( $diagnostics ) ) {
+			return $diagnostics;
+		}
+		$admitted = array();
+		foreach ( $diagnostics['reports'] as $item ) {
+			if ( 'unresolved' === $item['state'] ) {
+				return new \WP_Error(
+					'settlement_reconciliation_required',
+					__( 'Ticket-sales evidence must be reconciled before settlement.', 'extrachill-events' ),
+					array(
+						'status'    => 409,
+						'report_id' => $item['report_id'],
+						'issues'    => $item['issues'],
+					)
+				);
+			}
+			if ( 'admitted' === $item['state'] ) {
+				$admitted[] = $reports[ $item['report_index'] ];
+			}
+		}
+		return $admitted;
+	}
+
+	/** Return the immutable reconciliation decision bound into settlement evidence. */
+	public function settlement_resolution_evidence( int $report_id, bool $lock = false ) {
+		$resolution = $this->latest_resolution( $report_id, $lock );
+		if ( is_wp_error( $resolution ) || null === $resolution ) {
+			return $resolution;
+		}
+		return array(
+			'id'               => $resolution['id'],
+			'version'          => $resolution['version'],
+			'decision'         => $resolution['decision'],
+			'ticket_source_id' => $resolution['ticket_source_id'],
+			'request_hash'     => $resolution['request_hash'],
+		);
+	}
+
+	/** Verify report provenance against current immutable source and attachment contracts. */
+	public function validate_provenance( array $report, array $booking ) {
+		$source_id = $report['ticket_source_id'] ?? null;
+		if ( null !== $source_id ) {
+			$source = $this->get_source( (int) $source_id );
+			if ( ! is_array( $source ) || $source['booking_id'] !== $booking['id'] || $source['event_id'] !== $booking['event_id'] || $source['venue_term_id'] !== $booking['venue_term_id'] || $source['provider'] !== $report['provider'] ) {
+				return new \WP_Error( 'invalid_sales_report_source_identity', __( 'The ticket source does not match this booking, event, and provider.', 'extrachill-events' ), array( 'status' => 400 ) );
+			}
+		}
+		$attachment_id = $report['evidence_attachment_id'] ?? null;
+		if ( 'csv_certified' === $report['source_type'] ) {
+			if ( null === $attachment_id ) {
+				return new \WP_Error( 'sales_csv_attachment_required', __( 'Certified CSV evidence requires its approved private attachment.', 'extrachill-events' ), array( 'status' => 400 ) );
+			}
+			$attachment = $this->attachments->get_for_booking( $booking['id'], (int) $attachment_id );
+			if ( is_wp_error( $attachment ) || 'active' !== ( $attachment['state'] ?? '' ) || 'text/csv' !== ( $attachment['mime_type'] ?? '' ) || 'other_private_evidence' !== ( $attachment['purpose'] ?? '' ) ) {
+				return is_wp_error( $attachment ) ? $attachment : new \WP_Error( 'sales_csv_attachment_invalid', __( 'Certified CSV evidence requires an active approved private CSV attachment.', 'extrachill-events' ), array( 'status' => 400 ) );
+			}
+		} elseif ( null !== $attachment_id ) {
+			return new \WP_Error( 'sales_report_attachment_invalid', __( 'Only certified CSV evidence may bind a private file.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return true;
+	}
+
+	private function diagnostics_for_booking( array $booking ) {
+		global $wpdb;
+		$table = BookingSchema::sales_reports_table();
+		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d ORDER BY id ASC LIMIT 1001", $booking['id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded reconciliation snapshot.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'sales_report_list_failed', __( 'Ticket-sales evidence could not be read for reconciliation.', 'extrachill-events' ) );
+		}
+		if ( 1000 < count( (array) $rows ) ) {
+			return new \WP_Error( 'sales_reconciliation_too_large', __( 'Ticket-sales evidence exceeds the bounded reconciliation limit.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$reports = array();
+		foreach ( (array) $rows as $row ) {
+			$reports[] = $this->hydrate_report_row( $row );
+		}
+		return $this->derive_diagnostics( $booking, $reports );
+	}
+
+	private function derive_diagnostics( array $booking, array $reports ) {
+		$items = array();
+		foreach ( $reports as $index => $report ) {
+			if ( is_wp_error( $report ) ) {
+				return $report;
+			}
+			if ( $report['booking_id'] !== $booking['id'] || $report['event_id'] !== $booking['event_id'] || $report['venue_term_id'] !== $booking['venue_term_id'] ) {
+				return new \WP_Error(
+					'sales_report_booking_changed',
+					__( 'Ticket-sales evidence no longer matches the booking event and venue identity.', 'extrachill-events' ),
+					array(
+						'status'    => 409,
+						'report_id' => $report['id'],
+					)
+				);
+			}
+			$resolution = $this->latest_resolution( $report['id'] );
+			if ( is_wp_error( $resolution ) ) {
+				return $resolution;
+			}
+			$source_id = is_array( $resolution ) && null !== $resolution['ticket_source_id'] ? $resolution['ticket_source_id'] : $report['ticket_source_id'];
+			$issues    = array();
+			if ( null === $source_id ) {
+				$issues[] = 'unattributed';
+			}
+			if ( 'csv_certified' === $report['source_type'] && null === $report['evidence_attachment_id'] ) {
+				$issues[] = 'file_missing';
+			}
+			$deal_currency = strtoupper( (string) ( $booking['confirmed_deal']['data']['currency'] ?? $booking['deal']['data']['currency'] ?? '' ) );
+			if ( '' !== $deal_currency && $deal_currency !== $report['currency'] ) {
+				$issues[] = 'currency_mismatch';
+			}
+			$items[ $index ] = array(
+				'report_id'              => $report['id'],
+				'report_index'           => $index,
+				'ticket_source_id'       => $source_id,
+				'reconciliation_version' => is_array( $resolution ) ? $resolution['version'] : 0,
+				'decision'               => is_array( $resolution ) ? $resolution['decision'] : null,
+				'issues'                 => $issues,
+			);
+		}
+		foreach ( $reports as $left => $report ) {
+			foreach ( $reports as $right => $candidate ) {
+				if ( $right <= $left || $report['provider'] !== $candidate['provider'] || $report['period_start'] > $candidate['period_end'] || $candidate['period_start'] > $report['period_end'] ) {
+					continue;
+				}
+				$financial = array( 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'currency' );
+				$exact     = $report['period_start'] === $candidate['period_start'] && $report['period_end'] === $candidate['period_end'];
+				$same      = true;
+				foreach ( $financial as $field ) {
+					$same = $same && $report[ $field ] === $candidate[ $field ];
+				}
+				$issue                       = $exact ? ( $same ? 'duplicate' : 'contradictory' ) : 'overlap';
+				$items[ $left ]['issues'][]  = $issue;
+				$items[ $right ]['issues'][] = $issue;
+			}
+		}
+		$counts = array(
+			'admitted'   => 0,
+			'excluded'   => 0,
+			'unresolved' => 0,
+		);
+		foreach ( $items as &$item ) {
+			$item['issues'] = array_values( array_unique( $item['issues'] ) );
+			if ( 'exclude' === $item['decision'] ) {
+				$item['state'] = 'excluded';
+			} elseif ( 'admit' === $item['decision'] || empty( $item['issues'] ) ) {
+				$item['state'] = 'admitted';
+			} else {
+				$item['state'] = 'unresolved';
+			}
+			++$counts[ $item['state'] ];
+		}
+		unset( $item );
+		return array(
+			'booking_id'           => $booking['id'],
+			'reports'              => array_values( $items ),
+			'counts'               => $counts,
+			'ready_for_settlement' => 0 === $counts['unresolved'] && 0 < $counts['admitted'],
+		);
+	}
+
+	private function parse_csv_stream( $stream, array $booking, array $source, array $attachment ) {
+		$header = $this->read_csv_record( $stream, 1 );
+		if ( is_wp_error( $header ) ) {
+			return $header;
+		}
+		if ( self::CSV_HEADER !== $header ) {
+			return new \WP_Error( 'sales_csv_header_invalid', __( 'The CSV header does not match the canonical ticket-sales contract.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$inputs = array();
+		while ( true ) {
+			$values = $this->read_csv_record( $stream, count( $inputs ) + 2 );
+			if ( false === $values ) {
+				break;
+			}
+			if ( is_wp_error( $values ) ) {
+				return $values;
+			}
+			if ( array( '' ) === $values ) {
+				continue;
+			}
+			if ( count( $values ) !== count( self::CSV_HEADER ) || self::MAX_CSV_ROWS < count( $inputs ) + 1 ) {
+				return new \WP_Error(
+					'sales_csv_row_invalid',
+					__( 'The CSV contains a malformed row or exceeds the import limit.', 'extrachill-events' ),
+					array(
+						'status' => 400,
+						'row'    => count( $inputs ) + 2,
+					)
+				);
+			}
+			$row = array_combine( self::CSV_HEADER, $values );
+			foreach ( array( 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor' ) as $field ) {
+				if ( ! preg_match( '/^-?\d+$/', $row[ $field ] ) || ltrim( $row[ $field ], '+' ) !== (string) (int) $row[ $field ] ) {
+					return new \WP_Error(
+						'sales_csv_integer_invalid',
+						__( 'CSV counts and money must use canonical signed integers.', 'extrachill-events' ),
+						array(
+							'status' => 400,
+							'row'    => count( $inputs ) + 2,
+							'field'  => $field,
+						)
+					);
+				}
+				$row[ $field ] = (int) $row[ $field ];
+			}
+			$inputs[] = array_merge(
+				$row,
+				array(
+					'booking_id'             => $booking['id'],
+					'provider'               => $source['provider'],
+					'source_type'            => 'csv_certified',
+					'ticket_source_id'       => $source['id'],
+					'evidence_attachment_id' => $attachment['id'],
+					'source'                 => array(
+						'attachment_id' => $attachment['public_id'],
+						'row'           => count( $inputs ) + 2,
+					),
+				)
+			);
+		}
+		return empty( $inputs ) ? new \WP_Error( 'sales_csv_empty', __( 'The CSV contains no ticket-sales observations.', 'extrachill-events' ), array( 'status' => 400 ) ) : $inputs;
+	}
+
+	/** Copy and authenticate every private byte before parsing any observation. */
+	private function verified_csv_stream( $stream, array $attachment ) {
+		$verified = fopen( 'php://temp/maxmemory:' . BookingAttachmentPolicy::MAX_BYTES, 'w+b' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Bounded in-process verification copy.
+		if ( false === $verified ) {
+			return new \WP_Error( 'sales_csv_stream_invalid', __( 'A bounded CSV verification stream could not be created.', 'extrachill-events' ), array( 'status' => 500 ) );
+		}
+		$hash  = hash_init( 'sha256' );
+		$bytes = 0;
+		while ( ! feof( $stream ) ) {
+			$chunk = fread( $stream, 8192 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread -- Reads only the approved private stream.
+			if ( false === $chunk ) {
+				fclose( $verified ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Error-path cleanup.
+				return new \WP_Error( 'sales_csv_stream_invalid', __( 'The private CSV stream could not be read completely.', 'extrachill-events' ), array( 'status' => 502 ) );
+			}
+			$bytes += strlen( $chunk );
+			if ( BookingAttachmentPolicy::MAX_BYTES < $bytes || $attachment['byte_size'] < $bytes ) {
+				fclose( $verified ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Error-path cleanup.
+				return new \WP_Error( 'sales_csv_evidence_mismatch', __( 'The streamed CSV exceeds its immutable attachment evidence.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			hash_update( $hash, $chunk );
+			if ( strlen( $chunk ) !== fwrite( $verified, $chunk ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- Writes only to the bounded verification stream.
+				fclose( $verified ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Error-path cleanup.
+				return new \WP_Error( 'sales_csv_stream_invalid', __( 'The CSV verification copy could not be completed.', 'extrachill-events' ), array( 'status' => 500 ) );
+			}
+		}
+		if ( $bytes !== $attachment['byte_size'] || ! hash_equals( $attachment['content_hash'], hash_final( $hash ) ) ) {
+			fclose( $verified ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Error-path cleanup.
+			return new \WP_Error( 'sales_csv_evidence_mismatch', __( 'The streamed CSV does not match its immutable attachment evidence.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		rewind( $verified );
+		return $verified;
+	}
+
+	/** Read one physical CSV record without allowing multiline or overlong fields. */
+	private function read_csv_record( $stream, int $row ) {
+		$line = fgets( $stream, self::MAX_CSV_LINE_BYTES + 1 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fgets -- Explicit bounded physical record.
+		if ( false === $line ) {
+			return false;
+		}
+		$has_newline = "\n" === substr( $line, -1 );
+		if ( self::MAX_CSV_LINE_BYTES < strlen( $line ) || ( ! $has_newline && ! feof( $stream ) ) ) {
+			return $this->csv_record_error( 'sales_csv_line_too_long', __( 'A CSV record exceeds the bounded line length.', 'extrachill-events' ), $row );
+		}
+		$line   = rtrim( $line, "\r\n" );
+		$values = str_getcsv( $line );
+		if ( false !== strpos( $line, '"' ) && 1 === substr_count( $line, '"' ) % 2 ) {
+			return $this->csv_record_error( 'sales_csv_multiline_forbidden', __( 'Multiline or unterminated CSV fields are not supported.', 'extrachill-events' ), $row );
+		}
+		return $values;
+	}
+
+	private function csv_record_error( string $code, string $message, int $row ): \WP_Error {
+		return new \WP_Error(
+			$code,
+			$message,
+			array(
+				'status' => 400,
+				'row'    => $row,
+			)
+		);
+	}
+
+	private function canonical_url( $value ) {
+		if ( ! is_string( $value ) || 2048 < strlen( $value ) ) {
+			return new \WP_Error( 'invalid_ticket_source_url', __( 'The ticket source URL is invalid.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$url   = esc_url_raw( trim( $value ), array( 'http', 'https' ) );
+		$parts = wp_parse_url( $url );
+		if ( '' === $url || ! is_array( $parts ) || empty( $parts['host'] ) || ! in_array( strtolower( (string) ( $parts['scheme'] ?? '' ) ), array( 'http', 'https' ), true ) || isset( $parts['user'] ) || isset( $parts['pass'] ) || isset( $parts['fragment'] ) ) {
+			return new \WP_Error( 'invalid_ticket_source_url', __( 'The ticket source URL must be an HTTP or HTTPS URL without credentials or a fragment.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return $url;
+	}
+
+	private function present_source( array $source ): array {
+		$parts = wp_parse_url( $source['canonical_url'] );
+		$port  = isset( $parts['port'] ) ? ':' . (int) $parts['port'] : '';
+		return array(
+			'id'            => $source['id'],
+			'public_id'     => $source['public_id'],
+			'booking_id'    => $source['booking_id'],
+			'event_id'      => $source['event_id'],
+			'venue_term_id' => $source['venue_term_id'],
+			'provider'      => $source['provider'],
+			'source_key'    => $source['source_key'],
+			'display_url'   => strtolower( (string) $parts['scheme'] ) . '://' . strtolower( (string) $parts['host'] ) . $port,
+			'created_at'    => $source['created_at'],
+		);
+	}
+
+	private function authorized_booking( $booking_id, int $actor_id, string $action ) {
+		$booking = $this->booking( $booking_id );
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+		$allowed = $this->authorization->authorize( $actor_id, $booking['venue_term_id'], $action );
+		return true === $allowed ? $booking : $this->denied( $allowed );
+	}
+
+	private function booking( $booking_id ) {
+		$id = $this->positive_integer( $booking_id, 'booking_id' );
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+		$booking = $this->bookings->get( $id );
+		return is_array( $booking ) ? $booking : ( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ), array( 'status' => 404 ) ) );
+	}
+
+	private function begin_authorized( array $booking, int $actor_id, string $action ) {
+		global $wpdb;
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Financial attribution aggregate boundary.
+			return new \WP_Error( 'sales_reconciliation_transaction_start_failed', __( 'The ticket reconciliation transaction could not start.', 'extrachill-events' ) );
+		}
+		$this->transaction_active = true;
+		$table                    = BookingSchema::memberships_table();
+		$members                  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $booking['venue_term_id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks exact venue authority.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return $this->rollback( new \WP_Error( 'sales_reconciliation_authorization_lock_failed', __( 'Venue finance authority could not be locked.', 'extrachill-events' ) ) );
+		}
+		$allowed = $this->authorization->authorize_locked( $actor_id, $booking['venue_term_id'], $action, (array) $members );
+		return true === $allowed ? true : $this->rollback( $this->denied( $allowed ) );
+	}
+
+	private function find_source_identity( int $booking_id, string $provider, string $source_key, bool $lock = false ) {
+		global $wpdb;
+		$table = BookingSchema::ticket_sources_table();
+		$query = "SELECT * FROM {$table} WHERE booking_id = %d AND provider = %s AND source_key = %s LIMIT 1" . ( $lock ? ' FOR UPDATE' : '' );
+		$row   = $wpdb->get_row( $wpdb->prepare( $query, $booking_id, $provider, $source_key ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Stable source lookup.
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'ticket_source_read_failed', __( 'The ticket source could not be read.', 'extrachill-events' ) ) : ( is_array( $row ) ? $this->hydrate_source( $row ) : null );
+	}
+
+	private function get_source( int $id, bool $lock = false ) {
+		global $wpdb;
+		$table = BookingSchema::ticket_sources_table();
+		$query = "SELECT * FROM {$table} WHERE id = %d LIMIT 1" . ( $lock ? ' FOR UPDATE' : '' );
+		$row   = $wpdb->get_row( $wpdb->prepare( $query, $id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Immutable source lookup.
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'ticket_source_read_failed', __( 'The ticket source could not be read.', 'extrachill-events' ) ) : ( is_array( $row ) ? $this->hydrate_source( $row ) : null );
+	}
+
+	private function hydrate_source( array $row ) {
+		foreach ( array( 'id', 'booking_id', 'event_id', 'venue_term_id', 'created_by_user_id' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		$stored = strtolower( (string) $row['request_hash'] );
+		return preg_match( '/^[a-f0-9]{64}$/', $stored ) && hash_equals( $stored, $this->hash( $row, array( 'booking_id', 'event_id', 'venue_term_id', 'provider', 'source_key', 'canonical_url' ) ) )
+			? $row
+			: new \WP_Error(
+				'ticket_source_integrity_failed',
+				__( 'Stored ticket source identity failed its immutable content check.', 'extrachill-events' ),
+				array(
+					'status'    => 409,
+					'source_id' => $row['id'],
+				)
+			);
+	}
+
+	private function latest_resolution( int $report_id, bool $lock = false ) {
+		global $wpdb;
+		$table = BookingSchema::sales_resolutions_table();
+		$query = "SELECT * FROM {$table} WHERE report_id = %d ORDER BY version DESC LIMIT 1" . ( $lock ? ' FOR UPDATE' : '' );
+		$row   = $wpdb->get_row( $wpdb->prepare( $query, $report_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Current append-only decision.
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'sales_resolution_read_failed', __( 'The reconciliation decision could not be read.', 'extrachill-events' ) ) : ( is_array( $row ) ? $this->hydrate_resolution( $row ) : null );
+	}
+
+	private function resolution_version( int $report_id, int $version, bool $lock = false ) {
+		global $wpdb;
+		$table = BookingSchema::sales_resolutions_table();
+		$query = "SELECT * FROM {$table} WHERE report_id = %d AND version = %d LIMIT 1" . ( $lock ? ' FOR UPDATE' : '' );
+		$row   = $wpdb->get_row( $wpdb->prepare( $query, $report_id, $version ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact immutable decision.
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'sales_resolution_read_failed', __( 'The reconciliation decision could not be read.', 'extrachill-events' ) ) : ( is_array( $row ) ? $this->hydrate_resolution( $row ) : null );
+	}
+
+	private function hydrate_resolution( array $row ) {
+		foreach ( array( 'id', 'booking_id', 'report_id', 'venue_term_id', 'version', 'created_by_user_id' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		foreach ( array( 'ticket_source_id', 'supersedes_resolution_id' ) as $field ) {
+			$row[ $field ] = null === $row[ $field ] ? null : (int) $row[ $field ];
+		}
+		$stored = strtolower( (string) $row['request_hash'] );
+		return preg_match( '/^[a-f0-9]{64}$/', $stored ) && hash_equals( $stored, $this->hash( $row, array( 'booking_id', 'report_id', 'venue_term_id', 'version', 'decision', 'ticket_source_id', 'supersedes_resolution_id', 'reason', 'created_by_user_id', 'created_at' ) ) )
+			? $row
+			: new \WP_Error(
+				'sales_resolution_integrity_failed',
+				__( 'Stored reconciliation decision failed its immutable content check.', 'extrachill-events' ),
+				array(
+					'status'        => 409,
+					'resolution_id' => $row['id'],
+				)
+			);
+	}
+
+	private function get_report_row( int $report_id, bool $lock = false ) {
+		global $wpdb;
+		$table = BookingSchema::sales_reports_table();
+		$query = "SELECT * FROM {$table} WHERE id = %d LIMIT 1" . ( $lock ? ' FOR UPDATE' : '' );
+		$row   = $wpdb->get_row( $wpdb->prepare( $query, $report_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact report resolution target.
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'sales_report_read_failed', __( 'Ticket-sales evidence could not be read.', 'extrachill-events' ) ) : $row;
+	}
+
+	private function get_settlement_for_booking( int $booking_id, bool $lock = false ) {
+		global $wpdb;
+		$table = BookingSchema::settlements_table();
+		$query = "SELECT * FROM {$table} WHERE booking_id = %d LIMIT 1" . ( $lock ? ' FOR UPDATE' : '' );
+		$row   = $wpdb->get_row( $wpdb->prepare( $query, $booking_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Frozen settlement boundary.
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'settlement_read_failed', __( 'The booking settlement could not be read.', 'extrachill-events' ) ) : $row;
+	}
+
+	private function hydrate_report_row( array $row ) {
+		$source = json_decode( (string) ( $row['source_payload'] ?? '' ), true );
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $source ) || 1 !== ( $source['version'] ?? null ) || ! array_key_exists( 'data', $source ) ) {
+			return new \WP_Error( 'sales_report_source_invalid', __( 'Stored ticket-sales source evidence is malformed.', 'extrachill-events' ) );
+		}
+		foreach ( array( 'id', 'booking_id', 'event_id', 'venue_term_id', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		foreach ( array( 'ticket_source_id', 'evidence_attachment_id' ) as $field ) {
+			$row[ $field ] = null === ( $row[ $field ] ?? null ) ? null : (int) $row[ $field ];
+		}
+		$row['corrects_report_id'] = null === $row['corrects_report_id'] ? null : (int) $row['corrects_report_id'];
+		$row['source']             = $source['data'];
+		$stored_hash               = strtolower( (string) ( $row['request_hash'] ?? '' ) );
+		if ( ! preg_match( '/^[a-f0-9]{64}$/', $stored_hash ) || ! hash_equals( $stored_hash, TicketSettlementService::report_request_hash( $row ) ) ) {
+			return new \WP_Error(
+				'sales_report_integrity_failed',
+				__( 'Stored ticket-sales evidence failed its immutable content check.', 'extrachill-events' ),
+				array(
+					'status'    => 409,
+					'report_id' => $row['id'],
+				)
+			);
+		}
+		return $row;
+	}
+
+	private function hash( array $row, array $fields ): string {
+		$payload = array();
+		foreach ( $fields as $field ) {
+			$payload[ $field ] = $row[ $field ] ?? null;
+		}
+		return hash( 'sha256', wp_json_encode( $payload ) );
+	}
+
+	private function positive_integer( $value, string $field ) {
+		return is_int( $value ) && 0 < $value ? $value : new \WP_Error(
+			'invalid_ticket_reconciliation_integer',
+			__( 'A positive integer is required.', 'extrachill-events' ),
+			array(
+				'status' => 400,
+				'field'  => $field,
+			)
+		);
+	}
+
+	private function denied( $result ): \WP_Error {
+		return is_wp_error( $result ) ? $result : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+
+	private function commit() {
+		global $wpdb;
+		$result                   = $wpdb->query( 'COMMIT' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Financial attribution aggregate boundary.
+		$this->transaction_active = false;
+		return false === $result ? new \WP_Error( 'sales_reconciliation_commit_uncertain', __( 'The reconciliation transaction outcome could not be confirmed.', 'extrachill-events' ) ) : true;
+	}
+
+	private function rollback( \WP_Error $error ) {
+		global $wpdb;
+		if ( $this->transaction_active ) {
+			$wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Financial attribution rollback.
+			$this->transaction_active = false;
+		}
+		return $error;
+	}
+}

--- a/inc/Core/TicketSettlementService.php
+++ b/inc/Core/TicketSettlementService.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /** Owns validation, authorization, locking, and audit for ticket settlements. */
 class TicketSettlementService {
-	public const FORMULA_VERSION = 1;
+	public const FORMULA_VERSION = 2;
 	public const BASES           = array( 'gross_ticket_sales', 'net_ticket_sales' );
 	public const SOURCE_TYPES    = array( 'manual', 'csv_certified' );
 	public const STATUSES        = array( 'finalized', 'paid', 'void' );
@@ -29,14 +29,17 @@ class TicketSettlementService {
 	private $authorization;
 	/** @var VenueBookingConfig */
 	private $config;
+	/** @var TicketReconciliationService */
+	private $reconciliation;
 	/** @var bool */
 	private $transaction_active = false;
 
-	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, ?VenueBookingConfig $config = null ) {
-		$this->bookings      = $bookings ? $bookings : new BookingRepository();
-		$this->activity      = $activity ? $activity : new BookingActivityRepository();
-		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
-		$this->config        = $config ? $config : new VenueBookingConfig();
+	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, ?VenueBookingConfig $config = null, ?TicketReconciliationService $reconciliation = null ) {
+		$this->bookings       = $bookings ? $bookings : new BookingRepository();
+		$this->activity       = $activity ? $activity : new BookingActivityRepository();
+		$this->authorization  = $authorization ? $authorization : new VenueAuthorization();
+		$this->config         = $config ? $config : new VenueBookingConfig();
+		$this->reconciliation = $reconciliation ? $reconciliation : new TicketReconciliationService( $this->bookings, $this->activity, $this->authorization );
 	}
 
 	/** Record one immutable observation, returning an exact idempotent retry. */
@@ -65,22 +68,36 @@ class TicketSettlementService {
 		if ( is_wp_error( $identity ) ) {
 			return $this->rollback( $identity );
 		}
+		$provenance = $this->reconciliation->validate_provenance( $normalized, $booking );
+		if ( is_wp_error( $provenance ) ) {
+			return $this->rollback( $provenance );
+		}
+		$settlement = $this->get_settlement( $booking['id'], true );
+		if ( is_wp_error( $settlement ) ) {
+			return $this->rollback( $settlement );
+		}
 
-		$existing = $this->find_report_by_external( $normalized['provider'], $normalized['external_report_id'], true );
+		$existing = $this->find_report_by_external( $booking['id'], $normalized['provider'], $normalized['external_report_id'], true );
 		if ( is_wp_error( $existing ) ) {
 			return $this->rollback( $existing );
 		}
 		if ( is_array( $existing ) ) {
 			if ( hash_equals( $existing['request_hash'], $normalized['request_hash'] ) ) {
+				if ( is_array( $settlement ) && ! in_array( $existing['id'], $settlement['included_report_ids'], true ) ) {
+					return $this->rollback( $this->settlement_frozen_error( $settlement ) );
+				}
 				$committed = $this->commit();
 				return is_wp_error( $committed ) ? $committed : $existing;
 			}
 			return $this->rollback( new \WP_Error( 'sales_report_idempotency_conflict', __( 'This provider report ID is already bound to different evidence.', 'extrachill-events' ), array( 'status' => 409 ) ) );
 		}
+		if ( is_array( $settlement ) ) {
+			return $this->rollback( $this->settlement_frozen_error( $settlement ) );
+		}
 		if ( null !== $normalized['corrects_report_id'] ) {
 			$corrected = $this->get_report( $normalized['corrects_report_id'], true );
-			if ( ! is_array( $corrected ) || $corrected['booking_id'] !== $booking['id'] || $corrected['currency'] !== $normalized['currency'] ) {
-				return $this->rollback( new \WP_Error( 'invalid_sales_report_correction', __( 'A correction must identify evidence from the same booking and currency.', 'extrachill-events' ), array( 'status' => 400 ) ) );
+			if ( ! is_array( $corrected ) || $corrected['booking_id'] !== $booking['id'] || $corrected['currency'] !== $normalized['currency'] || $corrected['provider'] !== $normalized['provider'] || $corrected['ticket_source_id'] !== $normalized['ticket_source_id'] ) {
+				return $this->rollback( new \WP_Error( 'invalid_sales_report_correction', __( 'A correction must identify evidence from the same booking, currency, provider, and ticket source.', 'extrachill-events' ), array( 'status' => 400 ) ) );
 			}
 		}
 
@@ -89,12 +106,12 @@ class TicketSettlementService {
 		unset( $row['source'] );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Append-only private financial evidence.
 		if ( false === $wpdb->insert( BookingSchema::sales_reports_table(), $row ) ) {
-			$existing = $this->find_report_by_external( $normalized['provider'], $normalized['external_report_id'], true );
+			$existing = $this->find_report_by_external( $booking['id'], $normalized['provider'], $normalized['external_report_id'], true );
 			if ( is_array( $existing ) && hash_equals( $existing['request_hash'], $normalized['request_hash'] ) ) {
 				$committed = $this->commit();
 				return is_wp_error( $committed ) ? $committed : $existing;
 			}
-			return $this->rollback( new \WP_Error( 'sales_report_write_failed', __( 'The ticket-sales evidence could not be recorded.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
+			return $this->rollback( new \WP_Error( 'sales_report_write_failed', __( 'The ticket-sales evidence could not be recorded.', 'extrachill-events' ) ) );
 		}
 		$report = $this->get_report( (int) $wpdb->insert_id, true );
 		if ( ! is_array( $report ) ) {
@@ -140,9 +157,19 @@ class TicketSettlementService {
 		$offset = max( 0, $offset );
 		$rows   = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d ORDER BY id ASC LIMIT %d OFFSET %d", $booking['id'], $limit, $offset ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Immutable booking evidence page.
 		if ( '' !== (string) $wpdb->last_error ) {
-			return new \WP_Error( 'sales_report_list_failed', __( 'Ticket-sales evidence could not be listed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+			return new \WP_Error( 'sales_report_list_failed', __( 'Ticket-sales evidence could not be listed.', 'extrachill-events' ) );
 		}
-		return $this->hydrate_reports( (array) $rows );
+		$reports = $this->hydrate_reports( (array) $rows );
+		if ( is_wp_error( $reports ) ) {
+			return $reports;
+		}
+		foreach ( $reports as $report ) {
+			$identity = $this->validate_report_identity( $report, $booking );
+			if ( is_wp_error( $identity ) ) {
+				return $identity;
+			}
+		}
+		return $reports;
 	}
 
 	/** Calculate a deterministic, non-persisted settlement preview. */
@@ -172,16 +199,17 @@ class TicketSettlementService {
 		$expected_version = $this->positive_integer( $input['expected_booking_version'] ?? null, 'expected_booking_version' );
 		$expected_reports = $this->report_ids( $input['expected_report_ids'] ?? null );
 		$formula_version  = $input['formula_version'] ?? null;
+		$expected_hash    = strtolower( (string) ( $input['expected_evidence_hash'] ?? '' ) );
 		$terms            = $this->settlement_terms( $booking, $input, true );
 		foreach ( array( $expected_version, $expected_reports, $terms ) as $validated ) {
 			if ( is_wp_error( $validated ) ) {
 				return $validated;
 			}
 		}
-		if ( self::FORMULA_VERSION !== $formula_version ) {
+		if ( ! in_array( $formula_version, array( 1, self::FORMULA_VERSION ), true ) || ( self::FORMULA_VERSION === $formula_version && ! preg_match( '/^[a-f0-9]{64}$/', $expected_hash ) ) ) {
 			return new \WP_Error(
 				'settlement_formula_version_conflict',
-				__( 'The calculated settlement formula version is no longer current.', 'extrachill-events' ),
+				__( 'The calculated settlement formula version or evidence hash is invalid.', 'extrachill-events' ),
 				array(
 					'status'                  => 409,
 					'current_formula_version' => self::FORMULA_VERSION,
@@ -201,7 +229,7 @@ class TicketSettlementService {
 			return $this->rollback( $existing );
 		}
 		if ( is_array( $existing ) ) {
-			if ( ! $this->matches_finalization_retry( $existing, $expected_version, $expected_reports, $formula_version, $terms ) ) {
+			if ( ! $this->matches_finalization_retry( $existing, $expected_version, $expected_reports, $expected_hash, $formula_version, $terms ) ) {
 				return $this->rollback(
 					new \WP_Error(
 						'settlement_already_finalized',
@@ -220,6 +248,18 @@ class TicketSettlementService {
 			$committed = $this->commit();
 			return is_wp_error( $committed ) ? $committed : $existing;
 		}
+		if ( self::FORMULA_VERSION !== $formula_version ) {
+			return $this->rollback(
+				new \WP_Error(
+					'settlement_formula_version_conflict',
+					__( 'The calculated settlement formula version is no longer current.', 'extrachill-events' ),
+					array(
+						'status'                  => 409,
+						'current_formula_version' => self::FORMULA_VERSION,
+					)
+				)
+			);
+		}
 		if ( $booking['version'] !== $expected_version ) {
 			return $this->rollback(
 				new \WP_Error(
@@ -236,7 +276,7 @@ class TicketSettlementService {
 		if ( is_wp_error( $calculation ) ) {
 			return $this->rollback( $calculation );
 		}
-		if ( $calculation['included_report_ids'] !== $expected_reports ) {
+		if ( $calculation['included_report_ids'] !== $expected_reports || ! hash_equals( $calculation['evidence_hash'], $expected_hash ) ) {
 			return $this->rollback(
 				new \WP_Error(
 					'settlement_evidence_conflict',
@@ -280,7 +320,7 @@ class TicketSettlementService {
 		$row['integrity_hash'] = $this->settlement_integrity_hash( $row );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- One frozen private settlement per booking.
 		if ( false === $wpdb->insert( BookingSchema::settlements_table(), $row ) ) {
-			return $this->rollback( new \WP_Error( 'settlement_finalize_failed', __( 'The booking settlement could not be finalized.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) );
+			return $this->rollback( new \WP_Error( 'settlement_finalize_failed', __( 'The booking settlement could not be finalized.', 'extrachill-events' ) ) );
 		}
 		$settlement = $this->get_settlement( $booking['id'], true );
 		if ( ! is_array( $settlement ) ) {
@@ -447,8 +487,7 @@ class TicketSettlementService {
 					'settlement_version_conflict',
 					__( 'The booking settlement changed before the audit transition was saved.', 'extrachill-events' ),
 					array(
-						'status'         => 409,
-						'database_error' => $wpdb->last_error,
+						'status' => 409,
 					)
 				)
 			);
@@ -465,14 +504,14 @@ class TicketSettlementService {
 	private function calculate_from_storage( array $booking, array $terms, bool $lock ) {
 		global $wpdb;
 		$table = BookingSchema::sales_reports_table();
-		$query = "SELECT * FROM {$table} WHERE booking_id = %d AND currency = %s ORDER BY id ASC";
+		$query = "SELECT * FROM {$table} WHERE booking_id = %d ORDER BY id ASC";
 		if ( $lock ) {
 			$query .= ' FOR UPDATE';
 		}
-		$sql  = $wpdb->prepare( $query, $booking['id'], $terms['currency'] ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Internal lock suffix and trusted current-prefix table.
+		$sql  = $wpdb->prepare( $query, $booking['id'] ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Internal lock suffix and trusted current-prefix table.
 		$rows = $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Complete immutable evidence snapshot.
 		if ( '' !== (string) $wpdb->last_error ) {
-			return new \WP_Error( 'sales_report_list_failed', __( 'Ticket-sales evidence could not be read for settlement.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+			return new \WP_Error( 'sales_report_list_failed', __( 'Ticket-sales evidence could not be read for settlement.', 'extrachill-events' ) );
 		}
 		if ( $lock ) {
 			$this->after_evidence_locked( $booking );
@@ -484,6 +523,21 @@ class TicketSettlementService {
 		if ( empty( $reports ) ) {
 			return new \WP_Error( 'settlement_evidence_required', __( 'At least one ticket-sales report is required for settlement.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
+		$reports = $this->reconciliation->admitted_reports( $booking, $reports );
+		if ( is_wp_error( $reports ) ) {
+			return $reports;
+		}
+		$reports = array_values(
+			array_filter(
+				$reports,
+				static function ( array $report ) use ( $terms ): bool {
+					return $report['currency'] === $terms['currency'];
+				}
+			)
+		);
+		if ( empty( $reports ) ) {
+			return new \WP_Error( 'settlement_evidence_required', __( 'At least one reconciled ticket-sales report is required for settlement.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
 		$field        = 'gross_ticket_sales' === $terms['basis'] ? 'gross_minor' : 'net_minor';
 		$basis_amount = 0;
 		$ids          = array();
@@ -494,9 +548,14 @@ class TicketSettlementService {
 			}
 			$basis_amount += $report[ $field ];
 			$ids[]         = $report['id'];
-			$evidence[]    = array(
+			$resolution    = $this->reconciliation->settlement_resolution_evidence( $report['id'], $lock );
+			if ( is_wp_error( $resolution ) ) {
+				return $resolution;
+			}
+			$evidence[] = array(
 				'id'           => $report['id'],
 				'request_hash' => $report['request_hash'],
+				'resolution'   => $resolution,
 			);
 		}
 		$share = self::basis_points_amount( $basis_amount, $terms['basis_points'] );
@@ -564,17 +623,25 @@ class TicketSettlementService {
 		if ( null === $booking['event_id'] ) {
 			return new \WP_Error( 'sales_report_event_required', __( 'Ticket-sales evidence requires a booking linked to an event.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
-		$provider   = mb_substr( sanitize_key( (string) ( $input['provider'] ?? '' ) ), 0, 64 );
-		$external   = $this->required_text( $input['external_report_id'] ?? null, 'external_report_id', 191 );
-		$source     = sanitize_key( (string) ( $input['source_type'] ?? '' ) );
-		$start      = $this->datetime( $input['period_start'] ?? null, 'period_start' );
-		$end        = $this->datetime( $input['period_end'] ?? null, 'period_end' );
-		$currency   = strtoupper( sanitize_text_field( (string) ( $input['currency'] ?? '' ) ) );
+		$provider         = mb_substr( sanitize_key( (string) ( $input['provider'] ?? '' ) ), 0, 64 );
+		$external         = $this->required_text( $input['external_report_id'] ?? null, 'external_report_id', 191 );
+		$source           = sanitize_key( (string) ( $input['source_type'] ?? '' ) );
+		$start            = $this->datetime( $input['period_start'] ?? null, 'period_start' );
+		$end              = $this->datetime( $input['period_end'] ?? null, 'period_end' );
+		$currency         = strtoupper( sanitize_text_field( (string) ( $input['currency'] ?? '' ) ) );
+		$ticket_source_id = null;
+		$attachment_id    = null;
+		if ( array_key_exists( 'ticket_source_id', $input ) && null !== $input['ticket_source_id'] ) {
+			$ticket_source_id = $this->positive_integer( $input['ticket_source_id'], 'ticket_source_id' );
+		}
+		if ( array_key_exists( 'evidence_attachment_id', $input ) && null !== $input['evidence_attachment_id'] ) {
+			$attachment_id = $this->positive_integer( $input['evidence_attachment_id'], 'evidence_attachment_id' );
+		}
 		$correction = null;
 		if ( array_key_exists( 'corrects_report_id', $input ) && null !== $input['corrects_report_id'] ) {
 			$correction = $this->positive_integer( $input['corrects_report_id'], 'corrects_report_id' );
 		}
-		foreach ( array( $external, $start, $end, $correction ) as $validated ) {
+		foreach ( array( $external, $start, $end, $correction, $ticket_source_id, $attachment_id ) as $validated ) {
 			if ( is_wp_error( $validated ) ) {
 				return $validated;
 			}
@@ -608,26 +675,31 @@ class TicketSettlementService {
 		if ( false === $source_payload ) {
 			return new \WP_Error( 'sales_report_source_encode_failed', __( 'Ticket-sales source evidence could not be encoded.', 'extrachill-events' ), array( 'json_error' => json_last_error_msg() ) );
 		}
+		if ( 8192 < strlen( $source_payload ) ) {
+			return new \WP_Error( 'sales_report_source_too_large', __( 'Ticket-sales source evidence exceeds the bounded provenance limit.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
 		$row                 = array_merge(
 			array(
-				'booking_id'         => $booking['id'],
-				'event_id'           => $booking['event_id'],
-				'venue_term_id'      => $booking['venue_term_id'],
-				'provider'           => $provider,
-				'external_report_id' => $external,
-				'source_type'        => $source,
-				'period_start'       => $start,
-				'period_end'         => $end,
-				'currency'           => $currency,
-				'corrects_report_id' => $correction,
-				'source_payload'     => $source_payload,
-				'created_by_user_id' => $actor_id,
-				'created_at'         => gmdate( 'Y-m-d H:i:s' ),
+				'booking_id'             => $booking['id'],
+				'event_id'               => $booking['event_id'],
+				'venue_term_id'          => $booking['venue_term_id'],
+				'ticket_source_id'       => $ticket_source_id,
+				'evidence_attachment_id' => $attachment_id,
+				'provider'               => $provider,
+				'external_report_id'     => $external,
+				'source_type'            => $source,
+				'period_start'           => $start,
+				'period_end'             => $end,
+				'currency'               => $currency,
+				'corrects_report_id'     => $correction,
+				'source_payload'         => $source_payload,
+				'created_by_user_id'     => $actor_id,
+				'created_at'             => gmdate( 'Y-m-d H:i:s' ),
 			),
 			$integers
 		);
 		$row['source']       = $input['source'];
-		$row['request_hash'] = $this->report_request_hash( $row );
+		$row['request_hash'] = self::report_request_hash( $row );
 		unset( $row['source'] );
 		return $row;
 	}
@@ -638,10 +710,21 @@ class TicketSettlementService {
 			: new \WP_Error( 'sales_report_booking_changed', __( 'The booking identity changed before evidence was recorded.', 'extrachill-events' ), array( 'status' => 409 ) );
 	}
 
+	private function settlement_frozen_error( array $settlement ): \WP_Error {
+		return new \WP_Error(
+			'sales_report_settlement_frozen',
+			__( 'Ticket-sales evidence cannot change after settlement is finalized.', 'extrachill-events' ),
+			array(
+				'status'        => 409,
+				'settlement_id' => $settlement['id'],
+			)
+		);
+	}
+
 	private function begin_authorized( array $booking, int $actor_id, string $action ) {
 		global $wpdb;
 		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Financial aggregate boundary.
-			return new \WP_Error( 'settlement_transaction_start_failed', __( 'The ticket settlement transaction could not start.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+			return new \WP_Error( 'settlement_transaction_start_failed', __( 'The ticket settlement transaction could not start.', 'extrachill-events' ) );
 		}
 		$this->transaction_active = true;
 		$table                    = BookingSchema::memberships_table();
@@ -667,16 +750,16 @@ class TicketSettlementService {
 		return is_array( $booking ) ? $booking : ( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ), array( 'status' => 404 ) ) );
 	}
 
-	private function find_report_by_external( string $provider, string $external_id, bool $lock = false ) {
+	private function find_report_by_external( int $booking_id, string $provider, string $external_id, bool $lock = false ) {
 		global $wpdb;
 		$table = BookingSchema::sales_reports_table();
-		$query = "SELECT * FROM {$table} WHERE provider = %s AND external_report_id = %s LIMIT 1";
+		$query = "SELECT * FROM {$table} WHERE booking_id = %d AND provider = %s AND external_report_id = %s LIMIT 1";
 		if ( $lock ) {
 			$query .= ' FOR UPDATE';
 		}
-		$row = $wpdb->get_row( $wpdb->prepare( $query, $provider, $external_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Unique immutable evidence lookup with internal lock suffix.
+		$row = $wpdb->get_row( $wpdb->prepare( $query, $booking_id, $provider, $external_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Booking-scoped immutable evidence lookup with internal lock suffix.
 		if ( '' !== (string) $wpdb->last_error ) {
-			return new \WP_Error( 'sales_report_read_failed', __( 'Ticket-sales evidence could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+			return new \WP_Error( 'sales_report_read_failed', __( 'Ticket-sales evidence could not be read.', 'extrachill-events' ) );
 		}
 		return is_array( $row ) ? $this->hydrate_report( $row ) : null;
 	}
@@ -690,7 +773,7 @@ class TicketSettlementService {
 		}
 		$row = $wpdb->get_row( $wpdb->prepare( $query, $report_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact evidence read with internal lock suffix.
 		if ( '' !== (string) $wpdb->last_error ) {
-			return new \WP_Error( 'sales_report_read_failed', __( 'Ticket-sales evidence could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+			return new \WP_Error( 'sales_report_read_failed', __( 'Ticket-sales evidence could not be read.', 'extrachill-events' ) );
 		}
 		return is_array( $row ) ? $this->hydrate_report( $row ) : null;
 	}
@@ -704,7 +787,7 @@ class TicketSettlementService {
 		}
 		$row = $wpdb->get_row( $wpdb->prepare( $query, $booking_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- One settlement per booking with internal lock suffix.
 		if ( '' !== (string) $wpdb->last_error ) {
-			return new \WP_Error( 'settlement_read_failed', __( 'The booking settlement could not be read.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+			return new \WP_Error( 'settlement_read_failed', __( 'The booking settlement could not be read.', 'extrachill-events' ) );
 		}
 		return is_array( $row ) ? $this->hydrate_settlement( $row ) : null;
 	}
@@ -729,11 +812,13 @@ class TicketSettlementService {
 		foreach ( array( 'id', 'booking_id', 'event_id', 'venue_term_id', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'created_by_user_id' ) as $field ) {
 			$row[ $field ] = (int) $row[ $field ];
 		}
-		$row['corrects_report_id'] = null === $row['corrects_report_id'] ? null : (int) $row['corrects_report_id'];
-		$row['source']             = $source['data'];
+		$row['corrects_report_id']     = null === $row['corrects_report_id'] ? null : (int) $row['corrects_report_id'];
+		$row['ticket_source_id']       = null === ( $row['ticket_source_id'] ?? null ) ? null : (int) $row['ticket_source_id'];
+		$row['evidence_attachment_id'] = null === ( $row['evidence_attachment_id'] ?? null ) ? null : (int) $row['evidence_attachment_id'];
+		$row['source']                 = $source['data'];
 		unset( $row['source_payload'] );
 		$stored_hash = strtolower( (string) ( $row['request_hash'] ?? '' ) );
-		if ( ! preg_match( '/^[a-f0-9]{64}$/', $stored_hash ) || ! hash_equals( $stored_hash, $this->report_request_hash( $row ) ) ) {
+		if ( ! preg_match( '/^[a-f0-9]{64}$/', $stored_hash ) || ! hash_equals( $stored_hash, self::report_request_hash( $row ) ) ) {
 			return new \WP_Error(
 				'sales_report_integrity_failed',
 				__( 'Stored ticket-sales evidence failed its immutable content check.', 'extrachill-events' ),
@@ -744,6 +829,7 @@ class TicketSettlementService {
 			);
 		}
 		$row['request_hash'] = $stored_hash;
+		$row['source']       = $this->project_source( $row['source'] );
 		return $row;
 	}
 
@@ -779,10 +865,11 @@ class TicketSettlementService {
 		unset( $booking );
 	}
 
-	private function matches_finalization_retry( array $settlement, int $booking_version, array $report_ids, int $formula_version, array $terms ): bool {
+	private function matches_finalization_retry( array $settlement, int $booking_version, array $report_ids, string $evidence_hash, int $formula_version, array $terms ): bool {
 		return $settlement['booking_version'] === $booking_version
 			&& $settlement['included_report_ids'] === $report_ids
 			&& $settlement['formula_version'] === $formula_version
+			&& ( 1 === $formula_version || hash_equals( $settlement['evidence_hash'], $evidence_hash ) )
 			&& $settlement['basis'] === $terms['basis']
 			&& $settlement['basis_points'] === $terms['basis_points']
 			&& $settlement['currency'] === $terms['currency']
@@ -806,10 +893,18 @@ class TicketSettlementService {
 					)
 				);
 			}
-			$evidence[] = array(
+			$item = array(
 				'id'           => $report['id'],
 				'request_hash' => $report['request_hash'],
 			);
+			if ( 2 <= $settlement['formula_version'] ) {
+				$resolution = $this->reconciliation->settlement_resolution_evidence( $report['id'], $lock );
+				if ( is_wp_error( $resolution ) ) {
+					return $resolution;
+				}
+				$item['resolution'] = $resolution;
+			}
+			$evidence[] = $item;
 		}
 		return hash_equals( $settlement['evidence_hash'], $this->evidence_hash( $evidence ) )
 			? true
@@ -824,7 +919,7 @@ class TicketSettlementService {
 	}
 
 	private function evidence_hash( array $evidence ): string {
-		return hash( 'sha256', wp_json_encode( $this->canonicalize( $evidence ) ) );
+		return hash( 'sha256', wp_json_encode( self::canonicalize( $evidence ) ) );
 	}
 
 	private function settlement_integrity_hash( array $settlement ): string {
@@ -847,17 +942,36 @@ class TicketSettlementService {
 			'adjustment_minor'    => (int) ( $settlement['adjustment_minor'] ?? 0 ),
 			'amount_due_minor'    => (int) ( $settlement['amount_due_minor'] ?? 0 ),
 		);
-		return hash( 'sha256', wp_json_encode( $this->canonicalize( $payload ) ) );
+		return hash( 'sha256', wp_json_encode( self::canonicalize( $payload ) ) );
 	}
 
-	private function report_request_hash( array $report ): string {
-		$fields   = array( 'booking_id', 'event_id', 'venue_term_id', 'provider', 'external_report_id', 'source_type', 'period_start', 'period_end', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'currency', 'corrects_report_id' );
+	/** Return the canonical immutable report hash shared with diagnostics. */
+	public static function report_request_hash( array $report ): string {
+		$fields = array( 'booking_id', 'event_id', 'venue_term_id', 'provider', 'external_report_id', 'source_type', 'period_start', 'period_end', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'currency', 'corrects_report_id' );
+		if ( null !== ( $report['ticket_source_id'] ?? null ) || null !== ( $report['evidence_attachment_id'] ?? null ) ) {
+			array_splice( $fields, 3, 0, array( 'ticket_source_id', 'evidence_attachment_id' ) );
+		}
 		$hashable = array();
 		foreach ( $fields as $field ) {
 			$hashable[ $field ] = $report[ $field ] ?? null;
 		}
 		$hashable['source'] = $report['source'] ?? null;
-		return hash( 'sha256', wp_json_encode( $this->canonicalize( $hashable ) ) );
+		return hash( 'sha256', wp_json_encode( self::canonicalize( $hashable ) ) );
+	}
+
+	/** Return only server-owned provenance fields after integrity verification. */
+	private function project_source( $value ): array {
+		$projection = array( 'redacted' => true );
+		if ( ! is_array( $value ) ) {
+			return $projection;
+		}
+		if ( is_string( $value['attachment_id'] ?? null ) && wp_is_uuid( $value['attachment_id'], 4 ) ) {
+			$projection['attachment_id'] = $value['attachment_id'];
+		}
+		if ( is_int( $value['row'] ?? null ) && 1 < $value['row'] && 1002 >= $value['row'] ) {
+			$projection['row'] = $value['row'];
+		}
+		return $projection;
 	}
 
 	private function append_settlement_audit( int $booking_id, string $kind, int $actor_id, array $settlement ) {
@@ -940,7 +1054,7 @@ class TicketSettlementService {
 		);
 	}
 
-	private function canonicalize( $value ) {
+	private static function canonicalize( $value ) {
 		if ( ! is_array( $value ) ) {
 			return $value;
 		}
@@ -948,7 +1062,7 @@ class TicketSettlementService {
 			ksort( $value );
 		}
 		foreach ( $value as $key => $item ) {
-			$value[ $key ] = $this->canonicalize( $item );
+			$value[ $key ] = self::canonicalize( $item );
 		}
 		return $value;
 	}
@@ -961,7 +1075,7 @@ class TicketSettlementService {
 		global $wpdb;
 		$result                   = $wpdb->query( 'COMMIT' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Financial aggregate boundary.
 		$this->transaction_active = false;
-		return false === $result ? new \WP_Error( 'settlement_commit_uncertain', __( 'The ticket settlement transaction outcome could not be confirmed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) ) : true;
+		return false === $result ? new \WP_Error( 'settlement_commit_uncertain', __( 'The ticket settlement transaction outcome could not be confirmed.', 'extrachill-events' ) ) : true;
 	}
 
 	private function rollback( \WP_Error $error ) {

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -20,6 +20,7 @@
 			<file>tests/BookingMarketingTest.php</file>
 			<file>tests/BookingMarketingDelegatedSchemaTest.php</file>
 			<file>tests/TicketSettlementTest.php</file>
+			<file>tests/TicketReconciliationTest.php</file>
 			<file>tests/BookingNotificationTest.php</file>
 			<file>tests/LocalSupportNotificationTest.php</file>
 			<file>tests/CanonicalEventPublicationGuardTest.php</file>

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -309,7 +309,7 @@ final class BookingFoundationTest extends TestCase {
 		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '11';
 
 		$this->assertTrue( BookingSchema::maybe_install() );
-		$this->assertSame( '12', get_option( BookingSchema::VERSION_OPTION ) );
+		$this->assertSame( '13', get_option( BookingSchema::VERSION_OPTION ) );
 		$this->assertArrayHasKey( $sales, $wpdb->schemas );
 		$this->assertArrayHasKey( $settlements, $wpdb->schemas );
 		$this->assertSame( 'INNODB', strtoupper( $wpdb->engines[ $sales ] ) );

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -132,7 +132,7 @@ final class BookingHoldTest extends TestCase {
 	}
 
 	public function test_combined_schema_installs_site_scoped_holds_contract(): void {
-		$this->assertSame( '12', BookingSchema::SCHEMA_VERSION );
+		$this->assertSame( '13', BookingSchema::SCHEMA_VERSION );
 		$this->assertTrue( BookingSchema::install() );
 		$table = BookingSchema::holds_table();
 		$this->assertSame( 'wp_7_ec_booking_holds', $table );

--- a/tests/BookingMutationTest.php
+++ b/tests/BookingMutationTest.php
@@ -118,7 +118,7 @@ final class BookingMutationTest extends TestCase {
 	}
 
 	public function test_schema_and_public_inquiry_separate_requested_from_authoritative_fields(): void {
-		$this->assertSame( '12', BookingSchema::SCHEMA_VERSION );
+		$this->assertSame( '13', BookingSchema::SCHEMA_VERSION );
 		$this->assertTrue( BookingSchema::install() );
 		$columns = $GLOBALS['wpdb']->schemas[ BookingSchema::bookings_table() ]['columns'];
 		foreach ( array( 'requested_space_key', 'performance_start_at', 'performance_end_at', 'production_payload', 'confirmed_deal_payload' ) as $column ) {

--- a/tests/MySQLIntegration/BookingAttachmentMySQLIntegrationTest.php
+++ b/tests/MySQLIntegration/BookingAttachmentMySQLIntegrationTest.php
@@ -16,6 +16,7 @@ use ExtraChillEvents\Core\BookingPrivateFileProvider;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\TicketSettlementService;
+use ExtraChillEvents\Core\TicketReconciliationService;
 use ExtraChillEvents\Core\VenueBookingConfig;
 use ExtraChillEvents\Core\VenueAuthorization;
 use ExtraChillEvents\Core\VenueMembershipRepository;
@@ -182,7 +183,7 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 			'post',
 			array( 'public' => false )
 		);
-		$venue          = self::factory()->term->create_and_get(
+		$venue = self::factory()->term->create_and_get(
 			array(
 				'taxonomy' => 'venue',
 				'name'     => 'Integration Room ' . wp_generate_uuid4(),
@@ -215,7 +216,7 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 		if ( $this->contender instanceof mysqli ) {
 			$this->contender->close();
 		}
-		foreach ( array( BookingSchema::settlements_table(), BookingSchema::sales_reports_table(), BookingSchema::holds_table(), BookingSchema::attachment_deliveries_table(), BookingSchema::attachments_table(), BookingSchema::activity_table(), BookingSchema::bookings_table(), BookingSchema::memberships_table() ) as $table ) {
+		foreach ( array( BookingSchema::settlements_table(), BookingSchema::sales_resolutions_table(), BookingSchema::sales_reports_table(), BookingSchema::ticket_sources_table(), BookingSchema::holds_table(), BookingSchema::attachment_deliveries_table(), BookingSchema::attachments_table(), BookingSchema::activity_table(), BookingSchema::bookings_table(), BookingSchema::memberships_table() ) as $table ) {
 			$wpdb->query( "DROP TABLE IF EXISTS {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Disposable test database cleanup.
 		}
 		delete_option( BookingSchema::VERSION_OPTION );
@@ -315,9 +316,32 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 		$service   = new TicketSettlementMySQLProbeService();
 		$abilities = $this->register_settlement_abilities( $service );
 		wp_set_current_user( $this->actor_id );
+		$source = ( new TicketReconciliationService() )->register_source(
+			array(
+				'booking_id' => $booking['id'],
+				'provider'   => 'manual-certified',
+				'source_key' => 'primary',
+				'ticket_url' => 'https://tickets.example.test/mysql-primary?token=private',
+			),
+			$this->actor_id
+		);
+		$this->assertIsArray( $source, is_wp_error( $source ) ? $source->get_error_code() : '' );
+		$this->assertSame(
+			$source,
+			( new TicketReconciliationService() )->register_source(
+				array(
+					'booking_id' => $booking['id'],
+					'provider'   => 'manual-certified',
+					'source_key' => 'primary',
+					'ticket_url' => 'https://tickets.example.test/mysql-primary?token=private',
+				),
+				$this->actor_id
+			)
+		);
 		$report = $abilities['extrachill/record-booking-ticket-sales']->execute(
 			array(
 				'booking_id'         => $booking['id'],
+				'ticket_source_id'   => $source['id'],
 				'provider'           => 'manual-certified',
 				'external_report_id' => 'mysql-settlement-report-1',
 				'source_type'        => 'manual',
@@ -375,6 +399,7 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 				'booking_id'               => $booking['id'],
 				'expected_booking_version' => $booking['version'],
 				'expected_report_ids'      => $preview['included_report_ids'],
+				'expected_evidence_hash'   => $preview['evidence_hash'],
 				'basis'                    => $preview['basis'],
 				'basis_points'             => $preview['basis_points'],
 				'currency'                 => $preview['currency'],
@@ -429,7 +454,17 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 		);
 		$void_booking            = $bookings->claim_event( $void_booking['id'], $void_event_id, $void_booking['version'] );
 		$this->assertIsArray( $void_booking, is_wp_error( $void_booking ) ? $void_booking->get_error_code() : '' );
-		$this->assertIsArray( $abilities['extrachill/record-booking-ticket-sales']->execute( $this->settlement_report_input( $void_booking['id'], 'mysql-settlement-void-report' ) ) );
+		$void_source = ( new TicketReconciliationService() )->register_source(
+			array(
+				'booking_id' => $void_booking['id'],
+				'provider'   => 'manual-certified',
+				'source_key' => 'primary',
+				'ticket_url' => 'https://tickets.example.test/mysql-void',
+			),
+			$this->actor_id
+		);
+		$this->assertIsArray( $void_source, is_wp_error( $void_source ) ? $void_source->get_error_code() : '' );
+		$this->assertIsArray( $abilities['extrachill/record-booking-ticket-sales']->execute( $this->settlement_report_input( $void_booking['id'], 'mysql-settlement-void-report', $void_source['id'] ) ) );
 		$void_preview = $abilities['extrachill/calculate-booking-settlement']->execute(
 			array(
 				'booking_id'   => $void_booking['id'],
@@ -444,6 +479,7 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 				'booking_id'               => $void_booking['id'],
 				'expected_booking_version' => $void_preview['booking_version'],
 				'expected_report_ids'      => $void_preview['included_report_ids'],
+				'expected_evidence_hash'   => $void_preview['evidence_hash'],
 				'basis'                    => $void_preview['basis'],
 				'basis_points'             => $void_preview['basis_points'],
 				'currency'                 => $void_preview['currency'],
@@ -466,7 +502,7 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 
 	/** Register settlement definitions into the real Core Abilities registry. */
 	private function register_settlement_abilities( TicketSettlementService $service ): array {
-		$names = array( 'extrachill/record-booking-ticket-sales', 'extrachill/list-booking-ticket-sales', 'extrachill/calculate-booking-settlement', 'extrachill/finalize-booking-settlement', 'extrachill/mark-booking-settlement-paid', 'extrachill/void-booking-settlement' );
+		$names = array( 'extrachill/register-booking-ticket-source', 'extrachill/list-booking-ticket-sources', 'extrachill/record-booking-ticket-sales', 'extrachill/import-booking-ticket-sales-csv', 'extrachill/list-booking-ticket-sales', 'extrachill/diagnose-booking-ticket-sales', 'extrachill/resolve-booking-ticket-sales', 'extrachill/calculate-booking-settlement', 'extrachill/finalize-booking-settlement', 'extrachill/mark-booking-settlement-paid', 'extrachill/void-booking-settlement' );
 		foreach ( $names as $name ) {
 			if ( wp_has_ability( $name ) ) {
 				wp_unregister_ability( $name );
@@ -490,9 +526,10 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 	}
 
 	/** Build valid immutable evidence for an ability execution. */
-	private function settlement_report_input( int $booking_id, string $external_id ): array {
+	private function settlement_report_input( int $booking_id, string $external_id, int $source_id ): array {
 		return array(
 			'booking_id'         => $booking_id,
+			'ticket_source_id'   => $source_id,
 			'provider'           => 'manual-certified',
 			'external_report_id' => $external_id,
 			'source_type'        => 'manual',
@@ -547,5 +584,4 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 		$scope = get_current_blog_id() . ':' . BookingSchema::attachments_table() . ':' . $reference;
 		return 'ec_booking_file_' . substr( hash( 'sha256', $scope ), 0, 40 );
 	}
-
 }

--- a/tests/MySQLIntegration/BookingSchemaMultisiteTest.php
+++ b/tests/MySQLIntegration/BookingSchemaMultisiteTest.php
@@ -31,14 +31,16 @@ final class BookingSchemaMultisiteTest extends WP_UnitTestCase {
 				BookingSchema::invitations_table(),
 				BookingSchema::onboarding_audit_table(),
 				BookingSchema::holds_table(),
+				BookingSchema::ticket_sources_table(),
 				BookingSchema::sales_reports_table(),
+				BookingSchema::sales_resolutions_table(),
 				BookingSchema::settlements_table(),
 			);
 
 			$this->assertSame( $prefix, $wpdb->prefix );
 			$this->assertTrue( BookingSchema::is_ready() );
 			$this->assertTrue( BookingSchema::health() );
-			$this->assertCount( 12, $tables );
+			$this->assertCount( 14, $tables );
 			foreach ( $tables as $table ) {
 				$this->assertStringStartsWith( $prefix, $table );
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema integration assertion.
@@ -52,5 +54,55 @@ final class BookingSchemaMultisiteTest extends WP_UnitTestCase {
 		}
 
 		$this->assertSame( 1, get_current_blog_id() );
+	}
+
+	/** Verify the v12 global provider index is replaced without dropping evidence. */
+	public function test_v12_sales_report_index_upgrade_preserves_rows(): void {
+		global $wpdb;
+
+		switch_to_blog( 7 );
+		try {
+			$table       = BookingSchema::sales_reports_table();
+			$external_id = 'legacy-' . wp_generate_uuid4();
+			$wpdb->query( "ALTER TABLE `{$table}` DROP INDEX `provider_external_report`, ADD UNIQUE KEY `provider_external_report` (`provider`, `external_report_id`)" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Recreates the exact v12 index in a disposable test database.
+			$this->assertSame( '', (string) $wpdb->last_error );
+			$inserted = $wpdb->insert(
+				$table,
+				array(
+					'booking_id'         => 987654,
+					'event_id'           => 876543,
+					'venue_term_id'      => 765432,
+					'provider'           => 'legacy-provider',
+					'external_report_id' => $external_id,
+					'source_type'        => 'manual',
+					'period_start'       => '2026-07-01 00:00:00',
+					'period_end'         => '2026-07-01 23:59:59',
+					'tickets_sold'       => 1,
+					'tickets_refunded'   => 0,
+					'gross_minor'        => 100,
+					'fees_minor'         => 0,
+					'tax_minor'          => 0,
+					'refunds_minor'      => 0,
+					'net_minor'          => 100,
+					'currency'           => 'USD',
+					'source_payload'     => '{"version":1,"data":{}}',
+					'request_hash'       => str_repeat( 'a', 64 ),
+					'created_by_user_id' => 1,
+					'created_at'         => '2026-07-01 00:00:00',
+				)
+			); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Disposable migration fixture.
+			$this->assertSame( 1, $inserted );
+			update_option( BookingSchema::VERSION_OPTION, '12', false );
+
+			$this->assertTrue( BookingSchema::maybe_install() );
+			$this->assertSame( '13', get_option( BookingSchema::VERSION_OPTION ) );
+			$this->assertSame( '987654', $wpdb->get_var( $wpdb->prepare( "SELECT booking_id FROM `{$table}` WHERE external_report_id = %s", $external_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms migration preserved the fixture.
+
+			$index_rows = $wpdb->get_results( "SHOW INDEX FROM `{$table}` WHERE Key_name = 'provider_external_report'", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Verifies the repaired real-MySQL index.
+			usort( $index_rows, static fn( array $left, array $right ): int => (int) $left['Seq_in_index'] <=> (int) $right['Seq_in_index'] );
+			$this->assertSame( array( 'booking_id', 'provider', 'external_report_id' ), array_column( $index_rows, 'Column_name' ) );
+		} finally {
+			restore_current_blog();
+		}
 	}
 }

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -240,7 +240,10 @@ if ( ! function_exists( 'wp_get_object_terms' ) ) {
 if ( ! function_exists( 'extrachill_events_resolve_artist_term' ) ) {
 	function extrachill_events_resolve_artist_term( $artist_term_id ) {
 		$mapped = $GLOBALS['ec_artist_test']['artist_mappings'][ (int) $artist_term_id ] ?? 0;
-		return $mapped > 0 ? array( 'term_id' => $mapped, 'term_slug' => 'artist-' . $mapped ) : new WP_Error( 'artist_mapping_missing' );
+		return $mapped > 0 ? array(
+			'term_id'   => $mapped,
+			'term_slug' => 'artist-' . $mapped,
+		) : new WP_Error( 'artist_mapping_missing' );
 	}
 }
 if ( ! function_exists( 'ec_user_can' ) ) {
@@ -350,76 +353,76 @@ if ( ! function_exists( 'do_action' ) ) {
 
 /** Stateful wpdb fake that enforces the persistence contracts under test. */
 final class BookingWpdb {
-	public $prefix                            = 'wp_7_';
-	public $terms                             = 'wp_7_terms';
-	public $posts                             = 'wp_7_posts';
-	public $term_relationships                = 'wp_7_term_relationships';
-	public $term_taxonomy                     = 'wp_7_term_taxonomy';
-	public $insert_id                         = 0;
-	public $last_error                        = '';
-	public $rows                              = array();
-	public $schemas                           = array();
-	public $engines                           = array();
-	public $schema_omit                       = array();
-	public $schema_queries                    = 0;
-	public $dropped_indexes                   = array();
-	public $fail_reads                        = false;
-	public $fail_activity_reads               = false;
-	public $fail_attachment_reference_reads   = false;
-	public $fail_inserts                      = false;
-	public $fail_updates                      = false;
-	public $fail_communication_state_updates = false;
-	public $fail_engine_repair                = false;
-	public $race_activity_insert              = false;
-	public $race_booking_insert               = false;
-	public $race_booking_hash                 = null;
-	public $race_activity_read_fail           = false;
-	public $race_event_read_fail              = false;
-	public $concurrent_role_migration         = false;
-	public $reads_before_failure              = null;
-	public $last_query                        = '';
-	public $fail_activity_inserts             = false;
-	public $fail_activity_kinds               = array();
-	public $fail_transaction_start            = false;
-	public $fail_transaction_commit           = false;
-	public $fail_transaction_rollback         = false;
-	public $rollback_queries                  = 0;
-	public $after_membership_lock             = null;
-	public $after_booking_lock                = null;
-	public $after_venue_lock                  = null;
-	public $fail_venue_lock                   = false;
-	public $venue_lock_queries                = 0;
-	public $reference_locks                   = array();
-	public $lock_sequence                     = array();
-	public $reference_lock_queries            = 0;
-	public $fail_reference_unlock             = false;
-	public $after_reference_lock              = null;
-	public $after_reference_unlock            = null;
-	public $transaction_active                = false;
-	public $natural_key_reads_in_transaction  = 0;
-	public $get_lock_result                   = 1;
-	public $release_lock_result               = 1;
-	public $release_lock_results              = array();
-	public $release_lock_errors               = array();
-	public $lock_names                        = array();
-	public $event_dates                       = array();
-	public $booking_lock_queries              = 0;
-	public $communication_state_queries       = 0;
-	public $communication_attempt_queries     = 0;
-	public $communication_public_rows_returned = 0;
-	public $pending_reminder_rows_returned    = 0;
-	public $pending_reminder_query_limits     = array();
-	public $pending_reminder_query_cursors    = array();
-	public $elapse_hold_after_membership_lock = null;
-	public $elapse_hold_before_release_update = null;
+	public $prefix                               = 'wp_7_';
+	public $terms                                = 'wp_7_terms';
+	public $posts                                = 'wp_7_posts';
+	public $term_relationships                   = 'wp_7_term_relationships';
+	public $term_taxonomy                        = 'wp_7_term_taxonomy';
+	public $insert_id                            = 0;
+	public $last_error                           = '';
+	public $rows                                 = array();
+	public $schemas                              = array();
+	public $engines                              = array();
+	public $schema_omit                          = array();
+	public $schema_queries                       = 0;
+	public $dropped_indexes                      = array();
+	public $fail_reads                           = false;
+	public $fail_activity_reads                  = false;
+	public $fail_attachment_reference_reads      = false;
+	public $fail_inserts                         = false;
+	public $fail_updates                         = false;
+	public $fail_communication_state_updates     = false;
+	public $fail_engine_repair                   = false;
+	public $race_activity_insert                 = false;
+	public $race_booking_insert                  = false;
+	public $race_booking_hash                    = null;
+	public $race_activity_read_fail              = false;
+	public $race_event_read_fail                 = false;
+	public $concurrent_role_migration            = false;
+	public $reads_before_failure                 = null;
+	public $last_query                           = '';
+	public $fail_activity_inserts                = false;
+	public $fail_activity_kinds                  = array();
+	public $fail_transaction_start               = false;
+	public $fail_transaction_commit              = false;
+	public $fail_transaction_rollback            = false;
+	public $rollback_queries                     = 0;
+	public $after_membership_lock                = null;
+	public $after_booking_lock                   = null;
+	public $after_venue_lock                     = null;
+	public $fail_venue_lock                      = false;
+	public $venue_lock_queries                   = 0;
+	public $reference_locks                      = array();
+	public $lock_sequence                        = array();
+	public $reference_lock_queries               = 0;
+	public $fail_reference_unlock                = false;
+	public $after_reference_lock                 = null;
+	public $after_reference_unlock               = null;
+	public $transaction_active                   = false;
+	public $natural_key_reads_in_transaction     = 0;
+	public $get_lock_result                      = 1;
+	public $release_lock_result                  = 1;
+	public $release_lock_results                 = array();
+	public $release_lock_errors                  = array();
+	public $lock_names                           = array();
+	public $event_dates                          = array();
+	public $booking_lock_queries                 = 0;
+	public $communication_state_queries          = 0;
+	public $communication_attempt_queries        = 0;
+	public $communication_public_rows_returned   = 0;
+	public $pending_reminder_rows_returned       = 0;
+	public $pending_reminder_query_limits        = array();
+	public $pending_reminder_query_cursors       = array();
+	public $elapse_hold_after_membership_lock    = null;
+	public $elapse_hold_before_release_update    = null;
 	public $elapse_hold_before_conversion_update = null;
-	public $fail_read_after_conversion_update = false;
-	public $fail_clock_reads                  = false;
-	public $database_now                     = null;
-	public $ready                            = true;
-	public $close_calls                      = 0;
-	private $transaction_snapshot            = null;
-	private $savepoint_snapshot              = null;
+	public $fail_read_after_conversion_update    = false;
+	public $fail_clock_reads                     = false;
+	public $database_now                         = null;
+	public $ready                                = true;
+	public $close_calls                          = 0;
+	private $transaction_snapshot                = null;
+	private $savepoint_snapshot                  = null;
 
 	public function get_charset_collate() {
 		return 'DEFAULT CHARACTER SET utf8mb4'; }
@@ -519,8 +522,24 @@ final class BookingWpdb {
 		}
 		if ( false !== strpos( $table, 'ec_booking_sales_reports' ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $existing ) {
-				if ( $existing['provider'] === $row['provider'] && $existing['external_report_id'] === $row['external_report_id'] ) {
+				if ( (int) $existing['booking_id'] === (int) $row['booking_id'] && $existing['provider'] === $row['provider'] && $existing['external_report_id'] === $row['external_report_id'] ) {
 					$this->last_error = 'duplicate provider report ID';
+					return false;
+				}
+			}
+		}
+		if ( false !== strpos( $table, 'ec_booking_ticket_sources' ) ) {
+			foreach ( $this->rows[ $table ] ?? array() as $existing ) {
+				if ( (int) $existing['booking_id'] === (int) $row['booking_id'] && $existing['provider'] === $row['provider'] && $existing['source_key'] === $row['source_key'] ) {
+					$this->last_error = 'duplicate ticket source identity';
+					return false;
+				}
+			}
+		}
+		if ( false !== strpos( $table, 'ec_booking_sales_resolutions' ) ) {
+			foreach ( $this->rows[ $table ] ?? array() as $existing ) {
+				if ( (int) $existing['report_id'] === (int) $row['report_id'] && (int) $existing['version'] === (int) $row['version'] ) {
+					$this->last_error = 'duplicate sales resolution version';
 					return false;
 				}
 			}
@@ -541,15 +560,15 @@ final class BookingWpdb {
 				}
 			}
 		}
-		$this->insert_id                          = count( $this->rows[ $table ] ?? array() ) + 1;
-		$key                                      = false !== strpos( $table, 'ec_booking_communication_state' ) ? (int) $row['intent_id'] : $this->insert_id;
+		$this->insert_id = count( $this->rows[ $table ] ?? array() ) + 1;
+		$key             = false !== strpos( $table, 'ec_booking_communication_state' ) ? (int) $row['intent_id'] : $this->insert_id;
 		if ( ! isset( $row['id'] ) && false === strpos( $table, 'ec_booking_communication_state' ) ) {
 			$row['id'] = $this->insert_id;
 		}
 		$this->rows[ $table ][ $key ] = $row;
 		if ( false !== strpos( $table, 'ec_bookings' ) && $this->race_booking_insert ) {
-			$this->race_booking_insert = false;
-			$this->rows[ $table ][ $this->insert_id ]['status']                = 'submitted';
+			$this->race_booking_insert                          = false;
+			$this->rows[ $table ][ $this->insert_id ]['status'] = 'submitted';
 			$this->rows[ $table ][ $this->insert_id ]['admission_owner_token'] = null;
 			++$this->rows[ $table ][ $this->insert_id ]['version'];
 			if ( null !== $this->race_booking_hash ) {
@@ -665,7 +684,7 @@ final class BookingWpdb {
 			}
 			return null;
 		}
-		if ( false !== strpos( $query, 'SELECT b.id FROM' ) && false !== strpos( $query, 'INNER JOIN' ) && preg_match( "/b\.venue_term_id = (\d+).*h\.expires_at <= UTC_TIMESTAMP\(\)/", $query, $stale ) ) {
+		if ( false !== strpos( $query, 'SELECT b.id FROM' ) && false !== strpos( $query, 'INNER JOIN' ) && preg_match( '/b\.venue_term_id = (\d+).*h\.expires_at <= UTC_TIMESTAMP\(\)/', $query, $stale ) ) {
 			foreach ( $this->rows[ $this->prefix . 'ec_bookings' ] ?? array() as $booking ) {
 				if ( (int) $booking['venue_term_id'] !== (int) $stale[1] || 'held' !== $booking['status'] ) {
 					continue;
@@ -766,6 +785,8 @@ final class BookingWpdb {
 		$is_state      = false !== strpos( $query, 'ec_booking_communication_state' );
 		$is_hold       = false !== strpos( $query, 'ec_booking_holds' );
 		$is_sales      = false !== strpos( $query, 'ec_booking_sales_reports' );
+		$is_source     = false !== strpos( $query, 'ec_booking_ticket_sources' );
+		$is_resolution = false !== strpos( $query, 'ec_booking_sales_resolutions' );
 		$is_settlement = false !== strpos( $query, 'ec_booking_settlements' );
 		$is_membership = false !== strpos( $query, 'ec_venue_members' );
 		$database_now  = $this->current_database_time();
@@ -780,7 +801,7 @@ final class BookingWpdb {
 			$this->last_error = 'simulated row read failure';
 			return null;
 		}
-		$table = $is_membership ? $this->prefix . 'ec_venue_members' : ( $is_sales ? $this->prefix . 'ec_booking_sales_reports' : ( $is_settlement ? $this->prefix . 'ec_booking_settlements' : ( $is_delivery ? $this->prefix . 'ec_booking_attachment_deliveries' : ( $is_attachment ? $this->prefix . 'ec_booking_attachments' : ( $is_activity ? $this->prefix . 'ec_booking_activity' : ( $is_state ? $this->prefix . 'ec_booking_communication_state' : ( $is_hold ? $this->prefix . 'ec_booking_holds' : $this->prefix . 'ec_bookings' ) ) ) ) ) ) );
+		$table = $is_membership ? $this->prefix . 'ec_venue_members' : ( $is_source ? $this->prefix . 'ec_booking_ticket_sources' : ( $is_resolution ? $this->prefix . 'ec_booking_sales_resolutions' : ( $is_sales ? $this->prefix . 'ec_booking_sales_reports' : ( $is_settlement ? $this->prefix . 'ec_booking_settlements' : ( $is_delivery ? $this->prefix . 'ec_booking_attachment_deliveries' : ( $is_attachment ? $this->prefix . 'ec_booking_attachments' : ( $is_activity ? $this->prefix . 'ec_booking_activity' : ( $is_state ? $this->prefix . 'ec_booking_communication_state' : ( $is_hold ? $this->prefix . 'ec_booking_holds' : $this->prefix . 'ec_bookings' ) ) ) ) ) ) ) ) );
 		if ( $is_membership && preg_match( '/WHERE venue_term_id = (\d+) AND user_id = (\d+)/', $query, $membership ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
 				if ( (int) $row['venue_term_id'] === (int) $membership[1] && (int) $row['user_id'] === (int) $membership[2] ) {
@@ -789,13 +810,38 @@ final class BookingWpdb {
 			}
 			return null;
 		}
-		if ( $is_sales && preg_match( "/WHERE provider = '([^']+)' AND external_report_id = '([^']+)'/", $query, $external ) ) {
+		if ( $is_sales && preg_match( "/WHERE booking_id = (\d+) AND provider = '([^']+)' AND external_report_id = '([^']+)'/", $query, $external ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
-				if ( $row['provider'] === stripslashes( $external[1] ) && $row['external_report_id'] === stripslashes( $external[2] ) ) {
+				if ( (int) $row['booking_id'] === (int) $external[1] && $row['provider'] === stripslashes( $external[2] ) && $row['external_report_id'] === stripslashes( $external[3] ) ) {
 					return $row;
 				}
 			}
 			return null;
+		}
+		if ( $is_source && preg_match( "/WHERE booking_id = (\d+) AND provider = '([^']+)' AND source_key = '([^']+)'/", $query, $identity ) ) {
+			foreach ( $this->rows[ $table ] ?? array() as $row ) {
+				if ( (int) $row['booking_id'] === (int) $identity[1] && $row['provider'] === stripslashes( $identity[2] ) && $row['source_key'] === stripslashes( $identity[3] ) ) {
+					return $row;
+				}
+			}
+			return null;
+		}
+		if ( $is_resolution && preg_match( '/WHERE report_id = (\d+)(?: AND version = (\d+))?/', $query, $target ) ) {
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $table ] ?? array(),
+					static function ( $row ) use ( $target ) {
+						return (int) $row['report_id'] === (int) $target[1] && ( empty( $target[2] ) || (int) $row['version'] === (int) $target[2] );
+					}
+				)
+			);
+			usort(
+				$rows,
+				static function ( $left, $right ) {
+					return $right['version'] <=> $left['version'];
+				}
+			);
+			return $rows[0] ?? null;
 		}
 		if ( $is_settlement && preg_match( '/WHERE booking_id = (\d+)/', $query, $booking ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
@@ -819,36 +865,108 @@ final class BookingWpdb {
 		}
 		if ( $is_activity && preg_match( '/WHERE communication_intent_id = (\d+) ORDER BY id DESC LIMIT 1/', $query, $match ) ) {
 			++$this->communication_state_queries;
-			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static function ( $row ) use ( $match ) { return (int) ( $row['communication_intent_id'] ?? 0 ) === (int) $match[1]; } ) );
-			usort( $rows, static function ( $left, $right ) { return $right['id'] <=> $left['id']; } );
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $table ] ?? array(),
+					static function ( $row ) use ( $match ) {
+						return (int) ( $row['communication_intent_id'] ?? 0 ) === (int) $match[1];
+					}
+				)
+			);
+			usort(
+				$rows,
+				static function ( $left, $right ) {
+					return $right['id'] <=> $left['id'];
+				}
+			);
 			return $rows[0] ?? null;
 		}
 		if ( $is_activity && preg_match( "/WHERE external_id = '(\d+)' AND kind IN \('notification_delivered', 'notification_suppressed'\)/", $query, $match ) ) {
-			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static function ( $row ) use ( $match ) { return (string) ( $row['external_id'] ?? '' ) === $match[1] && in_array( $row['kind'], array( 'notification_delivered', 'notification_suppressed' ), true ); } ) );
-			usort( $rows, static function ( $left, $right ) { return $right['id'] <=> $left['id']; } );
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $table ] ?? array(),
+					static function ( $row ) use ( $match ) {
+						return (string) ( $row['external_id'] ?? '' ) === $match[1] && in_array( $row['kind'], array( 'notification_delivered', 'notification_suppressed' ), true );
+					}
+				)
+			);
+			usort(
+				$rows,
+				static function ( $left, $right ) {
+					return $right['id'] <=> $left['id'];
+				}
+			);
 			return $rows[0] ?? null;
 		}
 		if ( $is_activity && preg_match( "/WHERE booking_id = (\d+) AND kind = 'event_sync_started' ORDER BY id DESC LIMIT 1/", $query, $match ) ) {
-			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static function ( $row ) use ( $match ) { return (int) $row['booking_id'] === (int) $match[1] && 'event_sync_started' === $row['kind']; } ) );
-			usort( $rows, static function ( $left, $right ) { return $right['id'] <=> $left['id']; } );
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $table ] ?? array(),
+					static function ( $row ) use ( $match ) {
+						return (int) $row['booking_id'] === (int) $match[1] && 'event_sync_started' === $row['kind'];
+					}
+				)
+			);
+			usort(
+				$rows,
+				static function ( $left, $right ) {
+					return $right['id'] <=> $left['id'];
+				}
+			);
 			return $rows[0] ?? null;
 		}
 		if ( $is_activity && preg_match( "/WHERE booking_id = (\d+) AND external_id = '(\d+)' AND kind IN \('event_sync_succeeded', 'event_sync_noop', 'event_sync_conflict', 'event_sync_failed'\)/", $query, $match ) ) {
-			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static function ( $row ) use ( $match ) { return (int) $row['booking_id'] === (int) $match[1] && (string) ( $row['external_id'] ?? '' ) === $match[2] && in_array( $row['kind'], array( 'event_sync_succeeded', 'event_sync_noop', 'event_sync_conflict', 'event_sync_failed' ), true ); } ) );
-			usort( $rows, static function ( $left, $right ) { return $right['id'] <=> $left['id']; } );
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $table ] ?? array(),
+					static function ( $row ) use ( $match ) {
+						return (int) $row['booking_id'] === (int) $match[1] && (string) ( $row['external_id'] ?? '' ) === $match[2] && in_array( $row['kind'], array( 'event_sync_succeeded', 'event_sync_noop', 'event_sync_conflict', 'event_sync_failed' ), true );
+					}
+				)
+			);
+			usort(
+				$rows,
+				static function ( $left, $right ) {
+					return $right['id'] <=> $left['id'];
+				}
+			);
 			return $rows[0] ?? null;
 		}
 		if ( $is_activity && preg_match( "/WHERE booking_id = (\d+) AND external_id = '(\d+)' AND kind = 'event_sync_retryable'/", $query, $match ) ) {
-			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static function ( $row ) use ( $match ) { return (int) $row['booking_id'] === (int) $match[1] && (string) ( $row['external_id'] ?? '' ) === $match[2] && 'event_sync_retryable' === $row['kind']; } ) );
-			usort( $rows, static function ( $left, $right ) { return $right['id'] <=> $left['id']; } );
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $table ] ?? array(),
+					static function ( $row ) use ( $match ) {
+						return (int) $row['booking_id'] === (int) $match[1] && (string) ( $row['external_id'] ?? '' ) === $match[2] && 'event_sync_retryable' === $row['kind'];
+					}
+				)
+			);
+			usort(
+				$rows,
+				static function ( $left, $right ) {
+					return $right['id'] <=> $left['id'];
+				}
+			);
 			return $rows[0] ?? null;
 		}
 		if ( $is_activity && preg_match( "/WHERE booking_id = (\d+) AND kind IN \('event_sync_succeeded', 'event_sync_noop', 'event_converted'\)/", $query, $match ) ) {
-			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static function ( $row ) use ( $match ) { return (int) $row['booking_id'] === (int) $match[1] && in_array( $row['kind'], array( 'event_sync_succeeded', 'event_sync_noop', 'event_converted' ), true ); } ) );
-			usort( $rows, static function ( $left, $right ) { return $right['id'] <=> $left['id']; } );
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $table ] ?? array(),
+					static function ( $row ) use ( $match ) {
+						return (int) $row['booking_id'] === (int) $match[1] && in_array( $row['kind'], array( 'event_sync_succeeded', 'event_sync_noop', 'event_converted' ), true );
+					}
+				)
+			);
+			usort(
+				$rows,
+				static function ( $left, $right ) {
+					return $right['id'] <=> $left['id'];
+				}
+			);
 			return $rows[0] ?? null;
 		}
-		if ( ! $is_attachment && ! $is_delivery && ! $is_activity && ! $is_state && ! $is_hold && ! $is_sales && ! $is_settlement && ! $is_membership && false !== strpos( $query, 'FOR UPDATE' ) ) {
+		if ( ! $is_attachment && ! $is_delivery && ! $is_activity && ! $is_state && ! $is_hold && ! $is_sales && ! $is_source && ! $is_resolution && ! $is_settlement && ! $is_membership && false !== strpos( $query, 'FOR UPDATE' ) ) {
 			++$this->booking_lock_queries;
 			if ( is_callable( $this->after_booking_lock ) ) {
 				$callback                 = $this->after_booking_lock;
@@ -857,7 +975,7 @@ final class BookingWpdb {
 			}
 		}
 		if ( preg_match( '/WHERE id = (\d+)/', $query, $match ) ) {
-			if ( ! $is_attachment && ! $is_delivery && ! $is_activity && ! $is_state && ! $is_hold && ! $is_sales && ! $is_settlement && ! $is_membership && false !== strpos( $query, 'FOR UPDATE' ) ) {
+			if ( ! $is_attachment && ! $is_delivery && ! $is_activity && ! $is_state && ! $is_hold && ! $is_sales && ! $is_source && ! $is_resolution && ! $is_settlement && ! $is_membership && false !== strpos( $query, 'FOR UPDATE' ) ) {
 				$this->lock_sequence[] = 'booking:' . (int) $match[1];
 			}
 			$row = $this->rows[ $table ][ (int) $match[1] ] ?? null;
@@ -896,7 +1014,7 @@ final class BookingWpdb {
 			preg_match( "/venue_term_id = (\d+).*performance_start_at < '([^']+)'.*performance_end_at > '([^']+)'.*id = (\d+) OR event_id = (\d+)/", $query, $match );
 			preg_match_all( "/\(performance_start_at = '([^']+)' AND performance_end_at = '([^']+)'\)/", $query, $exact_matches, PREG_SET_ORDER );
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
-				$origin = ( (int) $match[4] > 0 && (int) $row['id'] === (int) $match[4] )
+				$origin       = ( (int) $match[4] > 0 && (int) $row['id'] === (int) $match[4] )
 					|| ( (int) $match[5] > 0 && (int) ( $row['event_id'] ?? 0 ) === (int) $match[5] );
 				$exact_exempt = $origin && array_filter( $exact_matches, static fn( array $exact ): bool => $row['performance_start_at'] === $exact[1] && $row['performance_end_at'] === $exact[2] );
 				if ( (int) $row['venue_term_id'] === (int) $match[1] && 'confirmed' === $row['status'] && $row['performance_start_at'] < $match[2] && $row['performance_end_at'] > $match[3] && ! $exact_exempt ) {
@@ -990,9 +1108,14 @@ final class BookingWpdb {
 			}
 		}
 		if ( $is_activity && preg_match( "/WHERE booking_id = (\d+) AND kind = '([^']+)' AND external_id = '([^']+)'/", $query, $match ) ) {
-			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static function ( $row ) use ( $match ) {
-				return (int) $row['booking_id'] === (int) $match[1] && $row['kind'] === stripslashes( $match[2] ) && (string) ( $row['external_id'] ?? '' ) === stripslashes( $match[3] );
-			} ) );
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $table ] ?? array(),
+					static function ( $row ) use ( $match ) {
+						return (int) $row['booking_id'] === (int) $match[1] && $row['kind'] === stripslashes( $match[2] ) && (string) ( $row['external_id'] ?? '' ) === stripslashes( $match[3] );
+					}
+				)
+			);
 			usort( $rows, static fn( array $left, array $right ): int => $right['id'] <=> $left['id'] );
 			return $rows[0] ?? null;
 		}
@@ -1037,8 +1160,20 @@ final class BookingWpdb {
 					$requests[] = (string) $row['external_id'];
 				}
 			}
-			$rows = array_values( array_filter( $this->rows[ $this->prefix . 'ec_booking_activity' ] ?? array(), static function ( $row ) use ( $requests ) { return in_array( $row['kind'], array( 'inquiry_submitted', 'assignment_changed', 'status_changed', 'hold_expired', 'event_conversion_failed' ), true ) && ! in_array( (string) $row['id'], $requests, true ); } ) );
-			usort( $rows, static function ( $left, $right ) { return $left['id'] <=> $right['id']; } );
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $this->prefix . 'ec_booking_activity' ] ?? array(),
+					static function ( $row ) use ( $requests ) {
+						return in_array( $row['kind'], array( 'inquiry_submitted', 'assignment_changed', 'status_changed', 'hold_expired', 'event_conversion_failed' ), true ) && ! in_array( (string) $row['id'], $requests, true );
+					}
+				)
+			);
+			usort(
+				$rows,
+				static function ( $left, $right ) {
+					return $left['id'] <=> $right['id'];
+				}
+			);
 			return array_slice( $rows, 0, (int) ( $limit[1] ?? 50 ) );
 		}
 		if ( false !== strpos( $query, 'SELECT request.* FROM' ) && false !== strpos( $query, "request.kind = 'notification_requested'" ) ) {
@@ -1053,15 +1188,27 @@ final class BookingWpdb {
 					$deferred[] = (string) $row['external_id'];
 				}
 			}
-			$rows = array_values( array_filter( $this->rows[ $this->prefix . 'ec_booking_activity' ] ?? array(), static function ( $row ) use ( $terminals, $deferred ) { return 'notification_requested' === $row['kind'] && ! in_array( (string) $row['id'], $terminals, true ) && ! in_array( (string) $row['id'], $deferred, true ); } ) );
-			usort( $rows, static function ( $left, $right ) { return $left['id'] <=> $right['id']; } );
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $this->prefix . 'ec_booking_activity' ] ?? array(),
+					static function ( $row ) use ( $terminals, $deferred ) {
+						return 'notification_requested' === $row['kind'] && ! in_array( (string) $row['id'], $terminals, true ) && ! in_array( (string) $row['id'], $deferred, true );
+					}
+				)
+			);
+			usort(
+				$rows,
+				static function ( $left, $right ) {
+					return $left['id'] <=> $right['id'];
+				}
+			);
 			return array_slice( $rows, 0, (int) ( $limit[1] ?? 50 ) );
 		}
 		if ( false !== strpos( $query, 'ec_booking_communication_state' ) && false !== strpos( $query, 'INNER JOIN' ) && preg_match( "/s\.booking_id = (\d+) AND s\.status = 'scheduled' AND s\.intent_id > (\d+).*LIMIT (\d+)/", $query, $match ) ) {
 			++$this->communication_state_queries;
 			$this->pending_reminder_query_cursors[] = (int) $match[2];
 			$this->pending_reminder_query_limits[]  = (int) $match[3];
-			$rows = array();
+			$rows                                   = array();
 			foreach ( $this->rows[ $this->prefix . 'ec_booking_communication_state' ] ?? array() as $state ) {
 				if ( (int) $state['booking_id'] !== (int) $match[1] || 'scheduled' !== $state['status'] || (int) $state['intent_id'] <= (int) $match[2] ) {
 					continue;
@@ -1071,16 +1218,21 @@ final class BookingWpdb {
 					$rows[] = array_merge(
 						$intent,
 						array(
-							'communication_status'              => $state['status'],
-							'communication_claim_stage'         => $state['claim_stage'],
-							'communication_action_id'           => $state['action_id'],
+							'communication_status'      => $state['status'],
+							'communication_claim_stage' => $state['claim_stage'],
+							'communication_action_id'   => $state['action_id'],
 							'communication_updated_activity_id' => $state['updated_activity_id'],
 						)
 					);
 				}
 			}
-			usort( $rows, static function ( $left, $right ) { return $left['id'] <=> $right['id']; } );
-			$rows = array_slice( $rows, 0, (int) $match[3] );
+			usort(
+				$rows,
+				static function ( $left, $right ) {
+					return $left['id'] <=> $right['id'];
+				}
+			);
+			$rows                                  = array_slice( $rows, 0, (int) $match[3] );
 			$this->pending_reminder_rows_returned += count( $rows );
 			return $rows;
 		}
@@ -1088,7 +1240,7 @@ final class BookingWpdb {
 			$this->last_error = 'simulated attachment reference read failure';
 			return null;
 		}
-		if ( false !== strpos( $query, 'INNER JOIN' ) && false !== strpos( $query, 'ec_booking_holds' ) && preg_match( "/b\.venue_term_id = (\d+).*h\.expires_at <= UTC_TIMESTAMP\(\)/", $query, $stale ) ) {
+		if ( false !== strpos( $query, 'INNER JOIN' ) && false !== strpos( $query, 'ec_booking_holds' ) && preg_match( '/b\.venue_term_id = (\d+).*h\.expires_at <= UTC_TIMESTAMP\(\)/', $query, $stale ) ) {
 			$rows = array();
 			foreach ( $this->rows[ $this->prefix . 'ec_bookings' ] ?? array() as $booking ) {
 				if ( (int) $booking['venue_term_id'] !== (int) $stale[1] || 'held' !== $booking['status'] ) {
@@ -1159,13 +1311,29 @@ final class BookingWpdb {
 		$is_state      = false !== strpos( $query, 'ec_booking_communication_state' );
 		$is_hold       = false !== strpos( $query, 'ec_booking_holds' );
 		$is_sales      = false !== strpos( $query, 'ec_booking_sales_reports' );
-		$table         = $is_sales ? $this->prefix . 'ec_booking_sales_reports' : ( $is_delivery ? $this->prefix . 'ec_booking_attachment_deliveries' : ( $is_attachment ? $this->prefix . 'ec_booking_attachments' : ( $is_activity ? $this->prefix . 'ec_booking_activity' : ( $is_state ? $this->prefix . 'ec_booking_communication_state' : ( $is_hold ? $this->prefix . 'ec_booking_holds' : $this->prefix . 'ec_bookings' ) ) ) ) );
+		$is_source     = false !== strpos( $query, 'ec_booking_ticket_sources' );
+		$is_resolution = false !== strpos( $query, 'ec_booking_sales_resolutions' );
+		$table         = $is_source ? $this->prefix . 'ec_booking_ticket_sources' : ( $is_resolution ? $this->prefix . 'ec_booking_sales_resolutions' : ( $is_sales ? $this->prefix . 'ec_booking_sales_reports' : ( $is_delivery ? $this->prefix . 'ec_booking_attachment_deliveries' : ( $is_attachment ? $this->prefix . 'ec_booking_attachments' : ( $is_activity ? $this->prefix . 'ec_booking_activity' : ( $is_state ? $this->prefix . 'ec_booking_communication_state' : ( $is_hold ? $this->prefix . 'ec_booking_holds' : $this->prefix . 'ec_bookings' ) ) ) ) ) ) );
 		$rows          = array_values( $this->rows[ $table ] ?? array() );
 		if ( false !== strpos( $query, "status <> 'admission_pending'" ) ) {
-			$rows = array_values( array_filter( $rows, static function ( $row ) { return 'admission_pending' !== ( $row['status'] ?? '' ); } ) );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) {
+						return 'admission_pending' !== ( $row['status'] ?? '' );
+					}
+				)
+			);
 		}
 		if ( $is_activity && false !== strpos( $query, 'is_communication = 1' ) ) {
-			$rows = array_values( array_filter( $rows, static function ( $row ) { return 1 === (int) ( $row['is_communication'] ?? 0 ); } ) );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) {
+						return 1 === (int) ( $row['is_communication'] ?? 0 );
+					}
+				)
+			);
 		}
 		if ( false !== strpos( $query, 'AS database_now' ) ) {
 			$database_now = $this->current_database_time();
@@ -1177,7 +1345,7 @@ final class BookingWpdb {
 		if ( $is_activity && false !== strpos( $query, "kind IN ('event_conversion_started', 'event_conversion_failed', 'event_converted')" ) ) {
 			preg_match( "/idempotency_key LIKE '([^']+)%'/", $query, $key_prefix );
 			$prefix = isset( $key_prefix[1] ) ? stripslashes( $key_prefix[1] ) : '';
-			$rows = array_values(
+			$rows   = array_values(
 				array_filter(
 					$rows,
 					static function ( $row ) use ( $prefix ) {
@@ -1185,15 +1353,34 @@ final class BookingWpdb {
 					}
 				)
 			);
-			usort( $rows, static function ( $left, $right ) { return $left['id'] <=> $right['id']; } );
+			usort(
+				$rows,
+				static function ( $left, $right ) {
+					return $left['id'] <=> $right['id'];
+				}
+			);
 		}
 		if ( $is_hold && false !== strpos( $query, "status = 'converted'" ) ) {
 			foreach ( array( 'space_key', 'start_at', 'end_at' ) as $field ) {
 				if ( preg_match( "/{$field} = '([^']+)'/", $query, $exact ) ) {
-					$rows = array_values( array_filter( $rows, static function ( $row ) use ( $field, $exact ) { return $row[ $field ] === stripslashes( $exact[1] ); } ) );
+					$rows = array_values(
+						array_filter(
+							$rows,
+							static function ( $row ) use ( $field, $exact ) {
+								return $row[ $field ] === stripslashes( $exact[1] );
+							}
+						)
+					);
 				}
 			}
-			$rows = array_values( array_filter( $rows, static function ( $row ) { return null !== $row['converted_at']; } ) );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) {
+						return null !== $row['converted_at'];
+					}
+				)
+			);
 		}
 		$filters = array( 'venue_term_id', 'artist_term_id', 'artist_profile_id', 'assignee_user_id', 'booking_id' );
 		foreach ( $filters as $field ) {
@@ -1209,7 +1396,14 @@ final class BookingWpdb {
 			}
 		}
 		if ( $is_sales && preg_match( "/currency = '([A-Z]{3})'/", $query, $currency ) ) {
-			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $currency ) { return $row['currency'] === $currency[1]; } ) );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $currency ) {
+						return $row['currency'] === $currency[1];
+					}
+				)
+			);
 		}
 		if ( $is_attachment && preg_match( '/id > (\d+)/', $query, $filter ) ) {
 			$rows = array_values(
@@ -1223,12 +1417,33 @@ final class BookingWpdb {
 		}
 		if ( $is_hold && false !== strpos( $query, "(status = 'expired' OR (status = 'active'" ) && false !== strpos( $query, 'expires_at <= UTC_TIMESTAMP()' ) ) {
 			$now  = $this->current_database_time();
-			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $now ) { return 'expired' === $row['status'] || ( 'active' === $row['status'] && $row['expires_at'] <= $now ); } ) );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $now ) {
+						return 'expired' === $row['status'] || ( 'active' === $row['status'] && $row['expires_at'] <= $now );
+					}
+				)
+			);
 		} elseif ( $is_hold && false !== strpos( $query, "status = 'active' AND expires_at > UTC_TIMESTAMP()" ) ) {
 			$now  = $this->current_database_time();
-			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $now ) { return 'active' === $row['status'] && $row['expires_at'] > $now; } ) );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $now ) {
+						return 'active' === $row['status'] && $row['expires_at'] > $now;
+					}
+				)
+			);
 		} elseif ( $is_hold && false !== strpos( $query, "(status = 'expired' OR (status = 'active'" ) && preg_match( "/expires_at <= '([^']+)'/", $query, $filter ) ) {
-			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $filter ) { return 'expired' === $row['status'] || ( 'active' === $row['status'] && $row['expires_at'] <= $filter[1] ); } ) );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $filter ) {
+						return 'expired' === $row['status'] || ( 'active' === $row['status'] && $row['expires_at'] <= $filter[1] );
+					}
+				)
+			);
 		} elseif ( $is_hold && false !== strpos( $query, "status = 'active' AND expires_at >" ) && preg_match( "/expires_at > '([^']+)'/", $query, $filter ) ) {
 			$rows = array_values(
 				array_filter(
@@ -1299,16 +1514,44 @@ final class BookingWpdb {
 			);
 		}
 		if ( $is_delivery && false !== strpos( $query, "state IN ('issued', 'consumed')" ) ) {
-			$rows = array_values( array_filter( $rows, static function ( $row ) { return in_array( $row['state'], array( 'issued', 'consumed' ), true ); } ) );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) {
+						return in_array( $row['state'], array( 'issued', 'consumed' ), true );
+					}
+				)
+			);
 		}
 		if ( $is_delivery && false !== strpos( $query, "state = 'terminal'" ) ) {
-			$rows = array_values( array_filter( $rows, static function ( $row ) { return 'terminal' === $row['state']; } ) );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) {
+						return 'terminal' === $row['state'];
+					}
+				)
+			);
 		}
 		if ( $is_delivery && preg_match( "/updated_at < '([^']+)'/", $query, $filter ) ) {
-			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $filter ) { return $row['updated_at'] < $filter[1]; } ) );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $filter ) {
+						return $row['updated_at'] < $filter[1];
+					}
+				)
+			);
 		}
 		if ( $is_delivery && preg_match( "/terminal_at < '([^']+)'/", $query, $filter ) ) {
-			$rows = array_values( array_filter( $rows, static function ( $row ) use ( $filter ) { return null !== $row['terminal_at'] && $row['terminal_at'] < $filter[1]; } ) );
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $filter ) {
+						return null !== $row['terminal_at'] && $row['terminal_at'] < $filter[1];
+					}
+				)
+			);
 		}
 		if ( preg_match( "/requested_start_at >= '([^']+)'/", $query, $filter ) ) {
 			$rows = array_values(
@@ -1351,7 +1594,12 @@ final class BookingWpdb {
 			);
 		}
 		if ( false !== strpos( $query, 'ORDER BY id ASC' ) ) {
-			usort( $rows, static function ( $a, $b ) { return $a['id'] <=> $b['id']; } );
+			usort(
+				$rows,
+				static function ( $a, $b ) {
+					return $a['id'] <=> $b['id'];
+				}
+			);
 		} elseif ( ! $is_delivery ) {
 			usort(
 				$rows,
@@ -1392,7 +1640,7 @@ final class BookingWpdb {
 
 	public function delete( $table, $where ) {
 		$this->last_error = '';
-		$deleted = 0;
+		$deleted          = 0;
 		foreach ( $this->rows[ $table ] ?? array() as $key => $row ) {
 			foreach ( $where as $field => $value ) {
 				if ( (string) ( $row[ $field ] ?? '' ) !== (string) $value ) {
@@ -1525,7 +1773,7 @@ final class BookingWpdb {
 				$this->elapse_hold_before_release_update = null;
 			}
 			if ( false !== strpos( $query, "status = 'converted'" ) && (int) $this->elapse_hold_before_conversion_update === $id ) {
-				$past = gmdate( 'Y-m-d H:i:s' );
+				$past                                      = gmdate( 'Y-m-d H:i:s' );
 				$this->rows[ $table ][ $id ]['expires_at'] = $past;
 				if ( is_array( $this->transaction_snapshot ) ) {
 					$this->transaction_snapshot[ $table ][ $id ]['expires_at'] = $past;
@@ -1533,15 +1781,15 @@ final class BookingWpdb {
 				$this->elapse_hold_before_conversion_update = null;
 			}
 			if ( false !== strpos( $query, "status = 'converted'" ) && $this->fail_read_after_conversion_update ) {
-				$this->reads_before_failure = 0;
+				$this->reads_before_failure              = 0;
 				$this->fail_read_after_conversion_update = false;
 			}
 			if ( ! isset( $this->rows[ $table ][ $id ] ) || (int) $this->rows[ $table ][ $id ]['version'] !== $expected || 'active' !== $this->rows[ $table ][ $id ]['status'] || $this->rows[ $table ][ $id ]['expires_at'] <= $this->current_database_time() ) {
 				return 0;
 			}
 		}
-		if ( false !== strpos( $query, "SET status = 'expired'" ) && preg_match( "/UPDATE ([^ ]+).*WHERE booking_id = (\d+).*expires_at <= UTC_TIMESTAMP\(\).*id <> (\d+)/", $query, $expired ) ) {
-			$count = 0;
+		if ( false !== strpos( $query, "SET status = 'expired'" ) && preg_match( '/UPDATE ([^ ]+).*WHERE booking_id = (\d+).*expires_at <= UTC_TIMESTAMP\(\).*id <> (\d+)/', $query, $expired ) ) {
+			$count                     = 0;
 			$this->rows[ $expired[1] ] = $this->rows[ $expired[1] ] ?? array();
 			foreach ( $this->rows[ $expired[1] ] as &$row ) {
 				if ( (int) $row['booking_id'] === (int) $expired[2] && 'active' === $row['status'] && $row['expires_at'] <= $this->current_database_time() && (int) $row['id'] !== (int) $expired[3] ) {
@@ -1554,8 +1802,8 @@ final class BookingWpdb {
 			unset( $row );
 			return $count;
 		}
-		if ( false !== strpos( $query, "SET status = 'released'" ) && preg_match( "/UPDATE ([^ ]+).*WHERE booking_id = (\d+).*expires_at > UTC_TIMESTAMP\(\).*id <> (\d+)/", $query, $release ) ) {
-			$count = 0;
+		if ( false !== strpos( $query, "SET status = 'released'" ) && preg_match( '/UPDATE ([^ ]+).*WHERE booking_id = (\d+).*expires_at > UTC_TIMESTAMP\(\).*id <> (\d+)/', $query, $release ) ) {
+			$count                     = 0;
 			$this->rows[ $release[1] ] = $this->rows[ $release[1] ] ?? array();
 			foreach ( $this->rows[ $release[1] ] as &$row ) {
 				if ( (int) $row['booking_id'] === (int) $release[2] && 'active' === $row['status'] && $row['expires_at'] > $this->current_database_time() && (int) $row['id'] !== (int) $release[3] ) {
@@ -1627,7 +1875,6 @@ final class BookingWpdb {
 		$this->savepoint_snapshot   = null;
 		return true;
 	}
-
 }
 
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingSchema.php';
@@ -1658,6 +1905,7 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingAttachmentDeliveryReposit
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingAttachmentService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingInquiryAdmissionService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueBookingConfig.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/TicketReconciliationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/TicketSettlementService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/CanonicalEventPublicationGuard.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingAbilities.php';
@@ -1671,10 +1919,10 @@ require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingMarketingAbilit
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/TicketSettlementAbilities.php';
 
 final class BookingTestAuthorization extends VenueAuthorization {
-	public $calls        = array();
-	public $direct_calls = array();
-	public $locked_calls = array();
-	public $allowed      = array();
+	public $calls                     = array();
+	public $direct_calls              = array();
+	public $locked_calls              = array();
+	public $allowed                   = array();
 	public $require_locked_membership = false;
 	public function __construct( array $allowed = array() ) {
 		parent::__construct();
@@ -1704,36 +1952,38 @@ final class BookingTestConfig extends VenueBookingConfig {
 }
 
 final class BookingTestPrivateFileProvider implements BookingPrivateFileProvider {
-	public $objects  = array();
-	public $claims   = array();
-	public $released = array();
-	public $retired  = array();
-	public $fail_release = false;
-	public $fail_retire  = false;
-	public $handoffs = array();
-	public $claim_records = array();
-	public $throw_claim = false;
+	public $objects           = array();
+	public $contents          = array();
+	public $claims            = array();
+	public $released          = array();
+	public $retired           = array();
+	public $fail_release      = false;
+	public $fail_retire       = false;
+	public $handoffs          = array();
+	public $claim_records     = array();
+	public $throw_claim       = false;
 	public $inspect_uncertain = 0;
 	public $inspect_truncated = false;
-	public $stage_count = 0;
-	public $fail_stage_at = 0;
+	public $stage_count       = 0;
+	public $fail_stage_at     = 0;
 	public $after_stage;
-	public $claim_count = 0;
+	public $claim_count   = 0;
 	public $fail_claim_at = 0;
 	public function stage( string $source_path, string $filename, string $purpose ) {
 		++$this->stage_count;
 		if ( $this->fail_stage_at === $this->stage_count ) {
 			return new WP_Error( 'simulated_stage_failure' );
 		}
-		$reference = sprintf( 'private_staged_object_%06d', $this->stage_count );
-		$filetype  = wp_check_filetype( $filename, BookingAttachmentPolicy::allowed_mimes() );
-		$this->objects[ $reference ] = array(
+		$reference                    = sprintf( 'private_staged_object_%06d', $this->stage_count );
+		$filetype                     = wp_check_filetype( $filename, BookingAttachmentPolicy::allowed_mimes() );
+		$this->objects[ $reference ]  = array(
 			'filename'     => $filename,
 			'mime_type'    => $filetype['type'],
 			'byte_size'    => filesize( $source_path ),
 			'content_hash' => hash_file( 'sha256', $source_path ),
 			'scan_status'  => BookingAttachmentPolicy::requires_malware_scan( $filetype['type'] ) ? 'clean' : 'not_required',
 		);
+		$this->contents[ $reference ] = file_get_contents( $source_path );
 		if ( is_callable( $this->after_stage ) ) {
 			call_user_func( $this->after_stage, $reference, $purpose );
 		}
@@ -1777,7 +2027,12 @@ final class BookingTestPrivateFileProvider implements BookingPrivateFileProvider
 			$claim['cursor'] = $key;
 			$candidates[]    = $claim;
 		}
-		usort( $candidates, static function ( array $left, array $right ): int { return strcmp( $left['cursor'], $right['cursor'] ); } );
+		usort(
+			$candidates,
+			static function ( array $left, array $right ): int {
+				return strcmp( $left['cursor'], $right['cursor'] );
+			}
+		);
 		$truncated    = $this->inspect_truncated || count( $candidates ) > 250;
 		$claims       = array_slice( $candidates, 0, 250 );
 		$continuation = $truncated && ! empty( $claims ) ? $claims[ count( $claims ) - 1 ]['cursor'] : null;
@@ -1793,7 +2048,7 @@ final class BookingTestPrivateFileProvider implements BookingPrivateFileProvider
 		);
 	}
 	public function download_descriptor( string $storage_reference, string $attachment_public_id, int $actor_id, string $purpose, string $claim_key, string $correlation_id ) {
-		$token = bin2hex( random_bytes( 32 ) );
+		$token                    = bin2hex( random_bytes( 32 ) );
 		$this->handoffs[ $token ] = array( $storage_reference, $attachment_public_id, $actor_id, $purpose, $claim_key, $correlation_id );
 		return isset( $this->objects[ $storage_reference ] ) ? array(
 			'stream_token' => $token,
@@ -1803,9 +2058,13 @@ final class BookingTestPrivateFileProvider implements BookingPrivateFileProvider
 	public function open_stream( string $stream_token, string $attachment_public_id, int $actor_id, string $purpose, string $correlation_id ) {
 		$handoff = $this->handoffs[ $stream_token ] ?? null;
 		unset( $this->handoffs[ $stream_token ] );
-		return is_array( $handoff ) && $handoff[1] === $attachment_public_id && $handoff[2] === $actor_id && $handoff[3] === $purpose && $handoff[5] === $correlation_id
-			? fopen( 'php://temp', 'rb+' )
-			: new WP_Error( 'booking_private_stream_invalid' );
+		if ( ! is_array( $handoff ) || $handoff[1] !== $attachment_public_id || $handoff[2] !== $actor_id || $handoff[3] !== $purpose || $handoff[5] !== $correlation_id ) {
+			return new WP_Error( 'booking_private_stream_invalid' );
+		}
+		$stream = fopen( 'php://temp', 'rb+' );
+		fwrite( $stream, (string) ( $this->contents[ $handoff[0] ] ?? '' ) );
+		rewind( $stream );
+		return $stream;
 	}
 	public function retire( string $storage_reference ) {
 		$this->retired[] = $storage_reference;
@@ -1822,10 +2081,16 @@ final class BookingTestVenueTaxonomy {
 		unset( $venue_data );
 		foreach ( $GLOBALS['ec_artist_test']['terms'][ get_current_blog_id() ] ?? array() as $term ) {
 			if ( 'venue' === $term->taxonomy && 0 === strcasecmp( $term->name, $venue_name ) ) {
-				return array( 'term_id' => (int) $term->term_id, 'match_status' => 'matched' );
+				return array(
+					'term_id'      => (int) $term->term_id,
+					'match_status' => 'matched',
+				);
 			}
 		}
-		return array( 'term_id' => null, 'match_status' => 'no_match' );
+		return array(
+			'term_id'      => null,
+			'match_status' => 'no_match',
+		);
 	}
 }
 

--- a/tests/TicketReconciliationTest.php
+++ b/tests/TicketReconciliationTest.php
@@ -1,0 +1,545 @@
+<?php
+/**
+ * Ticket attribution, import, and reconciliation tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+// Test fixtures intentionally use concise comments and disposable local files.
+// phpcs:disable Generic.Commenting.DocComment.MissingShort,Squiz.Commenting.FunctionComment.Missing,WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents,WordPress.WP.AlternativeFunctions.unlink_unlink
+
+use ExtraChillEvents\Abilities\TicketSettlementAbilities;
+use ExtraChillEvents\Core\BookingActivityRepository;
+use ExtraChillEvents\Core\BookingAttachmentRepository;
+use ExtraChillEvents\Core\BookingAttachmentService;
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\TicketReconciliationService;
+use ExtraChillEvents\Core\TicketSettlementService;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
+/** Verifies that unresolved or contradictory evidence never reaches settlement. */
+final class TicketReconciliationTest extends TestCase {
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var BookingTestAuthorization */
+	private $authorization;
+	/** @var BookingTestPrivateFileProvider */
+	private $provider;
+	/** @var BookingAttachmentService */
+	private $attachment_service;
+	/** @var TicketReconciliationService */
+	private $reconciliation;
+	/** @var TicketSettlementService */
+	private $settlements;
+
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id'       => 7,
+			'stack'         => array(),
+			'uuid'          => 0,
+			'options'       => array( BookingSchema::VERSION_OPTION => BookingSchema::SCHEMA_VERSION ),
+			'dbdelta'       => array(),
+			'abilities'     => array(),
+			'actions'       => array(),
+			'cache_deletes' => array(),
+			'terms'         => array(
+				7 => array(
+					55 => (object) array(
+						'term_id'  => 55,
+						'taxonomy' => 'venue',
+						'name'     => 'Reconciliation Room',
+					),
+					56 => (object) array(
+						'term_id'  => 56,
+						'taxonomy' => 'venue',
+						'name'     => 'Other Room',
+					),
+				),
+			),
+			'meta'          => array(),
+			'posts'         => array(
+				7 => array(
+					900 => (object) array(
+						'ID'          => 900,
+						'post_type'   => 'data_machine_events',
+						'post_status' => 'publish',
+					),
+					901 => (object) array(
+						'ID'          => 901,
+						'post_type'   => 'data_machine_events',
+						'post_status' => 'publish',
+					),
+				),
+			),
+			'post_meta'     => array(),
+		);
+		$GLOBALS['wpdb']           = new BookingWpdb();
+		$this->bookings            = new BookingRepository();
+		$this->authorization       = new BookingTestAuthorization();
+		$this->provider            = new BookingTestPrivateFileProvider();
+		$attachments               = new BookingAttachmentRepository();
+		$activity                  = new BookingActivityRepository();
+		$this->attachment_service  = new BookingAttachmentService( $attachments, $this->bookings, $activity, null, $this->provider, $this->authorization );
+		$this->reconciliation      = new TicketReconciliationService( $this->bookings, $activity, $this->authorization, $attachments, $this->attachment_service );
+		$this->settlements         = new TicketSettlementService( $this->bookings, $activity, $this->authorization, null, $this->reconciliation );
+	}
+
+	public function test_schema_upgrades_v12_without_replacing_settlement_tables(): void {
+		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '12';
+		$this->assertTrue( BookingSchema::maybe_install() );
+		$this->assertSame( '13', get_option( BookingSchema::VERSION_OPTION ) );
+		$this->assertTrue( BookingSchema::health() );
+		$this->assertArrayHasKey( BookingSchema::ticket_sources_table(), $GLOBALS['wpdb']->schemas );
+		$this->assertArrayHasKey( BookingSchema::sales_resolutions_table(), $GLOBALS['wpdb']->schemas );
+		$this->assertArrayHasKey( BookingSchema::settlements_table(), $GLOBALS['wpdb']->schemas );
+		$sales = $GLOBALS['wpdb']->schemas[ BookingSchema::sales_reports_table() ];
+		$this->assertArrayHasKey( 'ticket_source_id', $sales['columns'] );
+		$this->assertArrayHasKey( 'evidence_attachment_id', $sales['columns'] );
+		$this->assertSame( array( 'booking_id', 'provider', 'external_report_id' ), $sales['indexes']['provider_external_report']['columns'] );
+	}
+
+	public function test_sources_are_stable_idempotent_redacted_and_venue_scoped(): void {
+		$booking = $this->booking();
+		$input   = array(
+			'booking_id' => $booking['id'],
+			'provider'   => 'box-office',
+			'source_key' => 'campaign-a',
+			'ticket_url' => 'https://tickets.example.test/private-value/buy?token=private-value&utm_source=extrachill',
+		);
+		$first   = $this->reconciliation->register_source( $input, 12 );
+		$retry   = $this->reconciliation->register_source( $input, 12 );
+		$this->assertSame( $first, $retry );
+		$this->assertSame( 'https://tickets.example.test', $first['display_url'] );
+		$this->assertStringNotContainsString( 'private-value', wp_json_encode( $first ) );
+
+		$changed               = $input;
+		$changed['ticket_url'] = 'https://tickets.example.test/other';
+		$this->assertSame( 'ticket_source_idempotency_conflict', $this->reconciliation->register_source( $changed, 12 )->get_error_code() );
+		$this->assertSame( 'venue_action_forbidden', $this->reconciliation->register_source( $input, 99 )->get_error_code() );
+
+		$other               = $this->booking( 56, 901 );
+		$cross               = $input;
+		$cross['booking_id'] = $other['id'];
+		$cross['source_key'] = 'other';
+		$this->assertSame( 'venue_action_forbidden', $this->reconciliation->register_source( $cross, 12 )->get_error_code() );
+	}
+
+	public function test_unattributed_evidence_requires_immutable_resolution_before_settlement(): void {
+		$booking = $this->booking();
+		$source  = $this->source( $booking['id'] );
+		$input   = $this->report( $booking['id'], 'unattributed', null, '2026-07-01 00:00:00', '2026-07-01 23:59:59' );
+		$report  = $this->settlements->record_sales( $input, 12 );
+		$this->assertNull( $report['ticket_source_id'] );
+		$diagnostics = $this->reconciliation->diagnostics( $booking['id'], 12 );
+		$this->assertSame( array( 'unattributed' ), $diagnostics['reports'][0]['issues'] );
+		$this->assertFalse( $diagnostics['ready_for_settlement'] );
+		$this->assertSame( 'settlement_reconciliation_required', $this->preview( $booking['id'] )->get_error_code() );
+		$wrong_source = $this->reconciliation->register_source(
+			array(
+				'booking_id' => $booking['id'],
+				'provider'   => 'other-provider',
+				'source_key' => 'other',
+				'ticket_url' => 'https://other.example.test/buy',
+			),
+			12
+		);
+		$this->assertIsArray( $wrong_source );
+		$wrong_attribution = $this->reconciliation->resolve(
+			array(
+				'booking_id'       => $booking['id'],
+				'report_id'        => $report['id'],
+				'expected_version' => 0,
+				'decision'         => 'admit',
+				'ticket_source_id' => $wrong_source['id'],
+				'reason'           => 'Incorrect provider.',
+			),
+			12
+		);
+		$this->assertSame( 'ticket_source_not_found', $wrong_attribution->get_error_code() );
+
+		$resolution_input = array(
+			'booking_id'       => $booking['id'],
+			'report_id'        => $report['id'],
+			'expected_version' => 0,
+			'decision'         => 'admit',
+			'ticket_source_id' => $source['id'],
+			'reason'           => 'Matched against the signed venue export.',
+		);
+		$resolution       = $this->reconciliation->resolve(
+			$resolution_input,
+			12
+		);
+		$this->assertSame( 1, $resolution['version'] );
+		$this->assertSame( $source['id'], $resolution['ticket_source_id'] );
+		$this->assertSame( $resolution, $this->reconciliation->resolve( $resolution_input, 12 ) );
+		$this->assertTrue( $this->reconciliation->diagnostics( $booking['id'], 12 )['ready_for_settlement'] );
+		$this->assertSame( array( $report['id'] ), $this->preview( $booking['id'] )['included_report_ids'] );
+
+		$stale = $this->reconciliation->resolve(
+			array(
+				'booking_id'       => $booking['id'],
+				'report_id'        => $report['id'],
+				'expected_version' => 0,
+				'decision'         => 'exclude',
+				'reason'           => 'Stale overwrite.',
+			),
+			12
+		);
+		$this->assertSame( 'sales_resolution_version_conflict', $stale->get_error_code() );
+		$second = $this->reconciliation->resolve(
+			array(
+				'booking_id'       => $booking['id'],
+				'report_id'        => $report['id'],
+				'expected_version' => 1,
+				'decision'         => 'exclude',
+				'reason'           => 'Superseded by certified evidence.',
+			),
+			12
+		);
+		$this->assertSame( $resolution['id'], $second['supersedes_resolution_id'] );
+		$this->assertCount( 2, $GLOBALS['wpdb']->rows[ BookingSchema::sales_resolutions_table() ] );
+		$third      = $this->reconciliation->resolve(
+			array(
+				'booking_id'       => $booking['id'],
+				'report_id'        => $report['id'],
+				'expected_version' => 2,
+				'decision'         => 'admit',
+				'ticket_source_id' => $source['id'],
+				'reason'           => 'Final finance review restored admission.',
+			),
+			12
+		);
+		$preview = $this->preview( $booking['id'] );
+		$fourth  = $this->reconciliation->resolve(
+			array(
+				'booking_id'       => $booking['id'],
+				'report_id'        => $report['id'],
+				'expected_version' => $third['version'],
+				'decision'         => 'admit',
+				'ticket_source_id' => $source['id'],
+				'reason'           => 'Second finance review confirmed admission.',
+			),
+			12
+		);
+		$this->assertSame( 'settlement_evidence_conflict', $this->settlements->finalize( $this->resolution_finalization( $preview ), 12 )->get_error_code() );
+		$preview    = $this->preview( $booking['id'] );
+		$settlement = $this->settlements->finalize( $this->resolution_finalization( $preview ), 12 );
+		$this->assertIsArray( $settlement, is_wp_error( $settlement ) ? $settlement->get_error_code() : '' );
+		$this->assertSame( $report, $this->settlements->record_sales( $input, 12 ) );
+		$after_settlement                       = $input;
+		$after_settlement['external_report_id'] = 'after-settlement';
+		$this->assertSame( 'sales_report_settlement_frozen', $this->settlements->record_sales( $after_settlement, 12 )->get_error_code() );
+		$frozen = $this->reconciliation->resolve(
+			array(
+				'booking_id'       => $booking['id'],
+				'report_id'        => $report['id'],
+				'expected_version' => $fourth['version'],
+				'decision'         => 'exclude',
+				'reason'           => 'Must not alter frozen evidence.',
+			),
+			12
+		);
+		$this->assertSame( 'sales_resolution_settlement_frozen', $frozen->get_error_code() );
+		$GLOBALS['wpdb']->rows[ BookingSchema::sales_resolutions_table() ][ $fourth['id'] ]['request_hash'] = str_repeat( '0', 64 );
+		$this->assertSame( 'sales_resolution_integrity_failed', $this->settlements->finalize( $this->resolution_finalization( $preview ), 12 )->get_error_code() );
+	}
+
+	public function test_all_currencies_must_reconcile_before_one_currency_settles(): void {
+		$booking               = $this->booking();
+		$source                = $this->source( $booking['id'] );
+		$usd                   = $this->settlements->record_sales( $this->report( $booking['id'], 'usd-clean', $source['id'], '2026-07-01 00:00:00', '2026-07-01 23:59:59' ), 12 );
+		$eur_input             = $this->report( $booking['id'], 'eur-unattributed', null, '2026-07-02 00:00:00', '2026-07-02 23:59:59' );
+		$eur_input['currency'] = 'EUR';
+		$eur                   = $this->settlements->record_sales( $eur_input, 12 );
+		$this->assertSame( 'settlement_reconciliation_required', $this->preview( $booking['id'] )->get_error_code() );
+		$this->resolve_report( $booking['id'], $eur['id'], 'exclude' );
+		$this->assertSame( array( $usd['id'] ), $this->preview( $booking['id'] )['included_report_ids'] );
+	}
+
+	public function test_report_identity_is_scoped_to_booking_and_source_authority(): void {
+		$first        = $this->booking();
+		$first_source = $this->source( $first['id'] );
+		$first_report = $this->settlements->record_sales( $this->report( $first['id'], 'account-local-id', $first_source['id'], '2026-07-01 00:00:00', '2026-07-01 23:59:59' ), 12 );
+		$this->assertIsArray( $first_report );
+
+		$this->authorization->allowed['12:56'] = true;
+		$second                                = $this->booking( 56, 901 );
+		$second_source                         = $this->source( $second['id'] );
+		$second_report                         = $this->settlements->record_sales( $this->report( $second['id'], 'account-local-id', $second_source['id'], '2026-07-01 00:00:00', '2026-07-01 23:59:59' ), 12 );
+		$this->assertIsArray( $second_report, is_wp_error( $second_report ) ? $second_report->get_error_code() : '' );
+		$this->assertNotSame( $first_report['id'], $second_report['id'] );
+
+		$alternate_source = $this->reconciliation->register_source(
+			array(
+				'booking_id' => $first['id'],
+				'provider'   => 'box-office',
+				'source_key' => 'alternate',
+				'ticket_url' => 'https://tickets.example.test/alternate',
+			),
+			12
+		);
+		$correction                         = $this->report( $first['id'], 'cross-source-correction', $alternate_source['id'], '2026-07-01 00:00:00', '2026-07-01 23:59:59' );
+		$correction['corrects_report_id'] = $first_report['id'];
+		$this->assertSame( 'invalid_sales_report_correction', $this->settlements->record_sales( $correction, 12 )->get_error_code() );
+	}
+
+	public function test_stored_evidence_is_rejected_after_booking_identity_changes(): void {
+		$booking = $this->booking();
+		$source  = $this->source( $booking['id'] );
+		$report  = $this->settlements->record_sales( $this->report( $booking['id'], 'identity-change', $source['id'], '2026-07-01 00:00:00', '2026-07-01 23:59:59' ), 12 );
+
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['event_id'] = 901;
+		$this->assertSame( 'ticket_source_booking_changed', $this->reconciliation->list_sources( $booking['id'], 12 )->get_error_code() );
+		$this->assertSame( 'sales_report_booking_changed', $this->settlements->list_sales( $booking['id'], 12 )->get_error_code() );
+		$this->assertSame( 'sales_report_booking_changed', $this->reconciliation->diagnostics( $booking['id'], 12 )->get_error_code() );
+		$this->assertSame(
+			'sales_report_booking_changed',
+			$this->reconciliation->resolve(
+				array(
+					'booking_id'       => $booking['id'],
+					'report_id'        => $report['id'],
+					'expected_version' => 0,
+					'decision'         => 'exclude',
+					'reason'           => 'Must not reinterpret stale evidence.',
+				),
+				12
+			)->get_error_code()
+		);
+	}
+
+	public function test_duplicates_overlaps_contradictions_and_currency_mismatch_are_explicit(): void {
+		$booking                = $this->booking();
+		$source                 = $this->source( $booking['id'] );
+		$first                  = $this->settlements->record_sales( $this->report( $booking['id'], 'first', $source['id'], '2026-07-01 00:00:00', '2026-07-10 23:59:59' ), 12 );
+		$duplicate              = $this->report( $booking['id'], 'duplicate', $source['id'], '2026-07-01 00:00:00', '2026-07-10 23:59:59' );
+		$second                 = $this->settlements->record_sales( $duplicate, 12 );
+		$conflict               = $this->report( $booking['id'], 'conflict', $source['id'], '2026-07-01 00:00:00', '2026-07-10 23:59:59' );
+		$conflict['fees_minor'] = 999;
+		$third                  = $this->settlements->record_sales( $conflict, 12 );
+		$eur                    = $this->report( $booking['id'], 'eur', $source['id'], '2026-07-20 00:00:00', '2026-07-20 23:59:59' );
+		$eur['currency']        = 'EUR';
+		$fourth                 = $this->settlements->record_sales( $eur, 12 );
+
+		$diagnostics = $this->reconciliation->diagnostics( $booking['id'], 12 );
+		$this->assertContains( 'duplicate', $diagnostics['reports'][0]['issues'] );
+		$this->assertContains( 'contradictory', $diagnostics['reports'][0]['issues'] );
+		$this->assertContains( 'currency_mismatch', $diagnostics['reports'][3]['issues'] );
+		$this->assertSame( 4, $diagnostics['counts']['unresolved'] );
+
+		$this->resolve_report( $booking['id'], $first['id'], 'admit' );
+		$this->resolve_report( $booking['id'], $second['id'], 'exclude' );
+		$this->resolve_report( $booking['id'], $third['id'], 'exclude' );
+		$this->resolve_report( $booking['id'], $fourth['id'], 'exclude' );
+		$ready = $this->reconciliation->diagnostics( $booking['id'], 12 );
+		$this->assertTrue( $ready['ready_for_settlement'] );
+		$this->assertSame( array( $first['id'] ), $this->preview( $booking['id'] )['included_report_ids'] );
+	}
+
+	public function test_csv_import_uses_private_attachment_and_replays_idempotently(): void {
+		$booking    = $this->booking();
+		$source     = $this->source( $booking['id'] );
+		$csv        = implode( ',', array( 'external_report_id', 'period_start', 'period_end', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'currency' ) ) . "\n"
+			. 'csv-1,"2026-07-01 00:00:00","2026-07-01 23:59:59",10,1,10000,500,0,1000,8500,USD' . "\n"
+			. 'csv-2,"2026-07-02 00:00:00","2026-07-02 23:59:59",5,0,5000,250,0,0,4750,USD' . "\n";
+		$attachment = $this->csv_attachment( $booking['id'], $csv, 'canonical.csv' );
+		$input      = array(
+			'booking_id'       => $booking['id'],
+			'attachment_id'    => $attachment['id'],
+			'ticket_source_id' => $source['id'],
+		);
+		$rows       = $this->reconciliation->csv_report_inputs( $input, 12 );
+		$this->assertCount( 2, $rows );
+		$this->assertSame( $attachment['id'], $rows[0]['evidence_attachment_id'] );
+		$first      = array_map(
+			function ( $row ) {
+				return $this->settlements->record_sales( $row, 12 );
+			},
+			$rows
+		);
+		$retry_rows = $this->reconciliation->csv_report_inputs( $input, 12 );
+		$retry      = array_map(
+			function ( $row ) {
+				return $this->settlements->record_sales( $row, 12 );
+			},
+			$retry_rows
+		);
+		$this->assertSame( array_column( $first, 'id' ), array_column( $retry, 'id' ) );
+		$this->assertSame( array( 'csv_certified' ), array_values( array_unique( array_column( $first, 'source_type' ) ) ) );
+		$this->provider->contents[ $attachment['storage_reference'] ] = substr( $csv, 0, -5 );
+		$this->assertSame( 'sales_csv_evidence_mismatch', $this->reconciliation->csv_report_inputs( $input, 12 )->get_error_code() );
+		$this->provider->contents[ $attachment['storage_reference'] ] = $csv . 'extra';
+		$this->assertSame( 'sales_csv_evidence_mismatch', $this->reconciliation->csv_report_inputs( $input, 12 )->get_error_code() );
+
+		$bad_attachment = $this->csv_attachment( $booking['id'], "formula,total\n=HYPERLINK(\"https://evil.test\"),1\n", 'hostile.csv' );
+		$bad            = $this->reconciliation->csv_report_inputs(
+			array(
+				'booking_id'       => $booking['id'],
+				'attachment_id'    => $bad_attachment['id'],
+				'ticket_source_id' => $source['id'],
+			),
+			12
+		);
+		$this->assertSame( 'sales_csv_header_invalid', $bad->get_error_code() );
+		$long_csv        = implode( ',', array( 'external_report_id', 'period_start', 'period_end', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'currency' ) ) . "\n\"" . str_repeat( 'x', 17000 );
+		$long_attachment = $this->csv_attachment( $booking['id'], $long_csv, 'overlong.csv' );
+		$long            = $this->reconciliation->csv_report_inputs(
+			array(
+				'booking_id'       => $booking['id'],
+				'attachment_id'    => $long_attachment['id'],
+				'ticket_source_id' => $source['id'],
+			),
+			12
+		);
+		$this->assertSame( 'sales_csv_line_too_long', $long->get_error_code() );
+	}
+
+	public function test_abilities_expose_bounded_contracts_and_redact_provenance(): void {
+		$abilities = new TicketSettlementAbilities( $this->settlements, $this->bookings, $this->authorization, $this->reconciliation );
+		$abilities->register();
+		foreach ( array( 'extrachill/register-booking-ticket-source', 'extrachill/list-booking-ticket-sources', 'extrachill/import-booking-ticket-sales-csv', 'extrachill/diagnose-booking-ticket-sales', 'extrachill/resolve-booking-ticket-sales' ) as $name ) {
+			$this->assertArrayHasKey( $name, $GLOBALS['ec_artist_test']['abilities'] );
+			$this->assertTrue( $GLOBALS['ec_artist_test']['abilities'][ $name ]['meta']['show_in_rest'] );
+		}
+		$this->assertSame( 1000, $GLOBALS['ec_artist_test']['abilities']['extrachill/import-booking-ticket-sales-csv']['output_schema']['maxItems'] );
+		$this->assertFalse( $GLOBALS['ec_artist_test']['abilities']['extrachill/resolve-booking-ticket-sales']['meta']['annotations']['readonly'] );
+
+		$booking                = $this->booking();
+		$source                 = $this->source( $booking['id'] );
+		$report_input           = $this->report( $booking['id'], 'redacted', $source['id'], '2026-07-01 00:00:00', '2026-07-01 23:59:59' );
+		$report_input['source'] = array(
+			'certificate' => 'signed',
+			'api_key'     => 'must-not-leak',
+			'url'         => 'https://private.test/?token=secret',
+			'headers'     => array( 'X-Session' => 'private-session' ),
+		);
+		$report                 = $this->settlements->record_sales( $report_input, 12 );
+		$this->assertSame( array( 'redacted' => true ), $report['source'] );
+		$this->assertStringNotContainsString( 'must-not-leak', wp_json_encode( $this->settlements->list_sales( $booking['id'], 12 ) ) );
+		$this->assertStringNotContainsString( 'private-session', wp_json_encode( $this->settlements->list_sales( $booking['id'], 12 ) ) );
+		$this->assertStringNotContainsString( 'private.test', wp_json_encode( $this->settlements->list_sales( $booking['id'], 12 ) ) );
+		$oversized                       = $report_input;
+		$oversized['external_report_id'] = 'oversized';
+		$oversized['source']             = array( 'certificate' => str_repeat( 'x', 9000 ) );
+		$this->assertSame( 'sales_report_source_too_large', $this->settlements->record_sales( $oversized, 12 )->get_error_code() );
+		$GLOBALS['wpdb']->rows[ BookingSchema::sales_reports_table() ][ $report['id'] ]['gross_minor'] = 1;
+		$this->assertSame( 'sales_report_integrity_failed', $this->reconciliation->diagnostics( $booking['id'], 12 )->get_error_code() );
+	}
+
+	private function booking( int $venue_id = 55, int $event_id = 900 ): array {
+		$booking = $this->bookings->create(
+			array(
+				'venue_term_id' => $venue_id,
+				'artist_name'   => 'Evidence Artist',
+				'intake'        => array(),
+			)
+		);
+		$booking = $this->bookings->claim_event( $booking['id'], $event_id, $booking['version'] );
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['confirmed_deal_payload'] = wp_json_encode(
+			array(
+				'version' => 1,
+				'data'    => array( 'currency' => 'USD' ),
+			)
+		);
+		return $this->bookings->get( $booking['id'] );
+	}
+
+	private function source( int $booking_id ): array {
+		$source = $this->reconciliation->register_source(
+			array(
+				'booking_id' => $booking_id,
+				'provider'   => 'box-office',
+				'source_key' => 'primary',
+				'ticket_url' => 'https://tickets.example.test/buy?campaign=private',
+			),
+			12
+		);
+		$this->assertIsArray( $source, is_wp_error( $source ) ? $source->get_error_code() : '' );
+		return $source;
+	}
+
+	private function report( int $booking_id, string $external_id, ?int $source_id, string $start, string $end ): array {
+		return array(
+			'booking_id'         => $booking_id,
+			'ticket_source_id'   => $source_id,
+			'provider'           => 'box-office',
+			'external_report_id' => $external_id,
+			'source_type'        => 'manual',
+			'period_start'       => $start,
+			'period_end'         => $end,
+			'tickets_sold'       => 10,
+			'tickets_refunded'   => 1,
+			'gross_minor'        => 10000,
+			'fees_minor'         => 500,
+			'tax_minor'          => 0,
+			'refunds_minor'      => 1000,
+			'net_minor'          => 8500,
+			'currency'           => 'USD',
+			'source'             => array( 'certificate' => $external_id ),
+		);
+	}
+
+	private function preview( int $booking_id ) {
+		return $this->settlements->calculate(
+			array(
+				'booking_id'   => $booking_id,
+				'basis'        => 'gross_ticket_sales',
+				'basis_points' => 2000,
+				'currency'     => 'USD',
+			),
+			12
+		);
+	}
+
+	private function resolution_finalization( array $preview ): array {
+		return array(
+			'booking_id'               => $preview['booking_id'],
+			'expected_booking_version' => $preview['booking_version'],
+			'expected_report_ids'      => $preview['included_report_ids'],
+			'expected_evidence_hash'   => $preview['evidence_hash'],
+			'basis'                    => $preview['basis'],
+			'basis_points'             => $preview['basis_points'],
+			'currency'                 => $preview['currency'],
+			'formula_version'          => $preview['formula_version'],
+			'adjustment_minor'         => $preview['adjustment_minor'],
+		);
+	}
+
+	private function resolve_report( int $booking_id, int $report_id, string $decision ): void {
+		$result = $this->reconciliation->resolve(
+			array(
+				'booking_id'       => $booking_id,
+				'report_id'        => $report_id,
+				'expected_version' => 0,
+				'decision'         => $decision,
+				'reason'           => 'Operator reviewed conflicting evidence.',
+			),
+			12
+		);
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_code() : '' );
+	}
+
+	private function csv_attachment( int $booking_id, string $bytes, string $filename ): array {
+		$path = tempnam( sys_get_temp_dir(), 'ticket-csv-' );
+		file_put_contents( $path, $bytes );
+		$reference = $this->provider->stage( $path, $filename, 'other_private_evidence' );
+		unlink( $path );
+		$attachment = $this->attachment_service->attach(
+			array(
+				'booking_id'         => $booking_id,
+				'storage_reference'  => $reference,
+				'idempotency_key'    => 'csv-' . hash( 'sha256', $bytes ),
+				'purpose'            => 'other_private_evidence',
+				'uploader_type'      => 'user',
+				'uploader_user_id'   => 12,
+				'uploader_reference' => null,
+				'artist_term_id'     => null,
+				'artist_profile_id'  => null,
+			)
+		);
+		$this->assertIsArray( $attachment, is_wp_error( $attachment ) ? $attachment->get_error_code() : '' );
+		return $attachment;
+	}
+}

--- a/tests/TicketSettlementTest.php
+++ b/tests/TicketSettlementTest.php
@@ -10,6 +10,7 @@ use ExtraChillEvents\Core\BookingActivityRepository;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\TicketSettlementService;
+use ExtraChillEvents\Core\TicketReconciliationService;
 use ExtraChillEvents\Core\VenueAuthorization;
 use PHPUnit\Framework\TestCase;
 
@@ -22,6 +23,10 @@ final class TicketSettlementTest extends TestCase {
 	private $authorization;
 	/** @var TicketSettlementService */
 	private $service;
+	/** @var TicketReconciliationService */
+	private $reconciliation;
+	/** @var array<int,int> */
+	private $source_ids = array();
 
 	protected function setUp(): void {
 		$GLOBALS['ec_artist_test'] = array(
@@ -62,7 +67,8 @@ final class TicketSettlementTest extends TestCase {
 		$GLOBALS['wpdb']           = new BookingWpdb();
 		$this->bookings            = new BookingRepository();
 		$this->authorization       = new BookingTestAuthorization();
-		$this->service             = new TicketSettlementService( $this->bookings, new BookingActivityRepository(), $this->authorization );
+		$this->reconciliation      = new TicketReconciliationService( $this->bookings, new BookingActivityRepository(), $this->authorization );
+		$this->service             = new TicketSettlementService( $this->bookings, new BookingActivityRepository(), $this->authorization, null, $this->reconciliation );
 	}
 
 	public function test_schema_installs_signed_evidence_and_frozen_settlement_contracts(): void {
@@ -166,10 +172,12 @@ final class TicketSettlementTest extends TestCase {
 						array(
 							'id'           => $report['id'],
 							'request_hash' => $report['request_hash'],
+							'resolution'   => null,
 						),
 						array(
 							'id'           => $report_2['id'],
 							'request_hash' => $report_2['request_hash'],
+							'resolution'   => null,
 						),
 					)
 				)
@@ -236,6 +244,39 @@ final class TicketSettlementTest extends TestCase {
 				12
 			)->get_error_code()
 		);
+	}
+
+	public function test_formula_one_settlement_retry_and_terminal_transition_remain_compatible(): void {
+		$booking = $this->create_event_booking();
+		$report  = $this->service->record_sales( $this->report_input( $booking['id'], 'legacy-formula' ), 12 );
+		$preview = $this->preview( $booking['id'] );
+		$current = $this->service->finalize( $this->finalize_input( $preview ), 12 );
+		$table   = BookingSchema::settlements_table();
+		$row     = $GLOBALS['wpdb']->rows[ $table ][ $current['id'] ];
+
+		$row['formula_version'] = 1;
+		$row['evidence_hash']   = hash( 'sha256', wp_json_encode( array( array( 'id' => $report['id'], 'request_hash' => $report['request_hash'] ) ) ) );
+		$integrity              = new ReflectionMethod( TicketSettlementService::class, 'settlement_integrity_hash' );
+		$integrity->setAccessible( true );
+		$row['integrity_hash']                              = $integrity->invoke( $this->service, $row );
+		$GLOBALS['wpdb']->rows[ $table ][ $current['id'] ] = $row;
+
+		$retry                    = $this->finalize_input( $preview );
+		$retry['formula_version'] = 1;
+		unset( $retry['expected_evidence_hash'] );
+		$this->assertSame( 1, $this->service->finalize( $retry, 12 )['formula_version'] );
+		$voided = $this->service->void(
+			array(
+				'booking_id'               => $booking['id'],
+				'expected_booking_version' => $booking['version'],
+				'expected_version'         => 1,
+				'reason'                   => 'Legacy compatibility test.',
+			),
+			12
+		);
+		$this->assertIsArray( $voided, is_wp_error( $voided ) ? $voided->get_error_code() : '' );
+		$this->assertSame( 1, $voided['formula_version'] );
+		$this->assertSame( 'void', $voided['status'] );
 	}
 
 	public function test_frozen_financial_snapshot_tampering_fails_before_return_or_payment(): void {
@@ -562,13 +603,28 @@ final class TicketSettlementTest extends TestCase {
 	}
 
 	private function report_input( int $booking_id, string $external_id ): array {
+		if ( ! isset( $this->source_ids[ $booking_id ] ) ) {
+			$source = $this->reconciliation->register_source(
+				array(
+					'booking_id' => $booking_id,
+					'provider'   => 'manual-certified',
+					'source_key' => 'primary',
+					'ticket_url' => 'https://tickets.example.test/events/' . $booking_id . '?private_campaign=secret',
+				),
+				12
+			);
+			$this->assertIsArray( $source, is_wp_error( $source ) ? $source->get_error_code() : '' );
+			$this->source_ids[ $booking_id ] = $source['id'];
+		}
+		$day = 1 + ( hexdec( substr( hash( 'sha256', $external_id ), 0, 4 ) ) % 28 );
 		return array(
 			'booking_id'         => $booking_id,
+			'ticket_source_id'   => $this->source_ids[ $booking_id ],
 			'provider'           => 'manual-certified',
 			'external_report_id' => $external_id,
 			'source_type'        => 'manual',
-			'period_start'       => '2026-07-01 00:00:00',
-			'period_end'         => '2026-07-31 23:59:59',
+			'period_start'       => sprintf( '2026-07-%02d 00:00:00', $day ),
+			'period_end'         => sprintf( '2026-07-%02d 23:59:59', $day ),
 			'tickets_sold'       => 101,
 			'tickets_refunded'   => 1,
 			'gross_minor'        => 10001,
@@ -599,6 +655,7 @@ final class TicketSettlementTest extends TestCase {
 			'booking_id'               => $preview['booking_id'],
 			'expected_booking_version' => $preview['booking_version'],
 			'expected_report_ids'      => $preview['included_report_ids'],
+			'expected_evidence_hash'   => $preview['evidence_hash'],
 			'basis'                    => $preview['basis'],
 			'basis_points'             => $preview['basis_points'],
 			'currency'                 => $preview['currency'],
@@ -639,6 +696,7 @@ final class TicketSettlementTest extends TestCase {
 			$matches = $matches || ( 'null' === $type && null === $value )
 				|| ( 'integer' === $type && is_int( $value ) )
 				|| ( 'string' === $type && is_string( $value ) )
+				|| ( 'boolean' === $type && is_bool( $value ) )
 				|| ( in_array( $type, array( 'object', 'array' ), true ) && is_array( $value ) );
 		}
 		$this->assertTrue( $matches, $path . ' has an invalid type.' );


### PR DESCRIPTION
## Summary
- add immutable provider-neutral ticket source identities and approved private CSV evidence imports
- add bounded diagnostics plus append-only optimistic admit/exclude resolutions before settlement
- freeze report and reconciliation hashes into formula-v2 settlements while retaining formula-v1 retry compatibility
- add schema-v13 migration coverage, including preservation of v12 rows while replacing the legacy report index

## Verification
- `vendor/bin/phpunit -c phpunit-booking.xml.dist --filter 'Ticket(Settlement|Reconciliation)Test|Booking(Foundation|Mutation)Test'` (`69 tests`, `2474 assertions`)
- Homeboy changed-file lint: PHPCS passed, ESLint passed, PHPStan level 7 passed
- PHP syntax checks and `git diff --check` passed
- independent exact-diff review completed with all high/medium findings addressed

## Known Baseline
- the aggregate booking suite still exhibits the shared-bootstrap fixture pollution tracked in #400; focused suites covering this change pass
- disposable managed MySQL provisioning was unavailable locally, so the real-MySQL migration/concurrency tests are left to the configured CI workflow

Closes #316