### PR TITLE
fix: compose booking inquiry component styles

### DIFF
--- a/blocks/venue-booking-inquiry/src/style.scss
+++ b/blocks/venue-booking-inquiry/src/style.scss
@@ -1,3 +1,5 @@
+@use "@extrachill/components/styles/components.scss";
+
 .ec-venue-booking-inquiry { margin-block: var(--wp--preset--spacing--50, 2rem); }
 .ec-booking-inquiry__identity { align-items: start; display: flex; gap: 1rem; justify-content: space-between; }
 .ec-booking-inquiry__identity h3 { margin: .15rem 0; }
@@ -7,7 +9,6 @@
 .ec-booking-inquiry__requirements { display: grid; gap: .5rem; margin-bottom: 0; }
 .ec-booking-inquiry__form { display: grid; gap: 1.25rem; margin-top: 1.5rem; }
 .ec-booking-inquiry__grid { display: grid; gap: 1rem; grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.ec-booking-inquiry__form input:not([type="checkbox"]), .ec-booking-inquiry__form select, .ec-booking-inquiry__form textarea { box-sizing: border-box; width: 100%; }
 .ec-booking-inquiry__checkbox, .ec-booking-inquiry__consent { align-items: start; display: flex; gap: .55rem; line-height: 1.45; }
 .ec-booking-inquiry__checkbox input, .ec-booking-inquiry__consent input { flex: 0 0 auto; margin-top: .25rem; }
 .ec-booking-inquiry__turnstile { min-height: 65px; }

--- a/blocks/venue-booking-inquiry/src/style.test.js
+++ b/blocks/venue-booking-inquiry/src/style.test.js
@@ -1,0 +1,29 @@
+/* global describe, expect, it */
+
+/**
+ * External dependencies
+ */
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const styles = readFileSync( path.resolve( __dirname, 'style.scss' ), 'utf8' );
+
+describe( 'venue booking inquiry styles', () => {
+	it( 'composes the canonical shared component stylesheet', () => {
+		expect( styles ).toContain(
+			'@use "@extrachill/components/styles/components.scss";'
+		);
+	} );
+
+	it( 'retains inquiry-specific responsive and accessibility behavior', () => {
+		expect( styles ).toContain( '.ec-booking-inquiry__grid' );
+		expect( styles ).toContain(
+			'grid-template-columns: repeat(2, minmax(0, 1fr))'
+		);
+		expect( styles ).toContain( '@media (max-width: 700px)' );
+		expect( styles ).toContain( 'grid-template-columns: 1fr' );
+		expect( styles ).toContain( '.ec-booking-inquiry__result:focus' );
+		expect( styles ).toContain( '@media (prefers-reduced-motion: reduce)' );
+		expect( styles ).toContain( 'transition: none !important' );
+	} );
+} );


### PR DESCRIPTION
## Summary
- compose the canonical `@extrachill/components` stylesheet into the public booking inquiry block build
- remove the redundant local field-width rule now owned by shared `FieldGroup` styles
- add regression coverage for shared stylesheet composition and inquiry-specific desktop, mobile, focus, and reduced-motion behavior

The dynamic block remains server-bootstrapped and headless: `render.php` still emits only the React mount, JSON configuration, and Turnstile target, while `view.js` continues to mount the established component tree.

## Asset Evidence
- Before: `build/venue-booking-inquiry/style-index.css` was 1,908 bytes and contained none of `.ec-block-shell`, `.ec-block-shell-header`, `.ec-block-shell-inner`, `.ec-panel`, `.ec-field-group`, `.ec-inline-status`, or `.ec-action-row`.
- After: the same production asset is 18,580 bytes and contains those canonical shared selectors alongside the inquiry-specific two-column desktop grid, one-column mobile breakpoint, focused result outline, and reduced-motion override.
- `view.js` remains 11.9 KiB and the React/server bootstrap files are unchanged.

## Verification
- `npm run test:js -- --runInBand` (13 suites, 57 tests passed)
- `npm run build` (passed)
- `npm run build:venue-booking-inquiry` after final `main` fast-forward (passed)
- `homeboy review lint extrachill-events --path /var/lib/datamachine/workspace/extrachill-events@fix-430-booking-component-styles --placement local --summary` (PHPCS, ESLint, PHPStan passed)
- Homeboy tests were run with the required external MySQL environment. The adapter executed but exited before reporting any PHPUnit cases, returning only `artifact://files/test-results.json` and `artifact://files/phpunit-output.log`; a scoped retry for `VenueBookingInquiryRenderTest` had the same zero-test harness failure. Direct local PHPUnit confirms the plain repository bootstrap cannot load `WP_UnitTestCase`. No product-test failure was reported.

Closes #430
