### PR TITLE
fix: unblock production-scale event expansion

### DIFF
--- a/inc/Abilities/VenueExpansionAbilities.php
+++ b/inc/Abilities/VenueExpansionAbilities.php
@@ -6,6 +6,7 @@ namespace ExtraChillEvents\Abilities;
 defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
 use DataMachine\Engine\Tasks\TaskScheduler;
 use ExtraChillEvents\Core\VenueExpansionRunner;
 use ExtraChillEvents\Steps\VenueExpansion\VenueExpansionSystemTask;
@@ -83,6 +84,9 @@ class VenueExpansionAbilities {
 		if ( null === $this->scheduler && ! class_exists( TaskScheduler::class ) ) {
 			return new \WP_Error( 'batch_unavailable', 'Data Machine batch scheduling is unavailable.', array( 'status' => 503 ) );
 		}
+		if ( null === $this->scheduler && ! self::ensureExpansionTaskAvailable() ) {
+			return new \WP_Error( 'expansion_task_unavailable', 'Venue expansion task registration is unavailable.', array( 'status' => 503 ) );
+		}
 		$agent_context = array_filter(
 			array(
 				'agent_id'   => (int) ( $input['agent_id'] ?? 0 ),
@@ -106,6 +110,19 @@ class VenueExpansionAbilities {
 			'plan'  => $plan,
 			'batch' => $batch,
 		);
+	}
+
+	/** Load the task lazily for CLI requests that execute before task registry hydration. */
+	private static function ensureExpansionTaskAvailable(): bool {
+		if ( class_exists( VenueExpansionSystemTask::class ) ) {
+			return true;
+		}
+		if ( ! class_exists( SystemTask::class ) ) {
+			return false;
+		}
+		require_once dirname( __DIR__ ) . '/Core/VenueExpansionRunner.php';
+		require_once dirname( __DIR__ ) . '/Steps/VenueExpansion/VenueExpansionSystemTask.php';
+		return class_exists( VenueExpansionSystemTask::class );
 	}
 
 	/** Normalize bounds and allocate a global qualification-operation budget. */

--- a/inc/Core/EventSourceRampEvaluator.php
+++ b/inc/Core/EventSourceRampEvaluator.php
@@ -76,7 +76,7 @@ class EventSourceRampEvaluator {
 		return array(
 			'ticketmaster'      => array(
 				'handler'    => 'ticketmaster',
-				'stages'     => array( 1, 3, 5 ),
+				'stages'     => array( 25, 50, 100 ),
 				'thresholds' => array_merge(
 					$common,
 					array(
@@ -101,7 +101,7 @@ class EventSourceRampEvaluator {
 			),
 			'dice'              => array(
 				'handler'    => 'dice_fm',
-				'stages'     => array( 1, 3, 10 ),
+				'stages'     => array( 10, 25, 50 ),
 				'thresholds' => array_merge(
 					$common,
 					array(
@@ -126,7 +126,7 @@ class EventSourceRampEvaluator {
 			),
 			'universal_scraper' => array(
 				'handler'    => 'universal_web_scraper',
-				'stages'     => array( 1, 2 ),
+				'stages'     => array( 5, 10, 25 ),
 				'thresholds' => array_merge(
 					$common,
 					array(

--- a/tests/Unit/Core/EventSourceRampEvaluatorTest.php
+++ b/tests/Unit/Core/EventSourceRampEvaluatorTest.php
@@ -23,11 +23,11 @@ class EventSourceRampEvaluatorTest extends TestCase {
 	public function test_source_profiles_are_explicit(): void {
 		$profiles = EventSourceRampEvaluator::profiles();
 
-		$this->assertSame( array( 1, 3, 5 ), $profiles['ticketmaster']['stages'] );
+		$this->assertSame( array( 25, 50, 100 ), $profiles['ticketmaster']['stages'] );
 		$this->assertSame( 'ticketmaster', $profiles['ticketmaster']['handler'] );
-		$this->assertSame( array( 1, 3, 10 ), $profiles['dice']['stages'] );
+		$this->assertSame( array( 10, 25, 50 ), $profiles['dice']['stages'] );
 		$this->assertSame( 'dice_fm', $profiles['dice']['handler'] );
-		$this->assertSame( array( 1, 2 ), $profiles['universal_scraper']['stages'] );
+		$this->assertSame( array( 5, 10, 25 ), $profiles['universal_scraper']['stages'] );
 		$this->assertSame( 'universal_web_scraper', $profiles['universal_scraper']['handler'] );
 	}
 
@@ -55,9 +55,9 @@ class EventSourceRampEvaluatorTest extends TestCase {
 	 */
 	public function advancement_provider(): array {
 		return array(
-			'ticketmaster'      => array( 'ticketmaster', 1, 3 ),
-			'dice'              => array( 'dice', 1, 3 ),
-			'universal scraper' => array( 'universal_scraper', 1, 2 ),
+			'ticketmaster'      => array( 'ticketmaster', 25, 50 ),
+			'dice'              => array( 'dice', 10, 25 ),
+			'universal scraper' => array( 'universal_scraper', 5, 10 ),
 		);
 	}
 
@@ -66,7 +66,7 @@ class EventSourceRampEvaluatorTest extends TestCase {
 		$evidence = $this->passing_evidence();
 		unset( $evidence['metrics']['failed_rate'] );
 
-		$result = $this->evaluate( 'ticketmaster', 1, 'preflight', $evidence );
+		$result = $this->evaluate( 'ticketmaster', 25, 'preflight', $evidence );
 
 		$this->assertSame( 'hold', $result['decision'] );
 		$this->assertContains( 'failed_rate', $result['failed_gates'] );
@@ -78,7 +78,7 @@ class EventSourceRampEvaluatorTest extends TestCase {
 		$evidence                = $this->passing_evidence();
 		$evidence['observed_at'] = gmdate( 'c', self::NOW - EventSourceRampEvaluator::MAXIMUM_EVIDENCE_AGE_SECONDS - 1 );
 
-		$result = $this->evaluate( 'dice', 3, 'postflight', $evidence );
+		$result = $this->evaluate( 'dice', 25, 'postflight', $evidence );
 
 		$this->assertSame( 'hold', $result['decision'] );
 		$this->assertContains( 'freshness', $result['failed_gates'] );
@@ -90,7 +90,7 @@ class EventSourceRampEvaluatorTest extends TestCase {
 		$evidence                           = $this->passing_evidence();
 		$evidence['metrics']['queue_depth'] = 26;
 
-		$result = $this->evaluate( 'ticketmaster', 1, 'preflight', $evidence );
+		$result = $this->evaluate( 'ticketmaster', 25, 'preflight', $evidence );
 
 		$this->assertSame( 'hold', $result['decision'] );
 		$this->assertContains( 'queue_depth', $result['failed_gates'] );
@@ -98,7 +98,7 @@ class EventSourceRampEvaluatorTest extends TestCase {
 
 	/** Confirm a passing final stage cannot advance beyond policy. */
 	public function test_passing_final_stage_is_complete(): void {
-		$result = $this->evaluate( 'dice', 10, 'postflight', $this->passing_evidence() );
+		$result = $this->evaluate( 'dice', 50, 'postflight', $this->passing_evidence() );
 
 		$this->assertSame( 'complete', $result['decision'] );
 		$this->assertFalse( $result['can_advance'] );
@@ -111,11 +111,11 @@ class EventSourceRampEvaluatorTest extends TestCase {
 		$evidence                           = $this->passing_evidence();
 		$evidence['metrics']['failed_rate'] = 0.06;
 
-		$result = $this->evaluate( 'ticketmaster', 3, 'postflight', $evidence );
+		$result = $this->evaluate( 'ticketmaster', 50, 'postflight', $evidence );
 
 		$this->assertSame( 'rollback', $result['decision'] );
-		$this->assertStringContainsString( '"max_items":1', $result['apply_plan']['apply_command'] );
-		$this->assertStringContainsString( '"max_items":3', $result['apply_plan']['rollback_command'] );
+		$this->assertStringContainsString( '"max_items":25', $result['apply_plan']['apply_command'] );
+		$this->assertStringContainsString( '"max_items":50', $result['apply_plan']['rollback_command'] );
 		$this->assertTrue( $result['apply_plan']['canonical_events_preserved'] );
 	}
 
@@ -124,7 +124,7 @@ class EventSourceRampEvaluatorTest extends TestCase {
 		$evidence                                  = $this->passing_evidence();
 		$evidence['metrics']['ai_defer_exhausted'] = 1;
 
-		$result = $this->evaluate( 'universal_scraper', 1, 'postflight', $evidence );
+		$result = $this->evaluate( 'universal_scraper', 5, 'postflight', $evidence );
 
 		$this->assertSame( 'rollback', $result['decision'] );
 		$this->assertSame( 'wp datamachine flows pause --pipeline=10', $result['apply_plan']['apply_command'] );
@@ -133,7 +133,7 @@ class EventSourceRampEvaluatorTest extends TestCase {
 
 	/** Confirm evaluator output matches the declared top-level JSON schema. */
 	public function test_output_matches_declared_json_schema(): void {
-		$result = $this->evaluate( 'ticketmaster', 1, 'preflight', $this->passing_evidence() );
+		$result = $this->evaluate( 'ticketmaster', 25, 'preflight', $this->passing_evidence() );
 		$schema = EventSourceRampAbilities::output_schema();
 
 		$this->assertSame( array(), array_diff( $schema['required'], array_keys( $result ) ) );
@@ -160,7 +160,7 @@ class EventSourceRampEvaluatorTest extends TestCase {
 			}
 		);
 
-		$result = $this->evaluate( 'ticketmaster', 1, 'preflight', $this->passing_evidence() );
+		$result = $this->evaluate( 'ticketmaster', 25, 'preflight', $this->passing_evidence() );
 
 		$this->assertSame( 0, $GLOBALS['ec_ramp_mutations'] );
 		$this->assertTrue( $result['apply_plan']['observational'] );

--- a/tests/Unit/Core/VenueExpansionPlanTest.php
+++ b/tests/Unit/Core/VenueExpansionPlanTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 require_once dirname( __DIR__, 3 ) . '/inc/Core/VenueExpansionRunner.php';
 require_once dirname( __DIR__, 3 ) . '/inc/Abilities/VenueExpansionAbilities.php';
 require_once dirname( __DIR__, 3 ) . '/inc/Cli/ExpandVenuesCommand.php';
+require_once __DIR__ . '/Stubs/system-task-base-stub.php';
 
 class VenueExpansionPlanTest extends TestCase {
 	public function test_city_file_parser_ignores_comments_blanks_and_duplicates(): void {
@@ -88,6 +89,14 @@ class VenueExpansionPlanTest extends TestCase {
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'agent_context_required', $result->get_error_code() );
+	}
+
+	public function test_expansion_task_can_be_loaded_before_registry_hydration(): void {
+		$method = new \ReflectionMethod( VenueExpansionAbilities::class, 'ensureExpansionTaskAvailable' );
+		$method->setAccessible( true );
+
+		$this->assertTrue( $method->invoke( null ) );
+		$this->assertTrue( class_exists( \ExtraChillEvents\Steps\VenueExpansion\VenueExpansionSystemTask::class ) );
 	}
 
 	public function test_report_schema_preserves_per_city_and_aggregate_evidence(): void {


### PR DESCRIPTION
## Summary
- replace undersized source ramps with Ticketmaster `25 → 50 → 100`, Dice `10 → 25 → 50`, and scraper `5 → 10 → 25`
- lazy-load the venue expansion task when CLI apply runs before Data Machine task-registry hydration
- preserve all existing evidence thresholds and reversible rollback behavior

## Production impact
- fixes the `Class VenueExpansionSystemTask not found` error that blocked a planned 10-city/150-qualification expansion batch
- aligns policy with observed 100-item Ticketmaster production throughput

## Validation
- Event source evaluator: 12 tests, 47 assertions
- Venue expansion plan: 8 tests, 29 assertions
- Venue expansion task: 3 tests, 8 assertions
- PHPCS, ESLint, and PHPStan pass

Closes #428
Closes #431