### PR TITLE
fix: synchronize companion plugin version

### DIFF
--- a/extrachill-events-network-blocks.php
+++ b/extrachill-events-network-blocks.php
@@ -2,6 +2,7 @@
 /**
  * Plugin Name: Extra Chill Events Network Blocks
  * Description: Exposes Events-owned public blocks across the Extra Chill network without loading the Events runtime on other sites.
+ * Version: 0.54.1
  * Author: Chris Huber
  * Author URI: https://chubes.net
  * License: GPL v2 or later

--- a/homeboy.json
+++ b/homeboy.json
@@ -46,6 +46,10 @@
       "pattern": "EXTRACHILL_EVENTS_VERSION',\\s*'([0-9.]+)'"
     },
     {
+      "file": "extrachill-events-network-blocks.php",
+      "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"
+    },
+    {
       "file": "blocks/concert-stats/block.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\"",
       "artifact_path": "build/concert-stats/block.json"

--- a/tests/Unit/VenueBookingInquiryRenderTest.php
+++ b/tests/Unit/VenueBookingInquiryRenderTest.php
@@ -135,6 +135,7 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 		$plugins  = get_plugins( '/extrachill-events' );
 		$this->assertArrayHasKey( 'extrachill-events-network-blocks.php', $plugins );
 		$this->assertTrue( $plugins['extrachill-events-network-blocks.php']['Network'] );
+		$this->assertSame( EXTRACHILL_EVENTS_VERSION, $plugins['extrachill-events-network-blocks.php']['Version'] );
 
 		foreach ( array( self::MAIN_BLOG_ID, self::STUDIO_BLOG_ID ) as $blog_id ) {
 			if ( $registry->is_registered( 'extrachill/venue-booking-inquiry' ) ) {


### PR DESCRIPTION
## Summary
- version the network booking block companion alongside the canonical Events plugin
- register both entrypoint headers as Homeboy version targets
- assert shared version parity in managed WordPress coverage

## Verification
- Homeboy changed-file lint, PHPCS, and PHPStan pass
- package discovery selects `extrachill-events-network-blocks.php` and successfully extracts `v0.54.1`
- cold network suite passes: 3 tests, 20 assertions
- `php -l`, JSON validation, and `git diff --check` pass

Closes #458.

The builder's nondeterministic entrypoint selection is tracked separately in Extra-Chill/homeboy-extensions#2459. A subsequent installed-extension helper failure is tracked in Extra-Chill/homeboy-extensions#2460.