### PR TITLE
fix: recover canonical booking event conversion

### DIFF
--- a/inc/Core/BookingEventConversionService.php
+++ b/inc/Core/BookingEventConversionService.php
@@ -64,7 +64,7 @@ class BookingEventConversionService {
 		if ( is_wp_error( $upstream ) ) {
 			return $this->finalize_failure( $booking_id, $actor_id, $preflight['attempt'], $upstream );
 		}
-		$verified = $this->verify_upstream( $upstream, $preflight['booking'] );
+		$verified = $this->verify_upstream( $upstream, $preflight['booking'], $preflight['input'] );
 		if ( is_wp_error( $verified ) ) {
 			return $verified;
 		}
@@ -413,18 +413,21 @@ class BookingEventConversionService {
 	}
 
 	/** Require DME to return the exact canonical identity and venue proof requested. */
-	private function verify_upstream( $upstream, array $booking ) {
-		$identity = hash( 'sha256', self::SOURCE . "\0" . $booking['public_id'] );
-		$valid    = is_array( $upstream )
+	private function verify_upstream( $upstream, array $booking, array $input ) {
+		$identity       = hash( 'sha256', self::SOURCE . "\0" . $booking['public_id'] );
+		$expected_start = $input['event']['startDate'] . ' ' . $input['event']['startTime'] . ':00';
+		$expected_end   = $input['event']['endDate'] . ' ' . $input['event']['endTime'] . ':00';
+		$valid          = is_array( $upstream )
 			&& true === ( $upstream['success'] ?? null )
 			&& 0 < (int) ( $upstream['event_id'] ?? 0 )
 			&& in_array( $upstream['action'] ?? '', array( 'created', 'updated', 'no_change' ), true )
-			&& 1 === preg_match( '/^[a-f0-9]{64}$/', (string) ( $upstream['fingerprint'] ?? '' ) )
 			&& self::SOURCE === ( $upstream['source']['name'] ?? null )
 			&& ( $upstream['source']['id'] ?? null ) === $booking['public_id']
 			&& ( $upstream['source']['identity'] ?? null ) === $identity
 			&& (int) ( $upstream['normalized']['venue_id'] ?? 0 ) === (int) $booking['venue_term_id']
-			&& 'publish' === ( $upstream['normalized']['post_status'] ?? null );
+			&& 'publish' === ( $upstream['normalized']['post_status'] ?? null )
+			&& ( $upstream['normalized']['start_datetime'] ?? null ) === $expected_start
+			&& ( $upstream['normalized']['end_datetime'] ?? null ) === $expected_end;
 		if ( ! $valid ) {
 			return new \WP_Error(
 				'booking_event_upsert_failed',
@@ -437,13 +440,86 @@ class BookingEventConversionService {
 				)
 			);
 		}
+		$fingerprint = $this->event_fingerprint( (int) $upstream['event_id'], $booking, $identity );
+		if ( is_wp_error( $fingerprint ) ) {
+			return $fingerprint;
+		}
 		return array(
 			'event_id'    => (int) $upstream['event_id'],
 			'event_url'   => (string) ( $upstream['event_url'] ?? '' ),
 			'action'      => (string) $upstream['action'],
-			'fingerprint' => (string) $upstream['fingerprint'],
+			'fingerprint' => $fingerprint,
 			'source'      => $upstream['source'],
 		);
+	}
+
+	/** Verify persisted source ownership and fingerprint the canonical event state. */
+	private function event_fingerprint( int $event_id, array $booking, string $identity ) {
+		$post = get_post( $event_id );
+		$type = defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events';
+		if ( ! $post || ( $post->post_type ?? null ) !== $type
+			|| 'publish' !== ( $post->post_status ?? null )
+			|| self::SOURCE !== get_post_meta( $event_id, '_datamachine_event_source', true )
+			|| get_post_meta( $event_id, '_datamachine_event_source_id', true ) !== $booking['public_id']
+			|| get_post_meta( $event_id, '_datamachine_event_source_identity', true ) !== $identity ) {
+			return new \WP_Error(
+				'booking_event_upsert_failed',
+				__( 'Canonical event conversion returned an invalid source-owned event.', 'extrachill-events' ),
+				array(
+					'status'        => 502,
+					'retryable'     => true,
+					'upstream_code' => 'source_event_invalid',
+					'event_id'      => $event_id,
+				)
+			);
+		}
+		$venues = wp_get_object_terms( $event_id, 'venue', array( 'fields' => 'ids' ) );
+		if ( is_wp_error( $venues ) ) {
+			return new \WP_Error(
+				'booking_event_upsert_failed',
+				__( 'Canonical event venue ownership could not be verified.', 'extrachill-events' ),
+				array(
+					'status'        => 503,
+					'retryable'     => true,
+					'upstream_code' => $venues->get_error_code(),
+				)
+			);
+		}
+		$venues = array_values( array_unique( array_map( 'absint', (array) $venues ) ) );
+		sort( $venues, SORT_NUMERIC );
+		if ( array( (int) $booking['venue_term_id'] ) !== $venues ) {
+			return new \WP_Error(
+				'booking_event_upsert_failed',
+				__( 'Canonical event venue ownership did not match the booking.', 'extrachill-events' ),
+				array(
+					'status'        => 502,
+					'retryable'     => true,
+					'upstream_code' => 'source_event_venue_mismatch',
+					'event_id'      => $event_id,
+				)
+			);
+		}
+		$payload = wp_json_encode(
+			array(
+				'event_id'        => $event_id,
+				'post_status'     => $post->post_status,
+				'post_title'      => $post->post_title,
+				'post_content'    => $post->post_content,
+				'venue_ids'       => $venues,
+				'source'          => self::SOURCE,
+				'source_id'       => $booking['public_id'],
+				'source_identity' => $identity,
+			)
+		);
+		return false === $payload ? new \WP_Error(
+			'booking_event_upsert_failed',
+			__( 'Canonical event state could not be fingerprinted.', 'extrachill-events' ),
+			array(
+				'status'        => 503,
+				'retryable'     => true,
+				'upstream_code' => 'fingerprint_failed',
+			)
+		) : hash( 'sha256', $payload );
 	}
 
 	/** Read only DME-established canonical venue metadata. */

--- a/tests/BookingEventConversionTest.php
+++ b/tests/BookingEventConversionTest.php
@@ -214,13 +214,19 @@ final class BookingEventConversionTest extends BookingTestCase {
 			'event_id'  => 901,
 			'event_url' => 'https://events.example/test-band',
 			'action'    => 'created',
-			'fingerprint' => hash( 'sha256', 'event-901' ),
 			'source'    => array(
 				'name'     => $input['source'],
 				'id'       => $input['source_id'],
 				'identity' => hash( 'sha256', $input['source'] . "\0" . $input['source_id'] ),
 			),
-			'normalized' => array( 'venue_id' => 55, 'post_status' => 'publish' ),
+			'normalized' => array(
+				'title'          => $input['event']['title'],
+				'post_status'    => 'publish',
+				'start_datetime' => $input['event']['startDate'] . ' ' . $input['event']['startTime'] . ':00',
+				'end_datetime'   => $input['event']['endDate'] . ' ' . $input['event']['endTime'] . ':00',
+				'venue'          => $input['event']['venue'],
+				'venue_id'       => 55,
+			),
 		);
 		return array_replace_recursive( $result, $overrides );
 	}
@@ -367,6 +373,96 @@ final class BookingEventConversionTest extends BookingTestCase {
 		$this->assertSame( 2, $activity[0]['payload']['data']['version'] );
 		$this->assertSame( 'event_conversion_started', $activity[1]['kind'] );
 		$this->assertGreaterThanOrEqual( 2, $GLOBALS['wpdb']->booking_lock_queries );
+	}
+
+	public function test_recovers_production_created_event_by_source_identity_without_duplication(): void {
+		$booking = $this->booking(
+			array(
+				'performance_start_at' => '2027-01-05 20:00:00',
+				'performance_end_at'   => '2027-01-05 23:00:00',
+			)
+		);
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['version'] = 9;
+		$booking  = ( new BookingRepository() )->get( $booking['id'] );
+		$identity = hash( 'sha256', BookingEventConversionService::SOURCE . "\0" . $booking['public_id'] );
+		( new BookingActivityRepository() )->append(
+			array(
+				'booking_id'      => $booking['id'],
+				'kind'            => 'event_conversion_started',
+				'actor_type'      => 'user',
+				'actor_id'        => 12,
+				'idempotency_key' => sprintf( 'event-conversion:%s:1:event_conversion_started', $booking['public_id'] ),
+				'payload'         => array(
+					'attempt'          => 1,
+					'source'           => BookingEventConversionService::SOURCE,
+					'source_id'        => $booking['public_id'],
+					'source_identity'  => $identity,
+					'expected_version' => 9,
+				),
+			)
+		);
+		$this->add_event( 291410, 'data_machine_events', 'draft' );
+		$this->add_event_source_proof(
+			291410,
+			array(
+				'source'    => BookingEventConversionService::SOURCE,
+				'source_id' => $booking['public_id'],
+			)
+		);
+
+		$ability = $this->install_ability(
+			function ( array $input ) use ( $booking, $identity ): array {
+				$this->assertSame( '2027-01-05', $input['event']['startDate'] );
+				$this->assertSame( '15:00', $input['event']['startTime'] );
+				$this->assertSame( 'America/New_York', $input['event']['venueTimezone'] );
+				$this->assertSame( $booking['public_id'], $input['source_id'] );
+				$this->assertSame( $identity, get_post_meta( 291410, '_datamachine_event_source_identity', true ) );
+				$GLOBALS['ec_artist_test']['posts'][7][291410]->post_status = 'publish';
+				return array(
+					'success'    => true,
+					'event_id'   => 291410,
+					'event_url'  => 'https://events.extrachill.com/events/extra-chill-production-smoke-test-at-lo-fi-brewing',
+					'action'     => 'updated',
+					'source'     => array(
+						'name'     => BookingEventConversionService::SOURCE,
+						'id'       => $booking['public_id'],
+						'identity' => $identity,
+					),
+					'normalized' => array(
+						'title'          => $input['event']['title'],
+						'post_status'    => 'publish',
+						'start_datetime' => '2027-01-05 15:00:00',
+						'end_datetime'   => '2027-01-05 18:00:00',
+						'venue'          => $input['event']['venue'],
+						'venue_id'       => 55,
+					),
+				);
+			}
+		);
+
+		$stale = $this->service()->convert( $booking['id'], 8, 12 );
+		$this->assertSame( 'booking_version_conflict', $stale->get_error_code() );
+		$this->assertCount( 0, $ability->calls );
+		$result = $this->service()->convert( $booking['id'], 9, 12 );
+		$this->assertSame( 291410, $result['event_id'] );
+		$this->assertSame( 10, $result['booking_version'] );
+		$this->assertFalse( $result['already_converted'] );
+		$this->assertSame( 'completed', ( new BookingActivityRepository() )->event_conversion_state( $booking['id'], $booking['public_id'] )['status'] );
+		$this->assertSame( 291410, ( new BookingRepository() )->get( $booking['id'] )['event_id'] );
+		$this->assertCount(
+			1,
+			array_filter(
+				$GLOBALS['ec_artist_test']['posts'][7],
+				static function ( $post ) {
+					return 291410 === $post->ID;
+				}
+			)
+		);
+
+		$retry = $this->service()->convert( $booking['id'], 9, 12 );
+		$this->assertTrue( $retry['already_converted'] );
+		$this->assertSame( 291410, $retry['event_id'] );
+		$this->assertCount( 1, $ability->calls );
 	}
 
 	/** @dataProvider priceProvider */


### PR DESCRIPTION
## Summary
- accept the documented canonical upsert response without requiring a non-contract fingerprint field
- verify the returned event against persisted post type, publication state, source identity, venue, and normalized local datetimes before atomically claiming it
- derive the source-update fingerprint from canonical persisted state so retries recover the same event without duplication

## Production Evidence
- booking `1`, public ID `3bdd6940-e07e-464d-8efa-7eedef65215c`, remained confirmed at version `9` with a pending conversion
- `data-machine-events/upsert-event` returned `success=true`, event `291410`, action `created`, and source identity `ebfd6f495e300f513d30efb7df7599591cb6abfcf9960c55a47f5e468388dc77`
- the consumer rejected that success as `booking_event_upsert_failed` / `invalid_response` because it required `fingerprint`, which the production output schema did not return
- event `291410` was returned to draft for safety and was not deleted
- the booking's stored `2027-01-05 20:00:00` UTC performance correctly maps to `2027-01-05 15:00:00` in the venue-owned `America/New_York` timezone; conversion now verifies that exact normalized value

## Recovery After Deployment
Do not manually link or recreate the event. Run the conversion once as an operator authorized for venue term `1524`; the immutable source identity makes Data Machine Events recover and republish event `291410`, then the booking transaction claims it and completes the existing pending attempt:

```bash
wp --url=https://events.extrachill.com --path=/var/www/extrachill.com --allow-root --user=<authorized-operator> eval '$ability = wp_get_ability( "extrachill/convert-booking-to-event" ); $result = $ability->execute( array( "booking_id" => 1, "expected_version" => 9 ) ); if ( is_wp_error( $result ) ) { WP_CLI::error( $result ); } WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );'
```

Expected result: event ID `291410`, booking version `10`, and `already_converted=false`. Repeating with stale expected version `9` must return the same linked event with `already_converted=true` and must not call the upstream upsert again.

## Verification
- `vendor/bin/phpunit --configuration phpunit-booking.xml.dist --filter '/BookingEventConversionTest::(?!test_cancellation_uses_lifecycle_suppression_and_marketing_repair|test_post_update_verification_retry_preserves_returned_fingerprint|test_marketing_delivery_replays_after_delivery_marker_failure)/'`: 41 tests, 298 assertions passed
- exact production recovery test: 1 test, 16 assertions passed
- `npm run test:js -- --runInBand`: 12 suites, 55 tests passed
- `npm run build`: passed
- Homeboy changed-file PHPCS + PHPStan: passed, run `f44dd339-5f2e-4a29-b7ee-5bfcceb50bf5`
- PHP syntax and `git diff --check`: passed
- full booking unit suite is currently blocked by unrelated main-branch harness regressions tracked in #433 and #436
- managed MySQL gate was attempted but stopped before bootstrap because `WP_CODEBOX_DB_HOST` and related configured secret environment were unavailable, run `4f0bb426-41d6-4105-92af-54ae5fa242e3`

Closes #429