### PR TITLE
fix: load location guard for worker abilities

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -446,6 +446,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/PriorityEventAbilities.php';
 		new \ExtraChillEvents\Abilities\PriorityEventAbilities();
 
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/FlowLocationGuard.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/CityAbilities.php';
 		new \ExtraChillEvents\Abilities\CityAbilities();
 


### PR DESCRIPTION
## Summary
- load `FlowLocationGuard` alongside the City ability in every runtime
- fix expansion workers failing before add-city mutation

## Production evidence
- batch jobs `797132`-`797141` were scheduled successfully
- Manchester failed before mutation with `Class FlowLocationGuard not found`
- the dependency was previously loaded only inside the `WP_CLI` command-registration guard, while expansion jobs execute through WP Cron

## Validation
- `php -l extrachill-events.php`
- `git diff --check`
- Homeboy local lint was resource-policy deferred while the expansion worker load was high; CI remains required

Closes #439