### PR TITLE
fix: enrich known venues during expansion

### DIFF
--- a/inc/Abilities/VenueAddAbilities.php
+++ b/inc/Abilities/VenueAddAbilities.php
@@ -60,43 +60,47 @@ class VenueAddAbilities {
 						'type'       => 'object',
 						'required'   => array( 'pipeline_id', 'name', 'url' ),
 						'properties' => array(
-							'pipeline_id' => array(
+							'pipeline_id'   => array(
 								'type'        => 'integer',
 								'description' => 'Pipeline ID for the city this venue belongs to.',
 							),
-							'name'        => array(
+							'name'          => array(
 								'type'        => 'string',
 								'description' => 'Venue name, e.g. "Exit/In" or "The Station Inn".',
 							),
-							'url'         => array(
+							'venue_term_id' => array(
+								'type'        => 'integer',
+								'description' => 'Existing canonical venue term ID. Optional; prevents name-based duplication for known venues.',
+							),
+							'url'           => array(
 								'type'        => 'string',
 								'description' => 'Venue events page URL (the page the scraper will hit).',
 							),
-							'address'     => array(
+							'address'       => array(
 								'type'        => 'string',
 								'description' => 'Venue street address. Optional — used for geocoding.',
 							),
-							'city'        => array(
+							'city'          => array(
 								'type'        => 'string',
 								'description' => 'Venue city name. Optional — derived from pipeline if not provided.',
 							),
-							'state'       => array(
+							'state'         => array(
 								'type'        => 'string',
 								'description' => 'Venue state. Optional.',
 							),
-							'zip'         => array(
+							'zip'           => array(
 								'type'        => 'string',
 								'description' => 'Venue zip code. Optional.',
 							),
-							'website'     => array(
+							'website'       => array(
 								'type'        => 'string',
 								'description' => 'Venue homepage URL (may differ from events page URL). Optional.',
 							),
-							'interval'    => array(
+							'interval'      => array(
 								'type'        => 'string',
 								'description' => 'Scheduling interval. Defaults to "daily".',
 							),
-							'dry_run'     => array(
+							'dry_run'       => array(
 								'type'        => 'boolean',
 								'description' => 'Preview what would be created without making changes.',
 							),
@@ -130,16 +134,17 @@ class VenueAddAbilities {
 	 * @return array Result.
 	 */
 	public function executeAddVenue( array $input ): array|\WP_Error {
-		$pipeline_id = (int) ( $input['pipeline_id'] ?? 0 );
-		$name        = sanitize_text_field( $input['name'] ?? '' );
-		$url         = esc_url_raw( $input['url'] ?? '' );
-		$address     = sanitize_text_field( $input['address'] ?? '' );
-		$city        = sanitize_text_field( $input['city'] ?? '' );
-		$state       = sanitize_text_field( $input['state'] ?? '' );
-		$zip         = sanitize_text_field( $input['zip'] ?? '' );
-		$website     = esc_url_raw( $input['website'] ?? '' );
-		$interval    = sanitize_text_field( $input['interval'] ?? self::DEFAULT_INTERVAL );
-		$dry_run     = ! empty( $input['dry_run'] );
+		$pipeline_id   = (int) ( $input['pipeline_id'] ?? 0 );
+		$name          = sanitize_text_field( $input['name'] ?? '' );
+		$url           = esc_url_raw( $input['url'] ?? '' );
+		$address       = sanitize_text_field( $input['address'] ?? '' );
+		$city          = sanitize_text_field( $input['city'] ?? '' );
+		$state         = sanitize_text_field( $input['state'] ?? '' );
+		$zip           = sanitize_text_field( $input['zip'] ?? '' );
+		$website       = esc_url_raw( $input['website'] ?? '' );
+		$venue_term_id = (int) ( $input['venue_term_id'] ?? 0 );
+		$interval      = sanitize_text_field( $input['interval'] ?? self::DEFAULT_INTERVAL );
+		$dry_run       = ! empty( $input['dry_run'] );
 
 		if ( $pipeline_id <= 0 ) {
 			return new \WP_Error( 'missing_pipeline', 'pipeline_id is required.', array( 'status' => 400 ) );
@@ -149,6 +154,12 @@ class VenueAddAbilities {
 		}
 		if ( empty( $url ) ) {
 			return new \WP_Error( 'missing_url', 'Events page URL is required.', array( 'status' => 400 ) );
+		}
+		if ( $venue_term_id > 0 ) {
+			$known_term = get_term( $venue_term_id, 'venue' );
+			if ( ! $known_term || is_wp_error( $known_term ) ) {
+				return new \WP_Error( 'venue_not_found', 'The supplied canonical venue term was not found.', array( 'status' => 404 ) );
+			}
 		}
 
 		// Validate pipeline exists.
@@ -193,7 +204,7 @@ class VenueAddAbilities {
 		}
 
 		// Step 1: Create or find venue taxonomy term.
-		$venue_term_id = $this->ensureVenueTerm( $name );
+		$venue_term_id = $venue_term_id > 0 ? $venue_term_id : $this->ensureVenueTerm( $name );
 		if ( ! $venue_term_id ) {
 			return new \WP_Error( 'venue_term_failed', sprintf( 'Failed to create venue term for "%s".', $name ), array( 'status' => 500 ) );
 		}

--- a/inc/Abilities/VenueDiscoveryAbilities.php
+++ b/inc/Abilities/VenueDiscoveryAbilities.php
@@ -139,13 +139,14 @@ class VenueDiscoveryAbilities {
 		$known_count = 0;
 
 		foreach ( $places as $place ) {
-			$name    = $place['displayName']['text'] ?? '';
-			$address = $place['formattedAddress'] ?? '';
-			$website = $place['websiteUri'] ?? '';
-			$lat     = $place['location']['latitude'] ?? null;
-			$lng     = $place['location']['longitude'] ?? null;
-			$types   = $place['types'] ?? array();
-			$maps    = $place['googleMapsUri'] ?? '';
+			$name               = $place['displayName']['text'] ?? '';
+			$address_components = $this->extractAddressComponents( $place );
+			$address            = ! empty( $address_components['address'] ) ? $address_components['address'] : ( $place['formattedAddress'] ?? '' );
+			$website            = $place['websiteUri'] ?? '';
+			$lat                = $place['location']['latitude'] ?? null;
+			$lng                = $place['location']['longitude'] ?? null;
+			$types              = $place['types'] ?? array();
+			$maps               = $place['googleMapsUri'] ?? '';
 
 			if ( empty( $name ) ) {
 				continue;
@@ -155,7 +156,8 @@ class VenueDiscoveryAbilities {
 			$website = $this->cleanWebsiteUrl( $website );
 
 			// Check if venue already exists in taxonomy.
-			$is_known = $this->isKnownVenue( $name, $existing_venues );
+			$known_term_id = $this->findKnownVenueId( $name, $existing_venues );
+			$is_known      = $known_term_id > 0;
 
 			if ( $is_known ) {
 				++$known_count;
@@ -167,14 +169,19 @@ class VenueDiscoveryAbilities {
 			}
 
 			$venues[] = array(
-				'name'      => $name,
-				'address'   => $address,
-				'website'   => $website,
-				'latitude'  => $lat,
-				'longitude' => $lng,
-				'types'     => $types,
-				'maps_url'  => $maps,
-				'is_known'  => $is_known,
+				'name'          => $name,
+				'address'       => $address,
+				'city'          => $address_components['city'] ?? '',
+				'state'         => $address_components['state'] ?? '',
+				'zip'           => $address_components['zip'] ?? '',
+				'country'       => $address_components['country'] ?? '',
+				'website'       => $website,
+				'latitude'      => $lat,
+				'longitude'     => $lng,
+				'types'         => $types,
+				'maps_url'      => $maps,
+				'is_known'      => $is_known,
+				'known_term_id' => $known_term_id,
 			);
 		}
 
@@ -283,6 +290,7 @@ class VenueDiscoveryAbilities {
 						array(
 							'places.displayName',
 							'places.formattedAddress',
+							'places.addressComponents',
 							'places.websiteUri',
 							'places.types',
 							'places.location',
@@ -348,20 +356,20 @@ class VenueDiscoveryAbilities {
 	 *
 	 * @param string $name            Venue name from Places API.
 	 * @param array  $existing_venues Map of lowercase name => term_id.
-	 * @return bool True if venue is already known.
+	 * @return int Matched venue term ID, or zero when unknown.
 	 */
-	private function isKnownVenue( string $name, array $existing_venues ): bool {
+	private function findKnownVenueId( string $name, array $existing_venues ): int {
 		$normalized = strtolower( trim( $name ) );
 
 		// Exact match.
 		if ( isset( $existing_venues[ $normalized ] ) ) {
-			return true;
+			return (int) $existing_venues[ $normalized ];
 		}
 
 		// Without "The" prefix.
 		$without_the = preg_replace( '/^the\s+/i', '', $normalized );
 		if ( $without_the !== $normalized && isset( $existing_venues[ $without_the ] ) ) {
-			return true;
+			return (int) $existing_venues[ $without_the ];
 		}
 
 		// Check if any existing venue starts with the same name (handle "Exit/In" vs "EXIT/IN Nashville").
@@ -373,12 +381,38 @@ class VenueDiscoveryAbilities {
 				// Only match if the shorter string is at least 4 chars (avoid false positives).
 				$shorter = min( strlen( $without_the ), strlen( $existing_without_the ) );
 				if ( $shorter >= 4 ) {
-					return true;
+					return (int) $term_id;
 				}
 			}
 		}
 
-		return false;
+		return 0;
+	}
+
+	/** Extract canonical venue location fields from Places address components. */
+	private function extractAddressComponents( array $place ): array {
+		$parts = array();
+		foreach ( (array) ( $place['addressComponents'] ?? array() ) as $component ) {
+			foreach ( (array) ( $component['types'] ?? array() ) as $type ) {
+				$parts[ $type ] = $component;
+			}
+		}
+
+		$long   = static fn( string $type ): string => sanitize_text_field( (string) ( $parts[ $type ]['longText'] ?? '' ) );
+		$short  = static fn( string $type ): string => sanitize_text_field( (string) ( $parts[ $type ]['shortText'] ?? $parts[ $type ]['longText'] ?? '' ) );
+		$street = trim( $long( 'street_number' ) . ' ' . $long( 'route' ) );
+		$city   = $long( 'locality' );
+		if ( '' === $city ) {
+			$city = $long( 'postal_town' );
+		}
+
+		return array(
+			'address' => $street,
+			'city'    => $city,
+			'state'   => $short( 'administrative_area_level_1' ),
+			'zip'     => $long( 'postal_code' ),
+			'country' => $short( 'country' ),
+		);
 	}
 
 	/**

--- a/inc/Abilities/VenueExpansionAbilities.php
+++ b/inc/Abilities/VenueExpansionAbilities.php
@@ -255,6 +255,7 @@ class VenueExpansionAbilities {
 		$aggregate = array(
 			'discovered' => 0,
 			'qualified'  => 0,
+			'enriched'   => 0,
 			'added'      => 0,
 			'rejected'   => 0,
 			'skipped'    => 0,

--- a/inc/Core/VenueExpansionRunner.php
+++ b/inc/Core/VenueExpansionRunner.php
@@ -23,6 +23,9 @@ class VenueExpansionRunner {
 	/** @var callable */
 	private $flow_for_url;
 
+	/** @var callable */
+	private $known_venue_enricher;
+
 	/** @var array<string,array>|null */
 	private $flows_by_url = null;
 
@@ -32,14 +35,24 @@ class VenueExpansionRunner {
 	/**
 	 * Inject narrow lookups so the orchestration remains independently testable.
 	 */
-	public function __construct( ?callable $ability_resolver = null, ?callable $latest_verdict = null, ?callable $flow_for_url = null ) {
-		$this->ability_resolver = $ability_resolver ?? static function ( string $name ) {
+	public function __construct( ?callable $ability_resolver = null, ?callable $latest_verdict = null, ?callable $flow_for_url = null, ?callable $known_venue_enricher = null ) {
+		$this->ability_resolver     = $ability_resolver ?? static function ( string $name ) {
 			return function_exists( 'wp_get_ability' ) ? wp_get_ability( $name ) : null;
 		};
-		$this->latest_verdict   = $latest_verdict ?? static function ( string $url ): ?array {
+		$this->latest_verdict       = $latest_verdict ?? static function ( string $url ): ?array {
 			return QualifyVerdictsTable::latest_for_url( $url );
 		};
-		$this->flow_for_url     = $flow_for_url ?? array( $this, 'findFlowForUrl' );
+		$this->flow_for_url         = $flow_for_url ?? array( $this, 'findFlowForUrl' );
+		$this->known_venue_enricher = $known_venue_enricher ?? static function ( int $term_id, array $metadata ) {
+			if ( ! class_exists( '\DataMachineEvents\Core\VenueProfileMutations' ) ) {
+				return new \WP_Error( 'missing_venue_mutation_contract', 'Canonical venue metadata mutation is unavailable.' );
+			}
+			return \DataMachineEvents\Core\VenueProfileMutations::updateSystem(
+				$term_id,
+				$metadata,
+				\DataMachineEvents\Core\VenueProfileMutations::STRATEGY_FILL_EMPTY
+			);
+		};
 	}
 
 	/**
@@ -49,7 +62,6 @@ class VenueExpansionRunner {
 		$city                 = sanitize_text_field( (string) ( $params['city'] ?? '' ) );
 		$max_venues           = max( 1, min( 20, (int) ( $params['max_venues'] ?? 10 ) ) );
 		$qualification_budget = max( 0, min( $max_venues, (int) ( $params['qualification_budget'] ?? $max_venues ) ) );
-		$skip_existing        = ! array_key_exists( 'skip_existing', $params ) || (bool) $params['skip_existing'];
 		$country              = strtoupper( sanitize_text_field( (string) ( $params['country'] ?? '' ) ) );
 		$request_delay_ms     = max( 0, min( 10000, (int) ( $params['request_delay_ms'] ?? 0 ) ) );
 
@@ -111,46 +123,65 @@ class VenueExpansionRunner {
 		$report['rate']['discovery_used'] = 1;
 
 		foreach ( $venues as $venue ) {
-			$name    = sanitize_text_field( (string) ( $venue['name'] ?? '' ) );
-			$website = esc_url_raw( (string) ( $venue['website'] ?? '' ) );
-			$row     = array(
-				'name'       => $name,
-				'url'        => $website,
-				'status'     => '',
-				'verdict'    => '',
-				'flow_id'    => 0,
-				'events_url' => '',
+			$name                    = sanitize_text_field( (string) ( $venue['name'] ?? '' ) );
+			$website                 = esc_url_raw( (string) ( $venue['website'] ?? '' ) );
+			$is_known                = ! empty( $venue['is_known'] );
+			$term_id                 = (int) ( $venue['known_term_id'] ?? 0 );
+			$row                     = array(
+				'name'            => $name,
+				'url'             => $website,
+				'status'          => '',
+				'verdict'         => '',
+				'flow_id'         => 0,
+				'events_url'      => '',
+				'known_term_id'   => $term_id,
+				'enriched_fields' => array(),
 			);
+			$qualification_performed = false;
+
+			if ( $is_known ) {
+				if ( $term_id <= 0 ) {
+					return $this->fail( $report, 'known_venue_missing_term', 'Discovery did not identify the matched venue term.' );
+				}
+				$metadata = $this->knownVenueMetadata( $venue );
+				if ( ! empty( $metadata ) ) {
+					$enrichment = ( $this->known_venue_enricher )( $term_id, $metadata );
+					if ( is_wp_error( $enrichment ) ) {
+						return $this->fail( $report, $enrichment->get_error_code(), $enrichment->get_error_message() );
+					}
+					$row['enriched_fields'] = array_values( (array) ( $enrichment['updated_fields'] ?? array() ) );
+					if ( ! empty( $row['enriched_fields'] ) ) {
+						++$report['counts']['enriched'];
+					}
+				}
+			}
 
 			if ( '' === $website ) {
-				$this->reject( $report, $row, 'no_website' );
+				$this->reject( $report, $row, 'no_website', $is_known && ! empty( $row['enriched_fields'] ) ? 'known_enriched' : 'rejected' );
 				continue;
 			}
 			$existing_flow = $this->findExistingFlow( $website );
 			if ( is_array( $existing_flow ) ) {
-				$row['status']      = 'skipped_existing_flow';
-				$row['flow_id']     = (int) ( $existing_flow['flow_id'] ?? 0 );
-				$report['venues'][] = $row;
-				++$report['counts']['skipped'];
-				continue;
-			}
-			if ( $skip_existing && ! empty( $venue['is_known'] ) ) {
-				$row['status']      = 'skipped_existing_venue';
-				$report['venues'][] = $row;
+				$row['status']         = $is_known ? 'known_skipped_current' : 'skipped_existing_flow';
+				$row['current_reason'] = 'existing_flow';
+				$row['flow_id']        = (int) ( $existing_flow['flow_id'] ?? 0 );
+				$report['venues'][]    = $row;
 				++$report['counts']['skipped'];
 				continue;
 			}
 
 			$prior = ( $this->latest_verdict )( $website );
 			if ( is_array( $prior ) && $this->isReusableVerdict( $prior, (int) ( $params['max_verdict_age_days'] ?? 30 ) ) ) {
-				$qualification = $prior;
-				$row['status'] = 'resumed_verdict';
+				$qualification         = $prior;
+				$row['status']         = $is_known ? 'known_skipped_current' : 'resumed_verdict';
+				$row['current_reason'] = 'fresh_verdict';
 			} else {
 				if ( $report['rate']['qualification_used'] >= $qualification_budget ) {
-					$this->reject( $report, $row, 'rate_budget_exhausted' );
+					$this->reject( $report, $row, 'rate_budget_exhausted', $is_known && ! empty( $row['enriched_fields'] ) ? 'known_enriched' : 'rejected' );
 					continue;
 				}
 				++$report['rate']['qualification_used'];
+				$qualification_performed = true;
 				if ( $report['rate']['qualification_used'] > 1 && $request_delay_ms > 0 ) {
 					usleep( $request_delay_ms * 1000 );
 				}
@@ -170,31 +201,37 @@ class VenueExpansionRunner {
 			$row['verdict']    = $verdict;
 			$row['events_url'] = esc_url_raw( (string) ( $qualification['events_url'] ?? $website ) );
 			if ( QualifyVerdict::QUALIFIED_STRUCTURED !== $verdict ) {
-				$this->reject( $report, $row, '' !== $verdict ? $verdict : 'missing_verdict' );
+				$status = $is_known ? ( $qualification_performed ? 'known_qualified' : 'known_skipped_current' ) : 'rejected';
+				$this->reject( $report, $row, '' !== $verdict ? $verdict : 'missing_verdict', $status );
 				continue;
 			}
 			$events_flow = $this->findExistingFlow( $row['events_url'] );
 			if ( is_array( $events_flow ) ) {
-				$row['status']      = 'skipped_existing_flow';
-				$row['flow_id']     = (int) ( $events_flow['flow_id'] ?? 0 );
-				$report['venues'][] = $row;
+				$row['status']         = $is_known ? ( $qualification_performed ? 'known_qualified' : 'known_skipped_current' ) : 'skipped_existing_flow';
+				$row['current_reason'] = 'existing_flow';
+				$row['flow_id']        = (int) ( $events_flow['flow_id'] ?? 0 );
+				$report['venues'][]    = $row;
 				++$report['counts']['qualified'];
 				++$report['counts']['skipped'];
 				continue;
 			}
 
 			++$report['counts']['qualified'];
-			$add_result = $add->execute(
-				array(
-					'pipeline_id' => $report['pipeline']['id'],
-					'name'        => $name,
-					'url'         => $row['events_url'],
-					'website'     => $website,
-					'address'     => sanitize_text_field( (string) ( $venue['address'] ?? '' ) ),
-					'city'        => $city,
-					'interval'    => (string) ( $params['interval'] ?? 'daily' ),
-				)
+			$add_input = array(
+				'pipeline_id' => $report['pipeline']['id'],
+				'name'        => $name,
+				'url'         => $row['events_url'],
+				'website'     => $website,
+				'address'     => sanitize_text_field( (string) ( $venue['address'] ?? '' ) ),
+				'city'        => sanitize_text_field( (string) ( ! empty( $venue['city'] ) ? $venue['city'] : $city ) ),
+				'state'       => sanitize_text_field( (string) ( $venue['state'] ?? '' ) ),
+				'zip'         => sanitize_text_field( (string) ( $venue['zip'] ?? '' ) ),
+				'interval'    => (string) ( $params['interval'] ?? 'daily' ),
 			);
+			if ( $is_known ) {
+				$add_input['venue_term_id'] = $term_id;
+			}
+			$add_result = $add->execute( $add_input );
 			if ( is_wp_error( $add_result ) ) {
 				if ( 'venue_exists' !== $add_result->get_error_code() ) {
 					return $this->fail( $report, $add_result->get_error_code(), $add_result->get_error_message() );
@@ -209,6 +246,9 @@ class VenueExpansionRunner {
 				$this->rememberFlow( $website, $row );
 				$this->rememberFlow( $row['events_url'], $row );
 				++$report['counts']['added'];
+			}
+			if ( $is_known ) {
+				$row['status'] = $qualification_performed ? 'known_qualified' : 'known_skipped_current';
 			}
 			$report['venues'][] = $row;
 		}
@@ -230,6 +270,7 @@ class VenueExpansionRunner {
 			'counts'            => array(
 				'discovered' => 0,
 				'qualified'  => 0,
+				'enriched'   => 0,
 				'added'      => 0,
 				'rejected'   => 0,
 				'skipped'    => 0,
@@ -250,14 +291,30 @@ class VenueExpansionRunner {
 	}
 
 	/** Add a truthful rejection to the report. */
-	private function reject( array &$report, array $row, string $reason ): void {
-		$row['status'] = 'rejected';
+	private function reject( array &$report, array $row, string $reason, string $status = 'rejected' ): void {
+		$row['status'] = $status;
 		if ( '' === $row['verdict'] ) {
 			$row['verdict'] = $reason;
 		}
 		$report['venues'][] = $row;
 		++$report['counts']['rejected'];
 		$report['rejection_reasons'][ $reason ] = 1 + (int) ( $report['rejection_reasons'][ $reason ] ?? 0 );
+	}
+
+	/** Build bounded canonical metadata supplied by Places for fill-empty enrichment. */
+	private function knownVenueMetadata( array $venue ): array {
+		$metadata = array(
+			'website' => esc_url_raw( (string) ( $venue['website'] ?? '' ) ),
+			'address' => sanitize_text_field( (string) ( $venue['address'] ?? '' ) ),
+			'city'    => sanitize_text_field( (string) ( $venue['city'] ?? '' ) ),
+			'state'   => sanitize_text_field( (string) ( $venue['state'] ?? '' ) ),
+			'zip'     => sanitize_text_field( (string) ( $venue['zip'] ?? '' ) ),
+			'country' => sanitize_text_field( (string) ( $venue['country'] ?? '' ) ),
+		);
+		if ( is_numeric( $venue['latitude'] ?? null ) && is_numeric( $venue['longitude'] ?? null ) ) {
+			$metadata['coordinates'] = (string) (float) $venue['latitude'] . ',' . (string) (float) $venue['longitude'];
+		}
+		return array_filter( $metadata, static fn( string $value ): bool => '' !== $value );
 	}
 
 	/** Mark a task-level failure so Data Machine can retry the city safely. */

--- a/tests/Unit/Core/VenueExpansionRunnerTest.php
+++ b/tests/Unit/Core/VenueExpansionRunnerTest.php
@@ -3,22 +3,32 @@
 
 namespace ExtraChillEvents\Tests\Unit\Core;
 
+use ExtraChillEvents\Abilities\VenueDiscoveryAbilities;
 use ExtraChillEvents\Core\QualifyVerdict;
 use ExtraChillEvents\Core\VenueExpansionRunner;
 use PHPUnit\Framework\TestCase;
 
 require_once dirname( __DIR__, 3 ) . '/inc/Core/VenueExpansionRunner.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Abilities/VenueDiscoveryAbilities.php';
 
 class VenueExpansionRunnerTest extends TestCase {
+	public function test_discovery_returns_the_matched_known_term_id(): void {
+		$method = new \ReflectionMethod( VenueDiscoveryAbilities::class, 'findKnownVenueId' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 55, $method->invoke( new VenueDiscoveryAbilities(), 'The Lizard Lounge Boston', array( 'lizard lounge' => 55 ) ) );
+	}
+
 	public function test_existing_city_venue_flow_and_verdict_are_idempotent(): void {
 		$calls     = array();
 		$abilities = $this->abilities(
 			$calls,
 			array(
 				array(
-					'name'     => 'Known',
-					'website'  => 'https://known.test',
-					'is_known' => true,
+					'name'          => 'Known',
+					'website'       => 'https://known.test',
+					'is_known'      => true,
+					'known_term_id' => 55,
 				),
 				array(
 					'name'    => 'Flow',
@@ -60,10 +70,17 @@ class VenueExpansionRunnerTest extends TestCase {
 				return null;
 			},
 			static function ( string $url ) {
+				if ( 'https://known.test' === $url ) {
+					return array( 'flow_id' => 76 );
+				}
 				if ( 'https://flow.test' === $url ) {
 					return array( 'flow_id' => 77 );
 				}
-				return 'https://resume.test/events' === $url ? array( 'flow_id' => 78 ) : null; }
+				return 'https://resume.test/events' === $url ? array( 'flow_id' => 78 ) : null;
+			},
+			static function () {
+				return array( 'updated_fields' => array() );
+			}
 		);
 		$report    = $runner->runCity(
 			array(
@@ -83,6 +100,150 @@ class VenueExpansionRunnerTest extends TestCase {
 		$this->assertSame( 2, $report['counts']['rejected'] );
 		$this->assertSame( 1, $report['rejection_reasons'][ QualifyVerdict::UNSUPPORTED_SOURCE ] );
 		$this->assertSame( 1, $report['rejection_reasons']['no_website'] );
+	}
+
+	public function test_known_venue_missing_website_is_enriched_and_qualified_without_duplicate_term(): void {
+		$calls     = array();
+		$metadata  = array();
+		$term_id   = 0;
+		$add_input = array();
+		$abilities = $this->abilities(
+			$calls,
+			array(
+				array(
+					'name'          => 'Known Room',
+					'website'       => 'https://known-room.test',
+					'address'       => '123 Main St',
+					'city'          => 'Boston',
+					'state'         => 'MA',
+					'zip'           => '02118',
+					'country'       => 'US',
+					'latitude'      => 42.34,
+					'longitude'     => -71.07,
+					'is_known'      => true,
+					'known_term_id' => 55,
+				),
+			)
+		);
+		$abilities['extrachill/add-venue'] = new VenueExpansionFakeAbility(
+			static function ( array $input ) use ( &$calls, &$add_input ) {
+				++$calls['add'];
+				$add_input = $input;
+				return array(
+					'flow_id'       => 42,
+					'venue_term_id' => 55,
+				);
+			}
+		);
+		$report    = ( new VenueExpansionRunner(
+			static function ( string $name ) use ( $abilities ) {
+				return $abilities[ $name ];
+			},
+			static function () {
+				return null;
+			},
+			static function () {
+				return null;
+			},
+			static function ( int $known_term_id, array $candidate ) use ( &$term_id, &$metadata ) {
+				$term_id  = $known_term_id;
+				$metadata = $candidate;
+				return array( 'updated_fields' => array_keys( $candidate ) );
+			}
+		) )->runCity( array( 'city' => 'Boston, MA', 'qualification_budget' => 1 ) );
+
+		$this->assertSame( 55, $term_id );
+		$this->assertSame( 'https://known-room.test', $metadata['website'] );
+		$this->assertSame( '42.34,-71.07', $metadata['coordinates'] );
+		$this->assertSame( 1, $calls['qualify'] );
+		$this->assertSame( 1, $calls['add'] );
+		$this->assertSame( 55, $add_input['venue_term_id'] );
+		$this->assertSame( 1, $report['counts']['enriched'] );
+		$this->assertSame( 'known_qualified', $report['venues'][0]['status'] );
+		$this->assertSame( 55, $report['venues'][0]['known_term_id'] );
+	}
+
+	public function test_known_venue_qualification_spends_the_existing_budget(): void {
+		$calls     = array();
+		$abilities = $this->abilities(
+			$calls,
+			array(
+				array( 'name' => 'One', 'website' => 'https://one.test', 'is_known' => true, 'known_term_id' => 1 ),
+				array( 'name' => 'Two', 'website' => 'https://two.test', 'is_known' => true, 'known_term_id' => 2 ),
+			)
+		);
+		$report    = ( new VenueExpansionRunner(
+			static function ( string $name ) use ( $abilities ) {
+				return $abilities[ $name ];
+			},
+			static function () {
+				return null;
+			},
+			static function () {
+				return null;
+			},
+			static function () {
+				return array( 'updated_fields' => array( 'website' ) );
+			}
+		) )->runCity( array( 'city' => 'A', 'max_venues' => 2, 'qualification_budget' => 1 ) );
+
+		$this->assertSame( 1, $calls['qualify'] );
+		$this->assertSame( 1, $report['rate']['qualification_used'] );
+		$this->assertSame( 1, $report['rejection_reasons']['rate_budget_exhausted'] );
+		$this->assertSame( 'known_enriched', $report['venues'][1]['status'] );
+	}
+
+	public function test_known_venue_with_fresh_verdict_skips_requalification(): void {
+		$calls     = array();
+		$abilities = $this->abilities( $calls, array( array( 'name' => 'Current', 'website' => 'https://current.test', 'is_known' => true, 'known_term_id' => 8 ) ) );
+		$report    = ( new VenueExpansionRunner(
+			static function ( string $name ) use ( $abilities ) {
+				return $abilities[ $name ];
+			},
+			static function () {
+				return array(
+					'verdict'           => QualifyVerdict::EXTRACTION_GAP,
+					'qualified_at'      => gmdate( 'Y-m-d H:i:s' ),
+					'qualifier_version' => self::qualifierVersion(),
+				);
+			},
+			static function () {
+				return null;
+			},
+			static function () {
+				return array( 'updated_fields' => array() );
+			}
+		) )->runCity( array( 'city' => 'A', 'qualification_budget' => 1 ) );
+
+		$this->assertSame( 0, $calls['qualify'] );
+		$this->assertSame( 0, $report['rate']['qualification_used'] );
+		$this->assertSame( 'known_skipped_current', $report['venues'][0]['status'] );
+		$this->assertSame( 'fresh_verdict', $report['venues'][0]['current_reason'] );
+	}
+
+	public function test_known_venue_with_existing_flow_is_skipped_after_fill_empty_enrichment(): void {
+		$calls     = array();
+		$abilities = $this->abilities( $calls, array( array( 'name' => 'Covered', 'website' => 'https://covered.test', 'is_known' => true, 'known_term_id' => 9 ) ) );
+		$report    = ( new VenueExpansionRunner(
+			static function ( string $name ) use ( $abilities ) {
+				return $abilities[ $name ];
+			},
+			static function () {
+				return null;
+			},
+			static function () {
+				return array( 'flow_id' => 99 );
+			},
+			static function () {
+				return array( 'updated_fields' => array() );
+			}
+		) )->runCity( array( 'city' => 'A', 'qualification_budget' => 1 ) );
+
+		$this->assertSame( 0, $calls['qualify'] );
+		$this->assertSame( 0, $calls['add'] );
+		$this->assertSame( 'known_skipped_current', $report['venues'][0]['status'] );
+		$this->assertSame( 'existing_flow', $report['venues'][0]['current_reason'] );
+		$this->assertSame( 99, $report['venues'][0]['flow_id'] );
 	}
 
 	public function test_partial_failure_can_resume_from_persisted_verdict(): void {


### PR DESCRIPTION
## Summary
- return matched venue term IDs and canonical Places address components from discovery, then fill only missing website/location metadata through Data Machine Events' lock-protected `VenueProfileMutations::STRATEGY_FILL_EMPTY` contract
- qualify known venues within the existing per-city budget while reporting `known_enriched`, `known_qualified`, and `known_skipped_current` outcomes
- pass the matched canonical term ID into flow creation so fuzzy Places names cannot create duplicate venue terms

## Production evidence
Across Las Vegas, Atlantic City, Greensboro, Colorado Springs, New Haven, Syracuse, Boulder, Fort Lauderdale, Atlanta, and Boston, 352 event-linked venue terms exist. Only 2 have `_venue_website`; 350 lack websites. Lizard Lounge in Boston has a URL but no verdict, while Fremont Street Experience in Las Vegas has an `extraction_gap` verdict.

The runner already requested discovery with `include_known=true`, but it marked those matches `skipped_existing_venue` before metadata enrichment or qualification.

## Implementation rationale
No existing ability provides safe fill-empty known-venue enrichment: `data-machine-events/update-venue` owns canonical updates but uses overwrite semantics. This change reuses the dependency's canonical mutation owner directly with `STRATEGY_FILL_EMPTY`, which rechecks emptiness under the per-venue lock rather than introducing a parallel metadata writer.

Discovery now returns the exact matched term ID and structured Places location fields. Known candidates enrich that term in place before current-flow/verdict checks. `extrachill/add-venue` accepts the already resolved term ID for qualified known candidates, preventing name normalization differences from creating a second term.

## Idempotency and bounds
- fill-empty mutation preserves populated canonical metadata and reports only fields actually changed
- fresh version-compatible verdicts do not spend qualification budget
- existing homepage/events scraper flows remain skips
- qualified known candidates bind flow creation to the existing term ID
- discovery remains one request, candidates remain capped by `max_venues`, qualification remains capped by `qualification_budget`, and existing request delays remain qualification-operation based

## Tests
- `./vendor/bin/phpunit tests/Unit/Core/VenueExpansionRunnerTest.php tests/Unit/Core/VenueExpansionPlanTest.php` (`OK (16 tests, 60 assertions)`)
- `homeboy review lint --changed-only --summary --placement local` (passed PHPCS and PHPStan; run `4deb7895-6b63-4493-9767-9e1c5f163fdd`)
- PHP syntax checks passed for all modified PHP files
- `git diff --check` passed

The broader direct PHPUnit suite remains blocked by its existing plain-bootstrap `WP_UnitTestCase` loading failure. Homeboy audit/test execution was attempted but the host resource policy refused the test run at load 8.2/8 CPUs, and the forced local audit timed out; neither reached project tests or produced code findings.

Closes #450