### PR TITLE
test: reset inquiry temporary files between repeats

### DIFF
--- a/tests/BookingInquiryAdmissionTest.php
+++ b/tests/BookingInquiryAdmissionTest.php
@@ -35,6 +35,7 @@ final class BookingInquiryAdmissionTest extends BookingTestCase {
 
 	/** Initialize one Events-site admission fixture. */
 	protected function setUp(): void {
+		$this->temporary_files = array();
 		$GLOBALS['ec_artist_test'] = array(
 			'blog_id'         => 7,
 			'stack'           => array(),


### PR DESCRIPTION
## Summary
- reset `BookingInquiryAdmissionTest`'s temporary-file object fixture before every test invocation
- prevent PHPUnit in-process repetition from reusing a path deleted by the prior invocation
- keep the fix test-only and preserve all existing assertions

## Verification
- focused baseline reproduced before fix: 36 tests, 240 assertions, 1 stale-file error
- focused `--repeat=2`: 36 tests, 248 assertions, passing
- focused seeded random `--repeat=2` with seed 435: 36 tests, 248 assertions, passing
- aggregate `--repeat=2`: the #435 error is removed (105 -> 104 errors); unrelated current-main harness failures remain
- normal aggregate and seeded random aggregate reproduce the unrelated current-main failures tracked in #437
- changed-file Homeboy lint: passing
- PHP syntax: passing
- `git diff --check`: passing
- Homeboy PR audit: no finding in the changed file; repository-wide pre-existing drift remains
- independent exact-diff review: no findings

Closes #435