### PR TITLE
Complete core booking operator controls

### DIFF
--- a/blocks/venue-settings/src/api.js
+++ b/blocks/venue-settings/src/api.js
@@ -11,6 +11,7 @@ const METHODS = {
 	'extrachill/list-venue-claims': 'GET',
 	'extrachill/list-venue-bookings': 'GET',
 	'extrachill/get-venue-booking': 'GET',
+	'extrachill/get-venue-booking-activity': 'GET',
 	'extrachill/list-booking-holds': 'GET',
 	'extrachill/list-booking-communications': 'GET',
 	'extrachill/review-venue-claim': 'DELETE',

--- a/blocks/venue-settings/src/booking-console.js
+++ b/blocks/venue-settings/src/booking-console.js
@@ -123,6 +123,343 @@ const toLocalInput = ( value ) =>
 
 const statusLabel = ( status ) => STATUS_LABELS[ status ] || status;
 
+const payloadData = ( value ) => value?.data || value || null;
+const linesToItems = ( value ) =>
+	value
+		.split( '\n' )
+		.map( ( item ) => item.trim() )
+		.filter( Boolean );
+const nullableNumber = ( value ) => ( value === '' ? null : Number( value ) );
+
+export const activityLabel = ( kind ) =>
+	kind
+		.split( '_' )
+		.map( ( word ) => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
+		.join( ' ' );
+
+const eventActionLabel = ( booking, operations ) => {
+	if ( booking.event_id ) {
+		return operations.sync.retryable
+			? 'Retry event reconciliation'
+			: 'Reconcile event';
+	}
+	return operations.conversion.status === 'failed'
+		? 'Retry event conversion'
+		: 'Convert to event';
+};
+
+const dealDocument = ( booking, fallback ) => {
+	const source =
+		payloadData( booking.confirmed_deal || booking.deal ) || fallback || {};
+	return {
+		version: 1,
+		type: source.type || 'custom',
+		guarantee_cents: source.guarantee_cents ?? 0,
+		revenue_share_basis_points: source.revenue_share_basis_points ?? 0,
+		revenue_share_basis: source.revenue_share_basis || 'gross_ticket_sales',
+		currency: source.currency || 'USD',
+		capacity: source.capacity ?? null,
+		advance_ticket_price_cents: source.advance_ticket_price_cents ?? null,
+		door_ticket_price_cents: source.door_ticket_price_cents ?? null,
+		ticket_fee_cents: source.ticket_fee_cents ?? null,
+		tickets_on_sale_at: source.tickets_on_sale_at ?? null,
+		ticket_url: source.ticket_url ?? null,
+		additional_terms: source.additional_terms ?? null,
+	};
+};
+
+function DealEditor( { booking, defaultDeal, pending, onSave } ) {
+	const [ deal, setDeal ] = useState( () =>
+		dealDocument( booking, defaultDeal )
+	);
+	const update = ( key, value ) => setDeal( { ...deal, [ key ]: value } );
+	return (
+		<section className="ec-booking-detail__section">
+			<h3>Deal terms</h3>
+			<form
+				className="ec-booking-console__form"
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+					onSave( deal );
+				} }
+			>
+				<div className="ec-venue-settings__grid">
+					<FieldGroup label="Deal type" htmlFor="booking-deal-type">
+						<input
+							id="booking-deal-type"
+							value={ deal.type }
+							onChange={ ( event ) =>
+								update( 'type', event.target.value )
+							}
+							required
+						/>
+					</FieldGroup>
+					<FieldGroup
+						label="Currency"
+						htmlFor="booking-deal-currency"
+					>
+						<input
+							id="booking-deal-currency"
+							value={ deal.currency }
+							onChange={ ( event ) =>
+								update(
+									'currency',
+									event.target.value.toUpperCase()
+								)
+							}
+							required
+						/>
+					</FieldGroup>
+					<FieldGroup
+						label="Guarantee (cents)"
+						htmlFor="booking-deal-guarantee"
+					>
+						<input
+							id="booking-deal-guarantee"
+							type="number"
+							min="0"
+							value={ deal.guarantee_cents }
+							onChange={ ( event ) =>
+								update(
+									'guarantee_cents',
+									Number( event.target.value )
+								)
+							}
+							required
+						/>
+					</FieldGroup>
+					<FieldGroup
+						label="Revenue share (basis points)"
+						htmlFor="booking-deal-share"
+					>
+						<input
+							id="booking-deal-share"
+							type="number"
+							min="0"
+							max="10000"
+							value={ deal.revenue_share_basis_points }
+							onChange={ ( event ) =>
+								update(
+									'revenue_share_basis_points',
+									Number( event.target.value )
+								)
+							}
+							required
+						/>
+					</FieldGroup>
+					<FieldGroup
+						label="Revenue share basis"
+						htmlFor="booking-deal-basis"
+					>
+						<select
+							id="booking-deal-basis"
+							value={ deal.revenue_share_basis }
+							onChange={ ( event ) =>
+								update(
+									'revenue_share_basis',
+									event.target.value
+								)
+							}
+						>
+							<option value="gross_ticket_sales">
+								Gross ticket sales
+							</option>
+							<option value="net_ticket_sales">
+								Net ticket sales
+							</option>
+							<option value="door_receipts">Door receipts</option>
+						</select>
+					</FieldGroup>
+					{ [
+						[ 'capacity', 'Capacity', 1 ],
+						[
+							'advance_ticket_price_cents',
+							'Advance ticket price (cents)',
+							0,
+						],
+						[
+							'door_ticket_price_cents',
+							'Door ticket price (cents)',
+							0,
+						],
+						[ 'ticket_fee_cents', 'Ticket fee (cents)', 0 ],
+					].map( ( [ key, label, minimum ] ) => (
+						<FieldGroup
+							key={ key }
+							label={ label }
+							htmlFor={ `booking-deal-${ key }` }
+						>
+							<input
+								id={ `booking-deal-${ key }` }
+								type="number"
+								min={ minimum }
+								value={ deal[ key ] ?? '' }
+								onChange={ ( event ) =>
+									update(
+										key,
+										nullableNumber( event.target.value )
+									)
+								}
+							/>
+						</FieldGroup>
+					) ) }
+					<FieldGroup
+						label="Tickets on sale (UTC)"
+						htmlFor="booking-deal-on-sale"
+					>
+						<input
+							id="booking-deal-on-sale"
+							type="datetime-local"
+							value={ toLocalInput( deal.tickets_on_sale_at ) }
+							onChange={ ( event ) =>
+								update(
+									'tickets_on_sale_at',
+									toDatabaseDate( event.target.value )
+								)
+							}
+						/>
+					</FieldGroup>
+					<FieldGroup
+						label="Public ticket URL"
+						htmlFor="booking-deal-ticket-url"
+					>
+						<input
+							id="booking-deal-ticket-url"
+							type="url"
+							value={ deal.ticket_url || '' }
+							onChange={ ( event ) =>
+								update(
+									'ticket_url',
+									event.target.value || null
+								)
+							}
+						/>
+					</FieldGroup>
+				</div>
+				<FieldGroup
+					label="Additional terms"
+					htmlFor="booking-deal-terms"
+				>
+					<textarea
+						id="booking-deal-terms"
+						value={ deal.additional_terms || '' }
+						onChange={ ( event ) =>
+							update(
+								'additional_terms',
+								event.target.value || null
+							)
+						}
+					/>
+				</FieldGroup>
+				<button
+					type="submit"
+					className="button-2"
+					disabled={ pending !== '' }
+				>
+					Save deal terms
+				</button>
+			</form>
+		</section>
+	);
+}
+
+function ProductionEditor( { booking, pending, onSave } ) {
+	const source = payloadData( booking.production ) || {};
+	const [ requirements, setRequirements ] = useState(
+		( source.support_requirements || [] ).join( '\n' )
+	);
+	const [ offers, setOffers ] = useState(
+		( source.support_offers || [] ).join( '\n' )
+	);
+	const [ notes, setNotes ] = useState( source.production_notes || '' );
+	return (
+		<section className="ec-booking-detail__section">
+			<h3>Production details</h3>
+			<form
+				className="ec-booking-console__form"
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+					onSave( {
+						version: 1,
+						support_requirements: linesToItems( requirements ),
+						support_offers: linesToItems( offers ),
+						production_notes: notes || null,
+					} );
+				} }
+			>
+				<div className="ec-venue-settings__grid">
+					<FieldGroup
+						label="Artist requirements (one per line)"
+						htmlFor="booking-production-requirements"
+					>
+						<textarea
+							id="booking-production-requirements"
+							value={ requirements }
+							onChange={ ( event ) =>
+								setRequirements( event.target.value )
+							}
+						/>
+					</FieldGroup>
+					<FieldGroup
+						label="Venue offers (one per line)"
+						htmlFor="booking-production-offers"
+					>
+						<textarea
+							id="booking-production-offers"
+							value={ offers }
+							onChange={ ( event ) =>
+								setOffers( event.target.value )
+							}
+						/>
+					</FieldGroup>
+				</div>
+				<FieldGroup
+					label="Production notes"
+					htmlFor="booking-production-notes"
+				>
+					<textarea
+						id="booking-production-notes"
+						value={ notes }
+						onChange={ ( event ) => setNotes( event.target.value ) }
+					/>
+				</FieldGroup>
+				<button
+					type="submit"
+					className="button-2"
+					disabled={ pending !== '' }
+				>
+					Save production details
+				</button>
+			</form>
+		</section>
+	);
+}
+
+function ActivityTimeline( { operations } ) {
+	return (
+		<section className="ec-booking-detail__section">
+			<h3>Activity</h3>
+			{ operations.activity.length ? (
+				<ul className="ec-booking-console__timeline">
+					{ operations.activity.map( ( item ) => (
+						<li key={ item.id }>
+							<strong>{ activityLabel( item.kind ) }</strong>
+							<span>
+								{ item.actor_type === 'user' && item.actor_id
+									? `User #${ item.actor_id }`
+									: activityLabel( item.actor_type ) }
+							</span>
+							<small>{ formatDate( item.occurred_at ) }</small>
+						</li>
+					) ) }
+				</ul>
+			) : (
+				<p>No activity recorded.</p>
+			) }
+		</section>
+	);
+}
+
 function BookingStatus( { status } ) {
 	return (
 		<span className={ `ec-booking-status ec-booking-status--${ status }` }>
@@ -438,6 +775,8 @@ function BookingDetail( {
 	booking,
 	holds,
 	communications,
+	operations,
+	defaultDeal,
 	members,
 	currentUserId,
 	onMutate,
@@ -785,15 +1124,38 @@ function BookingDetail( {
 				value={ booking.intake }
 				empty="No intake answers were supplied."
 			/>
-			<JsonRecord
-				title="Deal state"
-				value={ booking.confirmed_deal || booking.deal }
-				empty="No deal document yet."
+			<DealEditor
+				key={ `deal-${ booking.id }-${ booking.version }` }
+				booking={ booking }
+				defaultDeal={ defaultDeal }
+				pending={ pending }
+				onSave={ ( deal ) =>
+					mutate(
+						'Deal update',
+						'extrachill/update-venue-booking-deal',
+						{
+							booking_id: booking.id,
+							expected_version: booking.version,
+							deal,
+						}
+					)
+				}
 			/>
-			<JsonRecord
-				title="Production state"
-				value={ booking.production }
-				empty="No production document yet."
+			<ProductionEditor
+				key={ `production-${ booking.id }-${ booking.version }` }
+				booking={ booking }
+				pending={ pending }
+				onSave={ ( production ) =>
+					mutate(
+						'Production update',
+						'extrachill/update-venue-booking-production',
+						{
+							booking_id: booking.id,
+							expected_version: booking.version,
+							production,
+						}
+					)
+				}
 			/>
 
 			<section className="ec-booking-detail__section">
@@ -803,6 +1165,52 @@ function BookingDetail( {
 						? `Linked event #${ booking.event_id } is synchronized through booking-owned abilities.`
 						: 'No canonical event has been created.' }
 				</p>
+				{ operations.conversion.status === 'failed' && (
+					<InlineStatus
+						tone={
+							operations.conversion.retryable
+								? 'warning'
+								: 'error'
+						}
+					>
+						Conversion attempt { operations.conversion.attempt }{ ' ' }
+						failed
+						{ operations.conversion.failure_code
+							? ` (${ operations.conversion.failure_code })`
+							: '' }
+						.{ ' ' }
+						{ operations.conversion.retryable
+							? 'Retry is available.'
+							: 'Manual review is required before retrying.' }
+					</InlineStatus>
+				) }
+				{ operations.conversion.status === 'pending' && (
+					<InlineStatus tone="warning">
+						Conversion attempt { operations.conversion.attempt } has
+						no terminal result yet.
+					</InlineStatus>
+				) }
+				{ booking.event_id && operations.sync.status !== 'none' && (
+					<InlineStatus
+						tone={
+							[ 'failed', 'conflict', 'retryable' ].includes(
+								operations.sync.status
+							)
+								? 'warning'
+								: 'info'
+						}
+					>
+						Event synchronization:{ ' ' }
+						{ activityLabel( operations.sync.status ) }
+						{ operations.sync.code
+							? ` (${ operations.sync.code })`
+							: '' }
+						.
+						{ operations.sync.retryable
+							? ' Reconciliation can be retried.'
+							: '' }
+					</InlineStatus>
+				) }
 				<button
 					type="button"
 					className="button-1"
@@ -822,9 +1230,7 @@ function BookingDetail( {
 						)
 					}
 				>
-					{ booking.event_id
-						? 'Reconcile event'
-						: 'Convert to event' }
+					{ eventActionLabel( booking, operations ) }
 				</button>
 			</section>
 
@@ -839,28 +1245,17 @@ function BookingDetail( {
 				private-file operations are not included in this focused console
 				slice.
 			</InlineStatus>
-			<section className="ec-booking-detail__section">
-				<h3>Activity</h3>
-				<ul className="ec-booking-console__timeline">
-					<li>
-						<strong>Booking created</strong>
-						<small>{ formatDate( booking.created_at ) }</small>
-					</li>
-					<li>
-						<strong>Booking last changed</strong>
-						<small>{ formatDate( booking.updated_at ) }</small>
-					</li>
-				</ul>
-			</section>
+			<ActivityTimeline operations={ operations } />
 		</Panel>
 	);
 }
 
-export function BookingConsole( { context, members, view } ) {
+export function BookingConsole( { context, members, defaultDeal, view } ) {
 	const venueId = context.selected_venue.id;
 	const [ bookings, setBookings ] = useState( [] );
 	const [ holds, setHolds ] = useState( [] );
 	const [ communications, setCommunications ] = useState( [] );
+	const [ operations, setOperations ] = useState( null );
 	const [ selectedId, setSelectedId ] = useState( context.booking_id || 0 );
 	const [ selected, setSelected ] = useState( null );
 	const [ loading, setLoading ] = useState( true );
@@ -910,35 +1305,24 @@ export function BookingConsole( { context, members, view } ) {
 		}
 	};
 
-	const loadCommunications = async ( bookingId = selectedId ) => {
-		if ( ! bookingId ) {
-			return;
-		}
-		try {
-			setCommunications(
-				await runAbility( 'extrachill/list-booking-communications', {
-					booking_id: bookingId,
-				} )
-			);
-		} catch ( caught ) {
-			setDetailError( errorDetails( caught ).message );
-		}
-	};
-
 	const loadDetail = async ( bookingId = selectedId ) => {
 		if ( ! bookingId ) {
 			setSelected( null );
 			setCommunications( [] );
+			setOperations( null );
 			return;
 		}
 		setDetailLoading( true );
 		setDetailError( '' );
 		try {
-			const [ booking, messages ] = await Promise.all( [
+			const [ booking, messages, activity ] = await Promise.all( [
 				runAbility( 'extrachill/get-venue-booking', {
 					booking_id: bookingId,
 				} ),
 				runAbility( 'extrachill/list-booking-communications', {
+					booking_id: bookingId,
+				} ),
+				runAbility( 'extrachill/get-venue-booking-activity', {
 					booking_id: bookingId,
 				} ),
 			] );
@@ -949,8 +1333,10 @@ export function BookingConsole( { context, members, view } ) {
 			}
 			setSelected( booking );
 			setCommunications( messages );
+			setOperations( activity );
 		} catch ( caught ) {
 			setSelected( null );
+			setOperations( null );
 			setDetailError( errorDetails( caught ).message );
 		} finally {
 			setDetailLoading( false );
@@ -1086,16 +1472,18 @@ export function BookingConsole( { context, members, view } ) {
 					<p aria-live="polite">Loading booking detail...</p>
 				</Panel>
 			) }
-			{ selected && ! detailLoading && (
+			{ selected && operations && ! detailLoading && (
 				<BookingDetail
 					booking={ selected }
 					holds={ selectedHolds }
 					communications={ communications }
+					operations={ operations }
+					defaultDeal={ defaultDeal }
 					members={ members }
 					currentUserId={ context.user.id }
 					onMutate={ refreshAfterMutation }
 					onClose={ closeDetail }
-					onRefreshCommunications={ loadCommunications }
+					onRefreshCommunications={ loadDetail }
 				/>
 			) }
 		</div>

--- a/blocks/venue-settings/src/booking-console.js
+++ b/blocks/venue-settings/src/booking-console.js
@@ -1417,6 +1417,7 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 			setSelected( null );
 			setCommunications( [] );
 			setOperations( null );
+			setDetailLoading( false );
 			return;
 		}
 		setDetailLoading( true );
@@ -1488,6 +1489,7 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 		++detailRequestId.current;
 		setSelectedId( 0 );
 		setSelected( null );
+		setDetailLoading( false );
 		const url = new URL( window.location.href );
 		url.searchParams.delete( 'booking_id' );
 		window.history.replaceState( {}, '', url );
@@ -1597,6 +1599,15 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 			{ detailLoading && (
 				<Panel>
 					<p aria-live="polite">Loading booking detail...</p>
+					{ selectedId > 0 && (
+						<button
+							type="button"
+							className="button-2"
+							onClick={ closeDetail }
+						>
+							Close detail
+						</button>
+					) }
 				</Panel>
 			) }
 			{ selected && operations && ! detailLoading && (

--- a/blocks/venue-settings/src/booking-console.js
+++ b/blocks/venue-settings/src/booking-console.js
@@ -123,13 +123,84 @@ const toLocalInput = ( value ) =>
 
 const statusLabel = ( status ) => STATUS_LABELS[ status ] || status;
 
-const payloadData = ( value ) => value?.data || value || null;
+const payloadData = ( value ) => {
+	if ( value === null || value === undefined ) {
+		return null;
+	}
+	if (
+		typeof value === 'object' &&
+		! Array.isArray( value ) &&
+		Object.prototype.hasOwnProperty.call( value, 'data' )
+	) {
+		return value.data;
+	}
+	return value;
+};
 const linesToItems = ( value ) =>
 	value
 		.split( '\n' )
 		.map( ( item ) => item.trim() )
 		.filter( Boolean );
 const nullableNumber = ( value ) => ( value === '' ? null : Number( value ) );
+
+const hasExactKeys = ( value, keys ) =>
+	value !== null &&
+	typeof value === 'object' &&
+	! Array.isArray( value ) &&
+	Object.keys( value ).length === keys.length &&
+	keys.every( ( key ) => Object.prototype.hasOwnProperty.call( value, key ) );
+
+const DEAL_KEYS = [
+	'version',
+	'type',
+	'guarantee_cents',
+	'revenue_share_basis_points',
+	'revenue_share_basis',
+	'currency',
+	'capacity',
+	'advance_ticket_price_cents',
+	'door_ticket_price_cents',
+	'ticket_fee_cents',
+	'tickets_on_sale_at',
+	'ticket_url',
+	'additional_terms',
+];
+const nullableInteger = ( value ) =>
+	value === null || Number.isInteger( value );
+const nullableString = ( value ) => value === null || typeof value === 'string';
+const validDealShape = ( value ) =>
+	hasExactKeys( value, DEAL_KEYS ) &&
+	value.version === 1 &&
+	typeof value.type === 'string' &&
+	Number.isInteger( value.guarantee_cents ) &&
+	Number.isInteger( value.revenue_share_basis_points ) &&
+	typeof value.revenue_share_basis === 'string' &&
+	typeof value.currency === 'string' &&
+	[
+		'capacity',
+		'advance_ticket_price_cents',
+		'door_ticket_price_cents',
+		'ticket_fee_cents',
+	].every( ( key ) => nullableInteger( value[ key ] ) ) &&
+	[ 'tickets_on_sale_at', 'ticket_url', 'additional_terms' ].every( ( key ) =>
+		nullableString( value[ key ] )
+	);
+
+const PRODUCTION_KEYS = [
+	'version',
+	'support_requirements',
+	'support_offers',
+	'production_notes',
+];
+const validProductionShape = ( value ) =>
+	hasExactKeys( value, PRODUCTION_KEYS ) &&
+	value.version === 1 &&
+	[ 'support_requirements', 'support_offers' ].every(
+		( key ) =>
+			Array.isArray( value[ key ] ) &&
+			value[ key ].every( ( item ) => typeof item === 'string' )
+	) &&
+	nullableString( value.production_notes );
 
 export const activityLabel = ( kind ) =>
 	kind
@@ -143,14 +214,23 @@ const eventActionLabel = ( booking, operations ) => {
 			? 'Retry event reconciliation'
 			: 'Reconcile event';
 	}
+	if (
+		operations.conversion.status === 'failed' &&
+		! operations.conversion.retryable
+	) {
+		return 'Conversion retry unavailable';
+	}
 	return operations.conversion.status === 'failed'
 		? 'Retry event conversion'
 		: 'Convert to event';
 };
 
 const dealDocument = ( booking, fallback ) => {
-	const source =
-		payloadData( booking.confirmed_deal || booking.deal ) || fallback || {};
+	const stored = payloadData( booking.confirmed_deal || booking.deal );
+	if ( stored !== null && ! validDealShape( stored ) ) {
+		return null;
+	}
+	const source = stored || fallback || {};
 	return {
 		version: 1,
 		type: source.type || 'custom',
@@ -172,6 +252,17 @@ function DealEditor( { booking, defaultDeal, pending, onSave } ) {
 	const [ deal, setDeal ] = useState( () =>
 		dealDocument( booking, defaultDeal )
 	);
+	if ( deal === null ) {
+		return (
+			<section className="ec-booking-detail__section">
+				<h3>Deal terms</h3>
+				<InlineStatus tone="error">
+					The stored deal document is malformed. Editing is
+					unavailable until the canonical record is repaired.
+				</InlineStatus>
+			</section>
+		);
+	}
 	const update = ( key, value ) => setDeal( { ...deal, [ key ]: value } );
 	return (
 		<section className="ec-booking-detail__section">
@@ -364,7 +455,9 @@ function DealEditor( { booking, defaultDeal, pending, onSave } ) {
 }
 
 function ProductionEditor( { booking, pending, onSave } ) {
-	const source = payloadData( booking.production ) || {};
+	const stored = payloadData( booking.production );
+	const malformed = stored !== null && ! validProductionShape( stored );
+	const source = malformed ? {} : stored || {};
 	const [ requirements, setRequirements ] = useState(
 		( source.support_requirements || [] ).join( '\n' )
 	);
@@ -372,6 +465,17 @@ function ProductionEditor( { booking, pending, onSave } ) {
 		( source.support_offers || [] ).join( '\n' )
 	);
 	const [ notes, setNotes ] = useState( source.production_notes || '' );
+	if ( malformed ) {
+		return (
+			<section className="ec-booking-detail__section">
+				<h3>Production details</h3>
+				<InlineStatus tone="error">
+					The stored production document is malformed. Editing is
+					unavailable until the canonical record is repaired.
+				</InlineStatus>
+			</section>
+		);
+	}
 	return (
 		<section className="ec-booking-detail__section">
 			<h3>Production details</h3>
@@ -444,11 +548,6 @@ function ActivityTimeline( { operations } ) {
 					{ operations.activity.map( ( item ) => (
 						<li key={ item.id }>
 							<strong>{ activityLabel( item.kind ) }</strong>
-							<span>
-								{ item.actor_type === 'user' && item.actor_id
-									? `User #${ item.actor_id }`
-									: activityLabel( item.actor_type ) }
-							</span>
 							<small>{ formatDate( item.occurred_at ) }</small>
 						</li>
 					) ) }
@@ -1214,7 +1313,12 @@ function BookingDetail( {
 				<button
 					type="button"
 					className="button-1"
-					disabled={ pending !== '' }
+					disabled={
+						pending !== '' ||
+						( ! booking.event_id &&
+							operations.conversion.status === 'failed' &&
+							! operations.conversion.retryable )
+					}
 					onClick={ () =>
 						mutate(
 							booking.event_id
@@ -1269,6 +1373,8 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 	const [ filterAssignee, setFilterAssignee ] = useState( '' );
 	const [ month, setMonth ] = useState( monthKey() );
 	const requestId = useRef( 0 );
+	const detailRequestId = useRef( 0 );
+	const selectedIdRef = useRef( context.booking_id || 0 );
 
 	const loadList = async () => {
 		const currentRequest = ++requestId.current;
@@ -1305,7 +1411,8 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 		}
 	};
 
-	const loadDetail = async ( bookingId = selectedId ) => {
+	const loadDetail = async ( bookingId = selectedIdRef.current ) => {
+		const currentRequest = ++detailRequestId.current;
 		if ( ! bookingId ) {
 			setSelected( null );
 			setCommunications( [] );
@@ -1331,15 +1438,32 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 					'The booking is outside this venue workspace.'
 				);
 			}
+			if (
+				currentRequest !== detailRequestId.current ||
+				selectedIdRef.current !== bookingId
+			) {
+				return;
+			}
 			setSelected( booking );
 			setCommunications( messages );
 			setOperations( activity );
 		} catch ( caught ) {
+			if (
+				currentRequest !== detailRequestId.current ||
+				selectedIdRef.current !== bookingId
+			) {
+				return;
+			}
 			setSelected( null );
 			setOperations( null );
 			setDetailError( errorDetails( caught ).message );
 		} finally {
-			setDetailLoading( false );
+			if (
+				currentRequest === detailRequestId.current &&
+				selectedIdRef.current === bookingId
+			) {
+				setDetailLoading( false );
+			}
 		}
 	};
 
@@ -1351,6 +1475,7 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 	}, [ selectedId ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const selectBooking = ( bookingId ) => {
+		selectedIdRef.current = bookingId;
 		setSelectedId( bookingId );
 		const url = new URL( window.location.href );
 		url.searchParams.set( 'venue_id', venueId );
@@ -1359,6 +1484,8 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 		window.history.replaceState( {}, '', url );
 	};
 	const closeDetail = () => {
+		selectedIdRef.current = 0;
+		++detailRequestId.current;
 		setSelectedId( 0 );
 		setSelected( null );
 		const url = new URL( window.location.href );

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -1272,6 +1272,7 @@ export function VenueSettingsApp( { context } ) {
 					key={ `${ selected.id }-${ tab }` }
 					context={ context }
 					members={ members }
+					defaultDeal={ config?.default_deal }
 					view={ tab }
 				/>
 			);

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -216,6 +216,17 @@ const buttonByText = ( container, text ) =>
 	[ ...container.querySelectorAll( 'button' ) ].find(
 		( button ) => button.textContent === text
 	);
+const buttonContaining = ( container, text ) =>
+	[ ...container.querySelectorAll( 'button' ) ].find( ( button ) =>
+		button.textContent.includes( text )
+	);
+const deferred = () => {
+	let resolve;
+	const promise = new Promise( ( done ) => {
+		resolve = done;
+	} );
+	return { promise, resolve };
+};
 
 const setInput = async ( input, value ) => {
 	await act( async () => {
@@ -718,6 +729,194 @@ describe( 'venue settings authorization-facing states', () => {
 			'Conversion attempt 2 failed (upstream_timeout). Retry is available.'
 		);
 		expect( container.textContent ).toContain( 'Retry event conversion' );
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'does not offer immediate retry for a non-retryable conversion failure', async () => {
+		apiFetch.mockImplementation( ( request ) => {
+			const input = request.data?.input || requestInput( request.path );
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-activity' ) ) {
+				return Promise.resolve(
+					bookingActivity( {
+						conversion: {
+							status: 'failed',
+							attempt: 1,
+							failure_code: 'invalid_event',
+							retryable: false,
+						},
+					} )
+				);
+			}
+			if ( request.path.includes( 'get-venue-booking' ) ) {
+				return Promise.resolve( booking( input.booking_id ) );
+			}
+			return Promise.resolve( [] );
+		} );
+		const { container, root } = await renderApp(
+			context( { booking_id: 15 } )
+		);
+		const action = buttonByText(
+			container,
+			'Conversion retry unavailable'
+		);
+		expect( action.disabled ).toBe( true );
+		expect( container.textContent ).not.toContain(
+			'Retry event conversion'
+		);
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'rejects malformed stored deal and production documents without crashing', async () => {
+		apiFetch.mockImplementation( ( request ) => {
+			const input = request.data?.input || requestInput( request.path );
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-activity' ) ) {
+				return Promise.resolve( bookingActivity() );
+			}
+			if ( request.path.includes( 'get-venue-booking' ) ) {
+				return Promise.resolve( {
+					...booking( input.booking_id ),
+					deal: { version: 1, data: { type: 'broken' } },
+					production: {
+						version: 1,
+						data: {
+							version: 1,
+							support_requirements: 'not-an-array',
+							support_offers: [],
+							production_notes: null,
+						},
+					},
+				} );
+			}
+			return Promise.resolve( [] );
+		} );
+		const { container, root } = await renderApp(
+			context( { booking_id: 16 } )
+		);
+		expect( container.textContent ).toContain(
+			'The stored deal document is malformed.'
+		);
+		expect( container.textContent ).toContain(
+			'The stored production document is malformed.'
+		);
+		expect( buttonByText( container, 'Save deal terms' ) ).toBeUndefined();
+		expect(
+			buttonByText( container, 'Save production details' )
+		).toBeUndefined();
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'keeps the latest rapid booking selection when responses resolve out of order', async () => {
+		const detailA = deferred();
+		const detailB = deferred();
+		const first = { ...booking( 21 ), artist_name: 'Artist A' };
+		const second = { ...booking( 22 ), artist_name: 'Artist B' };
+		apiFetch.mockImplementation( ( request ) => {
+			const input = request.data?.input || requestInput( request.path );
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-activity' ) ) {
+				return Promise.resolve( bookingActivity() );
+			}
+			if ( request.path.includes( 'get-venue-booking' ) ) {
+				return input.booking_id === 21
+					? detailA.promise
+					: detailB.promise;
+			}
+			if ( request.path.includes( 'list-venue-bookings' ) ) {
+				return Promise.resolve( [ first, second ] );
+			}
+			return Promise.resolve( [] );
+		} );
+		const { container, root } = await renderApp( context() );
+		await act( async () =>
+			buttonContaining( container, 'Artist A' ).click()
+		);
+		await act( async () =>
+			buttonContaining( container, 'Artist B' ).click()
+		);
+		await act( async () => {
+			detailB.resolve( second );
+			await detailB.promise;
+		} );
+		expect( container.textContent ).toContain( 'Booking #22' );
+		await act( async () => {
+			detailA.resolve( first );
+			await detailA.promise;
+		} );
+		expect( container.textContent ).toContain( 'Booking #22' );
+		expect( container.textContent ).not.toContain( 'Booking #21' );
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'refreshes the current selection after an earlier booking mutation resolves', async () => {
+		const mutation = deferred();
+		const detailIds = [];
+		const first = { ...booking( 31 ), artist_name: 'Mutation Artist A' };
+		const second = { ...booking( 32 ), artist_name: 'Mutation Artist B' };
+		apiFetch.mockImplementation( ( request ) => {
+			const input = request.data?.input || requestInput( request.path );
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-activity' ) ) {
+				return Promise.resolve( bookingActivity() );
+			}
+			if ( request.path.includes( 'get-venue-booking' ) ) {
+				detailIds.push( input.booking_id );
+				return Promise.resolve(
+					input.booking_id === 31 ? first : second
+				);
+			}
+			if ( request.path.includes( 'assign-venue-booking' ) ) {
+				return mutation.promise;
+			}
+			if ( request.path.includes( 'list-venue-bookings' ) ) {
+				return Promise.resolve( [ first, second ] );
+			}
+			return Promise.resolve( [] );
+		} );
+		const { container, root } = await renderApp( context() );
+		await act( async () =>
+			buttonContaining( container, 'Mutation Artist A' ).click()
+		);
+		await act( async () => {
+			const select = container.querySelector( '#booking-assignee' );
+			select.value = '7';
+			select.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		} );
+		await act( async () =>
+			buttonByText( container, 'Save assignment' ).click()
+		);
+		await act( async () =>
+			buttonContaining( container, 'Mutation Artist B' ).click()
+		);
+		expect( container.textContent ).toContain( 'Booking #32' );
+		await act( async () => {
+			mutation.resolve( { ...first, assignee_user_id: 7, version: 5 } );
+			await mutation.promise;
+			await Promise.resolve();
+		} );
+		expect( detailIds[ detailIds.length - 1 ] ).toBe( 32 );
+		expect( container.textContent ).toContain( 'Booking #32' );
 		await act( async () => root.unmount() );
 	} );
 } );

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -864,6 +864,57 @@ describe( 'venue settings authorization-facing states', () => {
 		await act( async () => root.unmount() );
 	} );
 
+	it( 'clears detail loading when an in-flight booking is closed', async () => {
+		const pending = deferred();
+		const first = { ...booking( 23 ), artist_name: 'Loaded Artist' };
+		const second = { ...booking( 24 ), artist_name: 'Pending Artist' };
+		apiFetch.mockImplementation( ( request ) => {
+			const input = request.data?.input || requestInput( request.path );
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-activity' ) ) {
+				return Promise.resolve( bookingActivity() );
+			}
+			if ( request.path.includes( 'get-venue-booking' ) ) {
+				return input.booking_id === 23
+					? Promise.resolve( first )
+					: pending.promise;
+			}
+			if ( request.path.includes( 'list-venue-bookings' ) ) {
+				return Promise.resolve( [ first, second ] );
+			}
+			return Promise.resolve( [] );
+		} );
+		const { container, root } = await renderApp( context() );
+		await act( async () =>
+			buttonContaining( container, 'Loaded Artist' ).click()
+		);
+		expect( container.textContent ).toContain( 'Booking #23' );
+		await act( async () =>
+			buttonContaining( container, 'Pending Artist' ).click()
+		);
+		expect( container.textContent ).toContain(
+			'Loading booking detail...'
+		);
+		await act( async () =>
+			buttonByText( container, 'Close detail' ).click()
+		);
+		expect( container.textContent ).not.toContain(
+			'Loading booking detail...'
+		);
+		expect( container.textContent ).not.toContain( 'Booking #23' );
+		await act( async () => {
+			pending.resolve( second );
+			await pending.promise;
+		} );
+		expect( container.textContent ).not.toContain( 'Booking #24' );
+		await act( async () => root.unmount() );
+	} );
+
 	it( 'refreshes the current selection after an earlier booking mutation resolves', async () => {
 		const mutation = deferred();
 		const detailIds = [];

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -129,6 +129,28 @@ const booking = ( id, venueId = 44 ) => ( {
 	created_at: '2026-07-20 12:00:00',
 	updated_at: '2026-07-20 12:00:00',
 } );
+const bookingActivity = ( overrides = {} ) => ( {
+	activity: [
+		{
+			id: 31,
+			kind: 'booking_submitted',
+			actor_type: 'user',
+			actor_id: 7,
+			direction: null,
+			channel: null,
+			external_id: null,
+			occurred_at: '2026-07-20 12:00:00',
+		},
+	],
+	conversion: {
+		status: 'none',
+		attempt: 0,
+		failure_code: null,
+		retryable: false,
+	},
+	sync: { status: 'none', code: null, retryable: false },
+	...overrides,
+} );
 const context = ( overrides = {} ) => ( {
 	user: { id: 7, name: 'Operator', is_admin: false },
 	venues: [ { id: 44, name: 'Venue 44', status: 'active', is_owner: false } ],
@@ -161,6 +183,9 @@ const installApi = () =>
 		}
 		if ( request.path.includes( 'get-venue-booking-config' ) ) {
 			return Promise.resolve( config( input.venue_term_id ) );
+		}
+		if ( request.path.includes( 'get-venue-booking-activity' ) ) {
+			return Promise.resolve( bookingActivity() );
 		}
 		if (
 			request.path.includes( 'list-venue-memberships' ) ||
@@ -199,6 +224,16 @@ const setInput = async ( input, value ) => {
 			'value'
 		).set.call( input, value );
 		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+	} );
+};
+
+const setControl = async ( control, value ) => {
+	await act( async () => {
+		Object.getOwnPropertyDescriptor(
+			control.constructor.prototype,
+			'value'
+		).set.call( control, value );
+		control.dispatchEvent( new Event( 'input', { bubbles: true } ) );
 	} );
 };
 
@@ -489,6 +524,9 @@ describe( 'venue settings authorization-facing states', () => {
 			if ( request.path.includes( 'get-venue-booking-config' ) ) {
 				return Promise.resolve( config( input.venue_term_id ) );
 			}
+			if ( request.path.includes( 'get-venue-booking-activity' ) ) {
+				return Promise.resolve( bookingActivity() );
+			}
 			if ( request.path.includes( 'get-venue-booking' ) ) {
 				return Promise.resolve( booking( input.booking_id ) );
 			}
@@ -505,6 +543,7 @@ describe( 'venue settings authorization-facing states', () => {
 			context( { booking_id: 9 } )
 		);
 		expect( container.textContent ).toContain( 'Booking #9' );
+		expect( container.textContent ).toContain( 'Booking Submitted' );
 		await act( async () => {
 			const select = container.querySelector( '#booking-assignee' );
 			select.value = '7';
@@ -524,6 +563,161 @@ describe( 'venue settings authorization-facing states', () => {
 					request.data.input.assignee_user_id === 7
 			)
 		).toBe( true );
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'sends complete canonical deal and production documents at the expected version', async () => {
+		apiFetch.mockImplementation( ( request ) => {
+			const input = request.data?.input || requestInput( request.path );
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-activity' ) ) {
+				return Promise.resolve( bookingActivity() );
+			}
+			if ( request.path.includes( 'get-venue-booking' ) ) {
+				return Promise.resolve( {
+					...booking( input.booking_id ),
+					status: 'negotiating',
+				} );
+			}
+			if (
+				request.path.includes( 'update-venue-booking-deal' ) ||
+				request.path.includes( 'update-venue-booking-production' )
+			) {
+				return Promise.resolve( {
+					...booking( input.booking_id ),
+					version: 5,
+				} );
+			}
+			return Promise.resolve( [] );
+		} );
+		const { container, root } = await renderApp(
+			context( { booking_id: 12 } )
+		);
+		await setControl(
+			container.querySelector( '#booking-deal-guarantee' ),
+			'125000'
+		);
+		await act( async () => {
+			buttonByText( container, 'Save deal terms' ).click();
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+		await setControl(
+			container.querySelector( '#booking-production-notes' ),
+			'House provides backline.'
+		);
+		await act( async () => {
+			buttonByText( container, 'Save production details' ).click();
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+		const dealRequest = apiFetch.mock.calls.find( ( [ request ] ) =>
+			request.path.includes( 'update-venue-booking-deal' )
+		)[ 0 ];
+		const productionRequest = apiFetch.mock.calls.find( ( [ request ] ) =>
+			request.path.includes( 'update-venue-booking-production' )
+		)[ 0 ];
+		expect( dealRequest.data.input ).toMatchObject( {
+			booking_id: 12,
+			expected_version: 4,
+			deal: { version: 1, guarantee_cents: 125000 },
+		} );
+		expect( Object.keys( dealRequest.data.input.deal ) ).toHaveLength( 13 );
+		expect( productionRequest.data.input ).toEqual( {
+			booking_id: 12,
+			expected_version: 4,
+			production: {
+				version: 1,
+				support_requirements: [],
+				support_offers: [],
+				production_notes: 'House provides backline.',
+			},
+		} );
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'reloads the booking and reports a stale deal conflict', async () => {
+		let detailReads = 0;
+		apiFetch.mockImplementation( ( request ) => {
+			const input = request.data?.input || requestInput( request.path );
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-activity' ) ) {
+				return Promise.resolve( bookingActivity() );
+			}
+			if ( request.path.includes( 'get-venue-booking' ) ) {
+				detailReads += 1;
+				return Promise.resolve( {
+					...booking( input.booking_id ),
+					status: 'negotiating',
+				} );
+			}
+			if ( request.path.includes( 'update-venue-booking-deal' ) ) {
+				return Promise.reject( {
+					code: 'booking_version_conflict',
+					message: 'The booking changed since it was read.',
+					data: { status: 409 },
+				} );
+			}
+			return Promise.resolve( [] );
+		} );
+		const { container, root } = await renderApp(
+			context( { booking_id: 14 } )
+		);
+		await act( async () => {
+			buttonByText( container, 'Save deal terms' ).click();
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+		expect( container.textContent ).toContain(
+			'The latest booking has been reloaded.'
+		);
+		expect( detailReads ).toBeGreaterThan( 1 );
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'renders conversion failure and retry state from authoritative activity', async () => {
+		apiFetch.mockImplementation( ( request ) => {
+			const input = request.data?.input || requestInput( request.path );
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-activity' ) ) {
+				return Promise.resolve(
+					bookingActivity( {
+						conversion: {
+							status: 'failed',
+							attempt: 2,
+							failure_code: 'upstream_timeout',
+							retryable: true,
+						},
+					} )
+				);
+			}
+			if ( request.path.includes( 'get-venue-booking' ) ) {
+				return Promise.resolve( booking( input.booking_id ) );
+			}
+			return Promise.resolve( [] );
+		} );
+		const { container, root } = await renderApp(
+			context( { booking_id: 13 } )
+		);
+		expect( container.textContent ).toContain(
+			'Conversion attempt 2 failed (upstream_timeout). Retry is available.'
+		);
+		expect( container.textContent ).toContain( 'Retry event conversion' );
 		await act( async () => root.unmount() );
 	} );
 } );

--- a/inc/Abilities/VenueBookingAbilities.php
+++ b/inc/Abilities/VenueBookingAbilities.php
@@ -10,6 +10,7 @@ namespace ExtraChillEvents\Abilities;
 use ExtraChillEvents\Core\BookingLifecycle;
 use ExtraChillEvents\Core\BookingInquiryAdmissionService;
 use ExtraChillEvents\Core\BookingAttachmentPolicy;
+use ExtraChillEvents\Core\BookingActivityRepository;
 use ExtraChillEvents\Core\BookingHoldRepository;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\VenueAuthorization;
@@ -49,6 +50,12 @@ class VenueBookingAbilities {
 	private $authorization;
 	/** @var BookingHoldRepository */
 	private $holds;
+	/**
+	 * Authoritative booking activity reads.
+	 *
+	 * @var BookingActivityRepository
+	 */
+	private $activity;
 
 	/**
 	 * Build and hook the booking ability surface.
@@ -58,10 +65,12 @@ class VenueBookingAbilities {
 	 * @param VenueAuthorization|null             $authorization Venue authorization.
 	 * @param BookingHoldRepository|null          $holds             Hold reconciliation.
 	 * @param BookingInquiryAdmissionService|null $inquiry_admission Inquiry admission.
+	 * @param BookingActivityRepository|null      $activity          Authoritative activity reads.
 	 */
-	public function __construct( ?BookingRepository $bookings = null, ?BookingLifecycle $lifecycle = null, ?VenueAuthorization $authorization = null, ?BookingHoldRepository $holds = null, ?BookingInquiryAdmissionService $inquiry_admission = null ) {
+	public function __construct( ?BookingRepository $bookings = null, ?BookingLifecycle $lifecycle = null, ?VenueAuthorization $authorization = null, ?BookingHoldRepository $holds = null, ?BookingInquiryAdmissionService $inquiry_admission = null, ?BookingActivityRepository $activity = null ) {
 		$this->bookings          = $bookings ? $bookings : new BookingRepository();
 		$this->authorization     = $authorization ? $authorization : new VenueAuthorization();
+		$this->activity          = $activity ? $activity : new BookingActivityRepository();
 		$this->holds             = $holds ? $holds : new BookingHoldRepository( $this->bookings, null, $this->authorization );
 		$this->lifecycle         = $lifecycle ? $lifecycle : new BookingLifecycle( $this->bookings, null, $this->authorization, null, $this->holds );
 		$this->inquiry_admission = $inquiry_admission ? $inquiry_admission : new BookingInquiryAdmissionService( $this->lifecycle );
@@ -144,6 +153,27 @@ class VenueBookingAbilities {
 					'show_in_rest' => true,
 					'annotations'  => array(
 						'readonly'    => false,
+						'idempotent'  => true,
+						'destructive' => false,
+					),
+				),
+			)
+		);
+
+		wp_register_ability(
+			'extrachill/get-venue-booking-activity',
+			array(
+				'label'               => __( 'Get Venue Booking Activity', 'extrachill-events' ),
+				'description'         => __( 'Get the authoritative activity and event synchronization state for one authorized booking.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => $booking_id_input,
+				'output_schema'       => $this->activity_schema(),
+				'execute_callback'    => array( $this, 'get_booking_activity' ),
+				'permission_callback' => array( $this, 'can_access_booking' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => true,
 						'idempotent'  => true,
 						'destructive' => false,
 					),
@@ -317,6 +347,39 @@ class VenueBookingAbilities {
 	public function get_booking( array $input ) {
 		$result = $this->holds->get_booking_authorized( absint( $input['booking_id'] ?? 0 ), get_current_user_id() );
 		return is_array( $result ) ? $this->present( $result ) : $result;
+	}
+
+	/**
+	 * Get sanitized activity plus canonical conversion and synchronization state.
+	 *
+	 * @param array $input Ability input.
+	 */
+	public function get_booking_activity( array $input ) {
+		$booking_id = absint( $input['booking_id'] ?? 0 );
+		$booking    = $this->bookings->get( $booking_id );
+		if ( ! is_array( $booking ) ) {
+			return is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'Booking not found.', 'extrachill-events' ), array( 'status' => 404 ) );
+		}
+
+		$activity   = $this->activity->list_for_booking( $booking_id, 200 );
+		$conversion = $this->activity->event_conversion_state( $booking_id, $booking['public_id'] );
+		$sync       = $this->activity->event_sync_state( $booking_id );
+		foreach ( array( $activity, $conversion, $sync ) as $result ) {
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+
+		return array(
+			'activity'   => array_map( array( $this, 'present_activity' ), $activity ),
+			'conversion' => array(
+				'status'       => $conversion['status'],
+				'attempt'      => (int) $conversion['attempt'],
+				'failure_code' => $conversion['failed']['payload']['data']['upstream_code'] ?? null,
+				'retryable'    => (bool) ( $conversion['failed']['payload']['data']['retryable'] ?? false ),
+			),
+			'sync'       => $this->present_sync_state( $sync ),
+		);
 	}
 
 	/**
@@ -588,6 +651,108 @@ class VenueBookingAbilities {
 			),
 			'required'             => array( 'id', 'public_id', 'venue_term_id', 'artist_term_id', 'artist_profile_id', 'artist_name', 'submitter_user_id', 'contact_name', 'contact_email', 'contact_phone', 'requested_space_key', 'space_key', 'status', 'version', 'assignee_user_id', 'requested_start_at', 'requested_end_at', 'performance_start_at', 'performance_end_at', 'intake', 'production', 'deal', 'confirmed_deal', 'event_id', 'created_at', 'updated_at' ),
 			'additionalProperties' => false,
+		);
+	}
+
+	/** Return the bounded operator activity projection schema. */
+	private function activity_schema(): array {
+		$nullable_string = array( 'type' => array( 'string', 'null' ) );
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'activity'   => array(
+					'type'     => 'array',
+					'maxItems' => 200,
+					'items'    => array(
+						'type'                 => 'object',
+						'properties'           => array(
+							'id'          => array( 'type' => 'integer' ),
+							'kind'        => array( 'type' => 'string' ),
+							'actor_type'  => array( 'type' => 'string' ),
+							'actor_id'    => array( 'type' => array( 'integer', 'null' ) ),
+							'direction'   => $nullable_string,
+							'channel'     => $nullable_string,
+							'external_id' => $nullable_string,
+							'occurred_at' => array( 'type' => 'string' ),
+						),
+						'required'             => array( 'id', 'kind', 'actor_type', 'actor_id', 'direction', 'channel', 'external_id', 'occurred_at' ),
+						'additionalProperties' => false,
+					),
+				),
+				'conversion' => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'status'       => array(
+							'type' => 'string',
+							'enum' => array( 'none', 'pending', 'failed', 'completed' ),
+						),
+						'attempt'      => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'failure_code' => $nullable_string,
+						'retryable'    => array( 'type' => 'boolean' ),
+					),
+					'required'             => array( 'status', 'attempt', 'failure_code', 'retryable' ),
+					'additionalProperties' => false,
+				),
+				'sync'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'status'    => array(
+							'type' => 'string',
+							'enum' => array( 'none', 'pending', 'succeeded', 'no_change', 'conflict', 'failed', 'retryable' ),
+						),
+						'code'      => $nullable_string,
+						'retryable' => array( 'type' => 'boolean' ),
+					),
+					'required'             => array( 'status', 'code', 'retryable' ),
+					'additionalProperties' => false,
+				),
+			),
+			'required'             => array( 'activity', 'conversion', 'sync' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Remove activity payloads outside this console's operational scope.
+	 *
+	 * @param array $activity Hydrated activity record.
+	 */
+	public function present_activity( array $activity ): array {
+		return array_intersect_key( $activity, array_flip( array( 'id', 'kind', 'actor_type', 'actor_id', 'direction', 'channel', 'external_id', 'occurred_at' ) ) );
+	}
+
+	/**
+	 * Present the durable latest synchronization state without private payload data.
+	 *
+	 * @param array $sync Canonical event synchronization state.
+	 */
+	private function present_sync_state( array $sync ): array {
+		if ( is_array( $sync['retry'] ?? null ) ) {
+			return array(
+				'status'    => 'retryable',
+				'code'      => $sync['retry']['payload']['data']['code'] ?? null,
+				'retryable' => true,
+			);
+		}
+		$terminal = $sync['terminal'] ?? null;
+		if ( ! is_array( $terminal ) ) {
+			return array(
+				'status'    => ! empty( $sync['pending'] ) ? 'pending' : 'none',
+				'code'      => null,
+				'retryable' => false,
+			);
+		}
+		$status = str_replace( 'event_sync_', '', $terminal['kind'] );
+		if ( 'noop' === $status ) {
+			$status = 'no_change';
+		}
+		return array(
+			'status'    => $status,
+			'code'      => $terminal['payload']['data']['code'] ?? null,
+			'retryable' => (bool) ( $terminal['payload']['data']['retryable'] ?? false ),
 		);
 	}
 

--- a/inc/Abilities/VenueBookingAbilities.php
+++ b/inc/Abilities/VenueBookingAbilities.php
@@ -376,14 +376,13 @@ class VenueBookingAbilities {
 	 * @param array $input Ability input.
 	 */
 	public function get_booking_activity( array $input ) {
-		$state = $this->holds->get_booking_activity_authorized( absint( $input['booking_id'] ?? 0 ), get_current_user_id() );
+		$state = $this->holds->get_booking_activity_authorized( absint( $input['booking_id'] ?? 0 ), get_current_user_id(), self::CORE_ACTIVITY_KINDS );
 		if ( ! is_array( $state ) ) {
 			return $state;
 		}
-		$activity = array_values( array_filter( $state['activity'], static fn( array $item ): bool => in_array( $item['kind'], self::CORE_ACTIVITY_KINDS, true ) ) );
 
 		return array(
-			'activity'   => array_map( array( $this, 'present_activity' ), $activity ),
+			'activity'   => array_map( array( $this, 'present_activity' ), $state['activity'] ),
 			'conversion' => array(
 				'status'       => $state['conversion']['status'],
 				'attempt'      => (int) $state['conversion']['attempt'],

--- a/inc/Abilities/VenueBookingAbilities.php
+++ b/inc/Abilities/VenueBookingAbilities.php
@@ -10,7 +10,6 @@ namespace ExtraChillEvents\Abilities;
 use ExtraChillEvents\Core\BookingLifecycle;
 use ExtraChillEvents\Core\BookingInquiryAdmissionService;
 use ExtraChillEvents\Core\BookingAttachmentPolicy;
-use ExtraChillEvents\Core\BookingActivityRepository;
 use ExtraChillEvents\Core\BookingHoldRepository;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\VenueAuthorization;
@@ -50,12 +49,36 @@ class VenueBookingAbilities {
 	private $authorization;
 	/** @var BookingHoldRepository */
 	private $holds;
-	/**
-	 * Authoritative booking activity reads.
-	 *
-	 * @var BookingActivityRepository
-	 */
-	private $activity;
+	private const CORE_ACTIVITY_KINDS = array(
+		'inquiry_submitted',
+		'assignment_changed',
+		'status_changed',
+		'artist_bound',
+		'intake_corrected',
+		'performance_selected',
+		'hold_created',
+		'hold_released',
+		'hold_expired',
+		'production_updated',
+		'deal_draft_updated',
+		'deal_confirmed',
+		'event_conversion_started',
+		'event_conversion_failed',
+		'event_converted',
+		'event_sync_started',
+		'event_sync_retryable',
+		'event_sync_failed',
+		'event_sync_conflict',
+		'event_sync_succeeded',
+		'event_sync_noop',
+		'booking_message_requested',
+		'booking_message_dispatching',
+		'booking_message_queued',
+		'booking_message_failed',
+		'booking_reminder_scheduling',
+		'booking_reminder_scheduled',
+		'booking_reminder_suppressed',
+	);
 
 	/**
 	 * Build and hook the booking ability surface.
@@ -65,12 +88,10 @@ class VenueBookingAbilities {
 	 * @param VenueAuthorization|null             $authorization Venue authorization.
 	 * @param BookingHoldRepository|null          $holds             Hold reconciliation.
 	 * @param BookingInquiryAdmissionService|null $inquiry_admission Inquiry admission.
-	 * @param BookingActivityRepository|null      $activity          Authoritative activity reads.
 	 */
-	public function __construct( ?BookingRepository $bookings = null, ?BookingLifecycle $lifecycle = null, ?VenueAuthorization $authorization = null, ?BookingHoldRepository $holds = null, ?BookingInquiryAdmissionService $inquiry_admission = null, ?BookingActivityRepository $activity = null ) {
+	public function __construct( ?BookingRepository $bookings = null, ?BookingLifecycle $lifecycle = null, ?VenueAuthorization $authorization = null, ?BookingHoldRepository $holds = null, ?BookingInquiryAdmissionService $inquiry_admission = null ) {
 		$this->bookings          = $bookings ? $bookings : new BookingRepository();
 		$this->authorization     = $authorization ? $authorization : new VenueAuthorization();
-		$this->activity          = $activity ? $activity : new BookingActivityRepository();
 		$this->holds             = $holds ? $holds : new BookingHoldRepository( $this->bookings, null, $this->authorization );
 		$this->lifecycle         = $lifecycle ? $lifecycle : new BookingLifecycle( $this->bookings, null, $this->authorization, null, $this->holds );
 		$this->inquiry_admission = $inquiry_admission ? $inquiry_admission : new BookingInquiryAdmissionService( $this->lifecycle );
@@ -355,30 +376,21 @@ class VenueBookingAbilities {
 	 * @param array $input Ability input.
 	 */
 	public function get_booking_activity( array $input ) {
-		$booking_id = absint( $input['booking_id'] ?? 0 );
-		$booking    = $this->bookings->get( $booking_id );
-		if ( ! is_array( $booking ) ) {
-			return is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'Booking not found.', 'extrachill-events' ), array( 'status' => 404 ) );
+		$state = $this->holds->get_booking_activity_authorized( absint( $input['booking_id'] ?? 0 ), get_current_user_id() );
+		if ( ! is_array( $state ) ) {
+			return $state;
 		}
-
-		$activity   = $this->activity->list_for_booking( $booking_id, 200 );
-		$conversion = $this->activity->event_conversion_state( $booking_id, $booking['public_id'] );
-		$sync       = $this->activity->event_sync_state( $booking_id );
-		foreach ( array( $activity, $conversion, $sync ) as $result ) {
-			if ( is_wp_error( $result ) ) {
-				return $result;
-			}
-		}
+		$activity = array_values( array_filter( $state['activity'], static fn( array $item ): bool => in_array( $item['kind'], self::CORE_ACTIVITY_KINDS, true ) ) );
 
 		return array(
 			'activity'   => array_map( array( $this, 'present_activity' ), $activity ),
 			'conversion' => array(
-				'status'       => $conversion['status'],
-				'attempt'      => (int) $conversion['attempt'],
-				'failure_code' => $conversion['failed']['payload']['data']['upstream_code'] ?? null,
-				'retryable'    => (bool) ( $conversion['failed']['payload']['data']['retryable'] ?? false ),
+				'status'       => $state['conversion']['status'],
+				'attempt'      => (int) $state['conversion']['attempt'],
+				'failure_code' => $state['conversion']['failed']['payload']['data']['upstream_code'] ?? null,
+				'retryable'    => (bool) ( $state['conversion']['failed']['payload']['data']['retryable'] ?? false ),
 			),
-			'sync'       => $this->present_sync_state( $sync ),
+			'sync'       => $this->present_sync_state( $state['sync'] ),
 		);
 	}
 
@@ -668,14 +680,9 @@ class VenueBookingAbilities {
 						'properties'           => array(
 							'id'          => array( 'type' => 'integer' ),
 							'kind'        => array( 'type' => 'string' ),
-							'actor_type'  => array( 'type' => 'string' ),
-							'actor_id'    => array( 'type' => array( 'integer', 'null' ) ),
-							'direction'   => $nullable_string,
-							'channel'     => $nullable_string,
-							'external_id' => $nullable_string,
 							'occurred_at' => array( 'type' => 'string' ),
 						),
-						'required'             => array( 'id', 'kind', 'actor_type', 'actor_id', 'direction', 'channel', 'external_id', 'occurred_at' ),
+						'required'             => array( 'id', 'kind', 'occurred_at' ),
 						'additionalProperties' => false,
 					),
 				),
@@ -721,7 +728,11 @@ class VenueBookingAbilities {
 	 * @param array $activity Hydrated activity record.
 	 */
 	public function present_activity( array $activity ): array {
-		return array_intersect_key( $activity, array_flip( array( 'id', 'kind', 'actor_type', 'actor_id', 'direction', 'channel', 'external_id', 'occurred_at' ) ) );
+		return array(
+			'id'          => $activity['id'],
+			'kind'        => $activity['kind'],
+			'occurred_at' => $activity['occurred_at'],
+		);
 	}
 
 	/**
@@ -730,6 +741,18 @@ class VenueBookingAbilities {
 	 * @param array $sync Canonical event synchronization state.
 	 */
 	private function present_sync_state( array $sync ): array {
+		$terminal = $sync['terminal'] ?? null;
+		if ( is_array( $terminal ) ) {
+			$status = str_replace( 'event_sync_', '', $terminal['kind'] );
+			if ( 'noop' === $status ) {
+				$status = 'no_change';
+			}
+			return array(
+				'status'    => $status,
+				'code'      => $terminal['payload']['data']['code'] ?? null,
+				'retryable' => (bool) ( $terminal['payload']['data']['retryable'] ?? false ),
+			);
+		}
 		if ( is_array( $sync['retry'] ?? null ) ) {
 			return array(
 				'status'    => 'retryable',
@@ -737,22 +760,10 @@ class VenueBookingAbilities {
 				'retryable' => true,
 			);
 		}
-		$terminal = $sync['terminal'] ?? null;
-		if ( ! is_array( $terminal ) ) {
-			return array(
-				'status'    => ! empty( $sync['pending'] ) ? 'pending' : 'none',
-				'code'      => null,
-				'retryable' => false,
-			);
-		}
-		$status = str_replace( 'event_sync_', '', $terminal['kind'] );
-		if ( 'noop' === $status ) {
-			$status = 'no_change';
-		}
 		return array(
-			'status'    => $status,
-			'code'      => $terminal['payload']['data']['code'] ?? null,
-			'retryable' => (bool) ( $terminal['payload']['data']['retryable'] ?? false ),
+			'status'    => ! empty( $sync['pending'] ) ? 'pending' : 'none',
+			'code'      => null,
+			'retryable' => false,
 		);
 	}
 

--- a/inc/Core/BookingActivityRepository.php
+++ b/inc/Core/BookingActivityRepository.php
@@ -134,6 +134,50 @@ class BookingActivityRepository {
 		return $hydrated;
 	}
 
+	/**
+	 * List recent activity restricted to validated kinds before pagination.
+	 *
+	 * @param int   $booking_id Booking ID.
+	 * @param array $kinds      Canonical activity kinds.
+	 * @param int   $limit      Maximum rows.
+	 * @param int   $offset     Row offset.
+	 */
+	public function list_for_booking_kinds( int $booking_id, array $kinds, int $limit = 100, int $offset = 0 ) {
+		global $wpdb;
+		$booking_id = $this->positive_id( $booking_id, 'booking_id', false );
+		if ( is_wp_error( $booking_id ) ) {
+			return $booking_id;
+		}
+		$kinds = array_values( array_unique( $kinds ) );
+		if ( empty( $kinds ) || count( $kinds ) > 100 ) {
+			return new \WP_Error( 'invalid_booking_activity_kinds', __( 'At least one valid activity kind is required.', 'extrachill-events' ) );
+		}
+		foreach ( $kinds as $kind ) {
+			if ( ! is_string( $kind ) || '' === $kind || $kind !== sanitize_key( $kind ) || strlen( $kind ) > 64 ) {
+				return new \WP_Error( 'invalid_booking_activity_kinds', __( 'Activity kinds must be canonical keys.', 'extrachill-events' ) );
+			}
+		}
+
+		$table        = BookingSchema::activity_table();
+		$limit        = max( 1, min( 200, $limit ) );
+		$offset       = max( 0, $offset );
+		$placeholders = implode( ', ', array_fill( 0, count( $kinds ), '%s' ) );
+		$values       = array_merge( array( $booking_id ), $kinds, array( $limit, $offset ) );
+		$rows         = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND kind IN ({$placeholders}) ORDER BY occurred_at DESC, id DESC LIMIT %d OFFSET %d", $values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Table and placeholder count are internal; every value is prepared.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'booking_activity_list_failed', __( 'Booking activity could not be listed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		$hydrated = array();
+		foreach ( (array) $rows as $row ) {
+			$item = $this->hydrate( $row );
+			if ( is_wp_error( $item ) ) {
+				return $item;
+			}
+			$hydrated[] = $item;
+		}
+		return $hydrated;
+	}
+
 	/** List the bounded public correspondence ledger without reconstructing state. */
 	public function list_communications( int $booking_id, int $limit = 200 ) {
 		global $wpdb;

--- a/inc/Core/BookingActivityRepository.php
+++ b/inc/Core/BookingActivityRepository.php
@@ -153,7 +153,7 @@ class BookingActivityRepository {
 			return new \WP_Error( 'invalid_booking_activity_kinds', __( 'At least one valid activity kind is required.', 'extrachill-events' ) );
 		}
 		foreach ( $kinds as $kind ) {
-			if ( ! is_string( $kind ) || '' === $kind || $kind !== sanitize_key( $kind ) || strlen( $kind ) > 64 ) {
+			if ( ! is_string( $kind ) || '' === $kind || sanitize_key( $kind ) !== $kind || strlen( $kind ) > 64 ) {
 				return new \WP_Error( 'invalid_booking_activity_kinds', __( 'Activity kinds must be canonical keys.', 'extrachill-events' ) );
 			}
 		}
@@ -163,7 +163,7 @@ class BookingActivityRepository {
 		$offset       = max( 0, $offset );
 		$placeholders = implode( ', ', array_fill( 0, count( $kinds ), '%s' ) );
 		$values       = array_merge( array( $booking_id ), $kinds, array( $limit, $offset ) );
-		$rows         = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND kind IN ({$placeholders}) ORDER BY occurred_at DESC, id DESC LIMIT %d OFFSET %d", $values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Table and placeholder count are internal; every value is prepared.
+		$rows         = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND kind IN ({$placeholders}) ORDER BY occurred_at DESC, id DESC LIMIT %d OFFSET %d", $values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Table and placeholder count are internal; every value is prepared.
 		if ( '' !== (string) $wpdb->last_error ) {
 			return new \WP_Error( 'booking_activity_list_failed', __( 'Booking activity could not be listed.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -166,10 +166,11 @@ class BookingHoldRepository {
 	/**
 	 * Read booking activity and event state while exact venue authority is locked.
 	 *
-	 * @param int $booking_id Booking ID.
-	 * @param int $actor_id   Acting user ID.
+	 * @param int   $booking_id     Booking ID.
+	 * @param int   $actor_id       Acting user ID.
+	 * @param array $activity_kinds Activity kinds allowed in the result.
 	 */
-	public function get_booking_activity_authorized( int $booking_id, int $actor_id ) {
+	public function get_booking_activity_authorized( int $booking_id, int $actor_id, array $activity_kinds ) {
 		$booking = $this->bookings->get( $booking_id );
 		if ( ! is_array( $booking ) ) {
 			return is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
@@ -190,7 +191,7 @@ class BookingHoldRepository {
 			return $this->rollback( new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) ) );
 		}
 
-		$activity   = $this->activity->list_for_booking( $booking_id, 200 );
+		$activity   = $this->activity->list_for_booking_kinds( $booking_id, $activity_kinds, 200 );
 		$conversion = $this->activity->event_conversion_state( $booking_id, $current['public_id'] );
 		$sync       = $this->activity->event_sync_state( $booking_id );
 		foreach ( array( $activity, $conversion, $sync ) as $result ) {

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -156,8 +156,54 @@ class BookingHoldRepository {
 		if ( ! is_array( $result ) ) {
 			return $this->rollback( is_wp_error( $result ) ? $result : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
 		}
+		if ( (int) $result['venue_term_id'] !== (int) $booking['venue_term_id'] ) {
+			return $this->rollback( new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) ) );
+		}
 		$committed = $this->commit();
 		return is_wp_error( $committed ) ? $committed : $result;
+	}
+
+	/**
+	 * Read booking activity and event state while exact venue authority is locked.
+	 *
+	 * @param int $booking_id Booking ID.
+	 * @param int $actor_id   Acting user ID.
+	 */
+	public function get_booking_activity_authorized( int $booking_id, int $actor_id ) {
+		$booking = $this->bookings->get( $booking_id );
+		if ( ! is_array( $booking ) ) {
+			return is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
+		$allowed = $this->authorize_venue_now( $booking['venue_term_id'], $actor_id );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		$started = $this->begin_venue_authorized( $booking['venue_term_id'], $actor_id );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$current = $this->bookings->get( $booking_id );
+		if ( ! is_array( $current ) ) {
+			return $this->rollback( is_wp_error( $current ) ? $current : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+		}
+		if ( (int) $current['venue_term_id'] !== (int) $booking['venue_term_id'] ) {
+			return $this->rollback( new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) ) );
+		}
+
+		$activity   = $this->activity->list_for_booking( $booking_id, 200 );
+		$conversion = $this->activity->event_conversion_state( $booking_id, $current['public_id'] );
+		$sync       = $this->activity->event_sync_state( $booking_id );
+		foreach ( array( $activity, $conversion, $sync ) as $result ) {
+			if ( is_wp_error( $result ) ) {
+				return $this->rollback( $result );
+			}
+		}
+		$committed = $this->commit();
+		return is_wp_error( $committed ) ? $committed : array(
+			'activity'   => $activity,
+			'conversion' => $conversion,
+			'sync'       => $sync,
+		);
 	}
 
 	/** Reconcile, then list bookings while exact venue authority is locked. */

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -1159,6 +1159,7 @@ final class BookingFoundationTest extends BookingTestCase {
 				'extrachill/create-booking-inquiry',
 				'extrachill/list-venue-bookings',
 				'extrachill/get-venue-booking',
+				'extrachill/get-venue-booking-activity',
 				'extrachill/assign-venue-booking',
 				'extrachill/transition-venue-booking',
 				'extrachill/bind-venue-booking-artist',
@@ -1172,6 +1173,7 @@ final class BookingFoundationTest extends BookingTestCase {
 			$this->assertTrue( $registered[ $reconciling_ability ]['meta']['annotations']['idempotent'] );
 			$this->assertFalse( $registered[ $reconciling_ability ]['meta']['annotations']['destructive'] );
 		}
+		$this->assertTrue( $registered['extrachill/get-venue-booking-activity']['meta']['annotations']['readonly'] );
 		foreach ( $registered as $definition ) {
 			$this->assertFalse( $definition['input_schema']['additionalProperties'] );
 			$this->assertFalse( $definition['output_schema']['additionalProperties'] ?? false );
@@ -1203,7 +1205,18 @@ final class BookingFoundationTest extends BookingTestCase {
 		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $stored['id'] ]['contact_email'] = 'changed@example.com';
 		$this->assertSame( $receipt, call_user_func( $registered['extrachill/create-booking-inquiry']['execute_callback'], $receipt_input ) );
 
-		$booking = $this->create_booking();
+		$booking  = $this->create_booking();
+		( new BookingActivityRepository() )->append(
+			array(
+				'booking_id' => $booking['id'],
+				'kind'       => 'booking_submitted',
+			)
+		);
+		$activity = call_user_func( $registered['extrachill/get-venue-booking-activity']['execute_callback'], array( 'booking_id' => $booking['id'] ) );
+		$this->assertSame( 'booking_submitted', $activity['activity'][0]['kind'] );
+		$this->assertArrayNotHasKey( 'payload', $activity['activity'][0] );
+		$this->assertSame( 'none', $activity['conversion']['status'] );
+		$this->assertSame( 'none', $activity['sync']['status'] );
 		$presented = $abilities->present(
 			array_merge(
 				$booking,

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -1225,6 +1225,15 @@ final class BookingFoundationTest extends BookingTestCase {
 				'external_id' => 'excluded-private-reference',
 			)
 		);
+		for ( $excluded = 0; $excluded < 205; ++$excluded ) {
+			( new BookingActivityRepository() )->append(
+				array(
+					'booking_id' => $booking['id'],
+					'kind'       => 'settlement_finalized',
+					'external_id' => 'excluded-settlement-' . $excluded,
+				)
+			);
+		}
 		$activity = call_user_func( $registered['extrachill/get-venue-booking-activity']['execute_callback'], array( 'booking_id' => $booking['id'] ) );
 		$this->assertCount( 1, $activity['activity'] );
 		$this->assertSame( 'inquiry_submitted', $activity['activity'][0]['kind'] );

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -1209,14 +1209,55 @@ final class BookingFoundationTest extends BookingTestCase {
 		( new BookingActivityRepository() )->append(
 			array(
 				'booking_id' => $booking['id'],
-				'kind'       => 'booking_submitted',
+				'kind'       => 'inquiry_submitted',
+				'actor_type' => 'user',
+				'actor_id'   => 12,
+				'external_id' => 'private-provider-reference',
+			)
+		);
+		( new BookingActivityRepository() )->append(
+			array(
+				'booking_id' => $booking['id'],
+				'kind'       => 'marketing_operation_submitted',
+				'actor_type' => 'user',
+				'actor_id'   => 12,
+				'channel'    => 'provider',
+				'external_id' => 'excluded-private-reference',
 			)
 		);
 		$activity = call_user_func( $registered['extrachill/get-venue-booking-activity']['execute_callback'], array( 'booking_id' => $booking['id'] ) );
-		$this->assertSame( 'booking_submitted', $activity['activity'][0]['kind'] );
+		$this->assertCount( 1, $activity['activity'] );
+		$this->assertSame( 'inquiry_submitted', $activity['activity'][0]['kind'] );
+		$this->assertSame( array( 'id', 'kind', 'occurred_at' ), array_keys( $activity['activity'][0] ) );
 		$this->assertArrayNotHasKey( 'payload', $activity['activity'][0] );
 		$this->assertSame( 'none', $activity['conversion']['status'] );
 		$this->assertSame( 'none', $activity['sync']['status'] );
+
+		$start = ( new BookingActivityRepository() )->append(
+			array(
+				'booking_id' => $booking['id'],
+				'kind'       => 'event_sync_started',
+			)
+		);
+		( new BookingActivityRepository() )->append(
+			array(
+				'booking_id'  => $booking['id'],
+				'kind'        => 'event_sync_retryable',
+				'external_id' => (string) $start['id'],
+				'payload'     => array( 'code' => 'upstream_timeout' ),
+			)
+		);
+		( new BookingActivityRepository() )->append(
+			array(
+				'booking_id'  => $booking['id'],
+				'kind'        => 'event_sync_succeeded',
+				'external_id' => (string) $start['id'],
+				'payload'     => array( 'code' => 'updated' ),
+			)
+		);
+		$replayed = call_user_func( $registered['extrachill/get-venue-booking-activity']['execute_callback'], array( 'booking_id' => $booking['id'] ) );
+		$this->assertSame( 'succeeded', $replayed['sync']['status'] );
+		$this->assertFalse( $replayed['sync']['retryable'] );
 		$presented = $abilities->present(
 			array_merge(
 				$booking,
@@ -1230,9 +1271,10 @@ final class BookingFoundationTest extends BookingTestCase {
 		$this->assertArrayNotHasKey( 'inquiry_idempotency_key', $presented );
 		$this->assertArrayNotHasKey( 'inquiry_request_hash', $presented );
 		$this->assertArrayNotHasKey( 'admission_owner_token', $presented );
+		$authorization_calls = count( $authorization->calls );
 		$this->assertTrue( $abilities->can_access_booking( array( 'booking_id' => $booking['id'] ) ) );
-		$this->assertSame( array( array( 12, 55, VenueAuthorization::ACTION_ACCESS_VENUE ) ), $authorization->calls );
+		$this->assertCount( $authorization_calls + 1, $authorization->calls );
 		$this->assertSame( 'venue_action_forbidden', $abilities->can_access_booking( array( 'booking_id' => 999 ) )->get_error_code() );
-		$this->assertSame( array( array( 12, 55, VenueAuthorization::ACTION_ACCESS_VENUE ) ), $authorization->calls, 'Missing bookings must not reach authorization with a guessed venue.' );
+		$this->assertCount( $authorization_calls + 1, $authorization->calls, 'Missing bookings must not reach authorization with a guessed venue.' );
 	}
 }

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -557,6 +557,13 @@ final class BookingHoldTest extends BookingTestCase {
 		$list                                   = $abilities->list_bookings( array( 'venue_term_id' => 55 ) );
 		$this->assertSame( 'venue_action_forbidden', $list->get_error_code() );
 		$this->assertInstanceOf( WP_Error::class, $list );
+
+		$authorization->allowed['12:55']        = true;
+		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $authorization ) {
+			unset( $authorization->allowed['12:55'] );
+		};
+		$activity                               = $abilities->get_booking_activity( array( 'booking_id' => $booking['id'] ) );
+		$this->assertSame( 'venue_action_forbidden', $activity->get_error_code() );
 	}
 
 	public function test_booking_get_and_list_deny_before_reconciliation_mutation(): void {
@@ -579,6 +586,22 @@ final class BookingHoldTest extends BookingTestCase {
 		$this->assertSame( 'venue_action_forbidden', $list->get_error_code() );
 		$this->assertSame( 'held', ( new BookingRepository() )->get( $booking['id'] )['status'] );
 		$this->assertSame( 'active', $GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ][ $created['hold']['id'] ]['status'] );
+
+		$activity = $abilities->get_booking_activity( array( 'booking_id' => $booking['id'] ) );
+		$this->assertSame( 'venue_action_forbidden', $activity->get_error_code() );
+	}
+
+	public function test_booking_activity_denies_venue_change_across_locked_boundary(): void {
+		$authorization = new BookingTestAuthorization();
+		$holds         = new BookingHoldRepository( null, null, $authorization );
+		$abilities     = new VenueBookingAbilities( new BookingRepository(), null, $authorization, $holds );
+		$booking       = $this->booking();
+		$GLOBALS['wpdb']->after_membership_lock = static function () use ( $booking ) {
+			$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['venue_term_id'] = 66;
+		};
+
+		$result = $abilities->get_booking_activity( array( 'booking_id' => $booking['id'] ) );
+		$this->assertSame( 'venue_action_forbidden', $result->get_error_code() );
 	}
 
 	public function test_selected_hold_cannot_be_explicitly_released_while_held(): void {

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -1456,6 +1456,18 @@ final class BookingWpdb {
 				);
 			}
 		}
+		if ( $is_activity && false !== strpos( $query, 'ORDER BY occurred_at DESC, id DESC' ) && preg_match( '/kind IN \(([^)]+)\)/', $query, $kind_filter ) ) {
+			preg_match_all( "/'([^']+)'/", $kind_filter[1], $kind_matches );
+			$allowed_kinds = array_map( 'stripslashes', $kind_matches[1] );
+			$rows          = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $allowed_kinds ) {
+						return in_array( $row['kind'], $allowed_kinds, true );
+					}
+				)
+			);
+		}
 		if ( $is_sales && preg_match( "/currency = '([A-Z]{3})'/", $query, $currency ) ) {
 			$rows = array_values(
 				array_filter(


### PR DESCRIPTION
## Summary
- add canonical deal and production editors that call the existing booking abilities with exact expected versions
- expose a venue-authorized, read-only projection of the authoritative booking activity plus canonical event conversion and synchronization state
- render honest conversion/sync failures and route retry/reconcile actions through the existing conversion abilities
- preserve the existing assignment, lifecycle, holds, correspondence, venue authorization, conflict reload, and responsive console behavior

## Scope
- internal booking console only
- no marketing, settlement, finance operations, promoter tools, private files, Studio duplication, or external-operator surface
- no duplicated booking mutation or event synchronization rules in React

## Verification
- `vendor/bin/phpunit -c phpunit-booking.xml.dist` (401 tests, 4391 assertions)
- `npm run test:js -- --runInBand` (60 tests)
- `npm run lint:js`
- `npm run build` (passes; existing Sass deprecation warnings only)
- `php -l inc/Abilities/VenueBookingAbilities.php`
- `git diff --check`
- targeted WordPress PHPCS reports only the file's pre-existing filename and legacy docblock violations; no new changed-line violation

Closes #453