### PR TITLE
fix: bind certified ticket settlement evidence

### DIFF
--- a/.github/workflows/booking-attachment-mysql.yml
+++ b/.github/workflows/booking-attachment-mysql.yml
@@ -10,6 +10,7 @@ on:
       - inc/Core/BookingAttachmentService.php
       - inc/Core/BookingAttachmentRepository.php
       - inc/Core/TicketSettlementService.php
+      - inc/Core/TicketReconciliationService.php
       - inc/Core/BookingAttachmentPolicy.php
       - inc/Core/BookingInquiryAdmissionService.php
       - inc/Core/BookingLifecycle.php
@@ -24,9 +25,11 @@ on:
       - phpunit-booking-concurrency.xml.dist
       - inc/Abilities/VenueBookingAbilities.php
       - inc/Abilities/VenueBookingEventAbilities.php
+      - inc/Abilities/TicketSettlementAbilities.php
       - tests/BookingInquiryAdmissionTest.php
       - tests/MySQLIntegration/BookingAttachmentMySQLIntegrationTest.php
       - tests/MySQLIntegration/BookingEventSyncMySQLIntegrationTest.php
+      - tests/MySQLIntegration/BookingSchemaMultisiteTest.php
       - tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
       - tests/MySQLIntegration/booking-attachment-mysql-bootstrap.php
       - tests/MySQLIntegration/booking-schema-multisite-bootstrap.php
@@ -139,7 +142,7 @@ jobs:
               wp_codebox_phpunit_preload_files: [$schema_preload, $preload],
               validation_dependencies: [$data_machine_source, $data_machine_events_source]
             }')
-          node .ci/homeboy-extensions/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs --filter='BookingAttachmentMySQLIntegrationTest|BookingEventSyncMySQLIntegrationTest'
+          node .ci/homeboy-extensions/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs --filter='BookingAttachmentMySQLIntegrationTest|BookingEventSyncMySQLIntegrationTest|BookingSchemaMultisiteTest'
 
       - name: Install native WordPress test runtime
         run: |
@@ -188,7 +191,7 @@ jobs:
             | ($runs | length) == 1
               and $runs[0].exitCode == 0
               and $runs[0].result.status == "ok"
-              and ($runs[0].stdout | test("OK \\(3 tests, [1-9][0-9]* assertions?\\)"))
+              and ($runs[0].stdout | test("OK \\(9 tests, [1-9][0-9]* assertions?\\)"))
               and (($runs[0].stdout | test("skip|no tests executed|OK, but"; "i")) | not)
           ' "$commands" >/dev/null
           jq -e '
@@ -197,7 +200,7 @@ jobs:
           ' "$metadata" >/dev/null
           jq -rs '[.[] | select(.command == "wordpress.phpunit")][0].stdout' "$commands" > "$ARTIFACTS_DIR/booking-attachment-mysql-phpunit.txt"
           printf '%s\n' "Verified application-level MySQL proof:"
-          grep -E 'OK \(3 tests, [1-9][0-9]* assertions?\)' "$ARTIFACTS_DIR/booking-attachment-mysql-phpunit.txt"
+          grep -E 'OK \(9 tests, [1-9][0-9]* assertions?\)' "$ARTIFACTS_DIR/booking-attachment-mysql-phpunit.txt"
 
       - name: Upload WP Codebox evidence
         if: always()

--- a/.github/workflows/booking-attachment-mysql.yml
+++ b/.github/workflows/booking-attachment-mysql.yml
@@ -168,8 +168,8 @@ jobs:
           WP_TESTS_PHPUNIT_POLYFILLS_PATH: ${{ github.workspace }}/vendor/yoast/phpunit-polyfills
         run: |
           set -euo pipefail
-          vendor/bin/phpunit -c phpunit-booking-concurrency.xml.dist --filter test_concurrent_exact_inquiry_retry_reuses_one_complete_winner | tee "$RUNNER_TEMP/booking-admission-concurrency.txt"
-          grep -E 'OK \(1 test, [1-9][0-9]* assertions?\)' "$RUNNER_TEMP/booking-admission-concurrency.txt"
+          vendor/bin/phpunit -c phpunit-booking-concurrency.xml.dist --filter 'test_concurrent_booking_schema_installer_waits_and_converges|test_resolution_and_finalization_race_freezes_one_consistent_winner|test_concurrent_exact_inquiry_retry_reuses_one_complete_winner' | tee "$RUNNER_TEMP/booking-admission-concurrency.txt"
+          grep -E 'OK \(3 tests, [1-9][0-9]* assertions?\)' "$RUNNER_TEMP/booking-admission-concurrency.txt"
           if grep -Eiq 'skip|no tests executed|OK, but' "$RUNNER_TEMP/booking-admission-concurrency.txt"; then
             exit 1
           fi
@@ -191,7 +191,7 @@ jobs:
             | ($runs | length) == 1
               and $runs[0].exitCode == 0
               and $runs[0].result.status == "ok"
-              and ($runs[0].stdout | test("OK \\(9 tests, [1-9][0-9]* assertions?\\)"))
+              and ($runs[0].stdout | test("OK \\(7 tests, [1-9][0-9]* assertions?\\)"))
               and (($runs[0].stdout | test("skip|no tests executed|OK, but"; "i")) | not)
           ' "$commands" >/dev/null
           jq -e '
@@ -200,7 +200,7 @@ jobs:
           ' "$metadata" >/dev/null
           jq -rs '[.[] | select(.command == "wordpress.phpunit")][0].stdout' "$commands" > "$ARTIFACTS_DIR/booking-attachment-mysql-phpunit.txt"
           printf '%s\n' "Verified application-level MySQL proof:"
-          grep -E 'OK \(9 tests, [1-9][0-9]* assertions?\)' "$ARTIFACTS_DIR/booking-attachment-mysql-phpunit.txt"
+          grep -E 'OK \(7 tests, [1-9][0-9]* assertions?\)' "$ARTIFACTS_DIR/booking-attachment-mysql-phpunit.txt"
 
       - name: Upload WP Codebox evidence
         if: always()

--- a/docs/ticket-settlements.md
+++ b/docs/ticket-settlements.md
@@ -18,6 +18,10 @@ bind a ticket-source identity and, for CSV imports, the approved private booking
 attachment containing the exact evidence bytes. Arbitrary source provenance
 remains private; ability projections expose only a redaction marker plus
 server-owned attachment identity and CSV row when present.
+Provider source keys and report IDs are opaque UTF-8 identities: supported
+characters and bytes are stored losslessly, while controls, invalid UTF-8, and
+over-limit values are rejected before identity derivation. Binary SHA-256 keys,
+rather than text-collation normalization, enforce exact uniqueness.
 
 `ec_booking_sales_resolutions` is an append-only optimistic decision history.
 Every admit/exclude decision records a per-report version, optional corrected
@@ -33,18 +37,23 @@ basis amount, signed adjustment, amount due, finalizer, and a second integrity
 hash over the complete immutable financial snapshot. The snapshot hash binds
 booking/event/venue identity, frozen booking revision, basis, rate, currency,
 formula, evidence IDs/hash, and every calculated minor-unit amount. Formula
-version 2 binds each included report's immutable hash and latest reconciliation
-decision; version 1 settlements retain their legacy report-only verification.
+version 3 binds each included report's immutable hash, latest reconciliation
+decision, effective source request hash, and certified attachment request,
+content-hash, and byte-size evidence. It reopens and authenticates every private
+CSV byte before calculation, finalization, and terminal transitions. Formula
+version 2 retains report plus reconciliation verification; version 1 retains
+legacy report-only verification.
 The row also
 retains the terminal paid or void audit. Finalized evidence and terms are never
 rewritten.
 
-Schema version 13 preserves the version 12 report and settlement tables, adds
-nullable provenance references to existing observations, and creates the source
-and resolution tables. The existing `dbDelta` installer verifies exact
+Schema version 14 explicitly migrates version 13 in place. It preserves every
+current table and row, backfills exact identity hashes, and adds versioned,
+nullable source and attachment provenance columns without rewriting legacy
+report hashes. A site-scoped MySQL advisory lock serializes concurrent
+installers. The existing `dbDelta` installer then verifies exact
 columns/indexes/engines and stamps each multisite site only after health checks
-pass. Existing reports remain immutable and become explicitly unattributed
-until an operator resolves them.
+pass.
 
 ## Abilities
 
@@ -66,9 +75,10 @@ and void require active venue ownership through `manage_finances`; transport
 permission callbacks repeat the same policy.
 Transactions lock venue membership before booking, settlement, report, and
 resolution rows. Finalization requires the calculated booking version, ordered
-evidence IDs, and formula-2 evidence hash, so stale reconciliation decisions and
-concurrent writes fail with a conflict. Legacy formula-1 settlements retain
-exact retry and terminal-transition compatibility.
+evidence IDs, and formula-3 evidence hash, so stale reconciliation decisions,
+missing/corrupt private bytes, and concurrent writes fail with a conflict.
+Legacy formula-1 and formula-2 settlements retain exact retry and
+terminal-transition compatibility.
 An exact lost-response retry is resolved against the already-frozen booking
 version, terms, formula, and evidence before current mutable booking/evidence
 is considered, so later reports or booking revisions do not break idempotency.
@@ -85,7 +95,8 @@ exclusive lifecycle outcomes rather than independent stale writes.
 
 ## Formula
 
-Formula version 1 supports `gross_ticket_sales` and `net_ticket_sales` evidence.
+All formula versions support `gross_ticket_sales` and `net_ticket_sales` evidence;
+versions 2 and 3 strengthen provenance without changing the arithmetic.
 Evidence is filtered to one explicit ISO-style three-letter currency. The share
 is `basis_amount_minor * basis_points / 10000`, rounded to the nearest minor
 unit with exact halves away from zero. The signed adjustment is then added.
@@ -93,14 +104,18 @@ Integer overflow is rejected rather than converted to floating point.
 
 ## Import And Reconciliation
 
-Manual and CSV-certified paths both call the same immutable report recorder.
-CSV import accepts only an active `text/csv` booking attachment admitted under
+The generic recorder creates manual observations only and rejects
+`csv_certified`, even when called outside ability schema validation. The sole
+certified path is the authenticated CSV importer. It accepts only an active
+`text/csv` booking attachment admitted under
 the existing `other_private_evidence` policy. It obtains bytes through the
 opaque one-time private stream handoff, re-hashes and counts every streamed byte
 against immutable attachment metadata before parsing, requires an exact fixed
 header, forbids multiline records, limits rows and physical line lengths,
 rejects non-canonical integers, and never exposes bytes or storage references.
-Exact report IDs make a crash/retry replay deterministic.
+Each resulting report hash binds the source registration request hash and
+attachment request/content/size evidence. Exact report IDs make mid-loop and
+commit-uncertain crash/retry replay deterministic.
 
 Diagnostics are bounded to 1,000 observations and derive unattributed, missing
 file, currency mismatch, duplicate, overlapping, and contradictory evidence.

--- a/inc/Abilities/TicketSettlementAbilities.php
+++ b/inc/Abilities/TicketSettlementAbilities.php
@@ -133,35 +133,7 @@ class TicketSettlementAbilities {
 	}
 
 	public function import_csv( array $input ) {
-		$rows = $this->reconciliation->csv_report_inputs( $input, get_current_user_id() );
-		if ( is_wp_error( $rows ) ) {
-			return $rows;
-		}
-		$reports  = array();
-		$failures = array();
-		foreach ( $rows as $index => $row ) {
-			$report = $this->service->record_sales( $row, get_current_user_id() );
-			if ( is_wp_error( $report ) ) {
-				$failures[] = array(
-					'row'  => $index + 2,
-					'code' => $report->get_error_code(),
-				);
-				continue;
-			}
-			$reports[] = $report;
-		}
-		if ( ! empty( $failures ) ) {
-			return new \WP_Error(
-				'sales_csv_import_partial',
-				__( 'Some ticket-sales rows could not be imported.', 'extrachill-events' ),
-				array(
-					'status'              => 409,
-					'imported_report_ids' => array_column( $reports, 'id' ),
-					'failures'            => $failures,
-				)
-			);
-		}
-		return $reports;
+		return $this->service->import_csv( $input, get_current_user_id() );
 	}
 
 	public function diagnostics( array $input ) {
@@ -231,7 +203,7 @@ class TicketSettlementAbilities {
 			),
 			'source_type'            => array(
 				'type' => 'string',
-				'enum' => TicketSettlementService::SOURCE_TYPES,
+				'enum' => array( 'manual' ),
 			),
 			'period_start'           => $this->datetime_schema(),
 			'period_end'             => $this->datetime_schema(),
@@ -334,7 +306,7 @@ class TicketSettlementAbilities {
 				'currency'                 => $this->currency_schema(),
 				'formula_version'          => array(
 					'type' => 'integer',
-					'enum' => array( 1, TicketSettlementService::FORMULA_VERSION ),
+					'enum' => array( 1, 2, TicketSettlementService::FORMULA_VERSION ),
 				),
 				'adjustment_minor'         => array( 'type' => 'integer' ),
 			),
@@ -501,7 +473,7 @@ class TicketSettlementAbilities {
 				'currency'             => $this->currency_schema(),
 				'formula_version'      => array(
 					'type' => 'integer',
-					'enum' => array( 1, TicketSettlementService::FORMULA_VERSION ),
+					'enum' => array( 1, 2, TicketSettlementService::FORMULA_VERSION ),
 				),
 				'included_report_ids'  => array(
 					'type'     => 'array',

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Owns and verifies the site-scoped private booking schema. */
 class BookingSchema {
 
-	public const SCHEMA_VERSION = '13';
+	public const SCHEMA_VERSION = '14';
 	public const VERSION_OPTION = 'extrachill_events_booking_schema_version';
 	public const FAILURE_OPTION = 'extrachill_events_booking_schema_error';
 
@@ -109,6 +109,42 @@ class BookingSchema {
 	/** Create or repair all tables, stamping the version only after verification. */
 	public static function install() {
 		global $wpdb;
+		$schema_lock = null;
+		$lock_guard  = null;
+		if ( isset( $wpdb->dbh ) && $wpdb->dbh instanceof \mysqli ) {
+			$schema_lock = 'ec_booking_schema_' . substr( hash( 'sha256', (string) DB_NAME . "\0" . $wpdb->prefix ), 0, 40 );
+			$acquired    = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, 30)', $schema_lock ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serializes concurrent installers for this site prefix.
+			if ( 1 !== (int) $acquired ) {
+				return new \WP_Error( 'booking_schema_lock_failed', __( 'The booking schema installer could not acquire its site lock.', 'extrachill-events' ) );
+			}
+			$lock_guard = new class( $wpdb, $schema_lock ) {
+				/** Database session holding the advisory lock.
+				 *
+				 * @var \wpdb
+				 */
+				private $database;
+				/** Exact site-scoped advisory lock name.
+				 *
+				 * @var string
+				 */
+				private $name;
+
+				/** Retain the lock owner until every install return path completes.
+				 *
+				 * @param \wpdb  $database Database session.
+				 * @param string $name Lock name.
+				 */
+				public function __construct( $database, string $name ) {
+					$this->database = $database;
+					$this->name     = $name;
+				}
+
+				/** Release the exact advisory lock. */
+				public function __destruct() {
+					$this->database->get_var( $this->database->prepare( 'SELECT RELEASE_LOCK(%s)', $this->name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Releases the exact installer lock on every return path.
+				}
+			};
+		}
 
 		$bookings            = self::bookings_table();
 		$activity            = self::activity_table();
@@ -375,6 +411,7 @@ class BookingSchema {
 			venue_term_id BIGINT UNSIGNED NOT NULL,
 			provider VARCHAR(64) NOT NULL,
 			source_key VARCHAR(191) NOT NULL,
+			source_key_hash CHAR(64) NOT NULL,
 			canonical_url LONGTEXT NOT NULL,
 			url_hash CHAR(64) NOT NULL,
 			request_hash CHAR(64) NOT NULL,
@@ -382,7 +419,7 @@ class BookingSchema {
 			created_at DATETIME NOT NULL,
 			PRIMARY KEY (id),
 			UNIQUE KEY public_id (public_id),
-			UNIQUE KEY booking_provider_source (booking_id, provider, source_key),
+			UNIQUE KEY booking_provider_source (booking_id, provider, source_key_hash),
 			KEY event_provider (event_id, provider),
 			KEY venue_created (venue_term_id, created_at, id)
 		) ENGINE=InnoDB {$charset};";
@@ -396,7 +433,13 @@ class BookingSchema {
 			evidence_attachment_id BIGINT UNSIGNED NULL,
 			provider VARCHAR(64) NOT NULL,
 			external_report_id VARCHAR(191) NOT NULL,
+			external_report_id_hash CHAR(64) NOT NULL,
 			source_type VARCHAR(32) NOT NULL,
+			provenance_version BIGINT UNSIGNED NOT NULL DEFAULT '1',
+			ticket_source_request_hash CHAR(64) NULL,
+			evidence_attachment_request_hash CHAR(64) NULL,
+			evidence_content_hash CHAR(64) NULL,
+			evidence_byte_size BIGINT UNSIGNED NULL,
 			period_start DATETIME NOT NULL,
 			period_end DATETIME NOT NULL,
 			tickets_sold BIGINT NOT NULL,
@@ -413,7 +456,7 @@ class BookingSchema {
 			created_by_user_id BIGINT UNSIGNED NOT NULL,
 			created_at DATETIME NOT NULL,
 			PRIMARY KEY (id),
-			UNIQUE KEY provider_external_report (booking_id, provider, external_report_id),
+			UNIQUE KEY provider_external_report (booking_id, provider, external_report_id_hash),
 			KEY booking_created (booking_id, created_at, id),
 			KEY booking_currency_id (booking_id, currency, id),
 			KEY ticket_source_id (ticket_source_id),
@@ -479,6 +522,12 @@ class BookingSchema {
 			KEY event_id (event_id),
 			KEY status_updated (status, updated_at)
 		) ENGINE=InnoDB {$charset};";
+
+		$migration = self::migrate_v13_ticket_provenance();
+		if ( is_wp_error( $migration ) ) {
+			self::record_failure( $migration );
+			return $migration;
+		}
 
 		$repair = self::drop_conflicting_indexes();
 		if ( is_wp_error( $repair ) ) {
@@ -560,6 +609,7 @@ class BookingSchema {
 
 		update_option( self::VERSION_OPTION, self::SCHEMA_VERSION, false );
 		delete_option( self::FAILURE_OPTION );
+		unset( $lock_guard );
 		return true;
 	}
 
@@ -793,6 +843,59 @@ class BookingSchema {
 			}
 		}
 
+		return true;
+	}
+
+	/** Add and backfill v14 identity/provenance storage before unique-index repair. */
+	private static function migrate_v13_ticket_provenance() {
+		global $wpdb;
+
+		if ( ! isset( $wpdb->dbh ) || ! $wpdb->dbh instanceof \mysqli || version_compare( (string) get_option( self::VERSION_OPTION, '0' ), '14', '>=' ) ) {
+			return true;
+		}
+		$tables = array(
+			self::ticket_sources_table() => array(
+				'columns'  => array( 'source_key_hash CHAR(64) NULL' ),
+				'backfill' => 'source_key_hash = SHA2(source_key, 256)',
+				'where'    => "source_key_hash IS NULL OR source_key_hash = ''",
+				'final'    => 'source_key_hash CHAR(64) NOT NULL',
+			),
+			self::sales_reports_table()  => array(
+				'columns'  => array(
+					'external_report_id_hash CHAR(64) NULL',
+					"provenance_version BIGINT UNSIGNED NOT NULL DEFAULT '1'",
+					'ticket_source_request_hash CHAR(64) NULL',
+					'evidence_attachment_request_hash CHAR(64) NULL',
+					'evidence_content_hash CHAR(64) NULL',
+					'evidence_byte_size BIGINT UNSIGNED NULL',
+				),
+				'backfill' => 'external_report_id_hash = SHA2(external_report_id, 256)',
+				'where'    => "external_report_id_hash IS NULL OR external_report_id_hash = ''",
+				'final'    => 'external_report_id_hash CHAR(64) NOT NULL',
+			),
+		);
+		foreach ( $tables as $table => $migration ) {
+			$found = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Explicit private schema migration.
+			if ( $found !== $table ) {
+				continue;
+			}
+			$found_columns = array_column( (array) $wpdb->get_results( "SHOW COLUMNS FROM `{$table}`", ARRAY_A ), 'Field' ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Explicit private schema migration.
+			foreach ( $migration['columns'] as $definition ) {
+				$name = strtok( $definition, ' ' );
+				if ( in_array( $name, $found_columns, true ) ) {
+					continue;
+				}
+				if ( false === $wpdb->query( "ALTER TABLE `{$table}` ADD COLUMN {$definition}" ) ) { // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Fixed internal migration definitions.
+					return self::database_error( __( 'Could not add ticket provenance storage.', 'extrachill-events' ), $table );
+				}
+			}
+			if ( false === $wpdb->query( "UPDATE `{$table}` SET {$migration['backfill']} WHERE {$migration['where']}" ) ) { // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Deterministic in-place identity hash backfill.
+				return self::database_error( __( 'Could not backfill lossless ticket identity hashes.', 'extrachill-events' ), $table );
+			}
+			if ( false === $wpdb->query( "ALTER TABLE `{$table}` MODIFY COLUMN {$migration['final']}" ) ) { // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Makes the completed identity migration mandatory.
+				return self::database_error( __( 'Could not finalize ticket identity hash storage.', 'extrachill-events' ), $table );
+			}
+		}
 		return true;
 	}
 
@@ -1282,6 +1385,7 @@ class BookingSchema {
 					'venue_term_id'      => $required( 'bigint unsigned', false ),
 					'provider'           => $required( 'varchar(64)', false ),
 					'source_key'         => $required( 'varchar(191)', false ),
+					'source_key_hash'    => $required( 'char(64)', false ),
 					'canonical_url'      => $required( 'longtext', false ),
 					'url_hash'           => $required( 'char(64)', false ),
 					'request_hash'       => $required( 'char(64)', false ),
@@ -1291,7 +1395,7 @@ class BookingSchema {
 				'indexes' => array(
 					'PRIMARY'                 => $index( true, 'id' ),
 					'public_id'               => $index( true, 'public_id' ),
-					'booking_provider_source' => $index( true, 'booking_id', 'provider', 'source_key' ),
+					'booking_provider_source' => $index( true, 'booking_id', 'provider', 'source_key_hash' ),
 					'event_provider'          => $index( false, 'event_id', 'provider' ),
 					'venue_created'           => $index( false, 'venue_term_id', 'created_at', 'id' ),
 				),
@@ -1299,30 +1403,36 @@ class BookingSchema {
 			self::sales_reports_table()         => array(
 				'engine'  => 'innodb',
 				'columns' => array(
-					'id'                     => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
-					'booking_id'             => $required( 'bigint unsigned', false ),
-					'event_id'               => $required( 'bigint unsigned', false ),
-					'venue_term_id'          => $required( 'bigint unsigned', false ),
-					'ticket_source_id'       => $required( 'bigint unsigned', true ),
-					'evidence_attachment_id' => $required( 'bigint unsigned', true ),
-					'provider'               => $required( 'varchar(64)', false ),
-					'external_report_id'     => $required( 'varchar(191)', false ),
-					'source_type'            => $required( 'varchar(32)', false ),
-					'period_start'           => $required( 'datetime', false ),
-					'period_end'             => $required( 'datetime', false ),
-					'tickets_sold'           => $required( 'bigint', false ),
-					'tickets_refunded'       => $required( 'bigint', false ),
-					'gross_minor'            => $required( 'bigint', false ),
-					'fees_minor'             => $required( 'bigint', false ),
-					'tax_minor'              => $required( 'bigint', false ),
-					'refunds_minor'          => $required( 'bigint', false ),
-					'net_minor'              => $required( 'bigint', false ),
-					'currency'               => $required( 'char(3)', false ),
-					'corrects_report_id'     => $required( 'bigint unsigned', true ),
-					'source_payload'         => $required( 'longtext', false ),
-					'request_hash'           => $required( 'char(64)', false ),
-					'created_by_user_id'     => $required( 'bigint unsigned', false ),
-					'created_at'             => $required( 'datetime', false ),
+					'id'                               => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'booking_id'                       => $required( 'bigint unsigned', false ),
+					'event_id'                         => $required( 'bigint unsigned', false ),
+					'venue_term_id'                    => $required( 'bigint unsigned', false ),
+					'ticket_source_id'                 => $required( 'bigint unsigned', true ),
+					'evidence_attachment_id'           => $required( 'bigint unsigned', true ),
+					'provider'                         => $required( 'varchar(64)', false ),
+					'external_report_id'               => $required( 'varchar(191)', false ),
+					'external_report_id_hash'          => $required( 'char(64)', false ),
+					'source_type'                      => $required( 'varchar(32)', false ),
+					'provenance_version'               => $required( 'bigint unsigned', false, array( 'default' => '1' ) ),
+					'ticket_source_request_hash'       => $required( 'char(64)', true ),
+					'evidence_attachment_request_hash' => $required( 'char(64)', true ),
+					'evidence_content_hash'            => $required( 'char(64)', true ),
+					'evidence_byte_size'               => $required( 'bigint unsigned', true ),
+					'period_start'                     => $required( 'datetime', false ),
+					'period_end'                       => $required( 'datetime', false ),
+					'tickets_sold'                     => $required( 'bigint', false ),
+					'tickets_refunded'                 => $required( 'bigint', false ),
+					'gross_minor'                      => $required( 'bigint', false ),
+					'fees_minor'                       => $required( 'bigint', false ),
+					'tax_minor'                        => $required( 'bigint', false ),
+					'refunds_minor'                    => $required( 'bigint', false ),
+					'net_minor'                        => $required( 'bigint', false ),
+					'currency'                         => $required( 'char(3)', false ),
+					'corrects_report_id'               => $required( 'bigint unsigned', true ),
+					'source_payload'                   => $required( 'longtext', false ),
+					'request_hash'                     => $required( 'char(64)', false ),
+					'created_by_user_id'               => $required( 'bigint unsigned', false ),
+					'created_at'                       => $required( 'datetime', false ),
 				),
 				'indexes' => array(
 					'PRIMARY'                  => array(
@@ -1331,7 +1441,7 @@ class BookingSchema {
 					),
 					'provider_external_report' => array(
 						'unique'  => true,
-						'columns' => array( 'booking_id', 'provider', 'external_report_id' ),
+						'columns' => array( 'booking_id', 'provider', 'external_report_id_hash' ),
 					),
 					'booking_created'          => array(
 						'unique'  => false,

--- a/inc/Core/TicketReconciliationService.php
+++ b/inc/Core/TicketReconciliationService.php
@@ -49,10 +49,10 @@ class TicketReconciliationService {
 			return $booking;
 		}
 		$provider = mb_substr( sanitize_key( (string) ( $input['provider'] ?? '' ) ), 0, 64 );
-		$key      = mb_substr( sanitize_text_field( (string) ( $input['source_key'] ?? '' ) ), 0, 191 );
+		$key      = TicketSettlementService::opaque_identifier( $input['source_key'] ?? null, 'source_key' );
 		$url      = $this->canonical_url( $input['ticket_url'] ?? null );
-		if ( '' === $provider || '' === $key || is_wp_error( $url ) || null === $booking['event_id'] ) {
-			return is_wp_error( $url ) ? $url : new \WP_Error( 'invalid_ticket_source_identity', __( 'A linked event and valid provider source identity are required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		if ( '' === $provider || is_wp_error( $key ) || is_wp_error( $url ) || null === $booking['event_id'] ) {
+			return is_wp_error( $key ) ? $key : ( is_wp_error( $url ) ? $url : new \WP_Error( 'invalid_ticket_source_identity', __( 'A linked event and valid provider source identity are required.', 'extrachill-events' ), array( 'status' => 400 ) ) );
 		}
 		$row                 = array(
 			'public_id'          => wp_generate_uuid4(),
@@ -61,6 +61,7 @@ class TicketReconciliationService {
 			'venue_term_id'      => $booking['venue_term_id'],
 			'provider'           => $provider,
 			'source_key'         => $key,
+			'source_key_hash'    => hash( 'sha256', $key ),
 			'canonical_url'      => $url,
 			'url_hash'           => hash( 'sha256', $url ),
 			'created_by_user_id' => $actor_id,
@@ -393,28 +394,126 @@ class TicketReconciliationService {
 		);
 	}
 
-	/** Verify report provenance against current immutable source and attachment contracts. */
-	public function validate_provenance( array $report, array $booking ) {
+	/** Bind a new observation to current immutable source and authenticated bytes. */
+	public function validate_provenance( array $report, array $booking, ?array $csv_certification = null ) {
 		$source_id = $report['ticket_source_id'] ?? null;
+		$source    = null;
 		if ( null !== $source_id ) {
-			$source = $this->get_source( (int) $source_id );
+			$source = $this->get_source( (int) $source_id, true );
 			if ( ! is_array( $source ) || $source['booking_id'] !== $booking['id'] || $source['event_id'] !== $booking['event_id'] || $source['venue_term_id'] !== $booking['venue_term_id'] || $source['provider'] !== $report['provider'] ) {
 				return new \WP_Error( 'invalid_sales_report_source_identity', __( 'The ticket source does not match this booking, event, and provider.', 'extrachill-events' ), array( 'status' => 400 ) );
 			}
 		}
 		$attachment_id = $report['evidence_attachment_id'] ?? null;
 		if ( 'csv_certified' === $report['source_type'] ) {
-			if ( null === $attachment_id ) {
+			if ( null === $attachment_id || ! is_array( $source ) || ! is_array( $csv_certification ) ) {
 				return new \WP_Error( 'sales_csv_attachment_required', __( 'Certified CSV evidence requires its approved private attachment.', 'extrachill-events' ), array( 'status' => 400 ) );
 			}
 			$attachment = $this->attachments->get_for_booking( $booking['id'], (int) $attachment_id );
 			if ( is_wp_error( $attachment ) || 'active' !== ( $attachment['state'] ?? '' ) || 'text/csv' !== ( $attachment['mime_type'] ?? '' ) || 'other_private_evidence' !== ( $attachment['purpose'] ?? '' ) ) {
 				return is_wp_error( $attachment ) ? $attachment : new \WP_Error( 'sales_csv_attachment_invalid', __( 'Certified CSV evidence requires an active approved private CSV attachment.', 'extrachill-events' ), array( 'status' => 400 ) );
 			}
+			$expected = array(
+				'ticket_source_id'                 => $source['id'],
+				'ticket_source_request_hash'       => $source['request_hash'],
+				'evidence_attachment_id'           => $attachment['id'],
+				'evidence_attachment_request_hash' => $attachment['request_hash'],
+				'evidence_content_hash'            => $attachment['content_hash'],
+				'evidence_byte_size'               => $attachment['byte_size'],
+			);
+			if ( $expected !== $csv_certification ) {
+				return new \WP_Error( 'sales_csv_certification_invalid', __( 'Certified CSV evidence no longer matches the authenticated source and attachment bytes.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
 		} elseif ( null !== $attachment_id ) {
 			return new \WP_Error( 'sales_report_attachment_invalid', __( 'Only certified CSV evidence may bind a private file.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
-		return true;
+		return array(
+			'provenance_version'               => 2,
+			'ticket_source_request_hash'       => is_array( $source ) ? $source['request_hash'] : null,
+			'evidence_attachment_request_hash' => isset( $attachment ) ? $attachment['request_hash'] : null,
+			'evidence_content_hash'            => isset( $attachment ) ? $attachment['content_hash'] : null,
+			'evidence_byte_size'               => isset( $attachment ) ? $attachment['byte_size'] : null,
+		);
+	}
+
+	/** Revalidate and project the exact provenance frozen by formula v3. */
+	public function settlement_provenance_evidence( array $report, array $booking, ?array $resolution, int $actor_id, bool $lock, bool $authenticate_bytes = true ) {
+		$source_id = is_array( $resolution ) && null !== $resolution['ticket_source_id'] ? $resolution['ticket_source_id'] : $report['ticket_source_id'];
+		if ( null === $source_id ) {
+			return new \WP_Error( 'settlement_source_evidence_missing', __( 'Settlement evidence has no immutable ticket source attribution.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$source = $this->get_source( (int) $source_id, $lock );
+		if ( ! is_array( $source ) || $source['booking_id'] !== $booking['id'] || $source['event_id'] !== $booking['event_id'] || $source['venue_term_id'] !== $booking['venue_term_id'] || $source['provider'] !== $report['provider'] ) {
+			return new \WP_Error( 'settlement_source_evidence_invalid', __( 'Settlement ticket-source evidence is missing, corrupt, or belongs to another booking.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		if ( 2 <= (int) ( $report['provenance_version'] ?? 1 ) && $report['ticket_source_id'] === $source['id'] && ! hash_equals( (string) $report['ticket_source_request_hash'], $source['request_hash'] ) ) {
+			return new \WP_Error( 'settlement_source_evidence_invalid', __( 'Settlement ticket-source evidence no longer matches its observation hash.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+
+		$evidence = array(
+			'ticket_source_id'           => $source['id'],
+			'ticket_source_request_hash' => $source['request_hash'],
+			'attachment'                 => null,
+		);
+		if ( 'csv_certified' !== $report['source_type'] ) {
+			return $evidence;
+		}
+		if ( 2 > (int) ( $report['provenance_version'] ?? 1 ) ) {
+			return new \WP_Error( 'settlement_csv_evidence_legacy', __( 'Legacy CSV observations were not authenticated by the certified importer and cannot enter a new settlement.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$attachment = $this->attachments->get_for_booking( $booking['id'], (int) $report['evidence_attachment_id'] );
+		if ( is_wp_error( $attachment ) || 'active' !== ( $attachment['state'] ?? '' ) || 'text/csv' !== ( $attachment['mime_type'] ?? '' ) || 'other_private_evidence' !== ( $attachment['purpose'] ?? '' ) ) {
+			return new \WP_Error( 'settlement_csv_evidence_invalid', __( 'Settlement CSV evidence is retired, deleted, purged, or invalid.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		foreach ( array(
+			'evidence_attachment_request_hash' => 'request_hash',
+			'evidence_content_hash'            => 'content_hash',
+			'evidence_byte_size'               => 'byte_size',
+		) as $report_field => $attachment_field ) {
+			if ( $report[ $report_field ] !== $attachment[ $attachment_field ] ) {
+				return new \WP_Error( 'settlement_csv_evidence_invalid', __( 'Settlement CSV attachment metadata no longer matches its observation hash.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+		}
+		$verified = $authenticate_bytes ? $this->authenticate_attachment_bytes( $booking, $attachment, $actor_id ) : array(
+			'content_hash' => $attachment['content_hash'],
+			'byte_size'    => $attachment['byte_size'],
+		);
+		if ( is_wp_error( $verified ) ) {
+			return $verified;
+		}
+		$evidence['attachment'] = array(
+			'id'           => $attachment['id'],
+			'request_hash' => $attachment['request_hash'],
+			'content_hash' => $verified['content_hash'],
+			'byte_size'    => $verified['byte_size'],
+		);
+		return $evidence;
+	}
+
+	/** Authenticate the complete current private object against immutable metadata. */
+	private function authenticate_attachment_bytes( array $booking, array $attachment, int $actor_id ) {
+		$descriptor = $this->attachment_service->download_descriptor( $booking['id'], $attachment['id'], $actor_id );
+		if ( is_wp_error( $descriptor ) ) {
+			return new \WP_Error( 'settlement_csv_evidence_invalid', __( 'Settlement CSV bytes are unavailable for authentication.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$stream = $this->attachment_service->open_download_stream( $booking['id'], $attachment['id'], $descriptor['stream_token'], $actor_id, $descriptor['correlation_id'] );
+		if ( is_wp_error( $stream ) || ! is_resource( $stream ) ) {
+			return new \WP_Error( 'settlement_csv_evidence_invalid', __( 'Settlement CSV bytes are unavailable for authentication.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$verified = $this->verified_csv_stream( $stream, $attachment );
+		fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes the approved private stream after complete authentication.
+		if ( is_resource( $verified ) ) {
+			fclose( $verified ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- No parsing is needed during settlement revalidation.
+		}
+		$outcome = is_wp_error( $verified ) ? 'failed' : 'completed';
+		$logged  = $this->attachment_service->record_delivery_outcome( $booking['id'], $attachment['id'], $descriptor['correlation_id'], $outcome, 'completed' === $outcome ? $attachment['byte_size'] : 0, $actor_id );
+		if ( is_wp_error( $verified ) || is_wp_error( $logged ) ) {
+			return new \WP_Error( 'settlement_csv_evidence_invalid', __( 'Settlement CSV bytes failed complete authentication.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return array(
+			'content_hash' => $attachment['content_hash'],
+			'byte_size'    => $attachment['byte_size'],
+		);
 	}
 
 	private function diagnostics_for_booking( array $booking ) {
@@ -524,7 +623,15 @@ class TicketReconciliationService {
 		if ( self::CSV_HEADER !== $header ) {
 			return new \WP_Error( 'sales_csv_header_invalid', __( 'The CSV header does not match the canonical ticket-sales contract.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
-		$inputs = array();
+		$inputs        = array();
+		$certification = array(
+			'ticket_source_id'                 => $source['id'],
+			'ticket_source_request_hash'       => $source['request_hash'],
+			'evidence_attachment_id'           => $attachment['id'],
+			'evidence_attachment_request_hash' => $attachment['request_hash'],
+			'evidence_content_hash'            => $attachment['content_hash'],
+			'evidence_byte_size'               => $attachment['byte_size'],
+		);
 		while ( true ) {
 			$values = $this->read_csv_record( $stream, count( $inputs ) + 2 );
 			if ( false === $values ) {
@@ -573,6 +680,7 @@ class TicketReconciliationService {
 						'attachment_id' => $attachment['public_id'],
 						'row'           => count( $inputs ) + 2,
 					),
+					'_certified_evidence'    => $certification,
 				)
 			);
 		}
@@ -705,8 +813,8 @@ class TicketReconciliationService {
 	private function find_source_identity( int $booking_id, string $provider, string $source_key, bool $lock = false ) {
 		global $wpdb;
 		$table = BookingSchema::ticket_sources_table();
-		$query = "SELECT * FROM {$table} WHERE booking_id = %d AND provider = %s AND source_key = %s LIMIT 1" . ( $lock ? ' FOR UPDATE' : '' );
-		$row   = $wpdb->get_row( $wpdb->prepare( $query, $booking_id, $provider, $source_key ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Stable source lookup.
+		$query = "SELECT * FROM {$table} WHERE booking_id = %d AND provider = %s AND source_key_hash = %s LIMIT 1" . ( $lock ? ' FOR UPDATE' : '' );
+		$row   = $wpdb->get_row( $wpdb->prepare( $query, $booking_id, $provider, hash( 'sha256', $source_key ) ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Stable source lookup.
 		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'ticket_source_read_failed', __( 'The ticket source could not be read.', 'extrachill-events' ) ) : ( is_array( $row ) ? $this->hydrate_source( $row ) : null );
 	}
 
@@ -722,8 +830,9 @@ class TicketReconciliationService {
 		foreach ( array( 'id', 'booking_id', 'event_id', 'venue_term_id', 'created_by_user_id' ) as $field ) {
 			$row[ $field ] = (int) $row[ $field ];
 		}
-		$stored = strtolower( (string) $row['request_hash'] );
-		return preg_match( '/^[a-f0-9]{64}$/', $stored ) && hash_equals( $stored, $this->hash( $row, array( 'booking_id', 'event_id', 'venue_term_id', 'provider', 'source_key', 'canonical_url' ) ) )
+		$stored        = strtolower( (string) $row['request_hash'] );
+		$identity_hash = strtolower( (string) ( $row['source_key_hash'] ?? '' ) );
+		return preg_match( '/^[a-f0-9]{64}$/', $identity_hash ) && hash_equals( $identity_hash, hash( 'sha256', $row['source_key'] ) ) && preg_match( '/^[a-f0-9]{64}$/', $stored ) && hash_equals( $stored, $this->hash( $row, array( 'booking_id', 'event_id', 'venue_term_id', 'provider', 'source_key', 'canonical_url' ) ) )
 			? $row
 			: new \WP_Error(
 				'ticket_source_integrity_failed',
@@ -792,16 +901,18 @@ class TicketReconciliationService {
 		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $source ) || 1 !== ( $source['version'] ?? null ) || ! array_key_exists( 'data', $source ) ) {
 			return new \WP_Error( 'sales_report_source_invalid', __( 'Stored ticket-sales source evidence is malformed.', 'extrachill-events' ) );
 		}
-		foreach ( array( 'id', 'booking_id', 'event_id', 'venue_term_id', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor' ) as $field ) {
+		foreach ( array( 'id', 'booking_id', 'event_id', 'venue_term_id', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'provenance_version' ) as $field ) {
 			$row[ $field ] = (int) $row[ $field ];
 		}
 		foreach ( array( 'ticket_source_id', 'evidence_attachment_id' ) as $field ) {
 			$row[ $field ] = null === ( $row[ $field ] ?? null ) ? null : (int) $row[ $field ];
 		}
+		$row['evidence_byte_size'] = null === ( $row['evidence_byte_size'] ?? null ) ? null : (int) $row['evidence_byte_size'];
 		$row['corrects_report_id'] = null === $row['corrects_report_id'] ? null : (int) $row['corrects_report_id'];
 		$row['source']             = $source['data'];
 		$stored_hash               = strtolower( (string) ( $row['request_hash'] ?? '' ) );
-		if ( ! preg_match( '/^[a-f0-9]{64}$/', $stored_hash ) || ! hash_equals( $stored_hash, TicketSettlementService::report_request_hash( $row ) ) ) {
+		$identity_hash             = strtolower( (string) ( $row['external_report_id_hash'] ?? '' ) );
+		if ( ! preg_match( '/^[a-f0-9]{64}$/', $identity_hash ) || ! hash_equals( $identity_hash, hash( 'sha256', $row['external_report_id'] ) ) || ! preg_match( '/^[a-f0-9]{64}$/', $stored_hash ) || ! hash_equals( $stored_hash, TicketSettlementService::report_request_hash( $row ) ) ) {
 			return new \WP_Error(
 				'sales_report_integrity_failed',
 				__( 'Stored ticket-sales evidence failed its immutable content check.', 'extrachill-events' ),

--- a/inc/Core/TicketSettlementService.php
+++ b/inc/Core/TicketSettlementService.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /** Owns validation, authorization, locking, and audit for ticket settlements. */
 class TicketSettlementService {
-	public const FORMULA_VERSION = 2;
+	public const FORMULA_VERSION = 3;
 	public const BASES           = array( 'gross_ticket_sales', 'net_ticket_sales' );
 	public const SOURCE_TYPES    = array( 'manual', 'csv_certified' );
 	public const STATUSES        = array( 'finalized', 'paid', 'void' );
@@ -44,6 +44,53 @@ class TicketSettlementService {
 
 	/** Record one immutable observation, returning an exact idempotent retry. */
 	public function record_sales( array $input, int $actor_id ) {
+		if ( 'csv_certified' === ( $input['source_type'] ?? null ) ) {
+			return new \WP_Error( 'sales_csv_import_required', __( 'Certified CSV observations must be created by the authenticated CSV importer.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return $this->record_report( $input, $actor_id, null );
+	}
+
+	/** Authenticate and import every CSV row through the sole certified boundary. */
+	public function import_csv( array $input, int $actor_id ) {
+		$rows = $this->reconciliation->csv_report_inputs( $input, $actor_id );
+		if ( is_wp_error( $rows ) ) {
+			return $rows;
+		}
+		$this->after_csv_authenticated( $rows );
+		$reports  = array();
+		$failures = array();
+		foreach ( $rows as $index => $row ) {
+			$certification = $row['_certified_evidence'] ?? null;
+			unset( $row['_certified_evidence'] );
+			$report = $this->record_report( $row, $actor_id, is_array( $certification ) ? $certification : null );
+			if ( is_wp_error( $report ) && 'settlement_commit_uncertain' === $report->get_error_code() ) {
+				$report = $this->record_report( $row, $actor_id, is_array( $certification ) ? $certification : null );
+			}
+			if ( is_wp_error( $report ) ) {
+				$failures[] = array(
+					'row'  => $index + 2,
+					'code' => $report->get_error_code(),
+				);
+				continue;
+			}
+			$reports[] = $report;
+		}
+		if ( ! empty( $failures ) ) {
+			return new \WP_Error(
+				'sales_csv_import_partial',
+				__( 'Some ticket-sales rows could not be imported.', 'extrachill-events' ),
+				array(
+					'status'              => 409,
+					'imported_report_ids' => array_column( $reports, 'id' ),
+					'failures'            => $failures,
+				)
+			);
+		}
+		return $reports;
+	}
+
+	/** Record one already-normalized provenance class. */
+	private function record_report( array $input, int $actor_id, ?array $csv_certification ) {
 		$booking = $this->booking( $input['booking_id'] ?? 0 );
 		if ( is_wp_error( $booking ) ) {
 			return $booking;
@@ -52,7 +99,7 @@ class TicketSettlementService {
 		if ( true !== $allowed ) {
 			return $this->denied( $allowed );
 		}
-		$normalized = $this->normalize_report( $input, $booking, $actor_id );
+		$normalized = $this->normalize_report( $input, $booking, $actor_id, null !== $csv_certification );
 		if ( is_wp_error( $normalized ) ) {
 			return $normalized;
 		}
@@ -68,11 +115,13 @@ class TicketSettlementService {
 		if ( is_wp_error( $identity ) ) {
 			return $this->rollback( $identity );
 		}
-		$provenance = $this->reconciliation->validate_provenance( $normalized, $booking );
+		$provenance = $this->reconciliation->validate_provenance( $normalized, $booking, $csv_certification );
 		if ( is_wp_error( $provenance ) ) {
 			return $this->rollback( $provenance );
 		}
-		$settlement = $this->get_settlement( $booking['id'], true );
+		$normalized                 = array_merge( $normalized, $provenance );
+		$normalized['request_hash'] = self::report_request_hash( $normalized );
+		$settlement                 = $this->get_settlement( $booking['id'], true );
 		if ( is_wp_error( $settlement ) ) {
 			return $this->rollback( $settlement );
 		}
@@ -87,7 +136,7 @@ class TicketSettlementService {
 					return $this->rollback( $this->settlement_frozen_error( $settlement ) );
 				}
 				$committed = $this->commit();
-				return is_wp_error( $committed ) ? $committed : $existing;
+				return is_wp_error( $committed ) ? $committed : $this->present_report( $existing );
 			}
 			return $this->rollback( new \WP_Error( 'sales_report_idempotency_conflict', __( 'This provider report ID is already bound to different evidence.', 'extrachill-events' ), array( 'status' => 409 ) ) );
 		}
@@ -109,7 +158,7 @@ class TicketSettlementService {
 			$existing = $this->find_report_by_external( $booking['id'], $normalized['provider'], $normalized['external_report_id'], true );
 			if ( is_array( $existing ) && hash_equals( $existing['request_hash'], $normalized['request_hash'] ) ) {
 				$committed = $this->commit();
-				return is_wp_error( $committed ) ? $committed : $existing;
+				return is_wp_error( $committed ) ? $committed : $this->present_report( $existing );
 			}
 			return $this->rollback( new \WP_Error( 'sales_report_write_failed', __( 'The ticket-sales evidence could not be recorded.', 'extrachill-events' ) ) );
 		}
@@ -138,7 +187,7 @@ class TicketSettlementService {
 			return $this->rollback( $audit );
 		}
 		$committed = $this->commit();
-		return is_wp_error( $committed ) ? $committed : $report;
+		return is_wp_error( $committed ) ? $committed : $this->present_report( $report );
 	}
 
 	/** List a bounded page of immutable observations after operation-level authorization. */
@@ -169,7 +218,7 @@ class TicketSettlementService {
 				return $identity;
 			}
 		}
-		return $reports;
+		return array_map( array( $this, 'present_report' ), $reports );
 	}
 
 	/** Calculate a deterministic, non-persisted settlement preview. */
@@ -183,7 +232,7 @@ class TicketSettlementService {
 			return $this->denied( $allowed );
 		}
 		$terms = $this->settlement_terms( $booking, $input );
-		return is_wp_error( $terms ) ? $terms : $this->calculate_from_storage( $booking, $terms, false );
+		return is_wp_error( $terms ) ? $terms : $this->calculate_from_storage( $booking, $terms, false, $actor_id );
 	}
 
 	/** Freeze one settlement from an exact booking version and evidence snapshot. */
@@ -206,7 +255,7 @@ class TicketSettlementService {
 				return $validated;
 			}
 		}
-		if ( ! in_array( $formula_version, array( 1, self::FORMULA_VERSION ), true ) || ( self::FORMULA_VERSION === $formula_version && ! preg_match( '/^[a-f0-9]{64}$/', $expected_hash ) ) ) {
+		if ( ! in_array( $formula_version, array( 1, 2, self::FORMULA_VERSION ), true ) || ( 2 <= $formula_version && ! preg_match( '/^[a-f0-9]{64}$/', $expected_hash ) ) ) {
 			return new \WP_Error(
 				'settlement_formula_version_conflict',
 				__( 'The calculated settlement formula version or evidence hash is invalid.', 'extrachill-events' ),
@@ -216,6 +265,24 @@ class TicketSettlementService {
 				)
 			);
 		}
+		$authenticated_provenance = array();
+		$settlement_snapshot      = $this->get_settlement( $booking['id'] );
+		if ( is_wp_error( $settlement_snapshot ) ) {
+			return $settlement_snapshot;
+		}
+		if ( is_array( $settlement_snapshot ) && $this->matches_finalization_retry( $settlement_snapshot, $expected_version, $expected_reports, $expected_hash, $formula_version, $terms ) ) {
+			$authenticated_provenance = $this->verify_settlement_evidence( $settlement_snapshot, false, $actor_id, null, true );
+			if ( is_wp_error( $authenticated_provenance ) ) {
+				return $authenticated_provenance;
+			}
+		} elseif ( ! is_array( $settlement_snapshot ) && self::FORMULA_VERSION === $formula_version ) {
+			$preflight = $this->calculate_from_storage( $booking, $terms, false, $actor_id, null, true );
+			if ( is_wp_error( $preflight ) ) {
+				return $preflight;
+			}
+			$authenticated_provenance = $preflight['_provenance_evidence'];
+		}
+		$this->after_settlement_provenance_authenticated( $booking );
 		$started = $this->begin_authorized( $booking, $actor_id, VenueAuthorization::ACTION_MANAGE_FINANCES );
 		if ( is_wp_error( $started ) ) {
 			return $started;
@@ -241,7 +308,7 @@ class TicketSettlementService {
 					)
 				);
 			}
-			$integrity = $this->verify_settlement_evidence( $existing, true );
+			$integrity = $this->verify_settlement_evidence( $existing, true, $actor_id, $authenticated_provenance );
 			if ( is_wp_error( $integrity ) ) {
 				return $this->rollback( $integrity );
 			}
@@ -272,7 +339,7 @@ class TicketSettlementService {
 				)
 			);
 		}
-		$calculation = $this->calculate_from_storage( $booking, $terms, true );
+		$calculation = $this->calculate_from_storage( $booking, $terms, true, $actor_id, $authenticated_provenance );
 		if ( is_wp_error( $calculation ) ) {
 			return $this->rollback( $calculation );
 		}
@@ -391,6 +458,19 @@ class TicketSettlementService {
 		if ( true !== $allowed ) {
 			return $this->denied( $allowed );
 		}
+		$authenticated_provenance = array();
+		if ( $booking['version'] === $expected_booking && ( 'paid' !== $status || 'completed' === $booking['status'] ) ) {
+			$settlement_snapshot = $this->get_settlement( $booking['id'] );
+			if ( is_wp_error( $settlement_snapshot ) ) {
+				return $settlement_snapshot;
+			}
+			if ( is_array( $settlement_snapshot ) && $settlement_snapshot['version'] === $expected_settlement && 'finalized' === $settlement_snapshot['status'] ) {
+				$authenticated_provenance = $this->verify_settlement_evidence( $settlement_snapshot, false, $actor_id, null, true );
+				if ( is_wp_error( $authenticated_provenance ) ) {
+					return $authenticated_provenance;
+				}
+			}
+		}
 		$started = $this->begin_authorized( $booking, $actor_id, VenueAuthorization::ACTION_MANAGE_FINANCES );
 		if ( is_wp_error( $started ) ) {
 			return $started;
@@ -427,10 +507,6 @@ class TicketSettlementService {
 		if ( ! is_array( $settlement ) ) {
 			return $this->rollback( is_wp_error( $settlement ) ? $settlement : new \WP_Error( 'settlement_not_found', __( 'The booking settlement was not found.', 'extrachill-events' ), array( 'status' => 404 ) ) );
 		}
-		$integrity = $this->verify_settlement_evidence( $settlement, true );
-		if ( is_wp_error( $integrity ) ) {
-			return $this->rollback( $integrity );
-		}
 		if ( $settlement['version'] !== $expected_settlement ) {
 			return $this->rollback(
 				new \WP_Error(
@@ -454,6 +530,10 @@ class TicketSettlementService {
 					)
 				)
 			);
+		}
+		$integrity = $this->verify_settlement_evidence( $settlement, true, $actor_id, $authenticated_provenance );
+		if ( is_wp_error( $integrity ) ) {
+			return $this->rollback( $integrity );
 		}
 		global $wpdb;
 		$now     = gmdate( 'Y-m-d H:i:s' );
@@ -501,7 +581,7 @@ class TicketSettlementService {
 		return is_wp_error( $committed ) ? $committed : $settlement;
 	}
 
-	private function calculate_from_storage( array $booking, array $terms, bool $lock ) {
+	private function calculate_from_storage( array $booking, array $terms, bool $lock, int $actor_id, ?array $authenticated_provenance = null, bool $include_provenance = false ) {
 		global $wpdb;
 		$table = BookingSchema::sales_reports_table();
 		$query = "SELECT * FROM {$table} WHERE booking_id = %d ORDER BY id ASC";
@@ -538,10 +618,11 @@ class TicketSettlementService {
 		if ( empty( $reports ) ) {
 			return new \WP_Error( 'settlement_evidence_required', __( 'At least one reconciled ticket-sales report is required for settlement.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
-		$field        = 'gross_ticket_sales' === $terms['basis'] ? 'gross_minor' : 'net_minor';
-		$basis_amount = 0;
-		$ids          = array();
-		$evidence     = array();
+		$field               = 'gross_ticket_sales' === $terms['basis'] ? 'gross_minor' : 'net_minor';
+		$basis_amount        = 0;
+		$ids                 = array();
+		$evidence            = array();
+		$provenance_evidence = array();
 		foreach ( $reports as $report ) {
 			if ( ( $report[ $field ] > 0 && $basis_amount > PHP_INT_MAX - $report[ $field ] ) || ( $report[ $field ] < 0 && $basis_amount < PHP_INT_MIN - $report[ $field ] ) ) {
 				return new \WP_Error( 'settlement_amount_out_of_range', __( 'The settlement evidence exceeds the supported integer range.', 'extrachill-events' ) );
@@ -552,10 +633,19 @@ class TicketSettlementService {
 			if ( is_wp_error( $resolution ) ) {
 				return $resolution;
 			}
-			$evidence[] = array(
+			$provenance = $this->reconciliation->settlement_provenance_evidence( $report, $booking, $resolution, $actor_id, $lock, null === $authenticated_provenance );
+			if ( is_wp_error( $provenance ) ) {
+				return $provenance;
+			}
+			if ( null !== $authenticated_provenance && ( ! isset( $authenticated_provenance[ $report['id'] ] ) || $authenticated_provenance[ $report['id'] ] !== $provenance ) ) {
+				return new \WP_Error( 'settlement_csv_evidence_changed', __( 'Settlement private-byte evidence changed after authentication.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			$provenance_evidence[ $report['id'] ] = $provenance;
+			$evidence[]                           = array(
 				'id'           => $report['id'],
 				'request_hash' => $report['request_hash'],
 				'resolution'   => $resolution,
+				'provenance'   => $provenance,
 			);
 		}
 		$share = self::basis_points_amount( $basis_amount, $terms['basis_points'] );
@@ -565,7 +655,7 @@ class TicketSettlementService {
 		if ( ( $terms['adjustment_minor'] > 0 && $share > PHP_INT_MAX - $terms['adjustment_minor'] ) || ( $terms['adjustment_minor'] < 0 && $share < PHP_INT_MIN - $terms['adjustment_minor'] ) ) {
 			return new \WP_Error( 'settlement_amount_out_of_range', __( 'The adjusted settlement exceeds the supported integer range.', 'extrachill-events' ) );
 		}
-		return array(
+		$result = array(
 			'booking_id'          => $booking['id'],
 			'booking_version'     => $booking['version'],
 			'event_id'            => $booking['event_id'],
@@ -581,6 +671,10 @@ class TicketSettlementService {
 			'adjustment_minor'    => $terms['adjustment_minor'],
 			'amount_due_minor'    => $share + $terms['adjustment_minor'],
 		);
+		if ( $include_provenance ) {
+			$result['_provenance_evidence'] = $provenance_evidence;
+		}
+		return $result;
 	}
 
 	private function settlement_terms( array $booking, array $input, bool $require_explicit = false ) {
@@ -619,12 +713,12 @@ class TicketSettlementService {
 		);
 	}
 
-	private function normalize_report( array $input, array $booking, int $actor_id ) {
+	private function normalize_report( array $input, array $booking, int $actor_id, bool $csv_certified ) {
 		if ( null === $booking['event_id'] ) {
 			return new \WP_Error( 'sales_report_event_required', __( 'Ticket-sales evidence requires a booking linked to an event.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
 		$provider         = mb_substr( sanitize_key( (string) ( $input['provider'] ?? '' ) ), 0, 64 );
-		$external         = $this->required_text( $input['external_report_id'] ?? null, 'external_report_id', 191 );
+		$external         = self::opaque_identifier( $input['external_report_id'] ?? null, 'external_report_id' );
 		$source           = sanitize_key( (string) ( $input['source_type'] ?? '' ) );
 		$start            = $this->datetime( $input['period_start'] ?? null, 'period_start' );
 		$end              = $this->datetime( $input['period_end'] ?? null, 'period_end' );
@@ -646,7 +740,7 @@ class TicketSettlementService {
 				return $validated;
 			}
 		}
-		if ( '' === $provider || ! in_array( $source, self::SOURCE_TYPES, true ) || ! preg_match( '/^[A-Z]{3}$/', $currency ) || $end < $start ) {
+		if ( '' === $provider || ! in_array( $source, self::SOURCE_TYPES, true ) || ( 'csv_certified' === $source ) !== $csv_certified || ( 'manual' === $source && null !== $attachment_id ) || ! preg_match( '/^[A-Z]{3}$/', $currency ) || $end < $start ) {
 			return new \WP_Error( 'invalid_sales_report_identity', __( 'Ticket-sales report identity, source, period, or currency is invalid.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
 		$integers = array();
@@ -678,29 +772,28 @@ class TicketSettlementService {
 		if ( 8192 < strlen( $source_payload ) ) {
 			return new \WP_Error( 'sales_report_source_too_large', __( 'Ticket-sales source evidence exceeds the bounded provenance limit.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
-		$row                 = array_merge(
+		$row           = array_merge(
 			array(
-				'booking_id'             => $booking['id'],
-				'event_id'               => $booking['event_id'],
-				'venue_term_id'          => $booking['venue_term_id'],
-				'ticket_source_id'       => $ticket_source_id,
-				'evidence_attachment_id' => $attachment_id,
-				'provider'               => $provider,
-				'external_report_id'     => $external,
-				'source_type'            => $source,
-				'period_start'           => $start,
-				'period_end'             => $end,
-				'currency'               => $currency,
-				'corrects_report_id'     => $correction,
-				'source_payload'         => $source_payload,
-				'created_by_user_id'     => $actor_id,
-				'created_at'             => gmdate( 'Y-m-d H:i:s' ),
+				'booking_id'              => $booking['id'],
+				'event_id'                => $booking['event_id'],
+				'venue_term_id'           => $booking['venue_term_id'],
+				'ticket_source_id'        => $ticket_source_id,
+				'evidence_attachment_id'  => $attachment_id,
+				'provider'                => $provider,
+				'external_report_id'      => $external,
+				'external_report_id_hash' => hash( 'sha256', $external ),
+				'source_type'             => $source,
+				'period_start'            => $start,
+				'period_end'              => $end,
+				'currency'                => $currency,
+				'corrects_report_id'      => $correction,
+				'source_payload'          => $source_payload,
+				'created_by_user_id'      => $actor_id,
+				'created_at'              => gmdate( 'Y-m-d H:i:s' ),
 			),
 			$integers
 		);
-		$row['source']       = $input['source'];
-		$row['request_hash'] = self::report_request_hash( $row );
-		unset( $row['source'] );
+		$row['source'] = $input['source'];
 		return $row;
 	}
 
@@ -753,11 +846,11 @@ class TicketSettlementService {
 	private function find_report_by_external( int $booking_id, string $provider, string $external_id, bool $lock = false ) {
 		global $wpdb;
 		$table = BookingSchema::sales_reports_table();
-		$query = "SELECT * FROM {$table} WHERE booking_id = %d AND provider = %s AND external_report_id = %s LIMIT 1";
+		$query = "SELECT * FROM {$table} WHERE booking_id = %d AND provider = %s AND external_report_id_hash = %s LIMIT 1";
 		if ( $lock ) {
 			$query .= ' FOR UPDATE';
 		}
-		$row = $wpdb->get_row( $wpdb->prepare( $query, $booking_id, $provider, $external_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Booking-scoped immutable evidence lookup with internal lock suffix.
+		$row = $wpdb->get_row( $wpdb->prepare( $query, $booking_id, $provider, hash( 'sha256', $external_id ) ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Booking-scoped immutable evidence lookup with internal lock suffix.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'sales_report_read_failed', __( 'Ticket-sales evidence could not be read.', 'extrachill-events' ) );
 		}
@@ -809,16 +902,18 @@ class TicketSettlementService {
 		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $source ) || 1 !== ( $source['version'] ?? null ) || ! array_key_exists( 'data', $source ) ) {
 			return new \WP_Error( 'sales_report_source_invalid', __( 'Stored ticket-sales source evidence is malformed.', 'extrachill-events' ) );
 		}
-		foreach ( array( 'id', 'booking_id', 'event_id', 'venue_term_id', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'created_by_user_id' ) as $field ) {
+		foreach ( array( 'id', 'booking_id', 'event_id', 'venue_term_id', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'created_by_user_id', 'provenance_version' ) as $field ) {
 			$row[ $field ] = (int) $row[ $field ];
 		}
 		$row['corrects_report_id']     = null === $row['corrects_report_id'] ? null : (int) $row['corrects_report_id'];
 		$row['ticket_source_id']       = null === ( $row['ticket_source_id'] ?? null ) ? null : (int) $row['ticket_source_id'];
 		$row['evidence_attachment_id'] = null === ( $row['evidence_attachment_id'] ?? null ) ? null : (int) $row['evidence_attachment_id'];
+		$row['evidence_byte_size']     = null === ( $row['evidence_byte_size'] ?? null ) ? null : (int) $row['evidence_byte_size'];
 		$row['source']                 = $source['data'];
 		unset( $row['source_payload'] );
-		$stored_hash = strtolower( (string) ( $row['request_hash'] ?? '' ) );
-		if ( ! preg_match( '/^[a-f0-9]{64}$/', $stored_hash ) || ! hash_equals( $stored_hash, self::report_request_hash( $row ) ) ) {
+		$stored_hash   = strtolower( (string) ( $row['request_hash'] ?? '' ) );
+		$identity_hash = strtolower( (string) ( $row['external_report_id_hash'] ?? '' ) );
+		if ( ! preg_match( '/^[a-f0-9]{64}$/', $identity_hash ) || ! hash_equals( $identity_hash, hash( 'sha256', $row['external_report_id'] ) ) || ! preg_match( '/^[a-f0-9]{64}$/', $stored_hash ) || ! hash_equals( $stored_hash, self::report_request_hash( $row ) ) ) {
 			return new \WP_Error(
 				'sales_report_integrity_failed',
 				__( 'Stored ticket-sales evidence failed its immutable content check.', 'extrachill-events' ),
@@ -831,6 +926,12 @@ class TicketSettlementService {
 		$row['request_hash'] = $stored_hash;
 		$row['source']       = $this->project_source( $row['source'] );
 		return $row;
+	}
+
+	/** Remove private hash-key and provenance columns from public ability results. */
+	private function present_report( array $report ): array {
+		unset( $report['external_report_id_hash'], $report['provenance_version'], $report['ticket_source_request_hash'], $report['evidence_attachment_request_hash'], $report['evidence_content_hash'], $report['evidence_byte_size'] );
+		return $report;
 	}
 
 	private function hydrate_settlement( array $row ) {
@@ -865,6 +966,16 @@ class TicketSettlementService {
 		unset( $booking );
 	}
 
+	/** Test seam invoked after all bytes authenticate and before row commits begin. */
+	protected function after_csv_authenticated( array $rows ): void {
+		unset( $rows );
+	}
+
+	/** Test seam invoked between byte authentication and settlement locking. */
+	protected function after_settlement_provenance_authenticated( array $booking ): void {
+		unset( $booking );
+	}
+
 	private function matches_finalization_retry( array $settlement, int $booking_version, array $report_ids, string $evidence_hash, int $formula_version, array $terms ): bool {
 		return $settlement['booking_version'] === $booking_version
 			&& $settlement['included_report_ids'] === $report_ids
@@ -876,8 +987,16 @@ class TicketSettlementService {
 			&& $settlement['adjustment_minor'] === $terms['adjustment_minor'];
 	}
 
-	private function verify_settlement_evidence( array $settlement, bool $lock ) {
-		$evidence = array();
+	private function verify_settlement_evidence( array $settlement, bool $lock, int $actor_id, ?array $authenticated_provenance = null, bool $authenticate_bytes = false ) {
+		$evidence            = array();
+		$provenance_evidence = array();
+		$booking             = null;
+		if ( 3 <= $settlement['formula_version'] ) {
+			$booking = $this->bookings->get( $settlement['booking_id'] );
+			if ( ! is_array( $booking ) ) {
+				return new \WP_Error( 'settlement_evidence_integrity_failed', __( 'Frozen settlement booking evidence is missing.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+		}
 		foreach ( $settlement['included_report_ids'] as $report_id ) {
 			$report = $this->get_report( $report_id, $lock );
 			if ( is_wp_error( $report ) ) {
@@ -904,10 +1023,21 @@ class TicketSettlementService {
 				}
 				$item['resolution'] = $resolution;
 			}
+			if ( 3 <= $settlement['formula_version'] ) {
+				$provenance = $this->reconciliation->settlement_provenance_evidence( $report, $booking, $resolution ?? null, $actor_id, $lock, $authenticate_bytes );
+				if ( is_wp_error( $provenance ) ) {
+					return $provenance;
+				}
+				if ( ! $authenticate_bytes && ( null === $authenticated_provenance || ! isset( $authenticated_provenance[ $report['id'] ] ) || $authenticated_provenance[ $report['id'] ] !== $provenance ) ) {
+					return new \WP_Error( 'settlement_csv_evidence_changed', __( 'Frozen private-byte evidence changed after authentication.', 'extrachill-events' ), array( 'status' => 409 ) );
+				}
+				$item['provenance']                   = $provenance;
+				$provenance_evidence[ $report['id'] ] = $provenance;
+			}
 			$evidence[] = $item;
 		}
 		return hash_equals( $settlement['evidence_hash'], $this->evidence_hash( $evidence ) )
-			? true
+			? $provenance_evidence
 			: new \WP_Error(
 				'settlement_evidence_integrity_failed',
 				__( 'Frozen settlement evidence no longer matches its canonical content hash.', 'extrachill-events' ),
@@ -950,6 +1080,9 @@ class TicketSettlementService {
 		$fields = array( 'booking_id', 'event_id', 'venue_term_id', 'provider', 'external_report_id', 'source_type', 'period_start', 'period_end', 'tickets_sold', 'tickets_refunded', 'gross_minor', 'fees_minor', 'tax_minor', 'refunds_minor', 'net_minor', 'currency', 'corrects_report_id' );
 		if ( null !== ( $report['ticket_source_id'] ?? null ) || null !== ( $report['evidence_attachment_id'] ?? null ) ) {
 			array_splice( $fields, 3, 0, array( 'ticket_source_id', 'evidence_attachment_id' ) );
+		}
+		if ( 2 <= (int) ( $report['provenance_version'] ?? 1 ) ) {
+			array_splice( $fields, 3, 0, array( 'provenance_version', 'ticket_source_request_hash', 'evidence_attachment_request_hash', 'evidence_content_hash', 'evidence_byte_size' ) );
 		}
 		$hashable = array();
 		foreach ( $fields as $field ) {
@@ -1030,6 +1163,21 @@ class TicketSettlementService {
 				'field'  => $field,
 			)
 		);
+	}
+
+	/** Preserve opaque provider identifiers byte-for-byte or reject them. */
+	public static function opaque_identifier( $value, string $field ) {
+		if ( ! is_string( $value ) || '' === $value || ! mb_check_encoding( $value, 'UTF-8' ) || 191 < mb_strlen( $value, 'UTF-8' ) || 764 < strlen( $value ) || preg_match( '/[\x00-\x1F\x7F]|\p{C}/u', $value ) ) {
+			return new \WP_Error(
+				'invalid_opaque_identifier',
+				__( 'The provider identifier contains unsupported bytes or exceeds the bounded identity policy.', 'extrachill-events' ),
+				array(
+					'status' => 400,
+					'field'  => $field,
+				)
+			);
+		}
+		return $value;
 	}
 
 	private function datetime( $value, string $field ) {

--- a/phpunit-booking-mysql.xml.dist
+++ b/phpunit-booking-mysql.xml.dist
@@ -9,6 +9,7 @@
 		<testsuite name="booking-attachment-mysql">
 			<file>tests/MySQLIntegration/BookingAttachmentMySQLIntegrationTest.php</file>
 			<file>tests/MySQLIntegration/BookingEventSyncMySQLIntegrationTest.php</file>
+			<file>tests/MySQLIntegration/BookingSchemaMultisiteTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -309,7 +309,7 @@ final class BookingFoundationTest extends BookingTestCase {
 		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '11';
 
 		$this->assertTrue( BookingSchema::maybe_install() );
-		$this->assertSame( '13', get_option( BookingSchema::VERSION_OPTION ) );
+		$this->assertSame( '14', get_option( BookingSchema::VERSION_OPTION ) );
 		$this->assertArrayHasKey( $sales, $wpdb->schemas );
 		$this->assertArrayHasKey( $settlements, $wpdb->schemas );
 		$this->assertSame( 'INNODB', strtoupper( $wpdb->engines[ $sales ] ) );

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -132,7 +132,7 @@ final class BookingHoldTest extends BookingTestCase {
 	}
 
 	public function test_combined_schema_installs_site_scoped_holds_contract(): void {
-		$this->assertSame( '13', BookingSchema::SCHEMA_VERSION );
+		$this->assertSame( '14', BookingSchema::SCHEMA_VERSION );
 		$this->assertTrue( BookingSchema::install() );
 		$table = BookingSchema::holds_table();
 		$this->assertSame( 'wp_7_ec_booking_holds', $table );

--- a/tests/BookingMutationTest.php
+++ b/tests/BookingMutationTest.php
@@ -118,7 +118,7 @@ final class BookingMutationTest extends BookingTestCase {
 	}
 
 	public function test_schema_and_public_inquiry_separate_requested_from_authoritative_fields(): void {
-		$this->assertSame( '13', BookingSchema::SCHEMA_VERSION );
+		$this->assertSame( '14', BookingSchema::SCHEMA_VERSION );
 		$this->assertTrue( BookingSchema::install() );
 		$columns = $GLOBALS['wpdb']->schemas[ BookingSchema::bookings_table() ]['columns'];
 		foreach ( array( 'requested_space_key', 'performance_start_at', 'performance_end_at', 'production_payload', 'confirmed_deal_payload' ) as $column ) {

--- a/tests/LocalSupportDomainTest.php
+++ b/tests/LocalSupportDomainTest.php
@@ -11,11 +11,10 @@ use ExtraChillEvents\Core\LocalSupportRepository;
 use ExtraChillEvents\Core\LocalSupportSchema;
 use ExtraChillEvents\Core\LocalSupportService;
 use ExtraChillEvents\Core\VenueAuthorization;
-use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
-final class LocalSupportDomainTest extends TestCase {
+final class LocalSupportDomainTest extends BookingTestCase {
 
 	/** @var LocalSupportMemoryRepository */
 	private $repository;

--- a/tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
@@ -13,6 +13,16 @@ use ExtraChillEvents\Core\VenueBookingConfig;
 
 /** Prove overlapping application processes converge on one complete winner. */
 final class BookingAdmissionConcurrencyMySQLProof extends BookingAttachmentMySQLIntegrationTest {
+	/** Prove concurrent installers serialize on the exact site-scoped schema lock. */
+	public function test_concurrent_booking_schema_installer_waits_and_converges(): void {
+		$this->prove_concurrent_booking_schema_installer_waits_and_converges();
+	}
+
+	/** Prove a resolution racing finalization cannot alter the frozen snapshot. */
+	public function test_resolution_and_finalization_race_freezes_one_consistent_winner(): void {
+		$this->prove_resolution_and_finalization_race_freezes_one_consistent_winner();
+	}
+
 	/** Prove the loser replays the completed exact winner without duplicate effects. */
 	public function test_concurrent_exact_inquiry_retry_reuses_one_complete_winner(): void {
 		global $wpdb;

--- a/tests/MySQLIntegration/BookingAttachmentMySQLIntegrationTest.php
+++ b/tests/MySQLIntegration/BookingAttachmentMySQLIntegrationTest.php
@@ -45,10 +45,13 @@ final class BookingAttachmentMySQLProbeProvider implements BookingPrivateFilePro
 	public $stage_count = 0;
 	/** @var string Shared cross-process stage/retire journal. */
 	public $event_log = '';
+	/** @var array<string,string> Private bytes used by CSV integration probes. */
+	public $contents = array();
+	/** @var array<string,array<string,string>> Metadata for private byte probes. */
+	public $metadata = array();
 
 	/** Stage one deterministic probe object. */
 	public function stage( string $source_path, string $filename, string $purpose ) {
-		unset( $source_path, $filename, $purpose );
 		++$this->stage_count;
 		if ( '' !== $this->event_log ) {
 			file_put_contents( $this->event_log, "stage\n", FILE_APPEND | LOCK_EX );
@@ -56,14 +59,31 @@ final class BookingAttachmentMySQLProbeProvider implements BookingPrivateFilePro
 		if ( is_callable( $this->stage_probe ) ) {
 			( $this->stage_probe )();
 		}
-		return 'private_inquiry_probe_object_' . $this->stage_count;
+		$reference = 'private_inquiry_probe_object_' . $this->stage_count;
+		if ( 'other_private_evidence' === $purpose && is_file( $source_path ) ) {
+			$this->contents[ $reference ] = (string) file_get_contents( $source_path );
+			$this->metadata[ $reference ] = array(
+				'filename'  => $filename,
+				'mime_type' => 'text/csv',
+			);
+		}
+		return $reference;
 	}
 
 	/** Return fixed trusted metadata after running the concurrency probe. */
 	public function claim( string $storage_reference, string $claim_key, string $purpose = '' ) {
-		unset( $storage_reference, $claim_key, $purpose );
+		unset( $claim_key, $purpose );
 		if ( is_callable( $this->claim_probe ) ) {
 			( $this->claim_probe )();
+		}
+		if ( isset( $this->contents[ $storage_reference ] ) ) {
+			return array(
+				'filename'     => $this->metadata[ $storage_reference ]['filename'],
+				'mime_type'    => $this->metadata[ $storage_reference ]['mime_type'],
+				'byte_size'    => strlen( $this->contents[ $storage_reference ] ),
+				'content_hash' => hash( 'sha256', $this->contents[ $storage_reference ] ),
+				'scan_status'  => 'clean',
+			);
 		}
 		return array(
 			'filename'     => 'integration-rider.pdf',
@@ -93,14 +113,25 @@ final class BookingAttachmentMySQLProbeProvider implements BookingPrivateFilePro
 
 	/** Downloads are outside this integration scope. */
 	public function download_descriptor( string $storage_reference, string $attachment_public_id, int $actor_id, string $purpose, string $claim_key, string $correlation_id ) {
-		unset( $storage_reference, $attachment_public_id, $actor_id, $purpose, $claim_key, $correlation_id );
-		return new WP_Error( 'not_implemented' );
+		unset( $attachment_public_id, $actor_id, $purpose, $claim_key, $correlation_id );
+		return isset( $this->contents[ $storage_reference ] )
+			? array(
+				'stream_token' => $storage_reference,
+				'expires_at'   => gmdate( 'c', time() + 300 ),
+			)
+			: new WP_Error( 'not_implemented' );
 	}
 
 	/** Downloads are outside this integration scope. */
 	public function open_stream( string $stream_token, string $attachment_public_id, int $actor_id, string $purpose, string $correlation_id ) {
-		unset( $stream_token, $attachment_public_id, $actor_id, $purpose, $correlation_id );
-		return new WP_Error( 'not_implemented' );
+		unset( $attachment_public_id, $actor_id, $purpose, $correlation_id );
+		if ( ! isset( $this->contents[ $stream_token ] ) ) {
+			return new WP_Error( 'not_implemented' );
+		}
+		$stream = fopen( 'php://temp', 'w+b' );
+		fwrite( $stream, $this->contents[ $stream_token ] );
+		rewind( $stream );
+		return $stream;
 	}
 
 	/** Record retirement after probing the held production reference lock. */
@@ -126,6 +157,42 @@ final class TicketSettlementMySQLProbeService extends TicketSettlementService {
 		unset( $booking );
 		if ( is_callable( $this->evidence_probe ) ) {
 			( $this->evidence_probe )();
+		}
+	}
+}
+
+/** Real-MySQL connection that reports one already-committed transaction as uncertain. */
+final class BookingCommitUncertainWpdb extends wpdb {
+	/** @var bool */
+	public $fail_next_commit = false;
+
+	/** Commit normally, then simulate a lost acknowledgement once. */
+	public function query( $query ) {
+		$result = parent::query( $query );
+		if ( $this->fail_next_commit && 'COMMIT' === strtoupper( trim( (string) $query ) ) ) {
+			$this->fail_next_commit = false;
+			return false;
+		}
+		return $result;
+	}
+}
+
+/** CSV importer probe that loses the first row commit acknowledgement. */
+final class TicketSettlementCSVReplayProbeService extends TicketSettlementService {
+	/** @var callable|null Probe invoked between byte authentication and locking. */
+	public $provenance_probe;
+
+	/** Arm the real connection only after complete byte authentication. */
+	protected function after_csv_authenticated( array $rows ): void {
+		unset( $rows );
+		$GLOBALS['wpdb']->fail_next_commit = true;
+	}
+
+	/** Invoke a second-session mutation after complete byte authentication. */
+	protected function after_settlement_provenance_authenticated( array $booking ): void {
+		unset( $booking );
+		if ( is_callable( $this->provenance_probe ) ) {
+			( $this->provenance_probe )();
 		}
 	}
 }
@@ -292,6 +359,328 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 		$this->assertSame( 'purged', ( new BookingAttachmentRepository() )->get( $attachment['id'] )['state'] );
 	}
 
+	/** Prove concurrent installers serialize on the exact site-scoped schema lock. */
+	public function test_concurrent_booking_schema_installer_waits_and_converges(): void {
+		global $wpdb;
+		$this->assertTrue( function_exists( 'pcntl_fork' ), 'The installer concurrency proof requires pcntl_fork().' );
+		$lock_name = 'ec_booking_schema_' . substr( hash( 'sha256', (string) DB_NAME . "\0" . $wpdb->prefix ), 0, 40 );
+		$escaped   = $this->contender->real_escape_string( $lock_name );
+		$this->assertSame( 1, (int) $this->contender->query( "SELECT GET_LOCK('{$escaped}', 1)" )->fetch_row()[0] );
+		$started = wp_tempnam( 'booking-schema-started.txt' );
+		$result  = $started . '.result';
+		unlink( $started );
+		$pid = pcntl_fork();
+		$this->assertGreaterThanOrEqual( 0, $pid );
+		if ( 0 === $pid ) {
+			$this->reconnect_wordpress_database();
+			file_put_contents( $started, 'started', LOCK_EX );
+			$installed = BookingSchema::install();
+			file_put_contents( $result, is_wp_error( $installed ) ? $installed->get_error_code() : 'ok', LOCK_EX );
+			exit( 0 );
+		}
+		$deadline = microtime( true ) + 5;
+		while ( ! file_exists( $started ) && microtime( true ) < $deadline ) {
+			usleep( 10000 );
+		}
+		$this->assertFileExists( $started );
+		usleep( 200000 );
+		$this->assertFileDoesNotExist( $result, 'A concurrent installer bypassed the site schema lock.' );
+		$this->assertSame( 1, (int) $this->contender->query( "SELECT RELEASE_LOCK('{$escaped}')" )->fetch_row()[0] );
+		$status = 0;
+		pcntl_waitpid( $pid, $status );
+		$this->assertTrue( pcntl_wifexited( $status ) && 0 === pcntl_wexitstatus( $status ) );
+		$this->assertSame( 'ok', file_get_contents( $result ) );
+		$this->assertTrue( BookingSchema::health() );
+		foreach ( array( $started, $result ) as $file ) {
+			if ( file_exists( $file ) ) {
+				unlink( $file );
+			}
+		}
+	}
+
+	/** Prove second-session source/report competitors converge or conflict exactly. */
+	public function test_competing_source_and_report_identities_are_exact_and_lossless(): void {
+		$event_id       = self::factory()->post->create(
+			array(
+				'post_type'   => defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events',
+				'post_status' => 'publish',
+			)
+		);
+		$bookings       = new BookingRepository();
+		$booking        = $bookings->create(
+			array(
+				'venue_term_id' => $this->venue_id,
+				'artist_name'   => 'Competing Identity Artist',
+				'intake'        => array(),
+			)
+		);
+		$booking        = $bookings->claim_event( $booking['id'], $event_id, $booking['version'] );
+		$reconciliation = new TicketReconciliationService();
+		$source_input   = array(
+			'booking_id' => $booking['id'],
+			'provider'   => 'neutral-provider',
+			'source_key' => 'Opaque/Case ID',
+			'ticket_url' => 'https://tickets.example.test/identity-one',
+		);
+		$source         = $reconciliation->register_source( $source_input, $this->actor_id );
+		$this->assertIsArray( $source, is_wp_error( $source ) ? $source->get_error_code() : '' );
+		$sources          = BookingSchema::ticket_sources_table();
+		$duplicate_source = "INSERT INTO {$sources} (public_id,booking_id,event_id,venue_term_id,provider,source_key,source_key_hash,canonical_url,url_hash,request_hash,created_by_user_id,created_at) SELECT UUID(),booking_id,event_id,venue_term_id,provider,source_key,source_key_hash,'https://tickets.example.test/competitor',SHA2('competitor',256),SHA2('competitor',256),created_by_user_id,UTC_TIMESTAMP() FROM {$sources} WHERE id = " . (int) $source['id'];
+		$source_duplicate = false;
+		try {
+			$source_duplicate = false === $this->contender->query( $duplicate_source ) && 1062 === $this->contender->errno;
+		} catch ( mysqli_sql_exception $exception ) {
+			$source_duplicate = 1062 === $exception->getCode();
+		}
+		$this->assertTrue( $source_duplicate, 'A second session inserted a competing source identity.' );
+		$this->assertSame( $source['id'], $reconciliation->register_source( $source_input, $this->actor_id )['id'] );
+		$changed_url               = $source_input;
+		$changed_url['ticket_url'] = 'https://tickets.example.test/conflict';
+		$this->assertSame( 'ticket_source_idempotency_conflict', $reconciliation->register_source( $changed_url, $this->actor_id )->get_error_code() );
+		$case_distinct               = $source_input;
+		$case_distinct['source_key'] = 'opaque/case id';
+		$case_distinct['ticket_url'] = 'https://tickets.example.test/identity-two';
+		$this->assertIsArray( $reconciliation->register_source( $case_distinct, $this->actor_id ) );
+
+		$service           = new TicketSettlementService( $bookings, null, null, null, $reconciliation );
+		$input             = $this->settlement_report_input( $booking['id'], 'Opaque/Report ID', $source['id'] );
+		$input['provider'] = 'neutral-provider';
+		$report            = $service->record_sales( $input, $this->actor_id );
+		$this->assertIsArray( $report, is_wp_error( $report ) ? $report->get_error_code() : '' );
+		$sales            = BookingSchema::sales_reports_table();
+		$duplicate_report = "INSERT INTO {$sales} (booking_id,event_id,venue_term_id,ticket_source_id,evidence_attachment_id,provider,external_report_id,external_report_id_hash,source_type,provenance_version,ticket_source_request_hash,evidence_attachment_request_hash,evidence_content_hash,evidence_byte_size,period_start,period_end,tickets_sold,tickets_refunded,gross_minor,fees_minor,tax_minor,refunds_minor,net_minor,currency,corrects_report_id,source_payload,request_hash,created_by_user_id,created_at) SELECT booking_id,event_id,venue_term_id,ticket_source_id,evidence_attachment_id,provider,external_report_id,external_report_id_hash,source_type,provenance_version,ticket_source_request_hash,evidence_attachment_request_hash,evidence_content_hash,evidence_byte_size,period_start,period_end,tickets_sold,tickets_refunded,gross_minor + 1,fees_minor,tax_minor,refunds_minor,net_minor,currency,corrects_report_id,source_payload,SHA2('competitor',256),created_by_user_id,UTC_TIMESTAMP() FROM {$sales} WHERE id = " . (int) $report['id'];
+		$report_duplicate = false;
+		try {
+			$report_duplicate = false === $this->contender->query( $duplicate_report ) && 1062 === $this->contender->errno;
+		} catch ( mysqli_sql_exception $exception ) {
+			$report_duplicate = 1062 === $exception->getCode();
+		}
+		$this->assertTrue( $report_duplicate, 'A second session inserted a competing report identity.' );
+		$this->assertSame( $report['id'], $service->record_sales( $input, $this->actor_id )['id'] );
+		$conflict                = $input;
+		$conflict['gross_minor'] = $input['gross_minor'] + 1;
+		$this->assertSame( 'sales_report_idempotency_conflict', $service->record_sales( $conflict, $this->actor_id )->get_error_code() );
+	}
+
+	/** Prove a resolution racing finalization cannot alter the frozen snapshot. */
+	public function test_resolution_and_finalization_race_freezes_one_consistent_winner(): void {
+		$this->assertTrue( function_exists( 'pcntl_fork' ), 'The resolution race proof requires pcntl_fork().' );
+		$event_id       = self::factory()->post->create(
+			array(
+				'post_type'   => defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events',
+				'post_status' => 'publish',
+			)
+		);
+		$bookings       = new BookingRepository();
+		$booking        = $bookings->create(
+			array(
+				'venue_term_id' => $this->venue_id,
+				'artist_name'   => 'Resolution Race Artist',
+				'intake'        => array(),
+			)
+		);
+		$booking        = $bookings->claim_event( $booking['id'], $event_id, $booking['version'] );
+		$reconciliation = new TicketReconciliationService();
+		$source         = $reconciliation->register_source(
+			array(
+				'booking_id' => $booking['id'],
+				'provider'   => 'race-provider',
+				'source_key' => 'race-source',
+				'ticket_url' => 'https://tickets.example.test/race',
+			),
+			$this->actor_id
+		);
+		$this->assertIsArray( $source, is_wp_error( $source ) ? $source->get_error_code() : '' );
+		$service           = new TicketSettlementMySQLProbeService( $bookings, null, null, null, $reconciliation );
+		$input             = $this->settlement_report_input( $booking['id'], 'resolution-race-report', $source['id'] );
+		$input['provider'] = 'race-provider';
+		$report            = $service->record_sales( $input, $this->actor_id );
+		$this->assertIsArray( $report, is_wp_error( $report ) ? $report->get_error_code() : '' );
+		$preview = $service->calculate(
+			array(
+				'booking_id'   => $booking['id'],
+				'basis'        => 'gross_ticket_sales',
+				'basis_points' => 2000,
+				'currency'     => 'USD',
+			),
+			$this->actor_id
+		);
+		$this->assertIsArray( $preview, is_wp_error( $preview ) ? $preview->get_error_code() : '' );
+
+		$start   = wp_tempnam( 'resolution-race-start.txt' );
+		$attempt = $start . '.attempt';
+		$result  = $start . '.result';
+		unlink( $start );
+		$pid = pcntl_fork();
+		$this->assertGreaterThanOrEqual( 0, $pid );
+		if ( 0 === $pid ) {
+			$this->reconnect_wordpress_database();
+			$deadline = microtime( true ) + 20;
+			while ( ! file_exists( $start ) && microtime( true ) < $deadline ) {
+				usleep( 10000 );
+			}
+			file_put_contents( $attempt, 'attempt', LOCK_EX );
+			$resolved = ( new TicketReconciliationService() )->resolve(
+				array(
+					'booking_id'       => $booking['id'],
+					'report_id'        => $report['id'],
+					'expected_version' => 0,
+					'decision'         => 'exclude',
+					'reason'           => 'Racing finalization.',
+				),
+				$this->actor_id
+			);
+			file_put_contents( $result, is_wp_error( $resolved ) ? $resolved->get_error_code() : 'resolved', LOCK_EX );
+			exit( 0 );
+		}
+		$service->evidence_probe = function () use ( $start, $attempt, $result ): void {
+			file_put_contents( $start, 'locked', LOCK_EX );
+			$deadline = microtime( true ) + 5;
+			while ( ! file_exists( $attempt ) && microtime( true ) < $deadline ) {
+				usleep( 10000 );
+			}
+			$this->assertFileExists( $attempt );
+			usleep( 200000 );
+			$this->assertFileDoesNotExist( $result, 'Resolution bypassed finalization booking/evidence locks.' );
+		};
+		$settlement              = $service->finalize(
+			array(
+				'booking_id'               => $booking['id'],
+				'expected_booking_version' => $preview['booking_version'],
+				'expected_report_ids'      => $preview['included_report_ids'],
+				'expected_evidence_hash'   => $preview['evidence_hash'],
+				'basis'                    => $preview['basis'],
+				'basis_points'             => $preview['basis_points'],
+				'currency'                 => $preview['currency'],
+				'formula_version'          => $preview['formula_version'],
+				'adjustment_minor'         => 0,
+			),
+			$this->actor_id
+		);
+		$this->assertIsArray( $settlement, is_wp_error( $settlement ) ? $settlement->get_error_code() : '' );
+		$status = 0;
+		pcntl_waitpid( $pid, $status );
+		$this->assertTrue( pcntl_wifexited( $status ) && 0 === pcntl_wexitstatus( $status ) );
+		$this->assertSame( 'sales_resolution_settlement_frozen', file_get_contents( $result ) );
+		foreach ( array( $start, $attempt, $result ) as $file ) {
+			if ( file_exists( $file ) ) {
+				unlink( $file );
+			}
+		}
+	}
+
+	/** Prove a lost mid-import commit acknowledgement replays without duplicates. */
+	public function test_csv_mid_loop_commit_uncertain_replay_converges_exactly(): void {
+		global $wpdb, $table_prefix;
+		$event_id           = self::factory()->post->create(
+			array(
+				'post_type'   => defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events',
+				'post_status' => 'publish',
+			)
+		);
+		$bookings           = new BookingRepository();
+		$booking            = $bookings->create(
+			array(
+				'venue_term_id' => $this->venue_id,
+				'artist_name'   => 'CSV Replay Artist',
+				'intake'        => array(),
+			)
+		);
+		$booking            = $bookings->claim_event( $booking['id'], $event_id, $booking['version'] );
+		$attachments        = new BookingAttachmentRepository();
+		$activity           = new BookingActivityRepository();
+		$attachment_service = new BookingAttachmentService( $attachments, $bookings, $activity, null, $this->provider );
+		$csv                = "external_report_id,period_start,period_end,tickets_sold,tickets_refunded,gross_minor,fees_minor,tax_minor,refunds_minor,net_minor,currency\n"
+			. "mysql-csv-1,2026-07-01 00:00:00,2026-07-01 23:59:59,10,0,10000,500,0,0,9500,USD\n"
+			. "mysql-csv-2,2026-07-02 00:00:00,2026-07-02 23:59:59,5,0,5000,250,0,0,4750,USD\n";
+		$path               = wp_tempnam( 'ticket-sales.csv' );
+		file_put_contents( $path, $csv );
+		$reference  = $this->provider->stage( $path, 'ticket-sales.csv', 'other_private_evidence' );
+		$attachment = $attachment_service->attach(
+			array(
+				'booking_id'        => $booking['id'],
+				'storage_reference' => $reference,
+				'idempotency_key'   => 'mysql-csv-replay',
+				'purpose'           => 'other_private_evidence',
+				'uploader_type'     => 'user',
+				'uploader_user_id'  => $this->actor_id,
+			)
+		);
+		$this->assertIsArray( $attachment, is_wp_error( $attachment ) ? $attachment->get_error_code() : '' );
+		$reconciliation = new TicketReconciliationService( $bookings, $activity, null, $attachments, $attachment_service );
+		$source         = $reconciliation->register_source(
+			array(
+				'booking_id' => $booking['id'],
+				'provider'   => 'csv-provider',
+				'source_key' => 'csv-source',
+				'ticket_url' => 'https://tickets.example.test/csv',
+			),
+			$this->actor_id
+		);
+		$this->assertIsArray( $source, is_wp_error( $source ) ? $source->get_error_code() : '' );
+		$service   = new TicketSettlementCSVReplayProbeService( $bookings, $activity, null, null, $reconciliation );
+		$original  = $wpdb;
+		$uncertain = new BookingCommitUncertainWpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+		$uncertain->set_prefix( $table_prefix );
+		$wpdb = $uncertain;
+		try {
+			$input   = array(
+				'booking_id'       => $booking['id'],
+				'attachment_id'    => $attachment['id'],
+				'ticket_source_id' => $source['id'],
+			);
+			$reports = $service->import_csv( $input, $this->actor_id );
+			$this->assertIsArray( $reports, is_wp_error( $reports ) ? $reports->get_error_code() : '' );
+			$this->assertCount( 2, $reports );
+			$this->assertSame( array( 'mysql-csv-1', 'mysql-csv-2' ), array_column( $reports, 'external_report_id' ) );
+			$retry = $service->import_csv( $input, $this->actor_id );
+			$this->assertSame( array_column( $reports, 'id' ), array_column( $retry, 'id' ) );
+			$sales_table = BookingSchema::sales_reports_table();
+			$this->assertSame( 2, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$sales_table} WHERE booking_id = %d", $booking['id'] ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact disposable integration row count.
+			$preview = $service->calculate(
+				array(
+					'booking_id'   => $booking['id'],
+					'basis'        => 'gross_ticket_sales',
+					'basis_points' => 2000,
+					'currency'     => 'USD',
+				),
+				$this->actor_id
+			);
+			$this->assertIsArray( $preview, is_wp_error( $preview ) ? $preview->get_error_code() : '' );
+			$finalize                  = array(
+				'booking_id'               => $booking['id'],
+				'expected_booking_version' => $preview['booking_version'],
+				'expected_report_ids'      => $preview['included_report_ids'],
+				'expected_evidence_hash'   => $preview['evidence_hash'],
+				'basis'                    => $preview['basis'],
+				'basis_points'             => $preview['basis_points'],
+				'currency'                 => $preview['currency'],
+				'formula_version'          => $preview['formula_version'],
+				'adjustment_minor'         => 0,
+			);
+			$attachments_table         = BookingSchema::attachments_table();
+			$service->provenance_probe = function () use ( $attachments_table, $attachment ): void {
+				$this->assertTrue( $this->contender->query( "UPDATE {$attachments_table} SET state = 'purged', purged_at = UTC_TIMESTAMP() WHERE id = " . (int) $attachment['id'] ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Independent session wins between byte authentication and settlement locking.
+			};
+			$this->assertSame( 'settlement_csv_evidence_invalid', $service->finalize( $finalize, $this->actor_id )->get_error_code() );
+			$settlements_table = BookingSchema::settlements_table();
+			$this->assertSame( 0, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$settlements_table} WHERE booking_id = %d", $booking['id'] ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- No settlement may survive the won retirement race.
+			$this->assertTrue( $this->contender->query( "UPDATE {$attachments_table} SET state = 'active', purged_at = NULL WHERE id = " . (int) $attachment['id'] ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Restores the disposable fixture after proving the race.
+			$service->provenance_probe = null;
+			$settlement                = $service->finalize( $finalize, $this->actor_id );
+			$this->assertIsArray( $settlement, is_wp_error( $settlement ) ? $settlement->get_error_code() : '' );
+			$this->provider->contents[ $reference ] = substr( $csv, 0, -1 );
+			$this->assertSame( 'settlement_csv_evidence_invalid', $service->finalize( $finalize, $this->actor_id )->get_error_code() );
+			$this->assertSame( $settlement['id'], $service->get( $booking['id'], $this->actor_id )['id'] );
+		} finally {
+			$wpdb = $original;
+			$uncertain->dbh->close();
+			if ( file_exists( $path ) ) {
+				unlink( $path );
+			}
+		}
+	}
+
 	/** Prove settlement evidence snapshots block concurrent same-booking inserts. */
 	public function test_production_settlement_locks_evidence_and_preserves_payment_audit(): void {
 		global $wpdb;
@@ -363,18 +752,19 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 		$this->assertIsArray( $listed, is_wp_error( $listed ) ? $listed->get_error_code() : '' );
 		$this->assertSame( $report['id'], $listed[0]['id'] );
 
-		$sales        = BookingSchema::sales_reports_table();
-		$external     = wp_json_encode(
+		$sales         = BookingSchema::sales_reports_table();
+		$external      = wp_json_encode(
 			array(
 				'version' => 1,
 				'data'    => array( 'certificate' => 'contender' ),
 			)
 		);
-		$sql          = $this->contender->prepare( "INSERT INTO {$sales} (booking_id,event_id,venue_term_id,provider,external_report_id,source_type,period_start,period_end,tickets_sold,tickets_refunded,gross_minor,fees_minor,tax_minor,refunds_minor,net_minor,currency,corrects_report_id,source_payload,request_hash,created_by_user_id,created_at) VALUES (?,?,?,?,?,'manual','2026-07-01 00:00:00','2026-07-31 23:59:59',1,0,100,0,0,0,100,'USD',NULL,?,?,?,UTC_TIMESTAMP())" );
-		$provider     = 'manual-certified';
-		$external_id  = 'mysql-settlement-contender';
-		$request_hash = hash( 'sha256', 'contender' );
-		$sql->bind_param( 'iiissssi', $booking['id'], $event_id, $this->venue_id, $provider, $external_id, $external, $request_hash, $this->actor_id );
+		$sql           = $this->contender->prepare( "INSERT INTO {$sales} (booking_id,event_id,venue_term_id,provider,external_report_id,external_report_id_hash,source_type,provenance_version,period_start,period_end,tickets_sold,tickets_refunded,gross_minor,fees_minor,tax_minor,refunds_minor,net_minor,currency,corrects_report_id,source_payload,request_hash,created_by_user_id,created_at) VALUES (?,?,?,?,?,?,'manual',1,'2026-07-01 00:00:00','2026-07-31 23:59:59',1,0,100,0,0,0,100,'USD',NULL,?,?,?,UTC_TIMESTAMP())" );
+		$provider      = 'manual-certified';
+		$external_id   = 'mysql-settlement-contender';
+		$external_hash = hash( 'sha256', $external_id );
+		$request_hash  = hash( 'sha256', 'contender' );
+		$sql->bind_param( 'iiisssssi', $booking['id'], $event_id, $this->venue_id, $provider, $external_id, $external_hash, $external, $request_hash, $this->actor_id );
 		$preview = $abilities['extrachill/calculate-booking-settlement']->execute(
 			array(
 				'booking_id'   => $booking['id'],

--- a/tests/MySQLIntegration/BookingAttachmentMySQLIntegrationTest.php
+++ b/tests/MySQLIntegration/BookingAttachmentMySQLIntegrationTest.php
@@ -203,7 +203,7 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 	 *
 	 * @var mysqli
 	 */
-	private $contender;
+	protected $contender;
 	/** Probe provider injected into the production service.
 	 *
 	 * @var BookingAttachmentMySQLProbeProvider
@@ -360,7 +360,7 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 	}
 
 	/** Prove concurrent installers serialize on the exact site-scoped schema lock. */
-	public function test_concurrent_booking_schema_installer_waits_and_converges(): void {
+	protected function prove_concurrent_booking_schema_installer_waits_and_converges(): void {
 		global $wpdb;
 		$this->assertTrue( function_exists( 'pcntl_fork' ), 'The installer concurrency proof requires pcntl_fork().' );
 		$lock_name = 'ec_booking_schema_' . substr( hash( 'sha256', (string) DB_NAME . "\0" . $wpdb->prefix ), 0, 40 );
@@ -463,7 +463,7 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 	}
 
 	/** Prove a resolution racing finalization cannot alter the frozen snapshot. */
-	public function test_resolution_and_finalization_race_freezes_one_consistent_winner(): void {
+	protected function prove_resolution_and_finalization_race_freezes_one_consistent_winner(): void {
 		$this->assertTrue( function_exists( 'pcntl_fork' ), 'The resolution race proof requires pcntl_fork().' );
 		$event_id       = self::factory()->post->create(
 			array(
@@ -571,7 +571,7 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 
 	/** Prove a lost mid-import commit acknowledgement replays without duplicates. */
 	public function test_csv_mid_loop_commit_uncertain_replay_converges_exactly(): void {
-		global $wpdb, $table_prefix;
+		global $wpdb;
 		$event_id           = self::factory()->post->create(
 			array(
 				'post_type'   => defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events',
@@ -621,7 +621,8 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 		$service   = new TicketSettlementCSVReplayProbeService( $bookings, $activity, null, null, $reconciliation );
 		$original  = $wpdb;
 		$uncertain = new BookingCommitUncertainWpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
-		$uncertain->set_prefix( $table_prefix );
+		$uncertain->set_prefix( $original->base_prefix );
+		$uncertain->set_blog_id( $original->blogid, $original->siteid );
 		$wpdb = $uncertain;
 		try {
 			$input   = array(
@@ -916,7 +917,7 @@ class BookingAttachmentMySQLIntegrationTest extends WP_UnitTestCase {
 	}
 
 	/** Build valid immutable evidence for an ability execution. */
-	private function settlement_report_input( int $booking_id, string $external_id, int $source_id ): array {
+	protected function settlement_report_input( int $booking_id, string $external_id, int $source_id ): array {
 		return array(
 			'booking_id'         => $booking_id,
 			'ticket_source_id'   => $source_id,

--- a/tests/MySQLIntegration/BookingSchemaMultisiteTest.php
+++ b/tests/MySQLIntegration/BookingSchemaMultisiteTest.php
@@ -56,16 +56,38 @@ final class BookingSchemaMultisiteTest extends WP_UnitTestCase {
 		$this->assertSame( 1, get_current_blog_id() );
 	}
 
-	/** Verify the v12 global provider index is replaced without dropping evidence. */
-	public function test_v12_sales_report_index_upgrade_preserves_rows(): void {
+	/** Verify explicit v13 identity/provenance migration preserves every legacy row. */
+	public function test_v13_ticket_provenance_upgrade_preserves_rows(): void {
 		global $wpdb;
 
 		switch_to_blog( 7 );
 		try {
 			$table       = BookingSchema::sales_reports_table();
-			$external_id = 'legacy-' . wp_generate_uuid4();
-			$wpdb->query( "ALTER TABLE `{$table}` DROP INDEX `provider_external_report`, ADD UNIQUE KEY `provider_external_report` (`provider`, `external_report_id`)" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Recreates the exact v12 index in a disposable test database.
+			$sources     = BookingSchema::ticket_sources_table();
+			$external_id = 'Legacy/Report-é-' . wp_generate_uuid4();
+			$source_key  = 'Legacy/Case-é-' . wp_generate_uuid4();
+			$wpdb->query( "ALTER TABLE `{$sources}` DROP INDEX `booking_provider_source`, DROP COLUMN `source_key_hash`, ADD UNIQUE KEY `booking_provider_source` (`booking_id`, `provider`, `source_key`)" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Recreates the exact v13 source contract in a disposable test database.
+			$wpdb->query( "ALTER TABLE `{$table}` DROP INDEX `provider_external_report`, DROP COLUMN `external_report_id_hash`, DROP COLUMN `provenance_version`, DROP COLUMN `ticket_source_request_hash`, DROP COLUMN `evidence_attachment_request_hash`, DROP COLUMN `evidence_content_hash`, DROP COLUMN `evidence_byte_size`, ADD UNIQUE KEY `provider_external_report` (`booking_id`, `provider`, `external_report_id`)" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Recreates the exact v13 report contract in a disposable test database.
 			$this->assertSame( '', (string) $wpdb->last_error );
+			$this->assertSame(
+				1,
+				$wpdb->insert(
+					$sources,
+					array(
+						'public_id'          => wp_generate_uuid4(),
+						'booking_id'         => 987654,
+						'event_id'           => 876543,
+						'venue_term_id'      => 765432,
+						'provider'           => 'legacy-provider',
+						'source_key'         => $source_key,
+						'canonical_url'      => 'https://tickets.example.test/legacy',
+						'url_hash'           => hash( 'sha256', 'https://tickets.example.test/legacy' ),
+						'request_hash'       => str_repeat( 'b', 64 ),
+						'created_by_user_id' => 1,
+						'created_at'         => '2026-07-01 00:00:00',
+					)
+				)
+			); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Disposable migration fixture.
 			$inserted = $wpdb->insert(
 				$table,
 				array(
@@ -92,15 +114,18 @@ final class BookingSchemaMultisiteTest extends WP_UnitTestCase {
 				)
 			); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Disposable migration fixture.
 			$this->assertSame( 1, $inserted );
-			update_option( BookingSchema::VERSION_OPTION, '12', false );
+			update_option( BookingSchema::VERSION_OPTION, '13', false );
 
 			$this->assertTrue( BookingSchema::maybe_install() );
-			$this->assertSame( '13', get_option( BookingSchema::VERSION_OPTION ) );
+			$this->assertSame( '14', get_option( BookingSchema::VERSION_OPTION ) );
 			$this->assertSame( '987654', $wpdb->get_var( $wpdb->prepare( "SELECT booking_id FROM `{$table}` WHERE external_report_id = %s", $external_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms migration preserved the fixture.
+			$this->assertSame( hash( 'sha256', $external_id ), $wpdb->get_var( $wpdb->prepare( "SELECT external_report_id_hash FROM `{$table}` WHERE external_report_id = %s", $external_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms exact report identity backfill.
+			$this->assertSame( '1', $wpdb->get_var( $wpdb->prepare( "SELECT provenance_version FROM `{$table}` WHERE external_report_id = %s", $external_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Legacy hashes remain versioned and immutable.
+			$this->assertSame( hash( 'sha256', $source_key ), $wpdb->get_var( $wpdb->prepare( "SELECT source_key_hash FROM `{$sources}` WHERE source_key = %s", $source_key ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms exact source identity backfill.
 
 			$index_rows = $wpdb->get_results( "SHOW INDEX FROM `{$table}` WHERE Key_name = 'provider_external_report'", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Verifies the repaired real-MySQL index.
 			usort( $index_rows, static fn( array $left, array $right ): int => (int) $left['Seq_in_index'] <=> (int) $right['Seq_in_index'] );
-			$this->assertSame( array( 'booking_id', 'provider', 'external_report_id' ), array_column( $index_rows, 'Column_name' ) );
+			$this->assertSame( array( 'booking_id', 'provider', 'external_report_id_hash' ), array_column( $index_rows, 'Column_name' ) );
 		} finally {
 			restore_current_blog();
 		}

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -362,6 +362,21 @@ if ( ! function_exists( 'get_term_link' ) ) {
 		return 'https://events.example/venue/' . (int) $term;
 	}
 }
+if ( ! function_exists( 'ec_events_resolve_booking_console_destination' ) ) {
+	function ec_events_resolve_booking_console_destination( array $booking, array $recipient_ids, array $locked_rows ) {
+		$venue_id = (int) ( $booking['venue_term_id'] ?? 0 );
+		foreach ( $recipient_ids as $recipient_id ) {
+			$active = false;
+			foreach ( $locked_rows as $row ) {
+				$active = $active || (int) ( $row['venue_term_id'] ?? 0 ) === $venue_id && (int) ( $row['user_id'] ?? 0 ) === (int) $recipient_id && 'active' === ( $row['status'] ?? '' );
+			}
+			if ( ! $active ) {
+				return new WP_Error( 'booking_notification_destination_forbidden' );
+			}
+		}
+		return get_term_link( $venue_id, 'venue' );
+	}
+}
 if ( ! function_exists( 'ec_users_notify_with_receipts' ) ) {
 	function ec_users_notify_with_receipts( $user_ids, array $payload ): array {
 		return is_callable( $GLOBALS['ec_artist_test']['users_receipt'] ?? null )
@@ -444,6 +459,7 @@ final class BookingWpdb {
 	public $after_reference_lock                 = null;
 	public $after_reference_unlock               = null;
 	public $transaction_active                   = false;
+	public $nested_transaction_starts            = 0;
 	public $natural_key_reads_in_transaction     = 0;
 	public $get_lock_result                      = 1;
 	public $release_lock_result                  = 1;
@@ -567,7 +583,7 @@ final class BookingWpdb {
 		}
 		if ( false !== strpos( $table, 'ec_booking_sales_reports' ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $existing ) {
-				if ( (int) $existing['booking_id'] === (int) $row['booking_id'] && $existing['provider'] === $row['provider'] && $existing['external_report_id'] === $row['external_report_id'] ) {
+				if ( (int) $existing['booking_id'] === (int) $row['booking_id'] && $existing['provider'] === $row['provider'] && $existing['external_report_id_hash'] === $row['external_report_id_hash'] ) {
 					$this->last_error = 'duplicate provider report ID';
 					return false;
 				}
@@ -575,7 +591,7 @@ final class BookingWpdb {
 		}
 		if ( false !== strpos( $table, 'ec_booking_ticket_sources' ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $existing ) {
-				if ( (int) $existing['booking_id'] === (int) $row['booking_id'] && $existing['provider'] === $row['provider'] && $existing['source_key'] === $row['source_key'] ) {
+				if ( (int) $existing['booking_id'] === (int) $row['booking_id'] && $existing['provider'] === $row['provider'] && $existing['source_key_hash'] === $row['source_key_hash'] ) {
 					$this->last_error = 'duplicate ticket source identity';
 					return false;
 				}
@@ -855,17 +871,17 @@ final class BookingWpdb {
 			}
 			return null;
 		}
-		if ( $is_sales && preg_match( "/WHERE booking_id = (\d+) AND provider = '([^']+)' AND external_report_id = '([^']+)'/", $query, $external ) ) {
+		if ( $is_sales && preg_match( "/WHERE booking_id = (\d+) AND provider = '([^']+)' AND external_report_id_hash = '([^']+)'/", $query, $external ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
-				if ( (int) $row['booking_id'] === (int) $external[1] && $row['provider'] === stripslashes( $external[2] ) && $row['external_report_id'] === stripslashes( $external[3] ) ) {
+				if ( (int) $row['booking_id'] === (int) $external[1] && $row['provider'] === stripslashes( $external[2] ) && $row['external_report_id_hash'] === stripslashes( $external[3] ) ) {
 					return $row;
 				}
 			}
 			return null;
 		}
-		if ( $is_source && preg_match( "/WHERE booking_id = (\d+) AND provider = '([^']+)' AND source_key = '([^']+)'/", $query, $identity ) ) {
+		if ( $is_source && preg_match( "/WHERE booking_id = (\d+) AND provider = '([^']+)' AND source_key_hash = '([^']+)'/", $query, $identity ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
-				if ( (int) $row['booking_id'] === (int) $identity[1] && $row['provider'] === stripslashes( $identity[2] ) && $row['source_key'] === stripslashes( $identity[3] ) ) {
+				if ( (int) $row['booking_id'] === (int) $identity[1] && $row['provider'] === stripslashes( $identity[2] ) && $row['source_key_hash'] === stripslashes( $identity[3] ) ) {
 					return $row;
 				}
 			}
@@ -1706,6 +1722,9 @@ final class BookingWpdb {
 		$this->last_query = $query;
 		$this->last_error = '';
 		if ( 'START TRANSACTION' === $query ) {
+			if ( $this->transaction_active ) {
+				++$this->nested_transaction_starts;
+			}
 			if ( $this->fail_transaction_start ) {
 				$this->last_error = 'simulated transaction start failure';
 				return false;

--- a/tests/TicketReconciliationTest.php
+++ b/tests/TicketReconciliationTest.php
@@ -16,12 +16,11 @@ use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\TicketReconciliationService;
 use ExtraChillEvents\Core\TicketSettlementService;
-use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/Support/BookingTestHarness.php';
 
 /** Verifies that unresolved or contradictory evidence never reaches settlement. */
-final class TicketReconciliationTest extends TestCase {
+final class TicketReconciliationTest extends BookingTestCase {
 	/** @var BookingRepository */
 	private $bookings;
 	/** @var BookingTestAuthorization */
@@ -90,7 +89,7 @@ final class TicketReconciliationTest extends TestCase {
 	public function test_schema_upgrades_v12_without_replacing_settlement_tables(): void {
 		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '12';
 		$this->assertTrue( BookingSchema::maybe_install() );
-		$this->assertSame( '13', get_option( BookingSchema::VERSION_OPTION ) );
+		$this->assertSame( '14', get_option( BookingSchema::VERSION_OPTION ) );
 		$this->assertTrue( BookingSchema::health() );
 		$this->assertArrayHasKey( BookingSchema::ticket_sources_table(), $GLOBALS['wpdb']->schemas );
 		$this->assertArrayHasKey( BookingSchema::sales_resolutions_table(), $GLOBALS['wpdb']->schemas );
@@ -98,7 +97,7 @@ final class TicketReconciliationTest extends TestCase {
 		$sales = $GLOBALS['wpdb']->schemas[ BookingSchema::sales_reports_table() ];
 		$this->assertArrayHasKey( 'ticket_source_id', $sales['columns'] );
 		$this->assertArrayHasKey( 'evidence_attachment_id', $sales['columns'] );
-		$this->assertSame( array( 'booking_id', 'provider', 'external_report_id' ), $sales['indexes']['provider_external_report']['columns'] );
+		$this->assertSame( array( 'booking_id', 'provider', 'external_report_id_hash' ), $sales['indexes']['provider_external_report']['columns'] );
 	}
 
 	public function test_sources_are_stable_idempotent_redacted_and_venue_scoped(): void {
@@ -125,6 +124,47 @@ final class TicketReconciliationTest extends TestCase {
 		$cross['booking_id'] = $other['id'];
 		$cross['source_key'] = 'other';
 		$this->assertSame( 'venue_action_forbidden', $this->reconciliation->register_source( $cross, 12 )->get_error_code() );
+	}
+
+	public function test_opaque_source_and_report_ids_are_lossless_and_byte_bounded(): void {
+		$booking = $this->booking();
+		$upper   = $this->reconciliation->register_source(
+			array(
+				'booking_id' => $booking['id'],
+				'provider'   => 'box-office',
+				'source_key' => 'Opaque ID/Case A',
+				'ticket_url' => 'https://tickets.example.test/upper',
+			),
+			12
+		);
+		$lower   = $this->reconciliation->register_source(
+			array(
+				'booking_id' => $booking['id'],
+				'provider'   => 'box-office',
+				'source_key' => 'opaque id/case a',
+				'ticket_url' => 'https://tickets.example.test/lower',
+			),
+			12
+		);
+		$this->assertSame( 'Opaque ID/Case A', $upper['source_key'] );
+		$this->assertSame( 'opaque id/case a', $lower['source_key'] );
+		$this->assertNotSame( $upper['id'], $lower['id'] );
+
+		$first  = $this->settlements->record_sales( $this->report( $booking['id'], 'Report/Case A', $upper['id'], '2026-07-01 00:00:00', '2026-07-01 23:59:59' ), 12 );
+		$second = $this->settlements->record_sales( $this->report( $booking['id'], 'report/case a', $upper['id'], '2026-07-02 00:00:00', '2026-07-02 23:59:59' ), 12 );
+		$this->assertSame( 'Report/Case A', $first['external_report_id'] );
+		$this->assertSame( 'report/case a', $second['external_report_id'] );
+		$this->assertNotSame( $first['id'], $second['id'] );
+
+		$invalid_source = array(
+			'booking_id' => $booking['id'],
+			'provider'   => 'box-office',
+			'source_key' => "identity\ncollapse",
+			'ticket_url' => 'https://tickets.example.test/invalid',
+		);
+		$this->assertSame( 'invalid_opaque_identifier', $this->reconciliation->register_source( $invalid_source, 12 )->get_error_code() );
+		$invalid_report = $this->report( $booking['id'], "report\0id", $upper['id'], '2026-07-03 00:00:00', '2026-07-03 23:59:59' );
+		$this->assertSame( 'invalid_opaque_identifier', $this->settlements->record_sales( $invalid_report, 12 )->get_error_code() );
 	}
 
 	public function test_unattributed_evidence_requires_immutable_resolution_before_settlement(): void {
@@ -201,7 +241,7 @@ final class TicketReconciliationTest extends TestCase {
 		);
 		$this->assertSame( $resolution['id'], $second['supersedes_resolution_id'] );
 		$this->assertCount( 2, $GLOBALS['wpdb']->rows[ BookingSchema::sales_resolutions_table() ] );
-		$third      = $this->reconciliation->resolve(
+		$third   = $this->reconciliation->resolve(
 			array(
 				'booking_id'       => $booking['id'],
 				'report_id'        => $report['id'],
@@ -228,6 +268,7 @@ final class TicketReconciliationTest extends TestCase {
 		$preview    = $this->preview( $booking['id'] );
 		$settlement = $this->settlements->finalize( $this->resolution_finalization( $preview ), 12 );
 		$this->assertIsArray( $settlement, is_wp_error( $settlement ) ? $settlement->get_error_code() : '' );
+		$this->assertSame( 0, $GLOBALS['wpdb']->nested_transaction_starts, 'Settlement finalization must not release its locks through a nested attachment transaction.' );
 		$this->assertSame( $report, $this->settlements->record_sales( $input, 12 ) );
 		$after_settlement                       = $input;
 		$after_settlement['external_report_id'] = 'after-settlement';
@@ -272,7 +313,7 @@ final class TicketReconciliationTest extends TestCase {
 		$this->assertIsArray( $second_report, is_wp_error( $second_report ) ? $second_report->get_error_code() : '' );
 		$this->assertNotSame( $first_report['id'], $second_report['id'] );
 
-		$alternate_source = $this->reconciliation->register_source(
+		$alternate_source                 = $this->reconciliation->register_source(
 			array(
 				'booking_id' => $first['id'],
 				'provider'   => 'box-office',
@@ -281,7 +322,7 @@ final class TicketReconciliationTest extends TestCase {
 			),
 			12
 		);
-		$correction                         = $this->report( $first['id'], 'cross-source-correction', $alternate_source['id'], '2026-07-01 00:00:00', '2026-07-01 23:59:59' );
+		$correction                       = $this->report( $first['id'], 'cross-source-correction', $alternate_source['id'], '2026-07-01 00:00:00', '2026-07-01 23:59:59' );
 		$correction['corrects_report_id'] = $first_report['id'];
 		$this->assertSame( 'invalid_sales_report_correction', $this->settlements->record_sales( $correction, 12 )->get_error_code() );
 	}
@@ -353,25 +394,25 @@ final class TicketReconciliationTest extends TestCase {
 		$rows       = $this->reconciliation->csv_report_inputs( $input, 12 );
 		$this->assertCount( 2, $rows );
 		$this->assertSame( $attachment['id'], $rows[0]['evidence_attachment_id'] );
-		$first      = array_map(
-			function ( $row ) {
-				return $this->settlements->record_sales( $row, 12 );
-			},
-			$rows
-		);
-		$retry_rows = $this->reconciliation->csv_report_inputs( $input, 12 );
-		$retry      = array_map(
-			function ( $row ) {
-				return $this->settlements->record_sales( $row, 12 );
-			},
-			$retry_rows
-		);
+		$this->assertSame( 'sales_csv_import_required', $this->settlements->record_sales( $rows[0], 12 )->get_error_code() );
+		$first = $this->settlements->import_csv( $input, 12 );
+		$retry = $this->settlements->import_csv( $input, 12 );
 		$this->assertSame( array_column( $first, 'id' ), array_column( $retry, 'id' ) );
 		$this->assertSame( array( 'csv_certified' ), array_values( array_unique( array_column( $first, 'source_type' ) ) ) );
+		$preview = $this->preview( $booking['id'] );
+		$this->assertSame( array_column( $first, 'id' ), $preview['included_report_ids'] );
 		$this->provider->contents[ $attachment['storage_reference'] ] = substr( $csv, 0, -5 );
+		$this->assertSame( 'settlement_csv_evidence_invalid', $this->preview( $booking['id'] )->get_error_code() );
 		$this->assertSame( 'sales_csv_evidence_mismatch', $this->reconciliation->csv_report_inputs( $input, 12 )->get_error_code() );
 		$this->provider->contents[ $attachment['storage_reference'] ] = $csv . 'extra';
 		$this->assertSame( 'sales_csv_evidence_mismatch', $this->reconciliation->csv_report_inputs( $input, 12 )->get_error_code() );
+		$this->provider->contents[ $attachment['storage_reference'] ] = $csv;
+		$settlement = $this->settlements->finalize( $this->resolution_finalization( $preview ), 12 );
+		$this->assertIsArray( $settlement, is_wp_error( $settlement ) ? $settlement->get_error_code() : '' );
+		$GLOBALS['wpdb']->rows[ BookingSchema::attachments_table() ][ $attachment['id'] ]['state']     = 'purged';
+		$GLOBALS['wpdb']->rows[ BookingSchema::attachments_table() ][ $attachment['id'] ]['purged_at'] = gmdate( 'Y-m-d H:i:s' );
+		$this->assertSame( 'settlement_csv_evidence_invalid', $this->settlements->finalize( $this->resolution_finalization( $preview ), 12 )->get_error_code() );
+		$this->assertSame( $settlement['id'], $this->settlements->get( $booking['id'], 12 )['id'], 'Immutable historical reads must not depend on retained private bytes.' );
 
 		$bad_attachment = $this->csv_attachment( $booking['id'], "formula,total\n=HYPERLINK(\"https://evil.test\"),1\n", 'hostile.csv' );
 		$bad            = $this->reconciliation->csv_report_inputs(
@@ -404,6 +445,7 @@ final class TicketReconciliationTest extends TestCase {
 			$this->assertTrue( $GLOBALS['ec_artist_test']['abilities'][ $name ]['meta']['show_in_rest'] );
 		}
 		$this->assertSame( 1000, $GLOBALS['ec_artist_test']['abilities']['extrachill/import-booking-ticket-sales-csv']['output_schema']['maxItems'] );
+		$this->assertSame( array( 'manual' ), $GLOBALS['ec_artist_test']['abilities']['extrachill/record-booking-ticket-sales']['input_schema']['properties']['source_type']['enum'] );
 		$this->assertFalse( $GLOBALS['ec_artist_test']['abilities']['extrachill/resolve-booking-ticket-sales']['meta']['annotations']['readonly'] );
 
 		$booking                = $this->booking();

--- a/tests/TicketSettlementTest.php
+++ b/tests/TicketSettlementTest.php
@@ -164,6 +164,7 @@ final class TicketSettlementTest extends BookingTestCase {
 		$report   = $this->service->record_sales( $this->report_input( $booking['id'], 'integrity-1' ), 12 );
 		$report_2 = $this->service->record_sales( $this->report_input( $booking['id'], 'integrity-2' ), 12 );
 		$preview  = $this->preview( $booking['id'] );
+		$source   = $GLOBALS['wpdb']->rows[ BookingSchema::ticket_sources_table() ][ $this->source_ids[ $booking['id'] ] ];
 		$this->assertSame(
 			hash(
 				'sha256',
@@ -171,11 +172,21 @@ final class TicketSettlementTest extends BookingTestCase {
 					array(
 						array(
 							'id'           => $report['id'],
+							'provenance'   => array(
+								'attachment'       => null,
+								'ticket_source_id' => (int) $source['id'],
+								'ticket_source_request_hash' => $source['request_hash'],
+							),
 							'request_hash' => $report['request_hash'],
 							'resolution'   => null,
 						),
 						array(
 							'id'           => $report_2['id'],
+							'provenance'   => array(
+								'attachment'       => null,
+								'ticket_source_id' => (int) $source['id'],
+								'ticket_source_request_hash' => $source['request_hash'],
+							),
 							'request_hash' => $report_2['request_hash'],
 							'resolution'   => null,
 						),
@@ -255,10 +266,20 @@ final class TicketSettlementTest extends BookingTestCase {
 		$row     = $GLOBALS['wpdb']->rows[ $table ][ $current['id'] ];
 
 		$row['formula_version'] = 1;
-		$row['evidence_hash']   = hash( 'sha256', wp_json_encode( array( array( 'id' => $report['id'], 'request_hash' => $report['request_hash'] ) ) ) );
+		$row['evidence_hash']   = hash(
+			'sha256',
+			wp_json_encode(
+				array(
+					array(
+						'id'           => $report['id'],
+						'request_hash' => $report['request_hash'],
+					),
+				)
+			)
+		);
 		$integrity              = new ReflectionMethod( TicketSettlementService::class, 'settlement_integrity_hash' );
 		$integrity->setAccessible( true );
-		$row['integrity_hash']                              = $integrity->invoke( $this->service, $row );
+		$row['integrity_hash']                             = $integrity->invoke( $this->service, $row );
 		$GLOBALS['wpdb']->rows[ $table ][ $current['id'] ] = $row;
 
 		$retry                    = $this->finalize_input( $preview );
@@ -277,6 +298,33 @@ final class TicketSettlementTest extends BookingTestCase {
 		$this->assertIsArray( $voided, is_wp_error( $voided ) ? $voided->get_error_code() : '' );
 		$this->assertSame( 1, $voided['formula_version'] );
 		$this->assertSame( 'void', $voided['status'] );
+	}
+
+	public function test_formula_two_settlement_retry_remains_compatible(): void {
+		$booking                = $this->create_event_booking();
+		$report                 = $this->service->record_sales( $this->report_input( $booking['id'], 'legacy-formula-two' ), 12 );
+		$preview                = $this->preview( $booking['id'] );
+		$current                = $this->service->finalize( $this->finalize_input( $preview ), 12 );
+		$table                  = BookingSchema::settlements_table();
+		$row                    = $GLOBALS['wpdb']->rows[ $table ][ $current['id'] ];
+		$legacy_evidence        = array(
+			array(
+				'id'           => $report['id'],
+				'request_hash' => $report['request_hash'],
+				'resolution'   => null,
+			),
+		);
+		$row['formula_version'] = 2;
+		$row['evidence_hash']   = hash( 'sha256', wp_json_encode( $legacy_evidence ) );
+		$integrity              = new ReflectionMethod( TicketSettlementService::class, 'settlement_integrity_hash' );
+		$integrity->setAccessible( true );
+		$row['integrity_hash']                             = $integrity->invoke( $this->service, $row );
+		$GLOBALS['wpdb']->rows[ $table ][ $current['id'] ] = $row;
+
+		$retry                           = $this->finalize_input( $preview );
+		$retry['formula_version']        = 2;
+		$retry['expected_evidence_hash'] = $row['evidence_hash'];
+		$this->assertSame( 2, $this->service->finalize( $retry, 12 )['formula_version'] );
 	}
 
 	public function test_frozen_financial_snapshot_tampering_fails_before_return_or_payment(): void {
@@ -505,7 +553,7 @@ final class TicketSettlementTest extends BookingTestCase {
 			$this->assertTrue( $GLOBALS['ec_artist_test']['abilities'][ $name ]['meta']['show_in_rest'] );
 		}
 		$this->assertTrue( $GLOBALS['ec_artist_test']['abilities']['extrachill/finalize-booking-settlement']['meta']['annotations']['idempotent'] );
-		$this->assertSame( array( 'manual', 'csv_certified' ), $GLOBALS['ec_artist_test']['abilities']['extrachill/record-booking-ticket-sales']['input_schema']['properties']['source_type']['enum'] );
+		$this->assertSame( array( 'manual' ), $GLOBALS['ec_artist_test']['abilities']['extrachill/record-booking-ticket-sales']['input_schema']['properties']['source_type']['enum'] );
 		$this->assertContains( 'expected_booking_version', $GLOBALS['ec_artist_test']['abilities']['extrachill/mark-booking-settlement-paid']['input_schema']['required'] );
 
 		$booking = $this->create_event_booking();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -55,6 +55,12 @@ if ( ! class_exists( 'WP_Error' ) ) {
 		public function get_error_data() {
 			return $this->data;
 		}
+
+		public function add_data( $data, $code = '' ) {
+			if ( '' === $code || $this->code === $code ) {
+				$this->data = $data;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- restrict `csv_certified` observations to the authenticated private CSV importer and bind source plus attachment byte provenance into report/formula-v3 settlement hashes
- preserve opaque provider IDs losslessly through bounded validation and binary hash identities, with an explicit serialized v13-to-v14 migration and legacy formula-v1/v2 retry support
- add unit and real two-session MySQL coverage for identity competitors, report conflicts, installer/finalization races, attachment retirement, and commit-uncertain CSV replay
- repair booking test harness isolation/contracts uncovered by the required full-suite gate

## Verification
- `vendor/bin/phpunit -c phpunit-booking.xml.dist` (400 tests, 4,368 assertions)
- focused ticket reconciliation/settlement suite (21 tests, 1,953 assertions)
- `homeboy review lint` (PHPCS, ESLint, PHPStan clean)
- `npm run build`
- changed-PHP syntax checks and `git diff --check`
- independent exact-diff review: no findings after follow-up fixes
- hosted `Booking attachment MySQL concurrency` workflow now executes 9 MySQL tests, including v13 migration and two-session CSV settlement races

Closes #434
Closes #443
Closes #444
Closes #445
Closes #446