### PR TITLE
test: complete ticket settlement concurrency proof

### DIFF
--- a/.github/workflows/booking-attachment-mysql.yml
+++ b/.github/workflows/booking-attachment-mysql.yml
@@ -168,8 +168,8 @@ jobs:
           WP_TESTS_PHPUNIT_POLYFILLS_PATH: ${{ github.workspace }}/vendor/yoast/phpunit-polyfills
         run: |
           set -euo pipefail
-          vendor/bin/phpunit -c phpunit-booking-concurrency.xml.dist --filter 'test_concurrent_booking_schema_installer_waits_and_converges|test_resolution_and_finalization_race_freezes_one_consistent_winner|test_concurrent_exact_inquiry_retry_reuses_one_complete_winner' | tee "$RUNNER_TEMP/booking-admission-concurrency.txt"
-          grep -E 'OK \(3 tests, [1-9][0-9]* assertions?\)' "$RUNNER_TEMP/booking-admission-concurrency.txt"
+          vendor/bin/phpunit -c phpunit-booking-concurrency.xml.dist --filter 'test_concurrent_booking_schema_installer_waits_and_converges|test_resolution_and_finalization_race_freezes_one_consistent_winner|test_concurrent_source_and_report_registrations_converge_or_conflict_exactly|test_concurrent_exact_inquiry_retry_reuses_one_complete_winner' | tee "$RUNNER_TEMP/booking-admission-concurrency.txt"
+          grep -E 'OK \(4 tests, [1-9][0-9]* assertions?\)' "$RUNNER_TEMP/booking-admission-concurrency.txt"
           if grep -Eiq 'skip|no tests executed|OK, but' "$RUNNER_TEMP/booking-admission-concurrency.txt"; then
             exit 1
           fi

--- a/tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
@@ -291,7 +291,33 @@ final class BookingAdmissionConcurrencyMySQLProof extends BookingAttachmentMySQL
 		$this->assertTrue( $both_blocked, 'A service contender bypassed the held booking lock.' );
 		$this->assertTrue( $released, 'The fixture booking lock could not be released.' );
 		$this->assertSame( array( true, true ), $statuses, 'A service contender did not exit cleanly.' );
+		$this->contender = $this->connect_race_owner_session();
 		return $results;
+	}
+
+	/** Replace the fixture session closed by forked mysqli shutdown. */
+	private function connect_race_owner_session(): mysqli {
+		$host = (string) ( getenv( 'DB_HOST' ) ?: DB_HOST );
+		$port = (int) getenv( 'DB_PORT' );
+		if ( 0 === $port && 1 === preg_match( '/^(.+):(\d+)$/', $host, $match ) ) {
+			$host = $match[1];
+			$port = (int) $match[2];
+		}
+		$connection = mysqli_init();
+		$this->assertTrue(
+			mysqli_real_connect(
+				$connection,
+				$host,
+				(string) ( getenv( 'DB_USER' ) ?: DB_USER ),
+				(string) ( getenv( 'DB_PASSWORD' ) ?: DB_PASSWORD ),
+				(string) ( getenv( 'DB_NAME' ) ?: DB_NAME ),
+				$port > 0 ? $port : 3306
+			),
+			(string) mysqli_connect_error()
+		);
+		$connection->set_charset( 'utf8mb4' );
+		$connection->query( 'SET SESSION innodb_lock_wait_timeout = 1' );
+		return $connection;
 	}
 
 	/** Fork one independent WordPress service process and persist its bounded result. */

--- a/tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
@@ -34,6 +34,7 @@ final class BookingAdmissionConcurrencyMySQLProof extends BookingAttachmentMySQL
 		);
 		$booking  = $bookings->claim_event( $booking['id'], $event_id, $booking['version'] );
 		$this->assertIsArray( $booking, is_wp_error( $booking ) ? $booking->get_error_code() : '' );
+		$this->assertNotFalse( $wpdb->query( 'COMMIT' ), 'The source/report race fixture must be visible to independent sessions.' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Publishes the fixture before genuine cross-process contention.
 
 		$exact_source = array(
 			'booking_id' => $booking['id'],

--- a/tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
@@ -9,10 +9,89 @@ use ExtraChillEvents\Core\BookingInquiryAdmissionService;
 use ExtraChillEvents\Core\BookingLifecycle;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\TicketReconciliationService;
+use ExtraChillEvents\Core\TicketSettlementService;
 use ExtraChillEvents\Core\VenueBookingConfig;
 
 /** Prove overlapping application processes converge on one complete winner. */
 final class BookingAdmissionConcurrencyMySQLProof extends BookingAttachmentMySQLIntegrationTest {
+	/** Prove overlapping source and report registrations converge after real lock contention. */
+	public function test_concurrent_source_and_report_registrations_converge_or_conflict_exactly(): void {
+		global $wpdb;
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'   => defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events',
+				'post_status' => 'publish',
+			)
+		);
+		$bookings = new BookingRepository();
+		$booking  = $bookings->create(
+			array(
+				'venue_term_id' => $this->venue_id,
+				'artist_name'   => 'Concurrent Evidence Artist',
+				'intake'        => array(),
+			)
+		);
+		$booking  = $bookings->claim_event( $booking['id'], $event_id, $booking['version'] );
+		$this->assertIsArray( $booking, is_wp_error( $booking ) ? $booking->get_error_code() : '' );
+
+		$exact_source = array(
+			'booking_id' => $booking['id'],
+			'provider'   => 'manual-certified',
+			'source_key' => 'Concurrent/Exact Source',
+			'ticket_url' => 'https://tickets.example.test/concurrent-exact',
+		);
+		$exact_race   = $this->race_booking_services(
+			$booking['id'],
+			fn() => ( new TicketReconciliationService() )->register_source( $exact_source, $this->actor_id ),
+			fn() => ( new TicketReconciliationService() )->register_source( $exact_source, $this->actor_id ),
+			true
+		);
+		$this->assertSame( array( 'result', 'sales_reconciliation_commit_uncertain' ), $this->race_result_kinds( $exact_race ) );
+		$source = ( new TicketReconciliationService() )->register_source( $exact_source, $this->actor_id );
+		$this->assertIsArray( $source, is_wp_error( $source ) ? $source->get_error_code() : '' );
+		$sources = BookingSchema::ticket_sources_table();
+		$this->assertSame( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$sources} WHERE booking_id = %d AND provider = %s AND source_key_hash = %s", $booking['id'], $exact_source['provider'], hash( 'sha256', $exact_source['source_key'] ) ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact post-race row count.
+
+		$conflicting_source_a               = $exact_source;
+		$conflicting_source_a['source_key'] = 'Concurrent/Conflicting Source';
+		$conflicting_source_a['ticket_url'] = 'https://tickets.example.test/concurrent-conflict-a';
+		$conflicting_source_b               = $conflicting_source_a;
+		$conflicting_source_b['ticket_url'] = 'https://tickets.example.test/concurrent-conflict-b';
+		$source_conflict                    = $this->race_booking_services(
+			$booking['id'],
+			fn() => ( new TicketReconciliationService() )->register_source( $conflicting_source_a, $this->actor_id ),
+			fn() => ( new TicketReconciliationService() )->register_source( $conflicting_source_b, $this->actor_id )
+		);
+		$this->assertSame( array( 'result', 'ticket_source_idempotency_conflict' ), $this->race_result_kinds( $source_conflict ) );
+		$this->assertSame( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$sources} WHERE booking_id = %d AND provider = %s AND source_key_hash = %s", $booking['id'], $exact_source['provider'], hash( 'sha256', $conflicting_source_a['source_key'] ) ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Conflicting contenders cannot duplicate an identity.
+
+		$exact_report = $this->settlement_report_input( $booking['id'], 'Concurrent/Exact Report', $source['id'] );
+		$report_race  = $this->race_booking_services(
+			$booking['id'],
+			fn() => ( new TicketSettlementService() )->record_sales( $exact_report, $this->actor_id ),
+			fn() => ( new TicketSettlementService() )->record_sales( $exact_report, $this->actor_id ),
+			true
+		);
+		$this->assertSame( array( 'result', 'settlement_commit_uncertain' ), $this->race_result_kinds( $report_race ) );
+		$report = ( new TicketSettlementService() )->record_sales( $exact_report, $this->actor_id );
+		$this->assertIsArray( $report, is_wp_error( $report ) ? $report->get_error_code() : '' );
+		$reports = BookingSchema::sales_reports_table();
+		$this->assertSame( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$reports} WHERE booking_id = %d AND provider = %s AND external_report_id_hash = %s", $booking['id'], $exact_report['provider'], hash( 'sha256', $exact_report['external_report_id'] ) ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact post-race row count.
+
+		$conflicting_report_a                       = $this->settlement_report_input( $booking['id'], 'Concurrent/Conflicting Report', $source['id'] );
+		$conflicting_report_b                       = $conflicting_report_a;
+		$conflicting_report_b['gross_minor']        = 200;
+		$conflicting_report_b['net_minor']          = 200;
+		$report_conflict                            = $this->race_booking_services(
+			$booking['id'],
+			fn() => ( new TicketSettlementService() )->record_sales( $conflicting_report_a, $this->actor_id ),
+			fn() => ( new TicketSettlementService() )->record_sales( $conflicting_report_b, $this->actor_id )
+		);
+		$this->assertSame( array( 'result', 'sales_report_idempotency_conflict' ), $this->race_result_kinds( $report_conflict ) );
+		$this->assertSame( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$reports} WHERE booking_id = %d AND provider = %s AND external_report_id_hash = %s", $booking['id'], $conflicting_report_a['provider'], hash( 'sha256', $conflicting_report_a['external_report_id'] ) ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Conflicting contenders cannot duplicate an identity.
+	}
+
 	/** Prove concurrent installers serialize on the exact site-scoped schema lock. */
 	public function test_concurrent_booking_schema_installer_waits_and_converges(): void {
 		$this->prove_concurrent_booking_schema_installer_waits_and_converges();
@@ -141,5 +220,117 @@ final class BookingAdmissionConcurrencyMySQLProof extends BookingAttachmentMySQL
 			}
 		}
 		remove_filter( 'extrachill_events_allow_test_booking_file', '__return_true' );
+	}
+
+	/** Run two service calls while both are blocked behind the same booking lock. */
+	private function race_booking_services( int $booking_id, callable $first, callable $second, bool $first_commit_uncertain = false ): array {
+		$bookings = BookingSchema::bookings_table();
+		$this->assertTrue( $this->contender->begin_transaction() );
+		$locked = $this->contender->query( "SELECT id FROM {$bookings} WHERE id = {$booking_id} FOR UPDATE" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Independent fixture connection deliberately owns the application lock.
+		$this->assertInstanceOf( mysqli_result::class, $locked );
+		$locked->free();
+
+		$base = wp_tempnam( 'booking-service-race.txt' );
+		unlink( $base );
+		$files = array(
+			array( 'ready' => $base . '.first-ready', 'result' => $base . '.first-result' ),
+			array( 'ready' => $base . '.second-ready', 'result' => $base . '.second-result' ),
+		);
+		$pids  = array(
+			$this->fork_service_call( $first, $files[0], $first_commit_uncertain ),
+			$this->fork_service_call( $second, $files[1], false ),
+		);
+		$deadline = microtime( true ) + 5;
+		while ( ( ! file_exists( $files[0]['ready'] ) || ! file_exists( $files[1]['ready'] ) ) && microtime( true ) < $deadline ) {
+			usleep( 10000 );
+		}
+		$both_ready      = file_exists( $files[0]['ready'] ) && file_exists( $files[1]['ready'] );
+		$both_waiting    = false;
+		$booking_waiting = false;
+		if ( $both_ready ) {
+			$thread_ids = array_map( 'intval', array( file_get_contents( $files[0]['ready'] ), file_get_contents( $files[1]['ready'] ) ) );
+			$deadline   = microtime( true ) + 5;
+			do {
+				$processes = $this->contender->query( 'SELECT ID, INFO FROM information_schema.PROCESSLIST WHERE COMMAND = \'Query\' AND ID IN (' . implode( ',', $thread_ids ) . ')' );
+				if ( $processes instanceof mysqli_result ) {
+					$queries = array_column( $processes->fetch_all( MYSQLI_ASSOC ), 'INFO' );
+					$processes->free();
+					$both_waiting    = 2 === count( array_filter( $queries, static fn( string $query ): bool => false !== stripos( $query, 'FOR UPDATE' ) ) );
+					$booking_waiting = 1 === count( array_filter( $queries, static fn( string $query ): bool => false !== stripos( $query, $bookings ) && false !== stripos( $query, 'FOR UPDATE' ) ) );
+				}
+				if ( ! $both_waiting || ! $booking_waiting ) {
+					usleep( 10000 );
+				}
+			} while ( ( ! $both_waiting || ! $booking_waiting ) && microtime( true ) < $deadline );
+		}
+		$both_blocked = ! file_exists( $files[0]['result'] ) && ! file_exists( $files[1]['result'] );
+		$released     = $this->contender->commit();
+
+		$statuses = array();
+		foreach ( $pids as $pid ) {
+			$status = 0;
+			pcntl_waitpid( $pid, $status );
+			$statuses[] = pcntl_wifexited( $status ) && 0 === pcntl_wexitstatus( $status );
+		}
+		$results = array(
+			json_decode( (string) file_get_contents( $files[0]['result'] ), true ),
+			json_decode( (string) file_get_contents( $files[1]['result'] ), true ),
+		);
+		foreach ( $files as $paths ) {
+			foreach ( $paths as $path ) {
+				if ( file_exists( $path ) ) {
+					unlink( $path );
+				}
+			}
+		}
+
+		$this->assertTrue( $both_ready, 'Both service contenders must reach the held booking lock.' );
+		$this->assertTrue( $both_waiting, 'Both service contenders must overlap in production FOR UPDATE lock acquisition.' );
+		$this->assertTrue( $booking_waiting, 'At least one service contender must block on the production booking row lock.' );
+		$this->assertTrue( $both_blocked, 'A service contender bypassed the held booking lock.' );
+		$this->assertTrue( $released, 'The fixture booking lock could not be released.' );
+		$this->assertSame( array( true, true ), $statuses, 'A service contender did not exit cleanly.' );
+		return $results;
+	}
+
+	/** Fork one independent WordPress service process and persist its bounded result. */
+	private function fork_service_call( callable $call, array $files, bool $commit_uncertain ): int {
+		$pid = pcntl_fork();
+		$this->assertGreaterThanOrEqual( 0, $pid );
+		if ( 0 !== $pid ) {
+			return $pid;
+		}
+		$this->reconnect_wordpress_database();
+		if ( $commit_uncertain ) {
+			global $wpdb;
+			$original  = $wpdb;
+			$uncertain = new BookingCommitUncertainWpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+			$uncertain->set_prefix( $original->base_prefix );
+			$uncertain->set_blog_id( $original->blogid, $original->siteid );
+			$uncertain->fail_next_commit = true;
+			$wpdb                        = $uncertain;
+			$original->dbh->close();
+		}
+		global $wpdb;
+		file_put_contents( $files['ready'], (string) mysqli_thread_id( $wpdb->dbh ), LOCK_EX );
+		$result = $call();
+		file_put_contents(
+			$files['result'],
+			wp_json_encode( is_wp_error( $result ) ? array( 'error' => $result->get_error_code() ) : array( 'result' => $result ) ),
+			LOCK_EX
+		);
+		exit( 0 );
+	}
+
+	/** Return deterministic outcome labels for an unordered two-process race. */
+	private function race_result_kinds( array $results ): array {
+		$kinds = array_map(
+			static function ( array $result ): string {
+				return isset( $result['result'] ) ? 'result' : (string) ( $result['error'] ?? 'missing' );
+			},
+			$results
+		);
+		sort( $kinds );
+		return $kinds;
 	}
 }

--- a/tests/MySQLIntegration/BookingSchemaMultisiteTest.php
+++ b/tests/MySQLIntegration/BookingSchemaMultisiteTest.php
@@ -56,78 +56,192 @@ final class BookingSchemaMultisiteTest extends WP_UnitTestCase {
 		$this->assertSame( 1, get_current_blog_id() );
 	}
 
-	/** Verify explicit v13 identity/provenance migration preserves every legacy row. */
+	/** Verify explicit v13 identity/provenance migration preserves every legacy table. */
 	public function test_v13_ticket_provenance_upgrade_preserves_rows(): void {
 		global $wpdb;
 
 		switch_to_blog( 7 );
 		try {
-			$table       = BookingSchema::sales_reports_table();
+			$reports     = BookingSchema::sales_reports_table();
 			$sources     = BookingSchema::ticket_sources_table();
 			$external_id = 'Legacy/Report-é-' . wp_generate_uuid4();
 			$source_key  = 'Legacy/Case-é-' . wp_generate_uuid4();
 			$wpdb->query( "ALTER TABLE `{$sources}` DROP INDEX `booking_provider_source`, DROP COLUMN `source_key_hash`, ADD UNIQUE KEY `booking_provider_source` (`booking_id`, `provider`, `source_key`)" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Recreates the exact v13 source contract in a disposable test database.
-			$wpdb->query( "ALTER TABLE `{$table}` DROP INDEX `provider_external_report`, DROP COLUMN `external_report_id_hash`, DROP COLUMN `provenance_version`, DROP COLUMN `ticket_source_request_hash`, DROP COLUMN `evidence_attachment_request_hash`, DROP COLUMN `evidence_content_hash`, DROP COLUMN `evidence_byte_size`, ADD UNIQUE KEY `provider_external_report` (`booking_id`, `provider`, `external_report_id`)" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Recreates the exact v13 report contract in a disposable test database.
+			$wpdb->query( "ALTER TABLE `{$reports}` DROP INDEX `provider_external_report`, DROP COLUMN `external_report_id_hash`, DROP COLUMN `provenance_version`, DROP COLUMN `ticket_source_request_hash`, DROP COLUMN `evidence_attachment_request_hash`, DROP COLUMN `evidence_content_hash`, DROP COLUMN `evidence_byte_size`, ADD UNIQUE KEY `provider_external_report` (`booking_id`, `provider`, `external_report_id`)" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Recreates the exact v13 report contract in a disposable test database.
 			$this->assertSame( '', (string) $wpdb->last_error );
-			$this->assertSame(
-				1,
-				$wpdb->insert(
-					$sources,
-					array(
-						'public_id'          => wp_generate_uuid4(),
-						'booking_id'         => 987654,
-						'event_id'           => 876543,
-						'venue_term_id'      => 765432,
-						'provider'           => 'legacy-provider',
-						'source_key'         => $source_key,
-						'canonical_url'      => 'https://tickets.example.test/legacy',
-						'url_hash'           => hash( 'sha256', 'https://tickets.example.test/legacy' ),
-						'request_hash'       => str_repeat( 'b', 64 ),
-						'created_by_user_id' => 1,
-						'created_at'         => '2026-07-01 00:00:00',
-					)
-				)
-			); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Disposable migration fixture.
-			$inserted = $wpdb->insert(
-				$table,
-				array(
-					'booking_id'         => 987654,
-					'event_id'           => 876543,
-					'venue_term_id'      => 765432,
-					'provider'           => 'legacy-provider',
-					'external_report_id' => $external_id,
-					'source_type'        => 'manual',
-					'period_start'       => '2026-07-01 00:00:00',
-					'period_end'         => '2026-07-01 23:59:59',
-					'tickets_sold'       => 1,
-					'tickets_refunded'   => 0,
-					'gross_minor'        => 100,
-					'fees_minor'         => 0,
-					'tax_minor'          => 0,
-					'refunds_minor'      => 0,
-					'net_minor'          => 100,
-					'currency'           => 'USD',
-					'source_payload'     => '{"version":1,"data":{}}',
-					'request_hash'       => str_repeat( 'a', 64 ),
-					'created_by_user_id' => 1,
-					'created_at'         => '2026-07-01 00:00:00',
-				)
-			); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Disposable migration fixture.
-			$this->assertSame( 1, $inserted );
+			$fixtures  = $this->v13_fixture_rows( $external_id, $source_key );
+			$snapshots = $this->seed_and_snapshot_v13_rows( $fixtures );
+			$this->assertCount( 14, $snapshots );
 			update_option( BookingSchema::VERSION_OPTION, '13', false );
 
 			$this->assertTrue( BookingSchema::maybe_install() );
 			$this->assertSame( '14', get_option( BookingSchema::VERSION_OPTION ) );
-			$this->assertSame( '987654', $wpdb->get_var( $wpdb->prepare( "SELECT booking_id FROM `{$table}` WHERE external_report_id = %s", $external_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms migration preserved the fixture.
-			$this->assertSame( hash( 'sha256', $external_id ), $wpdb->get_var( $wpdb->prepare( "SELECT external_report_id_hash FROM `{$table}` WHERE external_report_id = %s", $external_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms exact report identity backfill.
-			$this->assertSame( '1', $wpdb->get_var( $wpdb->prepare( "SELECT provenance_version FROM `{$table}` WHERE external_report_id = %s", $external_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Legacy hashes remain versioned and immutable.
+			$this->assert_v13_snapshots_survive( $fixtures, $snapshots );
+			$this->assert_migrated_financial_graph_readable();
+			$this->assertSame( '73001', $wpdb->get_var( $wpdb->prepare( "SELECT booking_id FROM `{$reports}` WHERE external_report_id = %s", $external_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms migration preserved the fixture.
+			$this->assertSame( hash( 'sha256', $external_id ), $wpdb->get_var( $wpdb->prepare( "SELECT external_report_id_hash FROM `{$reports}` WHERE external_report_id = %s", $external_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms exact report identity backfill.
+			$this->assertSame( '1', $wpdb->get_var( $wpdb->prepare( "SELECT provenance_version FROM `{$reports}` WHERE external_report_id = %s", $external_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Legacy hashes remain versioned and immutable.
 			$this->assertSame( hash( 'sha256', $source_key ), $wpdb->get_var( $wpdb->prepare( "SELECT source_key_hash FROM `{$sources}` WHERE source_key = %s", $source_key ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms exact source identity backfill.
+			$this->assertSame( '73110', $wpdb->get_var( "SELECT ticket_source_id FROM `{$reports}` WHERE id = 73111" ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Immutable source relationship survives dbDelta.
+			$deliveries = BookingSchema::attachment_deliveries_table();
+			$this->assertSame( '73103', $wpdb->get_var( "SELECT attachment_id FROM `{$deliveries}` WHERE id = 73104" ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private-delivery attachment relationship survives dbDelta.
+			$resolutions = BookingSchema::sales_resolutions_table();
+			$settlements = BookingSchema::settlements_table();
+			$this->assertSame( '73111', $wpdb->get_var( "SELECT report_id FROM `{$resolutions}` WHERE id = 73112" ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Resolution remains bound to its immutable report.
+			$this->assertSame( '[73111]', $wpdb->get_var( "SELECT included_report_ids FROM `{$settlements}` WHERE id = 73113" ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Legacy settlement evidence remains frozen.
+			$this->assertSame( '2', $wpdb->get_var( "SELECT formula_version FROM `{$settlements}` WHERE id = 73113" ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Formula-v2 settlement remains immutable.
 
-			$index_rows = $wpdb->get_results( "SHOW INDEX FROM `{$table}` WHERE Key_name = 'provider_external_report'", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Verifies the repaired real-MySQL index.
+			$index_rows = $wpdb->get_results( "SHOW INDEX FROM `{$reports}` WHERE Key_name = 'provider_external_report'", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Verifies the repaired real-MySQL index.
 			usort( $index_rows, static fn( array $left, array $right ): int => (int) $left['Seq_in_index'] <=> (int) $right['Seq_in_index'] );
 			$this->assertSame( array( 'booking_id', 'provider', 'external_report_id_hash' ), array_column( $index_rows, 'Column_name' ) );
 		} finally {
 			restore_current_blog();
 		}
+	}
+
+	/** Return one coherent representative v13 row for every booking table. */
+	private function v13_fixture_rows( string $external_id, string $source_key ): array {
+		$created        = '2026-07-01 00:00:00';
+		$reconciliation = new ExtraChillEvents\Core\TicketReconciliationService();
+		$settlements    = new ExtraChillEvents\Core\TicketSettlementService();
+		$row_hash       = new ReflectionMethod( ExtraChillEvents\Core\TicketReconciliationService::class, 'hash' );
+		$row_hash->setAccessible( true );
+		$source_row                 = array( 'id' => 73110, 'public_id' => wp_generate_uuid4(), 'booking_id' => 73001, 'event_id' => 73002, 'venue_term_id' => 73003, 'provider' => 'legacy-provider', 'source_key' => $source_key, 'canonical_url' => 'https://tickets.example.test/legacy', 'url_hash' => hash( 'sha256', 'https://tickets.example.test/legacy' ), 'created_by_user_id' => 1, 'created_at' => $created );
+		$source_row['request_hash'] = $row_hash->invoke( $reconciliation, $source_row, array( 'booking_id', 'event_id', 'venue_term_id', 'provider', 'source_key', 'canonical_url' ) );
+		$report_source               = array( 'certificate' => 'legacy-v13-proof' );
+		$report_row                  = array( 'id' => 73111, 'booking_id' => 73001, 'event_id' => 73002, 'venue_term_id' => 73003, 'ticket_source_id' => 73110, 'evidence_attachment_id' => null, 'provider' => 'legacy-provider', 'external_report_id' => $external_id, 'source_type' => 'manual', 'period_start' => $created, 'period_end' => '2026-07-01 23:59:59', 'tickets_sold' => 10, 'tickets_refunded' => 1, 'gross_minor' => 10000, 'fees_minor' => 500, 'tax_minor' => 300, 'refunds_minor' => 1000, 'net_minor' => 8200, 'currency' => 'USD', 'source_payload' => wp_json_encode( array( 'version' => 1, 'data' => $report_source ) ), 'created_by_user_id' => 1, 'created_at' => $created );
+		$report_hashable             = $report_row;
+		$report_hashable['source']   = $report_source;
+		$report_row['request_hash']  = ExtraChillEvents\Core\TicketSettlementService::report_request_hash( $report_hashable );
+		$resolution_row              = array( 'id' => 73112, 'public_id' => wp_generate_uuid4(), 'booking_id' => 73001, 'report_id' => 73111, 'venue_term_id' => 73003, 'version' => 1, 'decision' => 'admit', 'ticket_source_id' => 73110, 'supersedes_resolution_id' => null, 'reason' => 'Legacy certified evidence accepted.', 'created_by_user_id' => 1, 'created_at' => $created );
+		$resolution_row['request_hash'] = $row_hash->invoke( $reconciliation, $resolution_row, array( 'booking_id', 'report_id', 'venue_term_id', 'version', 'decision', 'ticket_source_id', 'supersedes_resolution_id', 'reason', 'created_by_user_id', 'created_at' ) );
+		$evidence                    = array(
+			array(
+				'id'           => 73111,
+				'request_hash' => $report_row['request_hash'],
+				'resolution'   => array( 'id' => 73112, 'version' => 1, 'decision' => 'admit', 'ticket_source_id' => 73110, 'request_hash' => $resolution_row['request_hash'] ),
+			),
+		);
+		$evidence_hash               = new ReflectionMethod( ExtraChillEvents\Core\TicketSettlementService::class, 'evidence_hash' );
+		$evidence_hash->setAccessible( true );
+		$settlement_row              = array( 'id' => 73113, 'booking_id' => 73001, 'event_id' => 73002, 'venue_term_id' => 73003, 'status' => 'paid', 'version' => 2, 'booking_version' => 7, 'basis' => 'gross_ticket_sales', 'basis_points' => 2000, 'currency' => 'USD', 'formula_version' => 2, 'included_report_ids' => '[73111]', 'evidence_hash' => $evidence_hash->invoke( $settlements, $evidence ), 'basis_amount_minor' => 10000, 'adjustment_minor' => 0, 'amount_due_minor' => 2000, 'finalized_by_user_id' => 1, 'finalized_at' => '2026-07-02 00:00:00', 'paid_by_user_id' => 1, 'paid_at' => '2026-07-03 00:00:00', 'payment_reference' => 'legacy-payment-reference', 'created_at' => '2026-07-02 00:00:00', 'updated_at' => '2026-07-03 00:00:00' );
+		$integrity_hash              = new ReflectionMethod( ExtraChillEvents\Core\TicketSettlementService::class, 'settlement_integrity_hash' );
+		$integrity_hash->setAccessible( true );
+		$settlement_row['integrity_hash'] = $integrity_hash->invoke( $settlements, $settlement_row );
+		return array(
+			BookingSchema::bookings_table()              => array(
+				'key' => 'id',
+				'row' => array(
+					'id' => 73001, 'public_id' => wp_generate_uuid4(), 'venue_term_id' => 73003, 'artist_name' => 'Legacy Migration Artist', 'contact_email' => 'legacy@example.test', 'inquiry_idempotency_key' => 'legacy-migration-inquiry', 'inquiry_request_hash' => str_repeat( '1', 64 ), 'space_key' => 'main-room', 'status' => 'completed', 'version' => 7, 'intake_payload' => '{"version":1,"data":{"legacy":true}}', 'event_id' => 73002, 'created_at' => $created, 'updated_at' => '2026-07-02 00:00:00',
+				),
+			),
+			BookingSchema::activity_table()              => array(
+				'key' => 'id',
+				'row' => array(
+					'id' => 73101, 'booking_id' => 73001, 'kind' => 'legacy_notification', 'actor_type' => 'user', 'actor_id' => 1, 'direction' => 'outbound', 'channel' => 'email', 'communication_intent_id' => 73102, 'is_communication' => 1, 'payload' => '{"version":1,"data":{"subject":"Legacy"}}', 'external_id' => 'legacy-message-id', 'idempotency_key' => 'legacy-activity', 'occurred_at' => $created, 'created_at' => $created,
+				),
+			),
+			BookingSchema::communication_state_table()   => array(
+				'key' => 'intent_id',
+				'row' => array( 'intent_id' => 73102, 'booking_id' => 73001, 'status' => 'delivered', 'claim_stage' => 'completed', 'action_id' => 73120, 'updated_activity_id' => 73101, 'created_at' => $created, 'updated_at' => '2026-07-01 00:05:00' ),
+			),
+			BookingSchema::attachments_table()           => array(
+				'key' => 'id',
+				'row' => array(
+					'id' => 73103, 'public_id' => wp_generate_uuid4(), 'booking_id' => 73001, 'uploader_type' => 'user', 'uploader_user_id' => 1, 'purpose' => 'other_private_evidence', 'original_filename' => 'legacy-sales.csv', 'mime_type' => 'text/csv', 'byte_size' => 128, 'content_hash' => str_repeat( '2', 64 ), 'storage_reference' => 'legacy-private-reference', 'state' => 'active', 'idempotency_key' => 'legacy-attachment', 'request_hash' => str_repeat( '3', 64 ), 'created_at' => $created, 'updated_at' => $created,
+				),
+			),
+			BookingSchema::attachment_deliveries_table() => array(
+				'key' => 'id',
+				'row' => array( 'id' => 73104, 'correlation_id' => wp_generate_uuid4(), 'booking_id' => 73001, 'attachment_id' => 73103, 'actor_id' => 1, 'expected_bytes' => 128, 'state' => 'completed', 'outcome' => 'complete', 'bytes_sent' => 128, 'issued_at' => $created, 'consumed_at' => '2026-07-01 00:01:00', 'terminal_at' => '2026-07-01 00:02:00', 'updated_at' => '2026-07-01 00:02:00' ),
+			),
+			BookingSchema::memberships_table()           => array(
+				'key' => 'id',
+				'row' => array( 'id' => 73105, 'venue_term_id' => 73003, 'user_id' => 1, 'is_owner' => 1, 'status' => 'active', 'version' => 3, 'created_by_user_id' => 1, 'created_at' => $created, 'updated_at' => '2026-07-02 00:00:00' ),
+			),
+			BookingSchema::claims_table()                => array(
+				'key' => 'id',
+				'row' => array( 'id' => 73106, 'public_id' => wp_generate_uuid4(), 'venue_term_id' => 73003, 'claimant_user_id' => 2, 'status' => 'approved', 'version' => 2, 'reviewed_by_user_id' => 1, 'created_at' => $created, 'updated_at' => '2026-07-02 00:00:00', 'resolved_at' => '2026-07-02 00:00:00' ),
+			),
+			BookingSchema::invitations_table()           => array(
+				'key' => 'id',
+				'row' => array(
+					'id' => 73107, 'public_id' => wp_generate_uuid4(), 'venue_term_id' => 73003, 'user_id' => 3, 'is_owner' => 0, 'status' => 'accepted', 'token_hash' => str_repeat( '4', 64 ), 'email_hash' => str_repeat( '5', 64 ), 'account_created' => 1, 'delivery_id' => wp_generate_uuid4(), 'delivery_status' => 'delivered', 'delivery_attempts' => 1, 'version' => 2, 'invited_by_user_id' => 1, 'created_at' => $created, 'updated_at' => '2026-07-02 00:00:00', 'expires_at' => '2026-08-01 00:00:00', 'resolved_at' => '2026-07-02 00:00:00', 'delivered_at' => '2026-07-01 00:01:00',
+				),
+			),
+			BookingSchema::onboarding_audit_table()      => array(
+				'key' => 'id',
+				'row' => array( 'id' => 73108, 'venue_term_id' => 73003, 'entity_type' => 'membership', 'entity_id' => 73105, 'event' => 'legacy_membership_created', 'actor_user_id' => 1, 'subject_user_id' => 1, 'payload' => '{"version":1,"data":{"owner":true}}', 'created_at' => $created ),
+			),
+			BookingSchema::holds_table()                 => array(
+				'key' => 'id',
+				'row' => array( 'id' => 73109, 'booking_id' => 73001, 'venue_term_id' => 73003, 'space_key' => 'main-room', 'start_at' => '2026-08-01 18:00:00', 'end_at' => '2026-08-01 23:00:00', 'expires_at' => '2026-07-02 00:00:00', 'status' => 'converted', 'version' => 2, 'created_by_user_id' => 1, 'created_at' => $created, 'updated_at' => '2026-07-02 00:00:00', 'converted_at' => '2026-07-02 00:00:00', 'converted_by_user_id' => 1 ),
+			),
+			BookingSchema::ticket_sources_table()        => array(
+				'key' => 'id',
+				'row' => $source_row,
+			),
+			BookingSchema::sales_reports_table()         => array(
+				'key' => 'id',
+				'row' => $report_row,
+			),
+			BookingSchema::sales_resolutions_table()     => array(
+				'key' => 'id',
+				'row' => $resolution_row,
+			),
+			BookingSchema::settlements_table()           => array(
+				'key' => 'id',
+				'row' => $settlement_row,
+			),
+		);
+	}
+
+	/** Seed and snapshot the exact legacy columns before dbDelta runs. */
+	private function seed_and_snapshot_v13_rows( array $fixtures ): array {
+		global $wpdb;
+		$snapshots = array();
+		foreach ( $fixtures as $table => $fixture ) {
+			$this->assertSame( 1, $wpdb->insert( $table, $fixture['row'] ), $table . ': ' . $wpdb->last_error ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Disposable migration fixture.
+			$snapshots[ $table ] = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `{$table}` WHERE `{$fixture['key']}` = %d", $fixture['row'][ $fixture['key'] ] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Captures every v13 field before migration.
+			$this->assertIsArray( $snapshots[ $table ], $table );
+		}
+		return $snapshots;
+	}
+
+	/** Verify every legacy column remains byte-for-byte equal after migration. */
+	private function assert_v13_snapshots_survive( array $fixtures, array $snapshots ): void {
+		global $wpdb;
+		foreach ( $snapshots as $table => $before ) {
+			$fixture = $fixtures[ $table ];
+			$after   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `{$table}` WHERE `{$fixture['key']}` = %d", $fixture['row'][ $fixture['key'] ] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reads the migrated representative row.
+			$this->assertIsArray( $after, $table . ' row was lost during migration.' );
+			foreach ( $before as $column => $value ) {
+				$this->assertSame( $value, $after[ $column ] ?? null, $table . '.' . $column . ' changed during migration.' );
+			}
+		}
+	}
+
+	/** Prove migrated immutable hashes still hydrate and formula-v2 evidence verifies. */
+	private function assert_migrated_financial_graph_readable(): void {
+		global $wpdb;
+		$reconciliation = new ExtraChillEvents\Core\TicketReconciliationService();
+		$settlements    = new ExtraChillEvents\Core\TicketSettlementService();
+		$source_row     = $wpdb->get_row( 'SELECT * FROM `' . BookingSchema::ticket_sources_table() . '` WHERE id = 73110', ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Disposable migrated fixture read.
+		$report_row     = $wpdb->get_row( 'SELECT * FROM `' . BookingSchema::sales_reports_table() . '` WHERE id = 73111', ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Disposable migrated fixture read.
+		$settlement_row = $wpdb->get_row( 'SELECT * FROM `' . BookingSchema::settlements_table() . '` WHERE id = 73113', ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Disposable migrated fixture read.
+		$hydrate_source = new ReflectionMethod( ExtraChillEvents\Core\TicketReconciliationService::class, 'hydrate_source' );
+		$hydrate_report = new ReflectionMethod( ExtraChillEvents\Core\TicketSettlementService::class, 'hydrate_report' );
+		$hydrate_settlement = new ReflectionMethod( ExtraChillEvents\Core\TicketSettlementService::class, 'hydrate_settlement' );
+		$verify_evidence = new ReflectionMethod( ExtraChillEvents\Core\TicketSettlementService::class, 'verify_settlement_evidence' );
+		foreach ( array( $hydrate_source, $hydrate_report, $hydrate_settlement, $verify_evidence ) as $method ) {
+			$method->setAccessible( true );
+		}
+		$source     = $hydrate_source->invoke( $reconciliation, $source_row );
+		$report     = $hydrate_report->invoke( $settlements, $report_row );
+		$settlement = $hydrate_settlement->invoke( $settlements, $settlement_row );
+		$this->assertIsArray( $source, is_wp_error( $source ) ? $source->get_error_code() : '' );
+		$this->assertIsArray( $report, is_wp_error( $report ) ? $report->get_error_code() : '' );
+		$this->assertIsArray( $settlement, is_wp_error( $settlement ) ? $settlement->get_error_code() : '' );
+		$this->assertSame( array(), $verify_evidence->invoke( $settlements, $settlement, false, 1, null, false ) );
 	}
 }


### PR DESCRIPTION
## Summary
- complete the post-merge proof follow-up for #451 with genuine two-session source/report registration races at the production service lock boundary
- verify exact-retry and conflicting identities converge to one source/report row under overlap
- seed, snapshot, migrate, and restore representative rows across all 14 booking tables while preserving the financial evidence graph
- wire the fourth concurrency proof into the required hosted MySQL gate

## Review notes
- both forked WordPress sessions are observed concurrently in MySQL `PROCESSLIST` waiting on production `FOR UPDATE` queries before the fixture booking lock is released
- all 14 `BookingSchema` tables receive a representative v13 row; every legacy column is compared byte-for-byte after migration
- source/report/resolution, attachment/delivery, communication-state, booking, venue, event, and settlement identifiers remain coherent, and production hydration plus formula-v2 evidence verification succeeds

## Verification
- `vendor/bin/phpunit -c phpunit-booking.xml.dist` (401 tests, 4,384 assertions)
- `homeboy review lint --changed-since=origin/main --placement=local --summary`
- `homeboy review audit --changed-since=origin/main --profile=pr --placement=local --json-summary`
- changed PHP syntax checks and `git diff --check`
- hosted managed MySQL and native two-session gates are the authoritative database proof; local WP Codebox could not execute because the installed runner rejected its generated sandbox contract before PHPUnit started

Completes the post-merge proof follow-up for #451.

Related: #434