### PR TITLE
fix: polish Events homepage surfaces and stats

### DIFF
--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -68,7 +68,7 @@
     gap: var(--spacing-md);
     margin: 0 0 var(--spacing-lg);
     padding: var(--spacing-md);
-    background: var(--background-color);
+    background: var(--card-background);
     border: 1px solid var(--border-color);
     border-left: 3px solid var(--accent);
     border-radius: var(--border-radius, 8px);
@@ -150,7 +150,7 @@
     justify-content: space-between;
     gap: var(--spacing-lg);
     padding: var(--spacing-lg);
-    background: var(--background-color);
+    background: var(--card-background);
     border: 1px solid var(--border-color);
     border-left: 3px solid var(--accent);
     border-radius: var(--border-radius, 8px);
@@ -299,7 +299,7 @@
     flex-direction: column;
     gap: var(--spacing-xs);
     padding: var(--spacing-lg);
-    background: var(--background-color);
+    background: var(--card-background);
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius, 8px);
     box-shadow: var(--card-shadow);
@@ -310,6 +310,7 @@
 
 .events-feature-card:hover {
     border-color: var(--accent);
+    text-decoration: none;
     transform: translateY(-2px);
 }
 

--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -60,6 +60,11 @@
     margin-bottom: 0;
 }
 
+.events-homepage > .entry-content > .calendar-stats {
+    margin-top: var(--spacing-sm);
+    text-align: center;
+}
+
 /* Account-backed market context on primary discovery surfaces. */
 .events-market-context {
     display: flex;

--- a/inc/home/actions.php
+++ b/inc/home/actions.php
@@ -26,6 +26,17 @@ function extrachill_events_location_badges() {
 add_action( 'extrachill_events_home_before_calendar', 'extrachill_events_location_badges', 10 );
 
 /**
+ * Render aggregate calendar totals below the homepage discovery links.
+ *
+ * @hook extrachill_events_home_before_calendar
+ * @return void
+ */
+function extrachill_events_home_calendar_stats() {
+	extrachill_events_render_calendar_stats();
+}
+add_action( 'extrachill_events_home_before_calendar', 'extrachill_events_home_calendar_stats', 15 );
+
+/**
  * Render the homepage feature cards (My Shows + Submit) below the badges.
  *
  * @hook extrachill_events_home_before_calendar

--- a/inc/templates/homepage.php
+++ b/inc/templates/homepage.php
@@ -23,7 +23,6 @@ extrachill_breadcrumbs();
 			<p class="events-home-intro">
 				<?php esc_html_e( 'Find live music near you. Pick a city below, track your shows, or see every event.', 'extrachill-events' ); ?>
 			</p>
-			<?php extrachill_events_render_calendar_stats(); ?>
 		</header>
 	</div>
 

--- a/tests/Unit/Core/HomepageLayoutTest.php
+++ b/tests/Unit/Core/HomepageLayoutTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Homepage composition regression tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the homepage's component ordering contract.
+ */
+final class HomepageLayoutTest extends TestCase {
+	/**
+	 * Calendar totals belong between the location router and feature cards.
+	 */
+	public function test_calendar_stats_render_between_router_and_feature_cards(): void {
+		$plugin_root = dirname( __DIR__, 3 );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local source fixture.
+		$actions = file_get_contents( $plugin_root . '/inc/home/actions.php' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local source fixture.
+		$template = file_get_contents( $plugin_root . '/inc/templates/homepage.php' );
+
+		$this->assertIsString( $actions );
+		$this->assertIsString( $template );
+		$this->assertStringNotContainsString( 'extrachill_events_render_calendar_stats();', $template );
+		$this->assertMatchesRegularExpression(
+			"/extrachill_events_location_badges', 10.*extrachill_events_render_calendar_stats\(\).*extrachill_events_home_calendar_stats', 15.*extrachill_events_home_feature_cards', 20/s",
+			$actions
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- use the platform card background token for Events market and homepage feature surfaces
- prevent the full-card My Shows and Submit an Event links from underlining all descendant text on hover
- move aggregate calendar totals below the homepage discovery links while retaining their existing `/all/` placement

## Verification
- `git diff --check origin/main...HEAD`
- `vendor/bin/phpcs --standard=WordPress inc/home/actions.php inc/templates/homepage.php`
- `vendor/bin/phpunit tests/Unit/Core/AccountMarketTest.php` (29 tests, 77 assertions)
- confirmed the feature-card hover override has greater specificity than the theme's universal `a:hover` rule

Closes #447
Closes #449