### PR TITLE
feat: expose booking inquiry block across network

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -58,6 +58,13 @@ jobs:
           ref: e684ea4dbe7532cd2569f72a586933fe1e4fab51
           path: .ci/data-machine-events
 
+      - name: Checkout Extra Chill Network
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: Extra-Chill/extrachill-network
+          ref: feabb8756de9bf322f4d0d18116e722fbea710c2
+          path: .ci/extrachill-network
+
       - name: Checkout Homeboy Extensions adapter fix
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
@@ -97,6 +104,7 @@ jobs:
           vendor/bin/phpunit --configuration phpunit-artist-unit.xml.dist
           vendor/bin/phpunit --configuration phpunit-venue-unit.xml.dist
           vendor/bin/phpunit --configuration phpunit-local-scene-unit.xml.dist
+          vendor/bin/phpunit --configuration phpunit-network-block.xml.dist
 
       - name: Select managed WordPress suite
         if: ${{ matrix.command == 'review test' }}
@@ -105,7 +113,7 @@ jobs:
       - name: Run Homeboy ${{ matrix.command }}
         env:
           HOMEBOY_SETTINGS_JSON: >-
-            {"database_type":"mysql","validation_dependencies":["${{ github.workspace }}/.ci/data-machine","${{ github.workspace }}/.ci/data-machine-events"],"wp_codebox_multisite":true,"wp_codebox_phpunit_bootstrap_mode":"managed"}
+            {"database_type":"mysql","validation_dependencies":["${{ github.workspace }}/.ci/data-machine","${{ github.workspace }}/.ci/data-machine-events","${{ github.workspace }}/.ci/extrachill-network"],"wp_codebox_multisite":true,"wp_codebox_phpunit_bootstrap_mode":"managed"}
           HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: ${{ github.workspace }}/wp-codebox-artifacts
           HOMEBOY_WP_CODEBOX_INSTALL_MODE: source
           HOMEBOY_WP_CODEBOX_REF: 4a3ae649abfb94353dfbae3e101b2ec2a76113e8

--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -65,6 +65,13 @@ jobs:
           ref: feabb8756de9bf322f4d0d18116e722fbea710c2
           path: .ci/extrachill-network
 
+      - name: Checkout Extra Chill API
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: Extra-Chill/extrachill-api
+          ref: d449ed353f17b4c81cfd466fcbbefaa5ee637609
+          path: .ci/extrachill-api
+
       - name: Checkout Homeboy Extensions adapter fix
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
@@ -126,7 +133,7 @@ jobs:
       - name: Run Homeboy ${{ matrix.command }}
         env:
           HOMEBOY_SETTINGS_JSON: >-
-            {"database_type":"mysql","validation_dependencies":["${{ github.workspace }}/.ci/data-machine","${{ github.workspace }}/.ci/data-machine-events","${{ github.workspace }}/.ci/extrachill-network"],"wp_codebox_multisite":true,"wp_codebox_phpunit_bootstrap_mode":"managed"}
+            {"database_type":"mysql","validation_dependencies":["${{ github.workspace }}/.ci/data-machine","${{ github.workspace }}/.ci/data-machine-events","${{ github.workspace }}/.ci/extrachill-network","${{ github.workspace }}/.ci/extrachill-api"],"wp_codebox_multisite":true,"wp_codebox_phpunit_bootstrap_mode":"managed"}
           HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: ${{ github.workspace }}/wp-codebox-artifacts
           HOMEBOY_WP_CODEBOX_INSTALL_MODE: source
           HOMEBOY_WP_CODEBOX_REF: 4a3ae649abfb94353dfbae3e101b2ec2a76113e8

--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -98,6 +98,19 @@ jobs:
         if: ${{ matrix.command == 'review test' }}
         run: composer install --no-interaction --no-progress --prefer-dist
 
+      - name: Set up Node.js
+        if: ${{ matrix.command == 'review test' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Build block assets for tests
+        if: ${{ matrix.command == 'review test' }}
+        run: |
+          npm ci
+          npm run build
+
       - name: Run isolated unit tests
         if: ${{ matrix.command == 'review test' }}
         run: |

--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -65,13 +65,6 @@ jobs:
           ref: feabb8756de9bf322f4d0d18116e722fbea710c2
           path: .ci/extrachill-network
 
-      - name: Checkout Extra Chill API
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-        with:
-          repository: Extra-Chill/extrachill-api
-          ref: d449ed353f17b4c81cfd466fcbbefaa5ee637609
-          path: .ci/extrachill-api
-
       - name: Checkout Homeboy Extensions adapter fix
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
@@ -133,7 +126,7 @@ jobs:
       - name: Run Homeboy ${{ matrix.command }}
         env:
           HOMEBOY_SETTINGS_JSON: >-
-            {"database_type":"mysql","validation_dependencies":["${{ github.workspace }}/.ci/data-machine","${{ github.workspace }}/.ci/data-machine-events","${{ github.workspace }}/.ci/extrachill-network","${{ github.workspace }}/.ci/extrachill-api"],"wp_codebox_multisite":true,"wp_codebox_phpunit_bootstrap_mode":"managed"}
+            {"database_type":"mysql","validation_dependencies":["${{ github.workspace }}/.ci/data-machine","${{ github.workspace }}/.ci/data-machine-events","${{ github.workspace }}/.ci/extrachill-network"],"wp_codebox_multisite":true,"wp_codebox_phpunit_bootstrap_mode":"managed"}
           HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: ${{ github.workspace }}/wp-codebox-artifacts
           HOMEBOY_WP_CODEBOX_INSTALL_MODE: source
           HOMEBOY_WP_CODEBOX_REF: 4a3ae649abfb94353dfbae3e101b2ec2a76113e8

--- a/blocks/venue-booking-inquiry/render.php
+++ b/blocks/venue-booking-inquiry/render.php
@@ -9,32 +9,77 @@ use ExtraChillEvents\Core\VenueBookingConfig;
 
 defined( 'ABSPATH' ) || exit;
 
-$venue_id = absint( $attributes['venueId'] ?? 0 );
-if ( $venue_id < 1 && function_exists( 'extrachill_events_get_venue_archive_term' ) ) {
+$events_blog_id = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'events' ) ) : 0;
+$venue_id       = absint( $attributes['venueId'] ?? 0 );
+if ( $venue_id < 1 && (int) get_current_blog_id() === $events_blog_id && function_exists( 'extrachill_events_get_venue_archive_term' ) ) {
 	$archive_venue = extrachill_events_get_venue_archive_term();
 	$venue_id      = $archive_venue ? (int) $archive_venue->term_id : 0;
 }
-$venue = $venue_id > 0 ? get_term( $venue_id, 'venue' ) : null;
-if ( ! $venue instanceof WP_Term || 'venue' !== $venue->taxonomy || ! class_exists( VenueBookingConfig::class ) ) {
+if ( $events_blog_id < 1 || $venue_id < 1 || ! class_exists( VenueBookingConfig::class ) ) {
 	return;
 }
 
-$booking_config = ( new VenueBookingConfig() )->get( $venue_id );
-if ( is_wp_error( $booking_config ) || empty( $booking_config['enabled'] ) ) {
-	return;
-}
-
-$supported_types = array( 'text', 'textarea', 'email', 'phone', 'number', 'select', 'checkbox', 'url' );
-foreach ( $booking_config['intake']['fields'] as $field ) {
-	if ( ! in_array( $field['type'], $supported_types, true ) ) {
-		return;
+$canonical = ( static function () use ( $events_blog_id, $venue_id ) {
+	$switched = (int) get_current_blog_id() !== $events_blog_id;
+	if ( $switched ) {
+		if ( ! is_multisite() || ! get_site( $events_blog_id ) ) {
+			return null;
+		}
+		switch_to_blog( $events_blog_id );
 	}
+
+	try {
+		$venue = get_term( $venue_id, 'venue' );
+		if ( ! $venue instanceof WP_Term || 'venue' !== $venue->taxonomy ) {
+			return null;
+		}
+
+		$booking_config = ( new VenueBookingConfig() )->get_public_projection( $venue_id );
+		if ( is_wp_error( $booking_config ) || empty( $booking_config['enabled'] ) ) {
+			return null;
+		}
+
+		$supported_types = array( 'text', 'textarea', 'email', 'phone', 'number', 'select', 'checkbox', 'url' );
+		foreach ( $booking_config['fields'] as $field ) {
+			if ( ! in_array( $field['type'], $supported_types, true ) ) {
+				return null;
+			}
+		}
+
+		if ( function_exists( 'data_machine_events_get_venue_data' ) && function_exists( 'data_machine_events_get_venue_address' ) ) {
+			$venue_data = data_machine_events_get_venue_data( $venue_id );
+			$address    = data_machine_events_get_venue_address( $venue_id, $venue_data );
+		} else {
+			$street     = (string) get_term_meta( $venue_id, '_venue_address', true );
+			$city       = (string) get_term_meta( $venue_id, '_venue_city', true );
+			$state      = (string) get_term_meta( $venue_id, '_venue_state', true );
+			$zip        = (string) get_term_meta( $venue_id, '_venue_zip', true );
+			$city_state = implode( ', ', array_filter( array( $city, $state ) ) );
+			$address    = implode( ', ', array_filter( array( $street, $city_state, $zip ) ) );
+		}
+
+		return array(
+			'booking_config' => $booking_config,
+			'venue'          => array(
+				'id'          => $venue_id,
+				'name'        => $venue->name,
+				'description' => wp_strip_all_tags( $venue->description ),
+				'address'     => $address,
+			),
+		);
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
+} )();
+if ( ! is_array( $canonical ) ) {
+	return;
 }
 
-$venue_data = function_exists( 'data_machine_events_get_venue_data' ) ? data_machine_events_get_venue_data( $venue_id ) : array();
-$address    = function_exists( 'data_machine_events_get_venue_address' ) ? data_machine_events_get_venue_address( $venue_id, $venue_data ) : '';
-$instance   = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'ec-booking-' ) : 'ec-booking-' . $venue_id;
-$logged_in  = is_user_logged_in();
+$booking_config = $canonical['booking_config'];
+$instance       = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'ec-booking-' ) : 'ec-booking-' . $venue_id;
+$logged_in      = is_user_logged_in();
 if ( $logged_in ) {
 	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 		define( 'DONOTCACHEPAGE', true );
@@ -53,15 +98,10 @@ $public_config = array(
 	'heading'       => sanitize_text_field( (string) ( $attributes['heading'] ?? __( 'Booking inquiries', 'extrachill-events' ) ) ),
 	'buttonLabel'   => sanitize_text_field( (string) ( $attributes['buttonLabel'] ?? __( 'Send booking inquiry', 'extrachill-events' ) ) ),
 	'revision'      => (int) $booking_config['revision'],
-	'venue'         => array(
-		'id'          => $venue_id,
-		'name'        => $venue->name,
-		'description' => wp_strip_all_tags( term_description( $venue_id ) ),
-		'address'     => $address,
-	),
+	'venue'         => $canonical['venue'],
 	'requirements'  => array_values( $booking_config['public_requirements'] ),
 	'spaces'        => array_values( $booking_config['spaces'] ),
-	'fields'        => array_values( $booking_config['intake']['fields'] ),
+	'fields'        => array_values( $booking_config['fields'] ),
 	'consent'       => $booking_config['consent'],
 );
 

--- a/blocks/venue-booking-inquiry/render.php
+++ b/blocks/venue-booking-inquiry/render.php
@@ -80,12 +80,10 @@ if ( ! is_array( $canonical ) ) {
 $booking_config = $canonical['booking_config'];
 $instance       = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'ec-booking-' ) : 'ec-booking-' . $venue_id;
 $logged_in      = is_user_logged_in();
-if ( $logged_in ) {
-	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
-		define( 'DONOTCACHEPAGE', true );
-	}
-	nocache_headers();
+if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+	define( 'DONOTCACHEPAGE', true );
 }
+nocache_headers();
 if ( function_exists( 'ec_enqueue_turnstile_script' ) ) {
 	ec_enqueue_turnstile_script();
 }

--- a/extrachill-events-network-blocks.php
+++ b/extrachill-events-network-blocks.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin Name: Extra Chill Events Network Blocks
+ * Description: Exposes Events-owned public blocks across the Extra Chill network without loading the Events runtime on other sites.
+ * Author: Chris Huber
+ * Author URI: https://chubes.net
+ * Requires Plugins: extrachill-network, extrachill-api
+ * License: GPL v2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain: extrachill-events
+ * Requires at least: 6.9
+ * Tested up to: 6.9
+ * Requires PHP: 7.4
+ * Network: true
+ *
+ * @package ExtraChillEvents
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/inc/Core/VenueBookingConfig.php';
+
+/** Register Events-owned blocks that are safe to render on every network site. */
+function extrachill_events_register_network_blocks(): void {
+	$booking_inquiry_dir = __DIR__ . '/build/venue-booking-inquiry';
+	if ( file_exists( $booking_inquiry_dir . '/block.json' ) ) {
+		register_block_type( $booking_inquiry_dir );
+	}
+}
+add_action( 'init', 'extrachill_events_register_network_blocks' );

--- a/extrachill-events-network-blocks.php
+++ b/extrachill-events-network-blocks.php
@@ -4,7 +4,6 @@
  * Description: Exposes Events-owned public blocks across the Extra Chill network without loading the Events runtime on other sites.
  * Author: Chris Huber
  * Author URI: https://chubes.net
- * Requires Plugins: extrachill-network, extrachill-api
  * License: GPL v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: extrachill-events

--- a/extrachill-events-network-blocks.php
+++ b/extrachill-events-network-blocks.php
@@ -20,8 +20,59 @@ defined( 'ABSPATH' ) || exit;
 
 require_once __DIR__ . '/inc/Core/VenueBookingConfig.php';
 
+/**
+ * Return an activation error unless every runtime dependency is network-active.
+ *
+ * @param bool $network_wide Whether WordPress is activating across the network.
+ * @return WP_Error|null
+ */
+function extrachill_events_network_blocks_activation_error( bool $network_wide ) {
+	if ( ! is_multisite() || ! $network_wide ) {
+		return new WP_Error( 'network_activation_required', __( 'Extra Chill Events Network Blocks must be activated for the entire multisite network.', 'extrachill-events' ) );
+	}
+
+	if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$required = array(
+		'extrachill-network/extrachill-network.php' => 'Extra Chill Network',
+		'extrachill-api/extrachill-api.php'         => 'Extra Chill API',
+	);
+	$missing  = array();
+	foreach ( $required as $plugin => $label ) {
+		if ( ! is_plugin_active_for_network( $plugin ) ) {
+			$missing[] = $label;
+		}
+	}
+
+	if ( $missing ) {
+		/* translators: %s: Comma-separated plugin names. */
+		return new WP_Error( 'network_dependency_required', sprintf( __( 'Network-activate these required plugins first: %s.', 'extrachill-events' ), implode( ', ', $missing ) ) );
+	}
+
+	return null;
+}
+
+/**
+ * Fail activation clearly before WordPress records an unusable network plugin.
+ *
+ * @param bool $network_wide Whether WordPress is activating across the network.
+ */
+function extrachill_events_activate_network_blocks( bool $network_wide ): void {
+	$error = extrachill_events_network_blocks_activation_error( $network_wide );
+	if ( is_wp_error( $error ) ) {
+		wp_die( esc_html( $error->get_error_message() ), esc_html__( 'Network activation required', 'extrachill-events' ), array( 'response' => 500 ) );
+	}
+}
+register_activation_hook( __FILE__, 'extrachill_events_activate_network_blocks' );
+
 /** Register Events-owned blocks that are safe to render on every network site. */
 function extrachill_events_register_network_blocks(): void {
+	if ( defined( 'EXTRACHILL_EVENTS_PLUGIN_FILE' ) && function_exists( 'ec_is_events_site' ) && ec_is_events_site() ) {
+		return;
+	}
+
 	$booking_inquiry_dir = __DIR__ . '/build/venue-booking-inquiry';
 	if ( file_exists( $booking_inquiry_dir . '/block.json' ) ) {
 		register_block_type( $booking_inquiry_dir );

--- a/homeboy.json
+++ b/homeboy.json
@@ -25,7 +25,8 @@
           "data-machine",
           "data-machine-events",
           "data-machine-socials",
-          "extrachill-newsletter"
+          "extrachill-newsletter",
+          "extrachill-network"
         ],
         "wp_codebox_phpunit_preload_files": [
           "/wordpress/wp-content/plugins/extrachill-events/tests/MySQLIntegration/booking-schema-multisite-bootstrap.php"

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -51,6 +51,48 @@ class VenueBookingConfig {
 		return $this->normalize( $stored );
 	}
 
+	/**
+	 * Return the validated fields safe for the public inquiry block.
+	 *
+	 * @param int $venue_term_id Canonical venue term ID.
+	 * @return array|\WP_Error
+	 */
+	public function get_public_projection( int $venue_term_id ) {
+		$venue = $this->venue( $venue_term_id );
+		if ( is_wp_error( $venue ) ) {
+			return $venue;
+		}
+
+		$stored = get_term_meta( $venue_term_id, self::META_KEY, true );
+		if ( ! is_array( $stored ) || self::VERSION !== ( $stored['version'] ?? null ) ) {
+			return new \WP_Error( 'invalid_booking_public_config', __( 'The public venue booking configuration is unavailable.', 'extrachill-events' ) );
+		}
+
+		$revision = $stored['revision'] ?? null;
+		if ( ! is_int( $revision ) || $revision < 0 || ! is_array( $stored['intake'] ?? null ) || 1 !== ( $stored['intake']['version'] ?? null ) ) {
+			return new \WP_Error( 'invalid_booking_public_config', __( 'The public venue booking configuration is unavailable.', 'extrachill-events' ) );
+		}
+
+		$fields       = $this->normalize_intake_fields( $stored['intake']['fields'] ?? null );
+		$requirements = $this->normalize_public_requirements( $stored['public_requirements'] ?? null );
+		$consent      = $this->normalize_consent( $stored['consent'] ?? null );
+		$spaces       = $this->normalize_spaces( $stored['spaces'] ?? null );
+		foreach ( array( $fields, $requirements, $consent, $spaces ) as $section ) {
+			if ( is_wp_error( $section ) ) {
+				return $section;
+			}
+		}
+
+		return array(
+			'enabled'             => ! empty( $stored['enabled'] ),
+			'revision'            => $revision,
+			'fields'              => $fields,
+			'public_requirements' => $requirements,
+			'consent'             => $consent,
+			'spaces'              => $spaces,
+		);
+	}
+
 	/** Atomically replace a venue config at one expected revision. */
 	public function update( int $venue_term_id, array $config, int $expected_revision, int $actor_user_id ) {
 		global $wpdb;

--- a/inc/core/bootstrap.php
+++ b/inc/core/bootstrap.php
@@ -52,11 +52,6 @@ function extrachill_events_register_blocks() {
 	if ( file_exists( $venue_settings_dir . '/block.json' ) ) {
 		register_block_type( $venue_settings_dir );
 	}
-
-	$booking_inquiry_dir = EXTRACHILL_EVENTS_PLUGIN_DIR . 'build/venue-booking-inquiry';
-	if ( file_exists( $booking_inquiry_dir . '/block.json' ) ) {
-		register_block_type( $booking_inquiry_dir );
-	}
 }
 add_action( 'init', 'extrachill_events_register_blocks' );
 

--- a/inc/core/bootstrap.php
+++ b/inc/core/bootstrap.php
@@ -52,6 +52,11 @@ function extrachill_events_register_blocks() {
 	if ( file_exists( $venue_settings_dir . '/block.json' ) ) {
 		register_block_type( $venue_settings_dir );
 	}
+
+	$booking_inquiry_dir = EXTRACHILL_EVENTS_PLUGIN_DIR . 'build/venue-booking-inquiry';
+	if ( file_exists( $booking_inquiry_dir . '/block.json' ) ) {
+		register_block_type( $booking_inquiry_dir );
+	}
 }
 add_action( 'init', 'extrachill_events_register_blocks' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2150,6 +2150,150 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@cacheable/memory": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+			"integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@cacheable/utils": "^2.5.0",
+				"@keyv/bigmap": "^1.3.1",
+				"hookified": "^1.15.1",
+				"keyv": "^5.6.0"
+			}
+		},
+		"node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"hashery": "^1.4.0",
+				"hookified": "^1.15.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"keyv": "^5.6.0"
+			}
+		},
+		"node_modules/@cacheable/memory/node_modules/keyv": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1"
+			}
+		},
+		"node_modules/@cacheable/utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+			"integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"hashery": "^1.5.1",
+				"keyv": "^5.6.0"
+			}
+		},
+		"node_modules/@cacheable/utils/node_modules/keyv": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/media-query-list-parser": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
+			"integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
 		"node_modules/@csstools/selector-specificity": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
@@ -2189,6 +2333,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/@dual-bundle/import-meta-resolve": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
+			"integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/JounQin"
 			}
 		},
 		"node_modules/@emotion/babel-plugin": {
@@ -3099,6 +3256,15 @@
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
+		},
+		"node_modules/@keyv/serialize": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+			"integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@leichtgewicht/ip-codec": {
 			"version": "2.0.5",
@@ -7661,6 +7827,58 @@
 				}
 			}
 		},
+		"node_modules/@wordpress/ui/node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+			"integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"optional": true,
+			"peer": true,
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@csstools/selector-specificity": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"postcss-selector-parser": "^7.0.0"
+			}
+		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/hooks": {
 			"version": "4.50.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
@@ -7770,6 +7988,382 @@
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/@wordpress/ui/node_modules/balanced-match": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/@wordpress/ui/node_modules/cosmiconfig": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+			"integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"env-paths": "^2.2.1",
+				"import-fresh": "^3.3.0",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/file-entry-cache": {
+			"version": "11.1.5",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+			"integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"flat-cache": "^6.1.23"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/flat-cache": {
+			"version": "6.1.23",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+			"integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"cacheable": "^2.5.0",
+				"flatted": "^3.4.2",
+				"hookified": "^1.15.0"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/global-modules": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"global-prefix": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/global-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"ini": "^1.3.5",
+				"kind-of": "^6.0.2",
+				"which": "^1.3.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/ignore": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/js-yaml": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/known-css-properties": {
+			"version": "0.37.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/@wordpress/ui/node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/@wordpress/ui/node_modules/meow": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/postcss-safe-parser": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+			"integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/postcss-selector-parser": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+			"integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/stylelint": {
+			"version": "16.26.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+			"integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/stylelint"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/stylelint"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.19",
+				"@csstools/css-tokenizer": "^3.0.4",
+				"@csstools/media-query-list-parser": "^4.0.3",
+				"@csstools/selector-specificity": "^5.0.0",
+				"@dual-bundle/import-meta-resolve": "^4.2.1",
+				"balanced-match": "^2.0.0",
+				"colord": "^2.9.3",
+				"cosmiconfig": "^9.0.0",
+				"css-functions-list": "^3.2.3",
+				"css-tree": "^3.1.0",
+				"debug": "^4.4.3",
+				"fast-glob": "^3.3.3",
+				"fastest-levenshtein": "^1.0.16",
+				"file-entry-cache": "^11.1.1",
+				"global-modules": "^2.0.0",
+				"globby": "^11.1.0",
+				"globjoin": "^0.1.4",
+				"html-tags": "^3.3.1",
+				"ignore": "^7.0.5",
+				"imurmurhash": "^0.1.4",
+				"is-plain-object": "^5.0.0",
+				"known-css-properties": "^0.37.0",
+				"mathml-tag-names": "^2.1.3",
+				"meow": "^13.2.0",
+				"micromatch": "^4.0.8",
+				"normalize-path": "^3.0.0",
+				"picocolors": "^1.1.1",
+				"postcss": "^8.5.6",
+				"postcss-resolve-nested-selector": "^0.1.6",
+				"postcss-safe-parser": "^7.0.1",
+				"postcss-selector-parser": "^7.1.0",
+				"postcss-value-parser": "^4.2.0",
+				"resolve-from": "^5.0.0",
+				"string-width": "^4.2.3",
+				"supports-hyperlinks": "^3.2.0",
+				"svg-tags": "^1.0.0",
+				"table": "^6.9.0",
+				"write-file-atomic": "^5.0.1"
+			},
+			"bin": {
+				"stylelint": "bin/stylelint.mjs"
+			},
+			"engines": {
+				"node": ">=18.12.0"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/supports-hyperlinks": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
@@ -9318,6 +9912,34 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/cacheable": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+			"integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@cacheable/memory": "^2.2.0",
+				"@cacheable/utils": "^2.5.0",
+				"hookified": "^1.15.0",
+				"keyv": "^5.6.0",
+				"qified": "^0.10.1"
+			}
+		},
+		"node_modules/cacheable/node_modules/keyv": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1"
 			}
 		},
 		"node_modules/call-bind": {
@@ -11251,6 +11873,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/envinfo": {
@@ -13866,6 +14500,21 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/hashery": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+			"integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"hookified": "^1.15.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
 		"node_modules/hasown": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -13926,6 +14575,15 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/hookified": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+			"integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/hosted-git-info": {
 			"version": "4.1.0",
@@ -19600,6 +20258,30 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/qified": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+			"integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"hookified": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/qified/node_modules/hookified": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+			"integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/qs": {
 			"version": "6.15.2",

--- a/phpunit-managed.xml.dist
+++ b/phpunit-managed.xml.dist
@@ -19,6 +19,7 @@
 			<file>tests/Unit/VenueUpdateSubscriptionsTest.php</file>
 			<file>tests/Unit/SingleEventNetworkBridgeTest.php</file>
 			<file>tests/Unit/ConcertStatsPublicProfileRenderTest.php</file>
+			<file>tests/Unit/VenueBookingInquiryRenderTest.php</file>
 			<file>tests/MySQLIntegration/BookingSchemaMultisiteTest.php</file>
 		</testsuite>
 	</testsuites>

--- a/phpunit-network-block.xml.dist
+++ b/phpunit-network-block.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="tests/fixtures/network-booking-block-cold-bootstrap.inc"
+	colors="true"
+	beStrictAboutOutputDuringTests="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	failOnRisky="true"
+	failOnWarning="true">
+	<testsuites>
+		<testsuite name="network-booking-block-cold-load">
+			<file>tests/NetworkBookingBlockColdTest.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/NetworkBookingBlockColdTest.php
+++ b/tests/NetworkBookingBlockColdTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Cold network booking block tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+
+/** Proves the network companion in a cold non-Events process. */
+final class NetworkBookingBlockColdTest extends TestCase {
+	/** Render without loading private booking-domain dependencies. */
+	public function test_companion_only_render_has_bounded_dependencies_and_restores_main_context(): void {
+		require_once dirname( __DIR__ ) . '/extrachill-events-network-blocks.php';
+
+		$this->assertFalse( class_exists( '\ExtraChillEvents\Core\BookingRepository', false ) );
+		extrachill_events_register_network_blocks();
+		$this->assertCount( 1, $GLOBALS['ec_network_block_test']['registered'] );
+
+		$attributes = array( 'venueId' => 1524 );
+		ob_start();
+		include dirname( __DIR__ ) . '/blocks/venue-booking-inquiry/render.php';
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'Cold Room', $output );
+		$this->assertStringContainsString( 'https:\/\/extrachill.com\/wp-json\/extrachill\/v1\/venues\/1524\/booking-inquiries', $output );
+		$this->assertTrue( $GLOBALS['ec_network_block_test']['turnstile_enqueued'] );
+		$this->assertSame( 1, get_current_blog_id() );
+		$this->assertSame( array(), $GLOBALS['ec_network_block_test']['stack'] );
+	}
+}

--- a/tests/NetworkBookingBlockColdTest.php
+++ b/tests/NetworkBookingBlockColdTest.php
@@ -10,13 +10,30 @@ use PHPUnit\Framework\TestCase;
 
 /** Proves the network companion in a cold non-Events process. */
 final class NetworkBookingBlockColdTest extends TestCase {
+	/** Load only the network companion for this process. */
+	public static function setUpBeforeClass(): void {
+		require_once dirname( __DIR__ ) . '/extrachill-events-network-blocks.php';
+	}
+
+	/** Reset the simulated network request and activation state. */
+	protected function setUp(): void {
+		$GLOBALS['ec_network_block_test']['blog_id']         = 1;
+		$GLOBALS['ec_network_block_test']['stack']           = array();
+		$GLOBALS['ec_network_block_test']['registered']      = array();
+		$GLOBALS['ec_network_block_test']['nocache_headers'] = 0;
+		$GLOBALS['ec_network_block_test']['network_plugins'] = array(
+			'extrachill-network/extrachill-network.php',
+			'extrachill-api/extrachill-api.php',
+		);
+	}
+
 	/** Render without loading private booking-domain dependencies. */
 	public function test_companion_only_render_has_bounded_dependencies_and_restores_main_context(): void {
-		require_once dirname( __DIR__ ) . '/extrachill-events-network-blocks.php';
-
 		$this->assertFalse( class_exists( '\ExtraChillEvents\Core\BookingRepository', false ) );
 		extrachill_events_register_network_blocks();
 		$this->assertCount( 1, $GLOBALS['ec_network_block_test']['registered'] );
+		$this->assertFileExists( $GLOBALS['ec_network_block_test']['registered'][0] . '/block.json' );
+		$this->assertFileEquals( dirname( __DIR__ ) . '/blocks/venue-booking-inquiry/render.php', $GLOBALS['ec_network_block_test']['registered'][0] . '/render.php' );
 
 		$attributes = array( 'venueId' => 1524 );
 		ob_start();
@@ -26,7 +43,36 @@ final class NetworkBookingBlockColdTest extends TestCase {
 		$this->assertStringContainsString( 'Cold Room', $output );
 		$this->assertStringContainsString( 'https:\/\/extrachill.com\/wp-json\/extrachill\/v1\/venues\/1524\/booking-inquiries', $output );
 		$this->assertTrue( $GLOBALS['ec_network_block_test']['turnstile_enqueued'] );
+		$this->assertTrue( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE );
+		$this->assertSame( 1, $GLOBALS['ec_network_block_test']['nocache_headers'] );
 		$this->assertSame( 1, get_current_blog_id() );
 		$this->assertSame( array(), $GLOBALS['ec_network_block_test']['stack'] );
+	}
+
+	/** Require true network activation and network-active dependencies. */
+	public function test_activation_rejects_site_only_or_missing_dependencies(): void {
+		$this->assertSame( 'extrachill_events_activate_network_blocks', $GLOBALS['ec_network_block_test']['activation_callback'] );
+		$this->assertNull( extrachill_events_network_blocks_activation_error( true ) );
+		$this->assertSame( 'network_activation_required', extrachill_events_network_blocks_activation_error( false )->get_error_code() );
+
+		$GLOBALS['ec_network_block_test']['network_plugins'] = array( 'extrachill-network/extrachill-network.php' );
+		$error = extrachill_events_network_blocks_activation_error( true );
+		$this->assertSame( 'network_dependency_required', $error->get_error_code() );
+		$this->assertStringContainsString( 'Extra Chill API', $error->get_error_message() );
+	}
+
+	/** Skip Events when the full site plugin is loaded, but not other sites. */
+	public function test_companion_respects_full_plugin_active_site(): void {
+		if ( ! defined( 'EXTRACHILL_EVENTS_PLUGIN_FILE' ) ) {
+			define( 'EXTRACHILL_EVENTS_PLUGIN_FILE', dirname( __DIR__ ) . '/extrachill-events.php' );
+		}
+
+		$GLOBALS['ec_network_block_test']['blog_id'] = 7;
+		extrachill_events_register_network_blocks();
+		$this->assertSame( array(), $GLOBALS['ec_network_block_test']['registered'] );
+
+		$GLOBALS['ec_network_block_test']['blog_id'] = 1;
+		extrachill_events_register_network_blocks();
+		$this->assertCount( 1, $GLOBALS['ec_network_block_test']['registered'] );
 	}
 }

--- a/tests/Unit/VenueBookingInquiryRenderTest.php
+++ b/tests/Unit/VenueBookingInquiryRenderTest.php
@@ -136,7 +136,7 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'extrachill-events-network-blocks.php', $plugins );
 		$this->assertTrue( $plugins['extrachill-events-network-blocks.php']['Network'] );
 
-		foreach ( array( self::EVENTS_BLOG_ID, self::MAIN_BLOG_ID, self::STUDIO_BLOG_ID ) as $blog_id ) {
+		foreach ( array( self::MAIN_BLOG_ID, self::STUDIO_BLOG_ID ) as $blog_id ) {
 			if ( $registry->is_registered( 'extrachill/venue-booking-inquiry' ) ) {
 				$registry->unregister( 'extrachill/venue-booking-inquiry' );
 			}
@@ -169,26 +169,41 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 		}
 	}
 
-	/** Enforce network-active dependencies rather than site-only activation. */
+	/** Enforce network-active dependencies through WordPress's activation path. */
 	public function test_network_entrypoint_activation_uses_actual_network_plugin_state(): void {
 		require_once dirname( __DIR__, 2 ) . '/extrachill-events-network-blocks.php';
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 		$network_plugins = get_site_option( 'active_sitewide_plugins', array() );
 		$site_plugins    = get_option( 'active_plugins', array() );
+		$plugin          = 'extrachill-events/extrachill-events-network-blocks.php';
 		$required        = array(
 			'extrachill-network/extrachill-network.php' => time(),
 			'extrachill-api/extrachill-api.php'         => time(),
 		);
 		try {
 			update_site_option( 'active_sitewide_plugins', $required );
-			$this->assertNull( extrachill_events_network_blocks_activation_error( true ) );
+			$this->assertNull( activate_plugin( $plugin, '', true, false ) );
+			$this->assertTrue( is_plugin_active_for_network( $plugin ) );
+			deactivate_plugins( $plugin, true, true );
 
 			update_site_option( 'active_sitewide_plugins', array() );
 			update_option( 'active_plugins', array_keys( $required ) );
-			$error = extrachill_events_network_blocks_activation_error( true );
-			$this->assertWPError( $error );
-			$this->assertSame( 'network_dependency_required', $error->get_error_code() );
+			$die_handler = static function () {
+				return static function ( $message ): void {
+					throw new RuntimeException( wp_strip_all_tags( $message ) );
+				};
+			};
+			add_filter( 'wp_die_handler', $die_handler );
+			try {
+				activate_plugin( $plugin, '', true, false );
+				$this->fail( 'Site-only dependencies must not permit network activation.' );
+			} catch ( RuntimeException $error ) {
+				$this->assertStringContainsString( 'Network-activate these required plugins first', $error->getMessage() );
+			} finally {
+				remove_filter( 'wp_die_handler', $die_handler );
+			}
+			$this->assertFalse( is_plugin_active_for_network( $plugin ) );
 		} finally {
 			update_site_option( 'active_sitewide_plugins', $network_plugins );
 			update_option( 'active_plugins', $site_plugins );

--- a/tests/Unit/VenueBookingInquiryRenderTest.php
+++ b/tests/Unit/VenueBookingInquiryRenderTest.php
@@ -7,30 +7,69 @@
 
 use ExtraChillEvents\Core\VenueBookingConfig;
 
+/** Proves the Events-owned booking block across canonical network contexts. */
 final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
+	private const EVENTS_BLOG_ID = 7;
+	private const MAIN_BLOG_ID   = 1;
+	private const STUDIO_BLOG_ID = 12;
+
+	/**
+	 * Canonical Events venue fixture ID.
+	 *
+	 * @var int
+	 */
 	private int $venue_id;
 
+	/** Create one enabled canonical venue booking projection. */
 	protected function setUp(): void {
 		parent::setUp();
 		wp_set_current_user( 0 );
-		$term           = self::factory()->term->create_and_get( array( 'taxonomy' => 'venue', 'name' => 'Test Room', 'description' => 'Independent room in Charleston.' ) );
-		$this->venue_id = (int) $term->term_id;
-		$config         = ( new VenueBookingConfig() )->defaults();
-		$config['enabled']             = true;
-		$config['revision']            = 4;
-		$config['public_requirements'] = array( 'Include recent draw and routing.' );
-		$config['spaces']              = array( array( 'key' => 'main-room', 'name' => 'Main Room', 'is_default' => true ) );
-		$config['intake']['fields']    = array( array( 'key' => 'draw', 'label' => 'Recent draw', 'type' => 'number', 'required' => true, 'options' => array() ) );
-		$config['ticket_provider_reference'] = 'private-provider-account';
+		switch_to_blog( self::EVENTS_BLOG_ID );
+		$term                                        = self::factory()->term->create_and_get(
+			array(
+				'taxonomy'    => 'venue',
+				'name'        => 'Test Room',
+				'description' => 'Independent room in Charleston.',
+			)
+		);
+		$this->venue_id                              = (int) $term->term_id;
+		$config                                      = ( new VenueBookingConfig() )->defaults();
+		$config['enabled']                           = true;
+		$config['revision']                          = 4;
+		$config['public_requirements']               = array( 'Include recent draw and routing.' );
+		$config['spaces']                            = array(
+			array(
+				'key'        => 'main-room',
+				'name'       => 'Main Room',
+				'is_default' => true,
+			),
+		);
+		$config['intake']['fields']                  = array(
+			array(
+				'key'      => 'draw',
+				'label'    => 'Recent draw',
+				'type'     => 'number',
+				'required' => true,
+				'options'  => array(),
+			),
+		);
+		$config['ticket_provider_reference']         = 'private-provider-account';
 		$config['correspondence']['booking_address'] = 'private-booking@example.com';
 		update_term_meta( $this->venue_id, VenueBookingConfig::META_KEY, $config );
+		update_term_meta( $this->venue_id, '_venue_address', '42 Test Street' );
+		update_term_meta( $this->venue_id, '_venue_city', 'Charleston' );
+		update_term_meta( $this->venue_id, '_venue_state', 'SC' );
+		update_term_meta( $this->venue_id, '_venue_zip', '29403' );
+		restore_current_blog();
 	}
 
+	/** Confirm that only the established public projection reaches markup. */
 	public function test_render_contains_only_redacted_public_projection(): void {
-		$output = $this->render( array( 'venueId' => $this->venue_id ) );
+		$output = $this->render_on( self::EVENTS_BLOG_ID, array( 'venueId' => $this->venue_id ) );
 
 		$this->assertStringContainsString( 'ec-venue-booking-inquiry', $output );
 		$this->assertStringContainsString( 'Test Room', $output );
+		$this->assertStringContainsString( '42 Test Street, Charleston, SC, 29403', $output );
 		$this->assertStringContainsString( 'Include recent draw and routing.', $output );
 		$this->assertStringContainsString( '"revision":4', $output );
 		$this->assertStringNotContainsString( 'private-provider-account', $output );
@@ -38,17 +77,126 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'attachment', strtolower( $output ) );
 	}
 
+	/** Disabled canonical configuration must fail closed on another site. */
 	public function test_disabled_config_fails_closed_without_form_markup(): void {
+		switch_to_blog( self::EVENTS_BLOG_ID );
 		$config            = get_term_meta( $this->venue_id, VenueBookingConfig::META_KEY, true );
 		$config['enabled'] = false;
 		update_term_meta( $this->venue_id, VenueBookingConfig::META_KEY, $config );
+		restore_current_blog();
 
-		$this->assertSame( '', $this->render( array( 'venueId' => $this->venue_id ) ) );
+		$this->assertSame( '', $this->render_on( self::MAIN_BLOG_ID, array( 'venueId' => $this->venue_id ) ) );
 	}
 
+	/** Render the same canonical venue through Events, main, and Studio. */
+	public function test_events_main_and_studio_render_from_canonical_events_data_without_context_leakage(): void {
+		foreach ( array( self::EVENTS_BLOG_ID, self::MAIN_BLOG_ID, self::STUDIO_BLOG_ID ) as $blog_id ) {
+			$output           = $this->render_on( $blog_id, array( 'venueId' => $this->venue_id ) );
+			$endpoint         = get_rest_url( $blog_id, 'extrachill/v1/venues/' . $this->venue_id . '/booking-inquiries' );
+			$encoded_endpoint = trim( wp_json_encode( $endpoint ), '"' );
+
+			$this->assertStringContainsString( 'Test Room', $output, 'Canonical venue data should render on blog ' . $blog_id );
+			$this->assertStringContainsString( $encoded_endpoint, $output, 'The caller-site route-affinity endpoint should render on blog ' . $blog_id );
+		}
+	}
+
+	/** Missing configuration must fail closed and leave the caller context intact. */
+	public function test_missing_venue_fails_closed_on_network_site_without_context_leakage(): void {
+		$this->assertSame( '', $this->render_on( self::STUDIO_BLOG_ID, array( 'venueId' => 999999 ) ) );
+		$this->assertSame( '', $this->render_on( self::MAIN_BLOG_ID, array() ) );
+	}
+
+	/** Preserve automatic venue resolution on canonical Events archives. */
+	public function test_events_archive_still_resolves_venue_automatically(): void {
+		global $wp_query;
+
+		switch_to_blog( self::EVENTS_BLOG_ID );
+		$previous_query              = $wp_query;
+		$wp_query                    = new WP_Query();
+		$wp_query->is_tax            = true;
+		$wp_query->queried_object    = get_term( $this->venue_id, 'venue' );
+		$wp_query->queried_object_id = $this->venue_id;
+
+		try {
+			$output = $this->render( array() );
+			$this->assertStringContainsString( 'Test Room', $output );
+		} finally {
+			$wp_query = $previous_query;
+			restore_current_blog();
+		}
+	}
+
+	/** Register the existing dynamic block assets without the Events runtime. */
+	public function test_network_entrypoint_registers_existing_assets_on_all_intended_sites(): void {
+		require_once dirname( __DIR__, 2 ) . '/extrachill-events-network-blocks.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		$registry = WP_Block_Type_Registry::get_instance();
+		$plugins  = get_plugins( '/extrachill-events' );
+		$this->assertArrayHasKey( 'extrachill-events-network-blocks.php', $plugins );
+		$this->assertTrue( $plugins['extrachill-events-network-blocks.php']['Network'] );
+
+		foreach ( array( self::EVENTS_BLOG_ID, self::MAIN_BLOG_ID, self::STUDIO_BLOG_ID ) as $blog_id ) {
+			if ( $registry->is_registered( 'extrachill/venue-booking-inquiry' ) ) {
+				$registry->unregister( 'extrachill/venue-booking-inquiry' );
+			}
+			switch_to_blog( $blog_id );
+			try {
+				extrachill_events_register_network_blocks();
+				$block = $registry->get_registered( 'extrachill/venue-booking-inquiry' );
+				$this->assertInstanceOf( WP_Block_Type::class, $block );
+				$this->assertIsCallable( $block->render_callback );
+				$this->assertNotEmpty( $block->style_handles );
+				$this->assertNotEmpty( $block->view_script_handles );
+			} finally {
+				restore_current_blog();
+			}
+		}
+
+		foreach ( array( 'extrachill/venue-booking-inquiry', 'extrachill/event-submission', 'extrachill/concert-stats', 'extrachill/venue-settings' ) as $block_name ) {
+			if ( $registry->is_registered( $block_name ) ) {
+				$registry->unregister( $block_name );
+			}
+		}
+		switch_to_blog( self::EVENTS_BLOG_ID );
+		try {
+			extrachill_events_register_network_blocks();
+			$network_block = $registry->get_registered( 'extrachill/venue-booking-inquiry' );
+			extrachill_events_register_blocks();
+			$this->assertSame( $network_block, $registry->get_registered( 'extrachill/venue-booking-inquiry' ) );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * Render from one caller blog and restore the test's original context.
+	 *
+	 * @param int   $blog_id    Caller blog ID.
+	 * @param array $attributes Block attributes.
+	 */
+	private function render_on( int $blog_id, array $attributes ): string {
+		switch_to_blog( $blog_id );
+		try {
+			return $this->render( $attributes );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * Include the dynamic template and assert its internal switch is balanced.
+	 *
+	 * @param array $attributes Block attributes.
+	 */
 	private function render( array $attributes ): string {
+		$blog_id      = get_current_blog_id();
+		$switch_depth = count( $GLOBALS['_wp_switched_stack'] ?? array() );
 		ob_start();
 		include dirname( __DIR__, 2 ) . '/blocks/venue-booking-inquiry/render.php';
-		return (string) ob_get_clean();
+		$output = (string) ob_get_clean();
+
+		$this->assertSame( $blog_id, get_current_blog_id() );
+		$this->assertCount( $switch_depth, $GLOBALS['_wp_switched_stack'] ?? array() );
+		return $output;
 	}
 }

--- a/tests/Unit/VenueBookingInquiryRenderTest.php
+++ b/tests/Unit/VenueBookingInquiryRenderTest.php
@@ -75,6 +75,7 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'private-provider-account', $output );
 		$this->assertStringNotContainsString( 'private-booking@example.com', $output );
 		$this->assertStringNotContainsString( 'attachment', strtolower( $output ) );
+		$this->assertTrue( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE );
 	}
 
 	/** Disabled canonical configuration must fail closed on another site. */
@@ -90,7 +91,7 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 
 	/** Render the same canonical venue through Events, main, and Studio. */
 	public function test_events_main_and_studio_render_from_canonical_events_data_without_context_leakage(): void {
-		foreach ( array( self::EVENTS_BLOG_ID, self::MAIN_BLOG_ID, self::STUDIO_BLOG_ID ) as $blog_id ) {
+		foreach ( array( self::MAIN_BLOG_ID, self::STUDIO_BLOG_ID ) as $blog_id ) {
 			$output           = $this->render_on( $blog_id, array( 'venueId' => $this->venue_id ) );
 			$endpoint         = get_rest_url( $blog_id, 'extrachill/v1/venues/' . $this->venue_id . '/booking-inquiries' );
 			$encoded_endpoint = trim( wp_json_encode( $endpoint ), '"' );
@@ -160,11 +161,37 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 		switch_to_blog( self::EVENTS_BLOG_ID );
 		try {
 			extrachill_events_register_network_blocks();
-			$network_block = $registry->get_registered( 'extrachill/venue-booking-inquiry' );
+			$this->assertFalse( $registry->is_registered( 'extrachill/venue-booking-inquiry' ) );
 			extrachill_events_register_blocks();
-			$this->assertSame( $network_block, $registry->get_registered( 'extrachill/venue-booking-inquiry' ) );
+			$this->assertTrue( $registry->is_registered( 'extrachill/venue-booking-inquiry' ) );
 		} finally {
 			restore_current_blog();
+		}
+	}
+
+	/** Enforce network-active dependencies rather than site-only activation. */
+	public function test_network_entrypoint_activation_uses_actual_network_plugin_state(): void {
+		require_once dirname( __DIR__, 2 ) . '/extrachill-events-network-blocks.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		$network_plugins = get_site_option( 'active_sitewide_plugins', array() );
+		$site_plugins    = get_option( 'active_plugins', array() );
+		$required        = array(
+			'extrachill-network/extrachill-network.php' => time(),
+			'extrachill-api/extrachill-api.php'         => time(),
+		);
+		try {
+			update_site_option( 'active_sitewide_plugins', $required );
+			$this->assertNull( extrachill_events_network_blocks_activation_error( true ) );
+
+			update_site_option( 'active_sitewide_plugins', array() );
+			update_option( 'active_plugins', array_keys( $required ) );
+			$error = extrachill_events_network_blocks_activation_error( true );
+			$this->assertWPError( $error );
+			$this->assertSame( 'network_dependency_required', $error->get_error_code() );
+		} finally {
+			update_site_option( 'active_sitewide_plugins', $network_plugins );
+			update_option( 'active_plugins', $site_plugins );
 		}
 	}
 

--- a/tests/Unit/VenueBookingInquiryRenderTest.php
+++ b/tests/Unit/VenueBookingInquiryRenderTest.php
@@ -171,8 +171,11 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 
 	/** Enforce network-active dependencies through WordPress's activation path. */
 	public function test_network_entrypoint_activation_uses_actual_network_plugin_state(): void {
-		require_once dirname( __DIR__, 2 ) . '/extrachill-events-network-blocks.php';
+		$plugin_file = dirname( __DIR__, 2 ) . '/extrachill-events-network-blocks.php';
+		require_once $plugin_file;
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		// WP_UnitTestCase resets hooks between tests after require_once has loaded the entrypoint.
+		register_activation_hook( $plugin_file, 'extrachill_events_activate_network_blocks' );
 
 		$network_plugins = get_site_option( 'active_sitewide_plugins', array() );
 		$site_plugins    = get_option( 'active_plugins', array() );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -248,13 +248,13 @@ require_once dirname( __DIR__ ) . '/inc/Core/PlatformDetector.php';
 require_once dirname( __DIR__ ) . '/inc/Core/QualifyFingerprinter.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueQualificationAbilities.php';
 
-// Managed multisite tests exercise the production network's Events blog ID.
-if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site' ) && function_exists( 'wpmu_create_blog' ) && ! get_site( 7 ) ) {
-	while ( ! get_site( 7 ) ) {
+// Managed multisite tests exercise the production Events and Studio blog IDs.
+if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site' ) && function_exists( 'wpmu_create_blog' ) && ! get_site( 12 ) ) {
+	while ( ! get_site( 12 ) ) {
 		$next_id = get_sites( array( 'count' => true ) ) + 1;
 		$created = wpmu_create_blog( 'site-' . $next_id . '.example.org', '/', 'Test Site ' . $next_id, 1 );
-		if ( is_wp_error( $created ) || (int) $created > 7 ) {
-			throw new RuntimeException( 'Unable to provision the Events multisite test fixture.' );
+		if ( is_wp_error( $created ) || (int) $created > 12 ) {
+			throw new RuntimeException( 'Unable to provision the Extra Chill multisite test fixture.' );
 		}
 	}
 }

--- a/tests/fixtures/network-booking-block-cold-bootstrap.inc
+++ b/tests/fixtures/network-booking-block-cold-bootstrap.inc
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Cold non-Events bootstrap for the network booking block.
+ *
+ * This fixture intentionally supplies only WordPress functions reached by the
+ * network companion and public render projection.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+final class WP_Error {}
+
+final class WP_Term {
+	public int $term_id = 1524;
+	public string $taxonomy = 'venue';
+	public string $name = 'Cold Room';
+	public string $description = 'Canonical Events venue.';
+}
+
+$GLOBALS['ec_network_block_test'] = array(
+	'blog_id'    => 1,
+	'stack'      => array(),
+	'registered' => array(),
+);
+
+function add_action( $hook, $callback ): void {
+	$GLOBALS['ec_network_block_test']['actions'][ $hook ][] = $callback;
+}
+
+function register_block_type( $path ) {
+	$GLOBALS['ec_network_block_test']['registered'][] = $path;
+	return true;
+}
+
+function absint( $value ): int {
+	return abs( (int) $value );
+}
+
+function ec_get_blog_id( $site ): ?int {
+	return 'events' === $site ? 7 : null;
+}
+
+function get_current_blog_id(): int {
+	return $GLOBALS['ec_network_block_test']['blog_id'];
+}
+
+function is_multisite(): bool {
+	return true;
+}
+
+function get_site( $blog_id ) {
+	return 7 === (int) $blog_id ? (object) array( 'blog_id' => 7 ) : null;
+}
+
+function switch_to_blog( $blog_id ): bool {
+	$GLOBALS['ec_network_block_test']['stack'][] = get_current_blog_id();
+	$GLOBALS['ec_network_block_test']['blog_id'] = (int) $blog_id;
+	return true;
+}
+
+function restore_current_blog(): bool {
+	$GLOBALS['ec_network_block_test']['blog_id'] = array_pop( $GLOBALS['ec_network_block_test']['stack'] );
+	return true;
+}
+
+function get_term( $term_id, $taxonomy ) {
+	return 7 === get_current_blog_id() && 1524 === (int) $term_id && 'venue' === $taxonomy ? new WP_Term() : null;
+}
+
+function get_term_meta( $term_id, $key, $single ) {
+	unset( $single );
+	if ( 7 !== get_current_blog_id() || 1524 !== (int) $term_id ) {
+		return '';
+	}
+	if ( '_extrachill_booking_config' === $key ) {
+		return array(
+			'version'             => 3,
+			'revision'            => 9,
+			'enabled'             => true,
+			'intake'              => array(
+				'version' => 1,
+				'fields'  => array(
+					array(
+						'key'      => 'draw',
+						'label'    => 'Recent draw',
+						'type'     => 'number',
+						'required' => true,
+						'options'  => array(),
+					),
+				),
+			),
+			'public_requirements' => array( 'Include routing.' ),
+			'consent'             => array(
+				'id'       => 'booking-privacy',
+				'version'  => 1,
+				'label'    => 'I agree.',
+				'required' => true,
+			),
+			'spaces'              => array(),
+		);
+	}
+	$meta = array(
+		'_venue_address' => '42 Test Street',
+		'_venue_city'    => 'Charleston',
+		'_venue_state'   => 'SC',
+		'_venue_zip'     => '29403',
+	);
+	return $meta[ $key ] ?? '';
+}
+
+function is_wp_error( $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function __( $text ): string {
+	return $text;
+}
+
+function sanitize_key( $value ): string {
+	return preg_replace( '/[^a-z0-9_-]/', '', strtolower( (string) $value ) );
+}
+
+function sanitize_text_field( $value ): string {
+	return trim( strip_tags( (string) $value ) );
+}
+
+function sanitize_textarea_field( $value ): string {
+	return sanitize_text_field( $value );
+}
+
+function sanitize_email( $value ): string {
+	return filter_var( $value, FILTER_VALIDATE_EMAIL ) ? (string) $value : '';
+}
+
+function wp_strip_all_tags( $value ): string {
+	return strip_tags( (string) $value );
+}
+
+function wp_unique_id( $prefix ): string {
+	return $prefix . 'cold';
+}
+
+function is_user_logged_in(): bool {
+	return false;
+}
+
+function ec_enqueue_turnstile_script(): void {
+	$GLOBALS['ec_network_block_test']['turnstile_enqueued'] = true;
+}
+
+function rest_url( $path ): string {
+	return 'https://extrachill.com/wp-json/' . ltrim( $path, '/' );
+}
+
+function wp_json_encode( $value, $flags = 0 ) {
+	return json_encode( $value, $flags );
+}
+
+function get_block_wrapper_attributes( $attributes ): string {
+	return 'class="' . $attributes['class'] . '"';
+}
+
+function ec_render_turnstile_widget(): string {
+	return '<div class="turnstile"></div>';
+}
+
+function wp_kses_post( $value ): string {
+	return $value;
+}
+
+function esc_html_e( $value ): void {
+	echo htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+}

--- a/tests/fixtures/network-booking-block-cold-bootstrap.inc
+++ b/tests/fixtures/network-booking-block-cold-bootstrap.inc
@@ -10,7 +10,23 @@
 
 define( 'ABSPATH', __DIR__ . '/' );
 
-final class WP_Error {}
+final class WP_Error {
+	private string $code;
+	private string $message;
+
+	public function __construct( $code = '', $message = '' ) {
+		$this->code    = (string) $code;
+		$this->message = (string) $message;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+}
 
 final class WP_Term {
 	public int $term_id = 1524;
@@ -23,10 +39,23 @@ $GLOBALS['ec_network_block_test'] = array(
 	'blog_id'    => 1,
 	'stack'      => array(),
 	'registered' => array(),
+	'network_plugins' => array(
+		'extrachill-network/extrachill-network.php',
+		'extrachill-api/extrachill-api.php',
+	),
 );
 
 function add_action( $hook, $callback ): void {
 	$GLOBALS['ec_network_block_test']['actions'][ $hook ][] = $callback;
+}
+
+function register_activation_hook( $file, $callback ): void {
+	unset( $file );
+	$GLOBALS['ec_network_block_test']['activation_callback'] = $callback;
+}
+
+function is_plugin_active_for_network( $plugin ): bool {
+	return in_array( $plugin, $GLOBALS['ec_network_block_test']['network_plugins'], true );
 }
 
 function register_block_type( $path ) {
@@ -48,6 +77,10 @@ function get_current_blog_id(): int {
 
 function is_multisite(): bool {
 	return true;
+}
+
+function ec_is_events_site(): bool {
+	return 7 === get_current_blog_id();
 }
 
 function get_site( $blog_id ) {
@@ -146,6 +179,10 @@ function is_user_logged_in(): bool {
 	return false;
 }
 
+function nocache_headers(): void {
+	$GLOBALS['ec_network_block_test']['nocache_headers'] = ( $GLOBALS['ec_network_block_test']['nocache_headers'] ?? 0 ) + 1;
+}
+
 function ec_enqueue_turnstile_script(): void {
 	$GLOBALS['ec_network_block_test']['turnstile_enqueued'] = true;
 }
@@ -172,4 +209,17 @@ function wp_kses_post( $value ): string {
 
 function esc_html_e( $value ): void {
 	echo htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+}
+
+function esc_html( $value ): string {
+	return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+}
+
+function esc_html__( $value ): string {
+	return esc_html( $value );
+}
+
+function wp_die( $message, $title = '', $args = array() ): void {
+	unset( $title, $args );
+	throw new RuntimeException( (string) $message );
 }


### PR DESCRIPTION
## Summary
- add a minimal network-only companion entrypoint that registers the existing `extrachill/venue-booking-inquiry` block without loading Events schemas, abilities, handlers, or storage on other sites
- preserve the existing Events-site registration so normal plugin updates keep the live form available before, during, and after companion activation; the companion skips Events when the full site plugin is loaded
- resolve the configured venue term, bounded public booking projection, and canonical venue profile fields under the Events blog, restoring the caller blog through `finally` before emitting Turnstile, assets, React config, and the caller-site route-affinity endpoint
- mark every successfully rendered inquiry page uncacheable for anonymous and authenticated visitors so canonical config, consent, and enabled-state changes cannot remain stale on embedding sites
- reject companion activation unless it is network-wide and both Extra Chill Network and Extra Chill API are actually network-active

## Activation
Network-activate `extrachill-events/extrachill-events-network-blocks.php`. Keep the main `extrachill-events/extrachill-events.php` plugin active on Events so Events remains the sole owner of booking storage, abilities, configuration, writes, and its compatibility registration path.

## Verification
- `./vendor/bin/phpunit --configuration phpunit-network-block.xml.dist` (3 tests, 20 assertions)
- `./vendor/bin/phpunit --configuration phpunit-venue-unit.xml.dist` (44 tests, 322 assertions)
- `npm run test:js -- --runInBand` (13 suites, 57 tests)
- `npm run build`
- `homeboy review lint --changed-only --summary --placement local` (PHPCS and PHPStan passed)
- stale-build proof: the cold suite failed on source/build mismatch before rebuilding, then passed after `npm run build`
- clean-tree proof: archive-derived source started without `build/venue-booking-inquiry/block.json`, built all assets, and passed the 3-test cold registration/activation/cache suite
- `git diff origin/main...HEAD --check`
- `git archive --format=tar HEAD | tar -tf - extrachill-events-network-blocks.php`
- focused managed multisite PHPUnit is included in `phpunit-managed.xml.dist` with pinned `extrachill-network` validation coverage; local execution remains blocked before PHPUnit by the installed WP Codebox policy parser, so the PR's pinned CI runtime is the executable managed gate

Closes #452