### PR TITLE
feat: add auditable show settlements

### DIFF
--- a/.github/workflows/booking-attachment-mysql.yml
+++ b/.github/workflows/booking-attachment-mysql.yml
@@ -168,8 +168,8 @@ jobs:
           WP_TESTS_PHPUNIT_POLYFILLS_PATH: ${{ github.workspace }}/vendor/yoast/phpunit-polyfills
         run: |
           set -euo pipefail
-          vendor/bin/phpunit -c phpunit-booking-concurrency.xml.dist --filter 'test_concurrent_booking_schema_installer_waits_and_converges|test_resolution_and_finalization_race_freezes_one_consistent_winner|test_concurrent_source_and_report_registrations_converge_or_conflict_exactly|test_concurrent_exact_inquiry_retry_reuses_one_complete_winner' | tee "$RUNNER_TEMP/booking-admission-concurrency.txt"
-          grep -E 'OK \(4 tests, [1-9][0-9]* assertions?\)' "$RUNNER_TEMP/booking-admission-concurrency.txt"
+          vendor/bin/phpunit -c phpunit-booking-concurrency.xml.dist --filter 'test_concurrent_booking_schema_installer_waits_and_converges|test_resolution_and_finalization_race_freezes_one_consistent_winner|test_concurrent_source_and_report_registrations_converge_or_conflict_exactly|test_concurrent_exact_inquiry_retry_reuses_one_complete_winner|test_show_settlement_revision_finalize_dispute_and_payment_races_serialize' | tee "$RUNNER_TEMP/booking-admission-concurrency.txt"
+          grep -E 'OK \(5 tests, [1-9][0-9]* assertions?\)' "$RUNNER_TEMP/booking-admission-concurrency.txt"
           if grep -Eiq 'skip|no tests executed|OK, but' "$RUNNER_TEMP/booking-admission-concurrency.txt"; then
             exit 1
           fi

--- a/.github/workflows/booking-attachment-mysql.yml
+++ b/.github/workflows/booking-attachment-mysql.yml
@@ -168,8 +168,8 @@ jobs:
           WP_TESTS_PHPUNIT_POLYFILLS_PATH: ${{ github.workspace }}/vendor/yoast/phpunit-polyfills
         run: |
           set -euo pipefail
-          vendor/bin/phpunit -c phpunit-booking-concurrency.xml.dist --filter 'test_concurrent_booking_schema_installer_waits_and_converges|test_resolution_and_finalization_race_freezes_one_consistent_winner|test_concurrent_source_and_report_registrations_converge_or_conflict_exactly|test_concurrent_exact_inquiry_retry_reuses_one_complete_winner|test_show_settlement_revision_finalize_dispute_and_payment_races_serialize' | tee "$RUNNER_TEMP/booking-admission-concurrency.txt"
-          grep -E 'OK \(5 tests, [1-9][0-9]* assertions?\)' "$RUNNER_TEMP/booking-admission-concurrency.txt"
+          vendor/bin/phpunit -c phpunit-booking-concurrency.xml.dist --filter 'test_concurrent_booking_schema_installer_waits_and_converges|test_resolution_and_finalization_race_freezes_one_consistent_winner|test_concurrent_source_and_report_registrations_converge_or_conflict_exactly|test_concurrent_exact_inquiry_retry_reuses_one_complete_winner|test_show_settlement_revision_finalize_dispute_and_payment_races_serialize|test_commission_void_races_show_create_finalize_and_payment' | tee "$RUNNER_TEMP/booking-admission-concurrency.txt"
+          grep -E 'OK \(6 tests, [1-9][0-9]* assertions?\)' "$RUNNER_TEMP/booking-admission-concurrency.txt"
           if grep -Eiq 'skip|no tests executed|OK, but' "$RUNNER_TEMP/booking-admission-concurrency.txt"; then
             exit 1
           fi

--- a/docs/show-settlements.md
+++ b/docs/show-settlements.md
@@ -65,8 +65,10 @@ Non-zero door gross requires at least one active booking attachment admitted as
 attachment under the same existing private policy. The service uses the existing
 opaque download handoff, streams and hashes every byte, checks exact byte size,
 and binds attachment public ID, request hash, content hash, size, MIME, and
-purpose. It authenticates bytes before draft calculation, finalization, and
-payment, then rechecks the exact metadata under the financial transaction lock.
+purpose. Exact booking and actor authorization always precede private stream
+issuance or delivery audit. The service authenticates bytes before draft
+calculation, finalization, and payment, then rechecks the exact metadata under
+the financial transaction lock.
 
 Historical reads compare the frozen metadata rather than rerunning current MIME
 or filename admission policy, so later policy changes do not invalidate valid
@@ -77,18 +79,37 @@ data, bank or tax identity, payment secrets, or database diagnostics.
 
 ## Authorization And Concurrency
 
-Every ability and every service method requires the existing
-`manage_finances` action. That action already combines the booking finance
-capability/feature gate with active owner membership for the exact venue. There
-is no administrator bypass and no speculative artist or venue role matrix.
-Cross-venue reads and writes fail closed.
+Every venue operation requires the existing `manage_finances` action. That
+action already combines the booking finance capability/feature gate with active
+owner membership for the exact venue. Direct counterparty acknowledgement is
+the sole exception and uses the existing canonical artist-manager authority.
+There is no administrator bypass. Cross-venue reads and writes fail closed.
 
 Transactions use the existing lock order: exact venue membership, booking,
-revision, then lifecycle rows. Exact retries return the prior authenticated
+commission, revision, then lifecycle rows. The exact commission row, integrity
+hash, currency, and non-void status are reloaded under that transaction and on
+every revision verification. Exact retries return the prior authenticated
 result. Reusing an idempotency key with changed input conflicts. Concurrent
-finalize, revise, dispute, correction, payment, and void transitions serialize
-through row locks plus unique revision/version keys. Payment additionally
-revalidates the booking as `completed` while its row is locked.
+commission void versus revision creation, finalization, or payment and all show
+lifecycle transitions serialize through row locks plus unique revision/version
+keys. Payment additionally revalidates the booking as `completed` while its row
+is locked.
+
+## Acknowledgement Attribution
+
+An `acknowledged` action never treats a venue operator's statement as direct
+counterparty assent. `counterparty_verified` is accepted only from a currently
+authorized manager of the canonical artist term/profile bound to the booking;
+the server records that authenticated user and canonical artist IDs in the
+immutable action. `venue_recorded` remains a venue-finance operation and
+requires authenticated immutable private evidence of the acknowledgement. It
+records the same canonical counterparty IDs but leaves the attesting user null.
+
+Clients cannot submit names, email addresses, account details, tax identity, or
+arbitrary counterparty IDs. Artist authority revocation blocks new direct
+attestations. Later disputes and correction revisions preserve the original
+attribution and evidence rather than rewriting it. Ability projections redact
+evidence hashes and storage metadata.
 
 ## Abilities
 

--- a/docs/show-settlements.md
+++ b/docs/show-settlements.md
@@ -1,0 +1,109 @@
+# Complete Show Settlements
+
+## Ownership Boundary
+
+The complete show settlement extends, and never replaces, the frozen commission
+contract documented in `ticket-settlements.md`. Ticket attribution, imported
+sales reports, report corrections, reconciliation, and certified CSV evidence
+remain owned by #316. `ec_booking_settlements` remains the sole #294 record of
+the Extra Chill share, including formula versions 1, 2, and 3. A show revision
+binds that row's ID and integrity hash and revalidates it through
+`TicketSettlementService` on every read, draft, finalization, and payment.
+The show service pages through the exact frozen `included_report_ids`, rechecks
+their immutable report hashes and currency through #316, and requires recorded
+ticket gross to equal their overflow-safe signed gross sum.
+
+The artist payout is a separate calculated field. It is never written to or
+read from `amount_due_minor`, which remains the distinct Extra Chill share.
+
+## Immutable Model
+
+Schema version 15 adds two site-stamped InnoDB tables:
+
+- `ec_booking_show_settlements` contains append-only calculation revisions.
+  Each row binds booking, event, exact venue, revision number, optional corrected
+  revision, frozen commission, currency, formula, normalized terms, private
+  evidence fingerprints, calculation, request hash, integrity hash, actor, and
+  timestamp. Unique booking/revision and booking/idempotency keys serialize
+  revision creation.
+- `ec_booking_show_settlement_actions` is an append-only optimistic lifecycle.
+  Every action binds one revision, its exact expected lifecycle version, action
+  payload, request hash, idempotency key, actor, and timestamp. A unique
+  revision/version key prevents concurrent transitions from both winning.
+
+Draft revisions are immutable too. Revising a draft appends its successor.
+Correcting a finalized, acknowledged, or disputed revision appends a linked
+correction draft and atomically marks the prior revision `corrected`. The prior
+financial data remains readable. Finalization, acknowledgement, dispute,
+payment, and void are actions, never silent updates to frozen terms.
+
+## Formula Version 1
+
+All money is signed integer minor units in one explicit three-letter currency.
+Rates are integer basis points. Floating point is never used, and every addition
+and multiplication rejects integer overflow.
+
+Definitions:
+
+1. `total_gross = ticket_gross + door_gross`
+2. `deductions = fees + taxes + refunds + venue_expenses + production_expenses`
+3. `adjustment_total = sum(signed_adjustments)`
+4. `artist_split_basis = total_gross - deductions + adjustment_total - extra_chill_share`
+5. `artist_split = max(0, artist_split_basis) * artist_split_basis_points / 10000`
+6. `artist_payout = max(artist_guarantee, artist_split)`
+7. `venue_net_after_payout = artist_split_basis - artist_payout`
+
+Basis-point products use the #294 integer helper: nearest minor unit, with exact
+halves away from zero. Deductions and artist guarantee cannot be negative.
+Adjustments are signed by the authenticated finance actor and bind amount,
+reason, actor, and a canonical signature hash.
+
+## Evidence And Privacy
+
+Non-zero door gross requires at least one active booking attachment admitted as
+`other_private_evidence`. Payment requires at least one payout-evidence
+attachment under the same existing private policy. The service uses the existing
+opaque download handoff, streams and hashes every byte, checks exact byte size,
+and binds attachment public ID, request hash, content hash, size, MIME, and
+purpose. It authenticates bytes before draft calculation, finalization, and
+payment, then rechecks the exact metadata under the financial transaction lock.
+
+Historical reads compare the frozen metadata rather than rerunning current MIME
+or filename admission policy, so later policy changes do not invalidate valid
+history. Missing, inactive, moved, or tampered evidence fails closed. Ability
+projections expose only attachment ID, public UUID, MIME, and byte size. They do
+not expose content hashes, storage references, paths, stream tokens, recipient
+data, bank or tax identity, payment secrets, or database diagnostics.
+
+## Authorization And Concurrency
+
+Every ability and every service method requires the existing
+`manage_finances` action. That action already combines the booking finance
+capability/feature gate with active owner membership for the exact venue. There
+is no administrator bypass and no speculative artist or venue role matrix.
+Cross-venue reads and writes fail closed.
+
+Transactions use the existing lock order: exact venue membership, booking,
+revision, then lifecycle rows. Exact retries return the prior authenticated
+result. Reusing an idempotency key with changed input conflicts. Concurrent
+finalize, revise, dispute, correction, payment, and void transitions serialize
+through row locks plus unique revision/version keys. Payment additionally
+revalidates the booking as `completed` while its row is locked.
+
+## Abilities
+
+- `extrachill/draft-booking-show-settlement`
+- `extrachill/read-booking-show-settlement`
+- `extrachill/revise-booking-show-settlement`
+- `extrachill/finalize-booking-show-settlement`
+- `extrachill/acknowledge-booking-show-settlement`
+- `extrachill/dispute-booking-show-settlement`
+- `extrachill/correct-booking-show-settlement`
+- `extrachill/mark-booking-artist-payout-paid`
+- `extrachill/void-booking-show-settlement`
+
+Payment records a bounded opaque reference, explicit `Y-m-d` payment date,
+authenticated payout evidence, and actor. Account numbers, routing data,
+recipient identity, and tax records are intentionally outside this contract.
+The raw payment reference remains private at rest; ability reads return only a
+`payment_reference_recorded` marker.

--- a/docs/ticket-settlements.md
+++ b/docs/ticket-settlements.md
@@ -47,10 +47,12 @@ The row also
 retains the terminal paid or void audit. Finalized evidence and terms are never
 rewritten.
 
-Schema version 14 explicitly migrates version 13 in place. It preserves every
-current table and row, backfills exact identity hashes, and adds versioned,
-nullable source and attachment provenance columns without rewriting legacy
-report hashes. A site-scoped MySQL advisory lock serializes concurrent
+Schema version 14 explicitly migrated version 13 in place, backfilled exact
+identity hashes, and added versioned nullable provenance without rewriting
+legacy report hashes. Schema version 15 adds complete show-settlement revision
+and lifecycle tables without changing this commission table or its formula
+compatibility, preserving every existing table and row. A site-scoped MySQL
+advisory lock serializes concurrent
 installers. The existing `dbDelta` installer then verifies exact
 columns/indexes/engines and stamps each multisite site only after health checks
 pass.
@@ -127,5 +129,6 @@ silently contribute to commission, and excluded evidence remains visible
 in diagnostics and immutable history.
 
 Provider adapters and provider-specific parsing remain outside this generic
-booking domain. Full show expenses or artist payouts from #318 are also outside
-this contract.
+booking domain. Complete show expenses and artist payouts are layered over this
+frozen commission by the separate show-settlement contract; they do not alter or
+reinterpret it.

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -304,6 +304,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingConfig.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/TicketReconciliationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/TicketSettlementService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ShowSettlementService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueProfile.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/CanonicalEventPublicationGuard.php';
 		\ExtraChillEvents\Core\BookingHoldRepository::register();
@@ -433,6 +434,9 @@ class ExtraChillEvents {
 
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/TicketSettlementAbilities.php';
 			new \ExtraChillEvents\Abilities\TicketSettlementAbilities();
+
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/ShowSettlementAbilities.php';
+			new \ExtraChillEvents\Abilities\ShowSettlementAbilities();
 		}
 
 		if ( \ExtraChillEvents\Core\LocalSupportSchema::is_ready() ) {

--- a/inc/Abilities/ShowSettlementAbilities.php
+++ b/inc/Abilities/ShowSettlementAbilities.php
@@ -1,0 +1,353 @@
+<?php
+/**
+ * Complete show-settlement abilities.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+// Repository convention uses concise method comments and translated registrar labels.
+// phpcs:disable Generic.Commenting.DocComment.MissingShort,Squiz.Commenting.FunctionComment.Missing,Squiz.Commenting.VariableComment.Missing,WordPress.WP.I18n.NonSingularStringLiteralText
+
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\ShowSettlementService;
+use ExtraChillEvents\Core\VenueAuthorization;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Registers bounded private finance operations over immutable show revisions. */
+class ShowSettlementAbilities {
+	private static bool $registered = false;
+	/** @var ShowSettlementService */
+	private $service;
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var VenueAuthorization */
+	private $authorization;
+
+	public function __construct( ?ShowSettlementService $service = null, ?BookingRepository $bookings = null, ?VenueAuthorization $authorization = null ) {
+		$this->bookings      = $bookings ? $bookings : new BookingRepository();
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+		$this->service       = $service ? $service : new ShowSettlementService( $this->bookings, null, $this->authorization );
+		if ( ! self::$registered ) {
+			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+			self::$registered = true;
+		}
+	}
+
+	/** Register the complete private show-settlement lifecycle. */
+	public function register(): void {
+		$this->register_ability( 'extrachill/draft-booking-show-settlement', 'Draft Booking Show Settlement', $this->revision_input( false ), 'draft', false, true );
+		$this->register_ability( 'extrachill/read-booking-show-settlement', 'Read Booking Show Settlement', $this->read_input(), 'read', true, true );
+		$this->register_ability( 'extrachill/revise-booking-show-settlement', 'Revise Booking Show Settlement', $this->revision_input( true ), 'revise', false, true );
+		$this->register_ability( 'extrachill/finalize-booking-show-settlement', 'Finalize Booking Show Settlement', $this->transition_input(), 'finalize', false, true );
+		$this->register_ability( 'extrachill/acknowledge-booking-show-settlement', 'Acknowledge Booking Show Settlement', $this->transition_input( 'note', false ), 'acknowledge', false, true );
+		$this->register_ability( 'extrachill/dispute-booking-show-settlement', 'Dispute Booking Show Settlement', $this->transition_input( 'reason' ), 'dispute', false, true );
+		$this->register_ability( 'extrachill/correct-booking-show-settlement', 'Correct Booking Show Settlement', $this->revision_input( true, true ), 'correct', false, true );
+		$this->register_ability( 'extrachill/mark-booking-artist-payout-paid', 'Mark Booking Artist Payout Paid', $this->payment_input(), 'mark_paid', false, true );
+		$this->register_ability( 'extrachill/void-booking-show-settlement', 'Void Booking Show Settlement', $this->transition_input( 'reason' ), 'void_settlement', false, true );
+	}
+
+	private function register_ability( string $name, string $label, array $input, string $execute, bool $is_readonly, bool $idempotent ): void {
+		wp_register_ability(
+			$name,
+			array(
+				'label'               => __( $label, 'extrachill-events' ),
+				'description'         => __( $label, 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => $input,
+				'output_schema'       => $this->output_schema(),
+				'execute_callback'    => array( $this, $execute ),
+				'permission_callback' => array( $this, 'can_manage' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => $is_readonly,
+						'idempotent'  => $idempotent,
+						'destructive' => ! $is_readonly,
+					),
+				),
+			)
+		);
+	}
+
+	public function draft( array $input ) {
+		return $this->service->draft( $input, get_current_user_id() );
+	}
+
+	public function read( array $input ) {
+		return $this->service->get( (int) $input['booking_id'], get_current_user_id(), isset( $input['revision'] ) ? (int) $input['revision'] : null );
+	}
+
+	public function revise( array $input ) {
+		return $this->service->revise( $input, get_current_user_id() );
+	}
+
+	public function finalize( array $input ) {
+		return $this->service->finalize( $input, get_current_user_id() );
+	}
+
+	public function acknowledge( array $input ) {
+		return $this->service->acknowledge( $input, get_current_user_id() );
+	}
+
+	public function dispute( array $input ) {
+		return $this->service->dispute( $input, get_current_user_id() );
+	}
+
+	public function correct( array $input ) {
+		return $this->service->correct( $input, get_current_user_id() );
+	}
+
+	public function mark_paid( array $input ) {
+		return $this->service->mark_paid( $input, get_current_user_id() );
+	}
+
+	public function void_settlement( array $input ) {
+		return $this->service->void( $input, get_current_user_id() );
+	}
+
+	public function can_manage( array $input ) {
+		$booking = $this->bookings->get( absint( $input['booking_id'] ?? 0 ) );
+		return is_array( $booking )
+			? $this->authorization->authorize( get_current_user_id(), $booking['venue_term_id'], VenueAuthorization::ACTION_MANAGE_FINANCES )
+			: new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to manage this venue settlement.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+
+	private function revision_input( bool $replacement, bool $correction = false ): array {
+		$properties = array(
+			'booking_id'                 => $this->id(),
+			'commission_settlement_id'   => $this->id(),
+			'currency'                   => $this->currency(),
+			'ticket_gross_minor'         => array( 'type' => 'integer' ),
+			'door_gross_minor'           => array( 'type' => 'integer' ),
+			'fees_minor'                 => array(
+				'type'    => 'integer',
+				'minimum' => 0,
+			),
+			'taxes_minor'                => array(
+				'type'    => 'integer',
+				'minimum' => 0,
+			),
+			'refunds_minor'              => array(
+				'type'    => 'integer',
+				'minimum' => 0,
+			),
+			'venue_expenses_minor'       => array(
+				'type'    => 'integer',
+				'minimum' => 0,
+			),
+			'production_expenses_minor'  => array(
+				'type'    => 'integer',
+				'minimum' => 0,
+			),
+			'artist_guarantee_minor'     => array(
+				'type'    => 'integer',
+				'minimum' => 0,
+			),
+			'artist_split_basis_points'  => array(
+				'type'    => 'integer',
+				'minimum' => 0,
+				'maximum' => 10000,
+			),
+			'adjustments'                => array(
+				'type'     => 'array',
+				'maxItems' => 100,
+				'items'    => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'amount_minor' => array( 'type' => 'integer' ),
+						'reason'       => array(
+							'type'      => 'string',
+							'minLength' => 1,
+							'maxLength' => 500,
+						),
+					),
+					'required'             => array( 'amount_minor', 'reason' ),
+					'additionalProperties' => false,
+				),
+			),
+			'door_report_attachment_ids' => $this->ids( 20, false ),
+			'idempotency_key'            => $this->key(),
+		);
+		$required   = array( 'booking_id', 'commission_settlement_id', 'currency', 'ticket_gross_minor', 'door_gross_minor', 'fees_minor', 'taxes_minor', 'refunds_minor', 'venue_expenses_minor', 'production_expenses_minor', 'artist_guarantee_minor', 'artist_split_basis_points', 'adjustments', 'door_report_attachment_ids', 'idempotency_key' );
+		if ( $replacement ) {
+			$properties['expected_revision_id'] = $this->id();
+			$required[]                         = 'expected_revision_id';
+		}
+		if ( $correction ) {
+			$properties['expected_version'] = $this->id();
+			$properties['reason']           = array(
+				'type'      => 'string',
+				'minLength' => 1,
+				'maxLength' => 1000,
+			);
+			$required[]                     = 'expected_version';
+			$required[]                     = 'reason';
+		}
+		return array(
+			'type'                 => 'object',
+			'properties'           => $properties,
+			'required'             => $required,
+			'additionalProperties' => false,
+		);
+	}
+
+	private function read_input(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'booking_id' => $this->id(),
+				'revision'   => $this->id(),
+			),
+			'required'             => array( 'booking_id' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function transition_input( ?string $field = null, bool $required = true ): array {
+		$properties      = array(
+			'booking_id'       => $this->id(),
+			'revision_id'      => $this->id(),
+			'expected_version' => $this->id(),
+			'idempotency_key'  => $this->key(),
+		);
+		$required_fields = array_keys( $properties );
+		if ( null !== $field ) {
+			$properties[ $field ] = array(
+				'type'      => 'string',
+				'minLength' => 1,
+				'maxLength' => 1000,
+			);
+			if ( $required ) {
+				$required_fields[] = $field;
+			}
+		}
+		return array(
+			'type'                 => 'object',
+			'properties'           => $properties,
+			'required'             => $required_fields,
+			'additionalProperties' => false,
+		);
+	}
+
+	private function payment_input(): array {
+		$schema                                    = $this->transition_input();
+		$schema['properties']['payment_reference'] = array(
+			'type'      => 'string',
+			'minLength' => 1,
+			'maxLength' => 191,
+		);
+		$schema['properties']['payment_date']      = array(
+			'type'    => 'string',
+			'pattern' => '^\d{4}-\d{2}-\d{2}$',
+		);
+		$schema['properties']['payout_evidence_attachment_ids'] = $this->ids( 20, true );
+		$schema['required'][]                                   = 'payment_reference';
+		$schema['required'][]                                   = 'payment_date';
+		$schema['required'][]                                   = 'payout_evidence_attachment_ids';
+		return $schema;
+	}
+
+	private function output_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'id'                        => $this->id(),
+				'public_id'                 => array(
+					'type'    => 'string',
+					'pattern' => '^[a-fA-F0-9-]{36}$',
+				),
+				'booking_id'                => $this->id(),
+				'event_id'                  => $this->id(),
+				'venue_term_id'             => $this->id(),
+				'revision'                  => $this->id(),
+				'corrects_revision_id'      => array(
+					'type'    => array( 'integer', 'null' ),
+					'minimum' => 1,
+				),
+				'commission_settlement_id'  => $this->id(),
+				'commission_integrity_hash' => array(
+					'type'    => 'string',
+					'pattern' => '^[a-f0-9]{64}$',
+				),
+				'currency'                  => $this->currency(),
+				'formula_version'           => array(
+					'type' => 'integer',
+					'enum' => array( ShowSettlementService::FORMULA_VERSION ),
+				),
+				'terms'                     => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
+				'evidence'                  => array(
+					'type'     => 'array',
+					'maxItems' => 20,
+					'items'    => array(
+						'type'                 => 'object',
+						'additionalProperties' => true,
+					),
+				),
+				'calculation'               => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
+				'integrity_hash'            => array(
+					'type'    => 'string',
+					'pattern' => '^[a-f0-9]{64}$',
+				),
+				'created_by_user_id'        => $this->id(),
+				'created_at'                => array( 'type' => 'string' ),
+				'status'                    => array(
+					'type' => 'string',
+					'enum' => array_merge( array( 'draft' ), ShowSettlementService::ACTIONS ),
+				),
+				'version'                   => $this->id(),
+				'actions'                   => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'                 => 'object',
+						'additionalProperties' => true,
+					),
+				),
+			),
+			'required'             => array( 'id', 'public_id', 'booking_id', 'event_id', 'venue_term_id', 'revision', 'corrects_revision_id', 'commission_settlement_id', 'commission_integrity_hash', 'currency', 'formula_version', 'terms', 'evidence', 'calculation', 'integrity_hash', 'created_by_user_id', 'created_at', 'status', 'version', 'actions' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function id(): array {
+		return array(
+			'type'    => 'integer',
+			'minimum' => 1,
+		);
+	}
+
+	private function currency(): array {
+		return array(
+			'type'    => 'string',
+			'pattern' => '^[A-Z]{3}$',
+		);
+	}
+
+	private function key(): array {
+		return array(
+			'type'      => 'string',
+			'minLength' => 1,
+			'maxLength' => 191,
+		);
+	}
+
+	private function ids( int $max, bool $required ): array {
+		return array(
+			'type'        => 'array',
+			'minItems'    => $required ? 1 : 0,
+			'maxItems'    => $max,
+			'uniqueItems' => true,
+			'items'       => $this->id(),
+		);
+	}
+}

--- a/inc/Abilities/ShowSettlementAbilities.php
+++ b/inc/Abilities/ShowSettlementAbilities.php
@@ -11,6 +11,7 @@ namespace ExtraChillEvents\Abilities;
 // phpcs:disable Generic.Commenting.DocComment.MissingShort,Squiz.Commenting.FunctionComment.Missing,Squiz.Commenting.VariableComment.Missing,WordPress.WP.I18n.NonSingularStringLiteralText
 
 use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\LocalSupportAuthorization;
 use ExtraChillEvents\Core\ShowSettlementService;
 use ExtraChillEvents\Core\VenueAuthorization;
 
@@ -27,11 +28,14 @@ class ShowSettlementAbilities {
 	private $bookings;
 	/** @var VenueAuthorization */
 	private $authorization;
+	/** @var LocalSupportAuthorization */
+	private $artist_authorization;
 
-	public function __construct( ?ShowSettlementService $service = null, ?BookingRepository $bookings = null, ?VenueAuthorization $authorization = null ) {
-		$this->bookings      = $bookings ? $bookings : new BookingRepository();
-		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
-		$this->service       = $service ? $service : new ShowSettlementService( $this->bookings, null, $this->authorization );
+	public function __construct( ?ShowSettlementService $service = null, ?BookingRepository $bookings = null, ?VenueAuthorization $authorization = null, ?LocalSupportAuthorization $artist_authorization = null ) {
+		$this->bookings             = $bookings ? $bookings : new BookingRepository();
+		$this->authorization        = $authorization ? $authorization : new VenueAuthorization();
+		$this->artist_authorization = $artist_authorization ? $artist_authorization : new LocalSupportAuthorization( $this->authorization );
+		$this->service              = $service ? $service : new ShowSettlementService( $this->bookings, null, $this->authorization, null, null, null, $this->artist_authorization );
 		if ( ! self::$registered ) {
 			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
 			self::$registered = true;
@@ -44,14 +48,14 @@ class ShowSettlementAbilities {
 		$this->register_ability( 'extrachill/read-booking-show-settlement', 'Read Booking Show Settlement', $this->read_input(), 'read', true, true );
 		$this->register_ability( 'extrachill/revise-booking-show-settlement', 'Revise Booking Show Settlement', $this->revision_input( true ), 'revise', false, true );
 		$this->register_ability( 'extrachill/finalize-booking-show-settlement', 'Finalize Booking Show Settlement', $this->transition_input(), 'finalize', false, true );
-		$this->register_ability( 'extrachill/acknowledge-booking-show-settlement', 'Acknowledge Booking Show Settlement', $this->transition_input( 'note', false ), 'acknowledge', false, true );
+		$this->register_ability( 'extrachill/acknowledge-booking-show-settlement', 'Acknowledge Booking Show Settlement', $this->acknowledgement_input(), 'acknowledge', false, true, 'can_acknowledge' );
 		$this->register_ability( 'extrachill/dispute-booking-show-settlement', 'Dispute Booking Show Settlement', $this->transition_input( 'reason' ), 'dispute', false, true );
 		$this->register_ability( 'extrachill/correct-booking-show-settlement', 'Correct Booking Show Settlement', $this->revision_input( true, true ), 'correct', false, true );
 		$this->register_ability( 'extrachill/mark-booking-artist-payout-paid', 'Mark Booking Artist Payout Paid', $this->payment_input(), 'mark_paid', false, true );
 		$this->register_ability( 'extrachill/void-booking-show-settlement', 'Void Booking Show Settlement', $this->transition_input( 'reason' ), 'void_settlement', false, true );
 	}
 
-	private function register_ability( string $name, string $label, array $input, string $execute, bool $is_readonly, bool $idempotent ): void {
+	private function register_ability( string $name, string $label, array $input, string $execute, bool $is_readonly, bool $idempotent, string $permission = 'can_manage' ): void {
 		wp_register_ability(
 			$name,
 			array(
@@ -61,7 +65,7 @@ class ShowSettlementAbilities {
 				'input_schema'        => $input,
 				'output_schema'       => $this->output_schema(),
 				'execute_callback'    => array( $this, $execute ),
-				'permission_callback' => array( $this, 'can_manage' ),
+				'permission_callback' => array( $this, $permission ),
 				'meta'                => array(
 					'show_in_rest' => true,
 					'annotations'  => array(
@@ -115,6 +119,19 @@ class ShowSettlementAbilities {
 		return is_array( $booking )
 			? $this->authorization->authorize( get_current_user_id(), $booking['venue_term_id'], VenueAuthorization::ACTION_MANAGE_FINANCES )
 			: new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to manage this venue settlement.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+
+	public function can_acknowledge( array $input ) {
+		$booking = $this->bookings->get( absint( $input['booking_id'] ?? 0 ) );
+		if ( ! is_array( $booking ) ) {
+			return new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to acknowledge this settlement.', 'extrachill-events' ), array( 'status' => 403 ) );
+		}
+		if ( 'counterparty_verified' === ( $input['acknowledgement_type'] ?? '' ) && null !== $booking['artist_term_id'] ) {
+			return $this->artist_authorization->authorize_artist( $booking['artist_term_id'], get_current_user_id() );
+		}
+		return 'venue_recorded' === ( $input['acknowledgement_type'] ?? '' )
+			? $this->authorization->authorize( get_current_user_id(), $booking['venue_term_id'], VenueAuthorization::ACTION_MANAGE_FINANCES )
+			: new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to acknowledge this settlement.', 'extrachill-events' ), array( 'status' => 403 ) );
 	}
 
 	private function revision_input( bool $replacement, bool $correction = false ): array {
@@ -232,6 +249,18 @@ class ShowSettlementAbilities {
 			'required'             => $required_fields,
 			'additionalProperties' => false,
 		);
+	}
+
+	private function acknowledgement_input(): array {
+		$schema                                       = $this->transition_input( 'note', false );
+		$schema['properties']['acknowledgement_type'] = array(
+			'type' => 'string',
+			'enum' => array( 'counterparty_verified', 'venue_recorded' ),
+		);
+		$schema['properties']['acknowledgement_evidence_attachment_ids'] = $this->ids( 20, false );
+		$schema['required'][] = 'acknowledgement_type';
+		$schema['required'][] = 'acknowledgement_evidence_attachment_ids';
+		return $schema;
 	}
 
 	private function payment_input(): array {

--- a/inc/Core/BookingSchema.php
+++ b/inc/Core/BookingSchema.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Owns and verifies the site-scoped private booking schema. */
 class BookingSchema {
 
-	public const SCHEMA_VERSION = '14';
+	public const SCHEMA_VERSION = '15';
 	public const VERSION_OPTION = 'extrachill_events_booking_schema_version';
 	public const FAILURE_OPTION = 'extrachill_events_booking_schema_error';
 
@@ -106,6 +106,18 @@ class BookingSchema {
 		return $wpdb->prefix . 'ec_booking_settlements';
 	}
 
+	/** Get the immutable complete show-settlement revisions table. */
+	public static function show_settlements_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_booking_show_settlements';
+	}
+
+	/** Get the append-only show-settlement lifecycle table. */
+	public static function show_settlement_actions_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_booking_show_settlement_actions';
+	}
+
 	/** Create or repair all tables, stamping the version only after verification. */
 	public static function install() {
 		global $wpdb;
@@ -160,6 +172,8 @@ class BookingSchema {
 		$sales_reports       = self::sales_reports_table();
 		$sales_resolutions   = self::sales_resolutions_table();
 		$settlements         = self::settlements_table();
+		$show_settlements    = self::show_settlements_table();
+		$show_actions        = self::show_settlement_actions_table();
 		$charset             = $wpdb->get_charset_collate();
 
 		$bookings_sql = "CREATE TABLE {$bookings} (
@@ -523,6 +537,59 @@ class BookingSchema {
 			KEY status_updated (status, updated_at)
 		) ENGINE=InnoDB {$charset};";
 
+		$show_settlements_sql = "CREATE TABLE {$show_settlements} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			public_id CHAR(36) NOT NULL,
+			booking_id BIGINT UNSIGNED NOT NULL,
+			event_id BIGINT UNSIGNED NOT NULL,
+			venue_term_id BIGINT UNSIGNED NOT NULL,
+			revision BIGINT UNSIGNED NOT NULL,
+			corrects_revision_id BIGINT UNSIGNED NULL,
+			commission_settlement_id BIGINT UNSIGNED NOT NULL,
+			commission_integrity_hash CHAR(64) NOT NULL,
+			currency CHAR(3) NOT NULL,
+			formula_version BIGINT UNSIGNED NOT NULL,
+			terms_payload LONGTEXT NOT NULL,
+			evidence_payload LONGTEXT NOT NULL,
+			calculation_payload LONGTEXT NOT NULL,
+			request_hash CHAR(64) NOT NULL,
+			integrity_hash CHAR(64) NOT NULL,
+			idempotency_key VARCHAR(191) NOT NULL,
+			created_by_user_id BIGINT UNSIGNED NOT NULL,
+			created_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY public_id (public_id),
+			UNIQUE KEY booking_revision (booking_id, revision),
+			UNIQUE KEY booking_idempotency (booking_id, idempotency_key),
+			KEY venue_created (venue_term_id, created_at, id),
+			KEY event_id (event_id),
+			KEY corrects_revision (corrects_revision_id),
+			KEY commission_settlement (commission_settlement_id)
+		) ENGINE=InnoDB {$charset};";
+
+		$show_actions_sql = "CREATE TABLE {$show_actions} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			public_id CHAR(36) NOT NULL,
+			booking_id BIGINT UNSIGNED NOT NULL,
+			venue_term_id BIGINT UNSIGNED NOT NULL,
+			show_settlement_id BIGINT UNSIGNED NOT NULL,
+			action VARCHAR(24) NOT NULL,
+			expected_version BIGINT UNSIGNED NOT NULL,
+			payload LONGTEXT NOT NULL,
+			request_hash CHAR(64) NOT NULL,
+			integrity_hash CHAR(64) NOT NULL,
+			idempotency_key VARCHAR(191) NOT NULL,
+			actor_user_id BIGINT UNSIGNED NOT NULL,
+			created_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY public_id (public_id),
+			UNIQUE KEY revision_version (show_settlement_id, expected_version),
+			UNIQUE KEY booking_idempotency (booking_id, idempotency_key),
+			KEY booking_created (booking_id, created_at, id),
+			KEY venue_action_created (venue_term_id, action, created_at),
+			KEY settlement_created (show_settlement_id, created_at, id)
+		) ENGINE=InnoDB {$charset};";
+
 		$migration = self::migrate_v13_ticket_provenance();
 		if ( is_wp_error( $migration ) ) {
 			self::record_failure( $migration );
@@ -564,7 +631,11 @@ class BookingSchema {
 		$sales_resolutions_error = (string) $wpdb->last_error;
 		dbDelta( $settlements_sql );
 		$settlements_error = (string) $wpdb->last_error;
-		if ( '' !== $bookings_error || '' !== $activity_error || '' !== $communication_state_error || '' !== $attachments_error || '' !== $deliveries_error || '' !== $members_error || '' !== $claims_error || '' !== $invites_error || '' !== $audit_error || '' !== $holds_error || '' !== $ticket_sources_error || '' !== $sales_reports_error || '' !== $sales_resolutions_error || '' !== $settlements_error ) {
+		dbDelta( $show_settlements_sql );
+		$show_settlements_error = (string) $wpdb->last_error;
+		dbDelta( $show_actions_sql );
+		$show_actions_error = (string) $wpdb->last_error;
+		if ( '' !== $bookings_error || '' !== $activity_error || '' !== $communication_state_error || '' !== $attachments_error || '' !== $deliveries_error || '' !== $members_error || '' !== $claims_error || '' !== $invites_error || '' !== $audit_error || '' !== $holds_error || '' !== $ticket_sources_error || '' !== $sales_reports_error || '' !== $sales_resolutions_error || '' !== $settlements_error || '' !== $show_settlements_error || '' !== $show_actions_error ) {
 			$error = new \WP_Error(
 				'booking_schema_dbdelta_failed',
 				__( 'The booking schema could not be reconciled.', 'extrachill-events' ),
@@ -583,6 +654,8 @@ class BookingSchema {
 					'sales_reports_error'       => $sales_reports_error,
 					'sales_resolutions_error'   => $sales_resolutions_error,
 					'settlements_error'         => $settlements_error,
+					'show_settlements_error'    => $show_settlements_error,
+					'show_actions_error'        => $show_actions_error,
 				)
 			);
 			self::record_failure( $error );
@@ -917,7 +990,7 @@ class BookingSchema {
 			);
 		};
 		return array(
-			self::bookings_table()              => array(
+			self::bookings_table()                => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                      => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -997,7 +1070,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::activity_table()              => array(
+			self::activity_table()                => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                      => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -1046,7 +1119,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::communication_state_table()   => array(
+			self::communication_state_table()     => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'intent_id'           => $required( 'bigint unsigned', false ),
@@ -1069,7 +1142,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::attachments_table()           => array(
+			self::attachments_table()             => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                     => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -1130,7 +1203,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::attachment_deliveries_table() => array(
+			self::attachment_deliveries_table()   => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'             => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -1174,7 +1247,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::memberships_table()           => array(
+			self::memberships_table()             => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                 => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -1207,7 +1280,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::claims_table()                => array(
+			self::claims_table()                  => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                  => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -1248,7 +1321,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::invitations_table()           => array(
+			self::invitations_table()             => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                 => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -1302,7 +1375,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::onboarding_audit_table()      => array(
+			self::onboarding_audit_table()        => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'              => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -1334,7 +1407,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::holds_table()                 => array(
+			self::holds_table()                   => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                   => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -1375,7 +1448,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::ticket_sources_table()        => array(
+			self::ticket_sources_table()          => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                 => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -1400,7 +1473,7 @@ class BookingSchema {
 					'venue_created'           => $index( false, 'venue_term_id', 'created_at', 'id' ),
 				),
 			),
-			self::sales_reports_table()         => array(
+			self::sales_reports_table()           => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                               => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -1463,7 +1536,7 @@ class BookingSchema {
 					),
 				),
 			),
-			self::sales_resolutions_table()     => array(
+			self::sales_resolutions_table()       => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                       => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -1490,7 +1563,7 @@ class BookingSchema {
 					'supersedes_resolution'  => $index( false, 'supersedes_resolution_id' ),
 				),
 			),
-			self::settlements_table()           => array(
+			self::settlements_table()             => array(
 				'engine'  => 'innodb',
 				'columns' => array(
 					'id'                   => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
@@ -1544,10 +1617,75 @@ class BookingSchema {
 					),
 				),
 			),
+			self::show_settlements_table()        => array(
+				'engine'  => 'innodb',
+				'columns' => array(
+					'id'                        => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'public_id'                 => $required( 'char(36)', false ),
+					'booking_id'                => $required( 'bigint unsigned', false ),
+					'event_id'                  => $required( 'bigint unsigned', false ),
+					'venue_term_id'             => $required( 'bigint unsigned', false ),
+					'revision'                  => $required( 'bigint unsigned', false ),
+					'corrects_revision_id'      => $required( 'bigint unsigned', true ),
+					'commission_settlement_id'  => $required( 'bigint unsigned', false ),
+					'commission_integrity_hash' => $required( 'char(64)', false ),
+					'currency'                  => $required( 'char(3)', false ),
+					'formula_version'           => $required( 'bigint unsigned', false ),
+					'terms_payload'             => $required( 'longtext', false ),
+					'evidence_payload'          => $required( 'longtext', false ),
+					'calculation_payload'       => $required( 'longtext', false ),
+					'request_hash'              => $required( 'char(64)', false ),
+					'integrity_hash'            => $required( 'char(64)', false ),
+					'idempotency_key'           => $required( 'varchar(191)', false ),
+					'created_by_user_id'        => $required( 'bigint unsigned', false ),
+					'created_at'                => $required( 'datetime', false ),
+				),
+				'indexes' => array(
+					'PRIMARY'               => $index( true, 'id' ),
+					'public_id'             => $index( true, 'public_id' ),
+					'booking_revision'      => $index( true, 'booking_id', 'revision' ),
+					'booking_idempotency'   => $index( true, 'booking_id', 'idempotency_key' ),
+					'venue_created'         => $index( false, 'venue_term_id', 'created_at', 'id' ),
+					'event_id'              => $index( false, 'event_id' ),
+					'corrects_revision'     => $index( false, 'corrects_revision_id' ),
+					'commission_settlement' => $index( false, 'commission_settlement_id' ),
+				),
+			),
+			self::show_settlement_actions_table() => array(
+				'engine'  => 'innodb',
+				'columns' => array(
+					'id'                 => $required( 'bigint unsigned', false, array( 'extra' => 'auto_increment' ) ),
+					'public_id'          => $required( 'char(36)', false ),
+					'booking_id'         => $required( 'bigint unsigned', false ),
+					'venue_term_id'      => $required( 'bigint unsigned', false ),
+					'show_settlement_id' => $required( 'bigint unsigned', false ),
+					'action'             => $required( 'varchar(24)', false ),
+					'expected_version'   => $required( 'bigint unsigned', false ),
+					'payload'            => $required( 'longtext', false ),
+					'request_hash'       => $required( 'char(64)', false ),
+					'integrity_hash'     => $required( 'char(64)', false ),
+					'idempotency_key'    => $required( 'varchar(191)', false ),
+					'actor_user_id'      => $required( 'bigint unsigned', false ),
+					'created_at'         => $required( 'datetime', false ),
+				),
+				'indexes' => array(
+					'PRIMARY'              => $index( true, 'id' ),
+					'public_id'            => $index( true, 'public_id' ),
+					'revision_version'     => $index( true, 'show_settlement_id', 'expected_version' ),
+					'booking_idempotency'  => $index( true, 'booking_id', 'idempotency_key' ),
+					'booking_created'      => $index( false, 'booking_id', 'created_at', 'id' ),
+					'venue_action_created' => $index( false, 'venue_term_id', 'action', 'created_at' ),
+					'settlement_created'   => $index( false, 'show_settlement_id', 'created_at', 'id' ),
+				),
+			),
 		);
 	}
 
-	/** Normalize one SHOW COLUMNS row to the declared contract shape. */
+	/**
+	 * Normalize one SHOW COLUMNS row to the declared contract shape.
+	 *
+	 * @param array $column Raw SHOW COLUMNS row.
+	 */
 	private static function normalize_column( array $column ): array {
 		$type = preg_replace(
 			'/\A(tinyint|smallint|mediumint|int|integer|bigint)\(\d+\)(\s+unsigned)?\z/',
@@ -1562,7 +1700,11 @@ class BookingSchema {
 		);
 	}
 
-	/** Normalize SHOW INDEX rows to exact uniqueness and ordered columns. */
+	/**
+	 * Normalize SHOW INDEX rows to exact uniqueness and ordered columns.
+	 *
+	 * @param array $indexes Raw SHOW INDEX rows.
+	 */
 	private static function normalize_indexes( array $indexes ): array {
 		$normalized = array();
 		foreach ( $indexes as $index ) {
@@ -1578,7 +1720,12 @@ class BookingSchema {
 		return $normalized;
 	}
 
-	/** Build a consistent database inspection error. */
+	/**
+	 * Build a consistent database inspection error.
+	 *
+	 * @param string $message Public error message.
+	 * @param string $table   Inspected table name.
+	 */
 	private static function database_error( string $message, string $table ): \WP_Error {
 		global $wpdb;
 		return new \WP_Error(
@@ -1591,7 +1738,11 @@ class BookingSchema {
 		);
 	}
 
-	/** Record an actionable install failure without advancing the version. */
+	/**
+	 * Record an actionable install failure without advancing the version.
+	 *
+	 * @param \WP_Error $error Installation failure.
+	 */
 	private static function record_failure( \WP_Error $error ): void {
 		global $wpdb;
 		update_option(

--- a/inc/Core/ShowSettlementService.php
+++ b/inc/Core/ShowSettlementService.php
@@ -31,16 +31,19 @@ class ShowSettlementService {
 	private $attachments;
 	/** @var BookingAttachmentService */
 	private $attachment_service;
+	/** @var LocalSupportAuthorization */
+	private $artist_authorization;
 	/** @var bool */
 	private $transaction_active = false;
 
-	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, ?TicketSettlementService $commissions = null, ?BookingAttachmentRepository $attachments = null, ?BookingAttachmentService $attachment_service = null ) {
-		$this->bookings           = $bookings ? $bookings : new BookingRepository();
-		$this->activity           = $activity ? $activity : new BookingActivityRepository();
-		$this->authorization      = $authorization ? $authorization : new VenueAuthorization();
-		$this->commissions        = $commissions ? $commissions : new TicketSettlementService( $this->bookings, $this->activity, $this->authorization );
-		$this->attachments        = $attachments ? $attachments : new BookingAttachmentRepository();
-		$this->attachment_service = $attachment_service ? $attachment_service : new BookingAttachmentService( $this->attachments, $this->bookings, $this->activity, null, null, $this->authorization );
+	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, ?TicketSettlementService $commissions = null, ?BookingAttachmentRepository $attachments = null, ?BookingAttachmentService $attachment_service = null, ?LocalSupportAuthorization $artist_authorization = null ) {
+		$this->bookings             = $bookings ? $bookings : new BookingRepository();
+		$this->activity             = $activity ? $activity : new BookingActivityRepository();
+		$this->authorization        = $authorization ? $authorization : new VenueAuthorization();
+		$this->commissions          = $commissions ? $commissions : new TicketSettlementService( $this->bookings, $this->activity, $this->authorization );
+		$this->attachments          = $attachments ? $attachments : new BookingAttachmentRepository();
+		$this->attachment_service   = $attachment_service ? $attachment_service : new BookingAttachmentService( $this->attachments, $this->bookings, $this->activity, null, null, $this->authorization );
+		$this->artist_authorization = $artist_authorization ? $artist_authorization : new LocalSupportAuthorization( $this->authorization );
 	}
 
 	/** Calculate and append the first immutable draft revision. */
@@ -86,10 +89,51 @@ class ShowSettlementService {
 		return $this->action( $input, $actor_id, 'finalized', array(), array( 'draft' ), true );
 	}
 
-	/** Record counterparty acknowledgement without changing frozen terms. */
+	/** Record either direct counterparty attestation or venue-recorded evidence. */
 	public function acknowledge( array $input, int $actor_id ) {
-		$note = $this->optional_text( $input['note'] ?? null, 1000 );
-		return $this->action( $input, $actor_id, 'acknowledged', array( 'note' => $note ), array( 'finalized' ), false );
+		$booking = $this->booking( $input['booking_id'] ?? 0 );
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+		$type = sanitize_key( (string) ( $input['acknowledgement_type'] ?? '' ) );
+		if ( ! in_array( $type, array( 'counterparty_verified', 'venue_recorded' ), true ) || null === $booking['artist_term_id'] || null === $booking['artist_profile_id'] ) {
+			return new \WP_Error( 'show_settlement_acknowledgement_invalid', __( 'Acknowledgement requires a supported type and canonical booking counterparty.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$authority = 'counterparty_verified' === $type ? 'artist' : 'venue';
+		$allowed   = $this->authorize_action( $booking, $actor_id, $authority );
+		if ( true !== $allowed ) {
+			return $this->denied( $allowed );
+		}
+		$evidence = array();
+		if ( 'venue_recorded' === $type ) {
+			$evidence = $this->attachment_evidence( $booking, $input['acknowledgement_evidence_attachment_ids'] ?? null, $actor_id, true );
+			if ( is_wp_error( $evidence ) ) {
+				return $evidence;
+			}
+		} elseif ( ! empty( $input['acknowledgement_evidence_attachment_ids'] ) ) {
+			return new \WP_Error( 'show_settlement_acknowledgement_invalid', __( 'Direct counterparty acknowledgement must not claim venue-recorded evidence.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return $this->action(
+			$input,
+			$actor_id,
+			'acknowledged',
+			array(
+				'acknowledgement_type' => $type,
+				'counterparty'         => array(
+					'type'              => 'artist',
+					'artist_term_id'    => $booking['artist_term_id'],
+					'artist_profile_id' => $booking['artist_profile_id'],
+				),
+				'attested_by_user_id'  => 'counterparty_verified' === $type ? $actor_id : null,
+				'evidence'             => $evidence,
+				'note'                 => $this->optional_text( $input['note'] ?? null, 1000 ),
+			),
+			array( 'finalized' ),
+			false,
+			null,
+			$authority,
+			$evidence
+		);
 	}
 
 	/** Record a bounded dispute against one frozen revision. */
@@ -108,6 +152,10 @@ class ShowSettlementService {
 		$booking = $this->booking( $input['booking_id'] ?? 0 );
 		if ( is_wp_error( $booking ) ) {
 			return $booking;
+		}
+		$allowed = $this->authorization->authorize( $actor_id, $booking['venue_term_id'], VenueAuthorization::ACTION_MANAGE_FINANCES );
+		if ( true !== $allowed ) {
+			return $this->denied( $allowed );
 		}
 		$evidence = $this->attachment_evidence( $booking, $input['payout_evidence_attachment_ids'] ?? null, $actor_id, true );
 		if ( is_wp_error( $evidence ) ) {
@@ -232,49 +280,52 @@ class ShowSettlementService {
 		if ( is_wp_error( $terms ) ) {
 			return $terms;
 		}
-		$commission = $this->commissions->get( $booking['id'], $actor_id );
-		if ( is_wp_error( $commission ) || ! is_array( $commission ) || (int) $input['commission_settlement_id'] !== $commission['id'] || 'void' === $commission['status'] || $commission['currency'] !== $terms['currency'] ) {
-			return new \WP_Error( 'show_settlement_commission_invalid', __( 'The frozen Extra Chill commission is missing, void, mismatched, or unauthenticated.', 'extrachill-events' ), array( 'status' => 409 ) );
-		}
-		$ticket_gross = $this->ticket_gross( $booking, $commission, $actor_id );
-		if ( is_wp_error( $ticket_gross ) || $ticket_gross !== $terms['ticket_gross_minor'] ) {
-			return is_wp_error( $ticket_gross ) ? $ticket_gross : new \WP_Error(
-				'show_settlement_ticket_gross_conflict',
-				__( 'Ticket gross does not match the frozen reconciled ticket evidence.', 'extrachill-events' ),
-				array(
-					'status'                      => 409,
-					'expected_ticket_gross_minor' => $ticket_gross,
-				)
-			);
-		}
 		$evidence = $this->attachment_evidence( $booking, $input['door_report_attachment_ids'] ?? array(), $actor_id, 0 !== $terms['door_gross_minor'] );
 		if ( is_wp_error( $evidence ) ) {
 			return $evidence;
 		}
-		$calculation = self::calculate_amounts( $terms, $commission['amount_due_minor'] );
-		if ( is_wp_error( $calculation ) ) {
-			return $calculation;
-		}
-		$request      = array(
-			'booking_id'                => $booking['id'],
-			'commission_settlement_id'  => $commission['id'],
-			'commission_integrity_hash' => $commission['integrity_hash'],
-			'terms'                     => $terms,
-			'evidence'                  => $evidence,
-			'expected_revision_id'      => $expected,
-			'expected_version'          => $expected_action_version,
-			'correction_reason'         => $input['_correction_reason'] ?? null,
-		);
-		$request_hash = self::hash( $request );
-		$started      = $this->begin_authorized( $booking, $actor_id );
+		$started = $this->begin_authorized( $booking, $actor_id );
 		if ( is_wp_error( $started ) ) {
 			return $started;
 		}
-		$booking = $this->bookings->get_for_update( $booking['id'] );
-		if ( ! is_array( $booking ) ) {
-			return $this->rollback( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+		$booking = $this->locked_booking( $booking['id'] );
+		if ( is_wp_error( $booking ) ) {
+			return $this->rollback( $booking );
 		}
-		$retry = $this->idempotent_revision( $booking['id'], $key, true );
+		$commission = $this->commission( $booking, $actor_id, (int) $input['commission_settlement_id'], null, $terms['currency'], true );
+		if ( is_wp_error( $commission ) ) {
+			return $this->rollback( $commission );
+		}
+		$ticket_gross = $this->ticket_gross( $booking, $commission, $actor_id, true );
+		if ( is_wp_error( $ticket_gross ) || $ticket_gross !== $terms['ticket_gross_minor'] ) {
+			return $this->rollback(
+				is_wp_error( $ticket_gross ) ? $ticket_gross : new \WP_Error(
+					'show_settlement_ticket_gross_conflict',
+					__( 'Ticket gross does not match the frozen reconciled ticket evidence.', 'extrachill-events' ),
+					array(
+						'status'                      => 409,
+						'expected_ticket_gross_minor' => $ticket_gross,
+					)
+				)
+			);
+		}
+		$calculation = self::calculate_amounts( $terms, $commission['amount_due_minor'] );
+		if ( is_wp_error( $calculation ) ) {
+			return $this->rollback( $calculation );
+		}
+		$request_hash = self::hash(
+			array(
+				'booking_id'                => $booking['id'],
+				'commission_settlement_id'  => $commission['id'],
+				'commission_integrity_hash' => $commission['integrity_hash'],
+				'terms'                     => $terms,
+				'evidence'                  => $evidence,
+				'expected_revision_id'      => $expected,
+				'expected_version'          => $expected_action_version,
+				'correction_reason'         => $input['_correction_reason'] ?? null,
+			)
+		);
+		$retry        = $this->idempotent_revision( $booking['id'], $key, true );
 		if ( is_wp_error( $retry ) ) {
 			return $this->rollback( $retry );
 		}
@@ -374,12 +425,12 @@ class ShowSettlementService {
 		return is_wp_error( $commit ) ? $commit : $this->present( $this->state( $created ) );
 	}
 
-	private function action( array $input, int $actor_id, string $action, array $payload, array $allowed_states, bool $authenticate_revision, ?array $authenticated_payout = null ) {
+	private function action( array $input, int $actor_id, string $action, array $payload, array $allowed_states, bool $authenticate_revision, ?array $authenticated_payout = null, string $authority = 'venue', ?array $authenticated_action_evidence = null ) {
 		$booking = $this->booking( $input['booking_id'] ?? 0 );
 		if ( is_wp_error( $booking ) ) {
 			return $booking;
 		}
-		$allowed = $this->authorization->authorize( $actor_id, $booking['venue_term_id'], VenueAuthorization::ACTION_MANAGE_FINANCES );
+		$allowed = $this->authorize_action( $booking, $actor_id, $authority );
 		if ( true !== $allowed ) {
 			return $this->denied( $allowed );
 		}
@@ -409,12 +460,25 @@ class ShowSettlementService {
 				return $verified;
 			}
 		}
-		$started = $this->begin_authorized( $booking, $actor_id );
+		$started = $this->begin_authorized( $booking, $actor_id, $authority );
 		if ( is_wp_error( $started ) ) {
 			return $started;
 		}
-		$booking = $this->bookings->get_for_update( $booking['id'] );
-		$retry   = $this->idempotent_action( $booking['id'], $key, true );
+		$booking = $this->locked_booking( $booking['id'] );
+		if ( is_wp_error( $booking ) ) {
+			return $this->rollback( $booking );
+		}
+		if ( 'artist' === $authority ) {
+			$locked_allowed = $this->authorize_action( $booking, $actor_id, $authority );
+			if ( true !== $locked_allowed ) {
+				return $this->rollback( $this->denied( $locked_allowed ) );
+			}
+		}
+		$commission = $this->commission( $booking, $actor_id, $revision['commission_settlement_id'], $revision['commission_integrity_hash'], $revision['currency'], true );
+		if ( is_wp_error( $commission ) ) {
+			return $this->rollback( $commission );
+		}
+		$retry = $this->idempotent_action( $booking['id'], $key, true );
 		if ( is_wp_error( $retry ) ) {
 			return $this->rollback( $retry );
 		}
@@ -423,8 +487,12 @@ class ShowSettlementService {
 				return $this->rollback( new \WP_Error( 'show_settlement_idempotency_conflict', __( 'This lifecycle idempotency key is bound to a different request.', 'extrachill-events' ), array( 'status' => 409 ) ) );
 			}
 			$current = $this->revision_id( $revision_id, true );
-			$commit  = $this->commit();
-			return is_wp_error( $commit ) ? $commit : $this->present( $this->state( $current ) );
+			if ( ! is_array( $current ) || $current['booking_id'] !== $booking['id'] ) {
+				return $this->rollback( is_wp_error( $current ) ? $current : new \WP_Error( 'show_settlement_not_found', __( 'The show settlement was not found.', 'extrachill-events' ), array( 'status' => 404 ) ) );
+			}
+			$verified = $this->verify_revision( $current, $booking, $actor_id, false, true );
+			$commit   = is_wp_error( $verified ) ? $this->rollback( $verified ) : $this->commit();
+			return is_wp_error( $commit ) ? $commit : $this->present( $verified );
 		}
 		$revision = $this->revision_id( $revision_id, true );
 		$latest   = $this->latest_revision( $booking['id'], true );
@@ -447,12 +515,18 @@ class ShowSettlementService {
 		if ( 'paid' === $action && 'completed' !== $booking['status'] ) {
 			return $this->rollback( new \WP_Error( 'show_settlement_payment_booking_status_conflict', __( 'The booking must be completed before artist payout is recorded.', 'extrachill-events' ), array( 'status' => 409 ) ) );
 		}
-		$verified = $this->verify_revision( $revision, $booking, $actor_id, false );
+		$verified = $this->verify_revision( $revision, $booking, $actor_id, false, true );
 		if ( is_wp_error( $verified ) ) {
 			return $this->rollback( $verified );
 		}
 		if ( null !== $authenticated_payout ) {
 			$metadata = $this->verify_attachment_snapshot( $booking, $authenticated_payout );
+			if ( is_wp_error( $metadata ) ) {
+				return $this->rollback( $metadata );
+			}
+		}
+		if ( null !== $authenticated_action_evidence ) {
+			$metadata = $this->verify_attachment_snapshot( $booking, $authenticated_action_evidence );
 			if ( is_wp_error( $metadata ) ) {
 				return $this->rollback( $metadata );
 			}
@@ -590,19 +664,19 @@ class ShowSettlementService {
 		return true;
 	}
 
-	private function verify_revision( array $revision, array $booking, int $actor_id, bool $authenticate_bytes ) {
+	private function verify_revision( array $revision, array $booking, int $actor_id, bool $authenticate_bytes, bool $lock_commission = false ) {
 		if ( $revision['booking_id'] !== $booking['id'] || $revision['event_id'] !== $booking['event_id'] || $revision['venue_term_id'] !== $booking['venue_term_id'] || ! hash_equals( $revision['integrity_hash'], self::hash( self::revision_hashable( $revision ) ) ) ) {
 			return new \WP_Error( 'show_settlement_integrity_failed', __( 'The immutable show-settlement revision failed integrity verification.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
-		$commission = $this->commissions->get( $booking['id'], $actor_id );
-		if ( is_wp_error( $commission ) || $commission['id'] !== $revision['commission_settlement_id'] || ! hash_equals( $commission['integrity_hash'], $revision['commission_integrity_hash'] ) || $commission['currency'] !== $revision['currency'] ) {
-			return new \WP_Error( 'show_settlement_commission_invalid', __( 'The bound Extra Chill commission failed integrity verification.', 'extrachill-events' ), array( 'status' => 409 ) );
+		$commission = $this->commission( $booking, $actor_id, $revision['commission_settlement_id'], $revision['commission_integrity_hash'], $revision['currency'], $lock_commission );
+		if ( is_wp_error( $commission ) ) {
+			return $commission;
 		}
 		$calculation = self::calculate_amounts( $revision['terms'], $commission['amount_due_minor'] );
 		if ( is_wp_error( $calculation ) || $calculation !== $revision['calculation'] ) {
 			return new \WP_Error( 'show_settlement_calculation_invalid', __( 'The frozen show-settlement calculation is not reproducible.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
-		$ticket_gross = $this->ticket_gross( $booking, $commission, $actor_id );
+		$ticket_gross = $this->ticket_gross( $booking, $commission, $actor_id, $lock_commission );
 		if ( is_wp_error( $ticket_gross ) || $ticket_gross !== $revision['terms']['ticket_gross_minor'] ) {
 			return is_wp_error( $ticket_gross ) ? $ticket_gross : new \WP_Error( 'show_settlement_ticket_gross_conflict', __( 'Frozen ticket gross no longer matches its reconciled ticket evidence.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
@@ -630,16 +704,22 @@ class ShowSettlementService {
 					return $payout;
 				}
 			}
+			if ( isset( $action['payload']['evidence'] ) ) {
+				$acknowledgement = $this->verify_attachment_snapshot( $booking, $action['payload']['evidence'] );
+				if ( is_wp_error( $acknowledgement ) ) {
+					return $acknowledgement;
+				}
+			}
 		}
 		return $state;
 	}
 
-	private function ticket_gross( array $booking, array $commission, int $actor_id ) {
+	private function ticket_gross( array $booking, array $commission, int $actor_id, bool $lock = false ) {
 		$by_id  = array();
 		$found  = 0;
 		$needed = count( $commission['included_report_ids'] );
 		for ( $offset = 0; $offset < 10000 && $found < $needed; $offset += 200 ) {
-			$reports = $this->commissions->list_sales( $booking['id'], $actor_id, 200, $offset );
+			$reports = $lock ? $this->commissions->included_reports_for_update( $commission ) : $this->commissions->list_sales( $booking['id'], $actor_id, 200, $offset );
 			if ( is_wp_error( $reports ) ) {
 				return $reports;
 			}
@@ -650,6 +730,9 @@ class ShowSettlementService {
 				}
 			}
 			if ( count( $reports ) < 200 ) {
+				break;
+			}
+			if ( $lock ) {
 				break;
 			}
 		}
@@ -807,16 +890,35 @@ class ShowSettlementService {
 		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'show_settlement_action_read_failed', __( 'The show-settlement lifecycle could not be read.', 'extrachill-events' ) ) : ( is_array( $row ) ? $this->hydrate_action( $row ) : null );
 	}
 
-	private function begin_authorized( array $booking, int $actor_id ) {
+	private function begin_authorized( array $booking, int $actor_id, string $authority = 'venue' ) {
 		global $wpdb;
 		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Complete financial transaction.
 			return new \WP_Error( 'show_settlement_transaction_start_failed', __( 'The show-settlement transaction could not start.', 'extrachill-events' ) );
 		}
 		$this->transaction_active = true;
-		$table                    = BookingSchema::memberships_table();
-		$members                  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $booking['venue_term_id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks exact venue authority first.
-		$allowed                  = '' === (string) $wpdb->last_error ? $this->authorization->authorize_locked( $actor_id, $booking['venue_term_id'], VenueAuthorization::ACTION_MANAGE_FINANCES, (array) $members ) : false;
+		if ( 'artist' === $authority ) {
+			$allowed = $this->authorize_action( $booking, $actor_id, $authority );
+			return true === $allowed ? true : $this->rollback( $this->denied( $allowed ) );
+		}
+		$table   = BookingSchema::memberships_table();
+		$members = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $booking['venue_term_id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks exact venue authority first.
+		$allowed = '' === (string) $wpdb->last_error ? $this->authorization->authorize_locked( $actor_id, $booking['venue_term_id'], VenueAuthorization::ACTION_MANAGE_FINANCES, (array) $members ) : false;
 		return true === $allowed ? true : $this->rollback( $this->denied( $allowed ) );
+	}
+
+	private function authorize_action( array $booking, int $actor_id, string $authority ) {
+		if ( 'artist' === $authority ) {
+			return null !== $booking['artist_term_id'] ? $this->artist_authorization->authorize_artist( $booking['artist_term_id'], $actor_id ) : false;
+		}
+		return $this->authorization->authorize( $actor_id, $booking['venue_term_id'], VenueAuthorization::ACTION_MANAGE_FINANCES );
+	}
+
+	private function commission( array $booking, int $actor_id, int $expected_id, ?string $expected_hash, string $currency, bool $lock ) {
+		$commission = $lock ? $this->commissions->get_for_update( $booking['id'] ) : $this->commissions->get( $booking['id'], $actor_id );
+		if ( is_wp_error( $commission ) || ! is_array( $commission ) || $commission['id'] !== $expected_id || ! in_array( $commission['status'], array( 'finalized', 'paid' ), true ) || $commission['currency'] !== $currency || ( null !== $expected_hash && ! hash_equals( $commission['integrity_hash'], $expected_hash ) ) ) {
+			return new \WP_Error( 'show_settlement_commission_invalid', __( 'The frozen Extra Chill commission is missing, void, mismatched, or failed integrity verification.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return $commission;
 	}
 
 	private function booking( $id ) {
@@ -826,6 +928,14 @@ class ShowSettlementService {
 		}
 		$booking = $this->bookings->get( $id );
 		return is_array( $booking ) && null !== $booking['event_id'] ? $booking : ( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'An event-linked booking was not found.', 'extrachill-events' ), array( 'status' => 404 ) ) );
+	}
+
+	private function locked_booking( int $booking_id ) {
+		$booking = $this->bookings->get_for_update( $booking_id );
+		if ( is_wp_error( $booking ) ) {
+			return new \WP_Error( 'show_settlement_booking_lock_failed', __( 'The booking could not be locked for this settlement operation.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+		return is_array( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ), array( 'status' => 404 ) );
 	}
 
 	private function append_audit( array $revision, string $kind, int $actor_id ) {
@@ -856,6 +966,9 @@ class ShowSettlementService {
 				}
 				if ( isset( $action['payload']['payout_evidence'] ) ) {
 					$action['payload']['payout_evidence'] = $this->project_evidence( $action['payload']['payout_evidence'] );
+				}
+				if ( isset( $action['payload']['evidence'] ) ) {
+					$action['payload']['evidence'] = $this->project_evidence( $action['payload']['evidence'] );
 				}
 			}
 			unset( $action );

--- a/inc/Core/ShowSettlementService.php
+++ b/inc/Core/ShowSettlementService.php
@@ -1,0 +1,1006 @@
+<?php
+/**
+ * Complete immutable show settlements layered over frozen commission settlements.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+// Repository convention uses concise method comments.
+// phpcs:disable Generic.Commenting.DocComment.MissingShort,Squiz.Commenting.FunctionComment.Missing,Squiz.Commenting.FunctionComment.MissingParamTag
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Owns complete show math, immutable revisions, evidence, and lifecycle audit. */
+class ShowSettlementService {
+	public const FORMULA_VERSION = 1;
+	public const ACTIONS         = array( 'finalized', 'acknowledged', 'disputed', 'corrected', 'paid', 'void' );
+
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var BookingActivityRepository */
+	private $activity;
+	/** @var VenueAuthorization */
+	private $authorization;
+	/** @var TicketSettlementService */
+	private $commissions;
+	/** @var BookingAttachmentRepository */
+	private $attachments;
+	/** @var BookingAttachmentService */
+	private $attachment_service;
+	/** @var bool */
+	private $transaction_active = false;
+
+	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, ?TicketSettlementService $commissions = null, ?BookingAttachmentRepository $attachments = null, ?BookingAttachmentService $attachment_service = null ) {
+		$this->bookings           = $bookings ? $bookings : new BookingRepository();
+		$this->activity           = $activity ? $activity : new BookingActivityRepository();
+		$this->authorization      = $authorization ? $authorization : new VenueAuthorization();
+		$this->commissions        = $commissions ? $commissions : new TicketSettlementService( $this->bookings, $this->activity, $this->authorization );
+		$this->attachments        = $attachments ? $attachments : new BookingAttachmentRepository();
+		$this->attachment_service = $attachment_service ? $attachment_service : new BookingAttachmentService( $this->attachments, $this->bookings, $this->activity, null, null, $this->authorization );
+	}
+
+	/** Calculate and append the first immutable draft revision. */
+	public function draft( array $input, int $actor_id ) {
+		return $this->create_revision( $input, $actor_id, false );
+	}
+
+	/** Append a replacement draft revision while the current revision is still a draft. */
+	public function revise( array $input, int $actor_id ) {
+		return $this->create_revision( $input, $actor_id, false, true );
+	}
+
+	/** Link a finalized revision to a new immutable correction draft. */
+	public function correct( array $input, int $actor_id ) {
+		$reason = $this->text( $input['reason'] ?? null, 'reason', 1000 );
+		if ( is_wp_error( $reason ) ) {
+			return $reason;
+		}
+		$input['_correction_reason'] = $reason;
+		return $this->create_revision( $input, $actor_id, true, true );
+	}
+
+	/** Read one revision or the latest revision with derived lifecycle state. */
+	public function get( int $booking_id, int $actor_id, ?int $revision = null ) {
+		$booking = $this->booking( $booking_id );
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+		$allowed = $this->authorization->authorize( $actor_id, $booking['venue_term_id'], VenueAuthorization::ACTION_MANAGE_FINANCES );
+		if ( true !== $allowed ) {
+			return $this->denied( $allowed );
+		}
+		$row = null === $revision ? $this->latest_revision( $booking['id'] ) : $this->revision_number( $booking['id'], $revision );
+		if ( ! is_array( $row ) ) {
+			return is_wp_error( $row ) ? $row : new \WP_Error( 'show_settlement_not_found', __( 'The show settlement was not found.', 'extrachill-events' ), array( 'status' => 404 ) );
+		}
+		$verified = $this->verify_revision( $row, $booking, $actor_id, false );
+		return is_wp_error( $verified ) ? $verified : $this->present( $verified );
+	}
+
+	/** Freeze one exact draft revision. */
+	public function finalize( array $input, int $actor_id ) {
+		return $this->action( $input, $actor_id, 'finalized', array(), array( 'draft' ), true );
+	}
+
+	/** Record counterparty acknowledgement without changing frozen terms. */
+	public function acknowledge( array $input, int $actor_id ) {
+		$note = $this->optional_text( $input['note'] ?? null, 1000 );
+		return $this->action( $input, $actor_id, 'acknowledged', array( 'note' => $note ), array( 'finalized' ), false );
+	}
+
+	/** Record a bounded dispute against one frozen revision. */
+	public function dispute( array $input, int $actor_id ) {
+		$reason = $this->text( $input['reason'] ?? null, 'reason', 1000 );
+		return is_wp_error( $reason ) ? $reason : $this->action( $input, $actor_id, 'disputed', array( 'reason' => $reason ), array( 'finalized', 'acknowledged' ), false );
+	}
+
+	/** Mark an undisputed revision paid after authenticating immutable payout evidence. */
+	public function mark_paid( array $input, int $actor_id ) {
+		$reference = $this->text( $input['payment_reference'] ?? null, 'payment_reference', 191 );
+		$date      = $this->date( $input['payment_date'] ?? null );
+		if ( is_wp_error( $reference ) || is_wp_error( $date ) ) {
+			return is_wp_error( $reference ) ? $reference : $date;
+		}
+		$booking = $this->booking( $input['booking_id'] ?? 0 );
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+		$evidence = $this->attachment_evidence( $booking, $input['payout_evidence_attachment_ids'] ?? null, $actor_id, true );
+		if ( is_wp_error( $evidence ) ) {
+			return $evidence;
+		}
+		return $this->action(
+			$input,
+			$actor_id,
+			'paid',
+			array(
+				'payment_reference' => $reference,
+				'payment_date'      => $date,
+				'payout_evidence'   => $evidence,
+			),
+			array( 'finalized', 'acknowledged' ),
+			true,
+			$evidence
+		);
+	}
+
+	/** Void an unpaid revision with immutable reason audit. */
+	public function void( array $input, int $actor_id ) {
+		$reason = $this->text( $input['reason'] ?? null, 'reason', 1000 );
+		return is_wp_error( $reason ) ? $reason : $this->action( $input, $actor_id, 'void', array( 'reason' => $reason ), array( 'draft', 'finalized', 'acknowledged', 'disputed' ), false );
+	}
+
+	/** Pure deterministic formula used by drafts and tests. */
+	public static function calculate_amounts( array $terms, int $extra_chill_share_minor ) {
+		$fields = array( 'ticket_gross_minor', 'door_gross_minor', 'fees_minor', 'taxes_minor', 'refunds_minor', 'venue_expenses_minor', 'production_expenses_minor', 'artist_guarantee_minor', 'artist_split_basis_points' );
+		foreach ( $fields as $field ) {
+			if ( ! isset( $terms[ $field ] ) || ! is_int( $terms[ $field ] ) ) {
+				return new \WP_Error(
+					'invalid_show_settlement_amount',
+					__( 'Show settlement money and rates must use integers.', 'extrachill-events' ),
+					array(
+						'status' => 400,
+						'field'  => $field,
+					)
+				);
+			}
+		}
+		if ( $terms['artist_split_basis_points'] < 0 || $terms['artist_split_basis_points'] > 10000 || $terms['artist_guarantee_minor'] < 0 ) {
+			return new \WP_Error( 'invalid_show_settlement_terms', __( 'The artist guarantee or split is outside the supported range.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$adjustment_total = 0;
+		foreach ( $terms['adjustments'] ?? array() as $adjustment ) {
+			if ( ! is_array( $adjustment ) || ! isset( $adjustment['amount_minor'] ) || ! is_int( $adjustment['amount_minor'] ) ) {
+				return new \WP_Error( 'invalid_show_settlement_adjustment', __( 'Every signed adjustment must use integer minor units.', 'extrachill-events' ), array( 'status' => 400 ) );
+			}
+			$adjustment_total = self::safe_add( $adjustment_total, $adjustment['amount_minor'] );
+			if ( is_wp_error( $adjustment_total ) ) {
+				return $adjustment_total;
+			}
+		}
+		$gross = self::safe_add( $terms['ticket_gross_minor'], $terms['door_gross_minor'] );
+		if ( is_wp_error( $gross ) ) {
+			return $gross;
+		}
+		$deductions = 0;
+		foreach ( array( 'fees_minor', 'taxes_minor', 'refunds_minor', 'venue_expenses_minor', 'production_expenses_minor' ) as $field ) {
+			if ( $terms[ $field ] < 0 ) {
+				return new \WP_Error(
+					'invalid_show_settlement_terms',
+					__( 'Show settlement deductions cannot be negative.', 'extrachill-events' ),
+					array(
+						'status' => 400,
+						'field'  => $field,
+					)
+				);
+			}
+			$deductions = self::safe_add( $deductions, $terms[ $field ] );
+			if ( is_wp_error( $deductions ) ) {
+				return $deductions;
+			}
+		}
+		$artist_basis = self::safe_subtract( $gross, $deductions );
+		$artist_basis = is_wp_error( $artist_basis ) ? $artist_basis : self::safe_add( $artist_basis, $adjustment_total );
+		$artist_basis = is_wp_error( $artist_basis ) ? $artist_basis : self::safe_subtract( $artist_basis, $extra_chill_share_minor );
+		if ( is_wp_error( $artist_basis ) ) {
+			return $artist_basis;
+		}
+		$artist_split = TicketSettlementService::basis_points_amount( max( 0, $artist_basis ), $terms['artist_split_basis_points'] );
+		if ( is_wp_error( $artist_split ) ) {
+			return $artist_split;
+		}
+		$artist_payout = max( $terms['artist_guarantee_minor'], $artist_split );
+		$venue_net     = self::safe_subtract( $artist_basis, $artist_payout );
+		if ( is_wp_error( $venue_net ) ) {
+			return $venue_net;
+		}
+		return array(
+			'total_gross_minor'            => $gross,
+			'total_deductions_minor'       => $deductions,
+			'adjustment_total_minor'       => $adjustment_total,
+			'extra_chill_share_minor'      => $extra_chill_share_minor,
+			'artist_split_basis_minor'     => $artist_basis,
+			'artist_split_amount_minor'    => $artist_split,
+			'artist_guarantee_minor'       => $terms['artist_guarantee_minor'],
+			'artist_payout_minor'          => $artist_payout,
+			'venue_net_after_payout_minor' => $venue_net,
+		);
+	}
+
+	private function create_revision( array $input, int $actor_id, bool $correction, bool $requires_current = false ) {
+		$booking = $this->booking( $input['booking_id'] ?? 0 );
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+		$allowed = $this->authorization->authorize( $actor_id, $booking['venue_term_id'], VenueAuthorization::ACTION_MANAGE_FINANCES );
+		if ( true !== $allowed ) {
+			return $this->denied( $allowed );
+		}
+		$key                     = TicketSettlementService::opaque_identifier( $input['idempotency_key'] ?? null, 'idempotency_key' );
+		$expected                = $requires_current ? $this->positive_integer( $input['expected_revision_id'] ?? null, 'expected_revision_id' ) : null;
+		$expected_action_version = $correction ? $this->positive_integer( $input['expected_version'] ?? null, 'expected_version' ) : null;
+		foreach ( array( $key, $expected, $expected_action_version ) as $validated ) {
+			if ( is_wp_error( $validated ) ) {
+				return $validated;
+			}
+		}
+		$terms = $this->terms( $input, $actor_id );
+		if ( is_wp_error( $terms ) ) {
+			return $terms;
+		}
+		$commission = $this->commissions->get( $booking['id'], $actor_id );
+		if ( is_wp_error( $commission ) || ! is_array( $commission ) || (int) $input['commission_settlement_id'] !== $commission['id'] || 'void' === $commission['status'] || $commission['currency'] !== $terms['currency'] ) {
+			return new \WP_Error( 'show_settlement_commission_invalid', __( 'The frozen Extra Chill commission is missing, void, mismatched, or unauthenticated.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$ticket_gross = $this->ticket_gross( $booking, $commission, $actor_id );
+		if ( is_wp_error( $ticket_gross ) || $ticket_gross !== $terms['ticket_gross_minor'] ) {
+			return is_wp_error( $ticket_gross ) ? $ticket_gross : new \WP_Error(
+				'show_settlement_ticket_gross_conflict',
+				__( 'Ticket gross does not match the frozen reconciled ticket evidence.', 'extrachill-events' ),
+				array(
+					'status'                      => 409,
+					'expected_ticket_gross_minor' => $ticket_gross,
+				)
+			);
+		}
+		$evidence = $this->attachment_evidence( $booking, $input['door_report_attachment_ids'] ?? array(), $actor_id, 0 !== $terms['door_gross_minor'] );
+		if ( is_wp_error( $evidence ) ) {
+			return $evidence;
+		}
+		$calculation = self::calculate_amounts( $terms, $commission['amount_due_minor'] );
+		if ( is_wp_error( $calculation ) ) {
+			return $calculation;
+		}
+		$request      = array(
+			'booking_id'                => $booking['id'],
+			'commission_settlement_id'  => $commission['id'],
+			'commission_integrity_hash' => $commission['integrity_hash'],
+			'terms'                     => $terms,
+			'evidence'                  => $evidence,
+			'expected_revision_id'      => $expected,
+			'expected_version'          => $expected_action_version,
+			'correction_reason'         => $input['_correction_reason'] ?? null,
+		);
+		$request_hash = self::hash( $request );
+		$started      = $this->begin_authorized( $booking, $actor_id );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$booking = $this->bookings->get_for_update( $booking['id'] );
+		if ( ! is_array( $booking ) ) {
+			return $this->rollback( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
+		}
+		$retry = $this->idempotent_revision( $booking['id'], $key, true );
+		if ( is_wp_error( $retry ) ) {
+			return $this->rollback( $retry );
+		}
+		if ( is_array( $retry ) ) {
+			if ( ! hash_equals( $retry['request_hash'], $request_hash ) ) {
+				return $this->rollback( new \WP_Error( 'show_settlement_idempotency_conflict', __( 'This show-settlement idempotency key is bound to different inputs.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+			}
+			$verified = $this->verify_revision( $retry, $booking, $actor_id, false );
+			$commit   = is_wp_error( $verified ) ? $this->rollback( $verified ) : $this->commit();
+			return is_wp_error( $commit ) ? $commit : $this->present( $verified );
+		}
+		$current = $this->latest_revision( $booking['id'], true );
+		if ( is_wp_error( $current ) ) {
+			return $this->rollback( $current );
+		}
+		if ( ! $requires_current && is_array( $current ) ) {
+			return $this->rollback( new \WP_Error( 'show_settlement_already_exists', __( 'Use a revision operation after the first show-settlement draft.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+		}
+		if ( $requires_current && ( ! is_array( $current ) || $current['id'] !== $expected ) ) {
+			return $this->rollback( new \WP_Error( 'show_settlement_revision_conflict', __( 'The current show-settlement revision changed.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+		}
+		if ( is_array( $current ) ) {
+			$state = $this->state( $current, true );
+			if ( is_wp_error( $state ) || ( $correction && $state['version'] !== $expected_action_version ) || ( $correction ? ! in_array( $state['status'], array( 'finalized', 'acknowledged', 'disputed' ), true ) : 'draft' !== $state['status'] ) ) {
+				return $this->rollback( is_wp_error( $state ) ? $state : new \WP_Error( 'show_settlement_status_conflict', __( 'The current revision cannot be replaced by this operation.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+			}
+		}
+		$metadata = $this->verify_attachment_snapshot( $booking, $evidence );
+		if ( is_wp_error( $metadata ) ) {
+			return $this->rollback( $metadata );
+		}
+		global $wpdb;
+		$now                   = gmdate( 'Y-m-d H:i:s' );
+		$row                   = array(
+			'public_id'                 => wp_generate_uuid4(),
+			'booking_id'                => $booking['id'],
+			'event_id'                  => $booking['event_id'],
+			'venue_term_id'             => $booking['venue_term_id'],
+			'revision'                  => is_array( $current ) ? $current['revision'] + 1 : 1,
+			'corrects_revision_id'      => $correction ? $current['id'] : null,
+			'commission_settlement_id'  => $commission['id'],
+			'commission_integrity_hash' => $commission['integrity_hash'],
+			'currency'                  => $terms['currency'],
+			'formula_version'           => self::FORMULA_VERSION,
+			'terms_payload'             => wp_json_encode(
+				array(
+					'version' => 1,
+					'data'    => $terms,
+				)
+			),
+			'evidence_payload'          => wp_json_encode(
+				array(
+					'version' => 1,
+					'data'    => $evidence,
+				)
+			),
+			'calculation_payload'       => wp_json_encode(
+				array(
+					'version' => 1,
+					'data'    => $calculation,
+				)
+			),
+			'request_hash'              => $request_hash,
+			'idempotency_key'           => $key,
+			'created_by_user_id'        => $actor_id,
+			'created_at'                => $now,
+		);
+		$row['integrity_hash'] = self::hash( self::revision_hashable( $row ) );
+		if ( false === $wpdb->insert( BookingSchema::show_settlements_table(), $row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Append-only financial revision.
+			return $this->rollback( new \WP_Error( 'show_settlement_write_failed', __( 'The show-settlement revision could not be recorded.', 'extrachill-events' ) ) );
+		}
+		$created = $this->revision_id( (int) $wpdb->insert_id, true );
+		if ( ! is_array( $created ) ) {
+			return $this->rollback( is_wp_error( $created ) ? $created : new \WP_Error( 'show_settlement_write_failed', __( 'The show-settlement revision could not be verified.', 'extrachill-events' ) ) );
+		}
+		if ( $correction ) {
+			$action = $this->append_action_row(
+				$current,
+				'corrected',
+				$state['version'],
+				array(
+					'replacement_revision_id' => $created['id'],
+					'reason'                  => $input['_correction_reason'],
+				),
+				'correction:' . $key,
+				$actor_id
+			);
+			if ( is_wp_error( $action ) ) {
+				return $this->rollback( $action );
+			}
+		}
+		$audit = $this->append_audit( $created, $correction ? 'show_settlement_corrected' : ( $requires_current ? 'show_settlement_revised' : 'show_settlement_drafted' ), $actor_id );
+		if ( is_wp_error( $audit ) ) {
+			return $this->rollback( $audit );
+		}
+		$commit = $this->commit();
+		return is_wp_error( $commit ) ? $commit : $this->present( $this->state( $created ) );
+	}
+
+	private function action( array $input, int $actor_id, string $action, array $payload, array $allowed_states, bool $authenticate_revision, ?array $authenticated_payout = null ) {
+		$booking = $this->booking( $input['booking_id'] ?? 0 );
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+		$allowed = $this->authorization->authorize( $actor_id, $booking['venue_term_id'], VenueAuthorization::ACTION_MANAGE_FINANCES );
+		if ( true !== $allowed ) {
+			return $this->denied( $allowed );
+		}
+		$revision_id      = $this->positive_integer( $input['revision_id'] ?? null, 'revision_id' );
+		$expected_version = $this->positive_integer( $input['expected_version'] ?? null, 'expected_version' );
+		$key              = TicketSettlementService::opaque_identifier( $input['idempotency_key'] ?? null, 'idempotency_key' );
+		foreach ( array( $revision_id, $expected_version, $key ) as $value ) {
+			if ( is_wp_error( $value ) ) {
+				return $value;
+			}
+		}
+		$request_hash = self::hash(
+			array(
+				'revision_id'      => $revision_id,
+				'expected_version' => $expected_version,
+				'action'           => $action,
+				'payload'          => $payload,
+			)
+		);
+		$revision     = $this->revision_id( $revision_id );
+		if ( ! is_array( $revision ) || $revision['booking_id'] !== $booking['id'] ) {
+			return new \WP_Error( 'show_settlement_not_found', __( 'The show settlement was not found.', 'extrachill-events' ), array( 'status' => 404 ) );
+		}
+		if ( $authenticate_revision ) {
+			$verified = $this->verify_revision( $revision, $booking, $actor_id, true );
+			if ( is_wp_error( $verified ) ) {
+				return $verified;
+			}
+		}
+		$started = $this->begin_authorized( $booking, $actor_id );
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$booking = $this->bookings->get_for_update( $booking['id'] );
+		$retry   = $this->idempotent_action( $booking['id'], $key, true );
+		if ( is_wp_error( $retry ) ) {
+			return $this->rollback( $retry );
+		}
+		if ( is_array( $retry ) ) {
+			if ( ! hash_equals( $retry['request_hash'], $request_hash ) ) {
+				return $this->rollback( new \WP_Error( 'show_settlement_idempotency_conflict', __( 'This lifecycle idempotency key is bound to a different request.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+			}
+			$current = $this->revision_id( $revision_id, true );
+			$commit  = $this->commit();
+			return is_wp_error( $commit ) ? $commit : $this->present( $this->state( $current ) );
+		}
+		$revision = $this->revision_id( $revision_id, true );
+		$latest   = $this->latest_revision( $booking['id'], true );
+		if ( ! is_array( $latest ) || ! is_array( $revision ) || $latest['id'] !== $revision['id'] ) {
+			return $this->rollback( new \WP_Error( 'show_settlement_revision_conflict', __( 'Only the current show-settlement revision may transition.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+		}
+		$state = is_array( $revision ) ? $this->state( $revision, true ) : $revision;
+		if ( ! is_array( $state ) || $state['version'] !== $expected_version || ! in_array( $state['status'], $allowed_states, true ) ) {
+			return $this->rollback(
+				is_wp_error( $state ) ? $state : new \WP_Error(
+					'show_settlement_version_conflict',
+					__( 'The show-settlement lifecycle changed before this transition.', 'extrachill-events' ),
+					array(
+						'status'          => 409,
+						'current_version' => is_array( $state ) ? $state['version'] : null,
+					)
+				)
+			);
+		}
+		if ( 'paid' === $action && 'completed' !== $booking['status'] ) {
+			return $this->rollback( new \WP_Error( 'show_settlement_payment_booking_status_conflict', __( 'The booking must be completed before artist payout is recorded.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+		}
+		$verified = $this->verify_revision( $revision, $booking, $actor_id, false );
+		if ( is_wp_error( $verified ) ) {
+			return $this->rollback( $verified );
+		}
+		if ( null !== $authenticated_payout ) {
+			$metadata = $this->verify_attachment_snapshot( $booking, $authenticated_payout );
+			if ( is_wp_error( $metadata ) ) {
+				return $this->rollback( $metadata );
+			}
+		}
+		$written = $this->append_action_row( $revision, $action, $expected_version, $payload, $key, $actor_id, $request_hash );
+		if ( is_wp_error( $written ) ) {
+			return $this->rollback( $written );
+		}
+		$audit = $this->append_audit( $revision, 'show_settlement_' . $action, $actor_id );
+		if ( is_wp_error( $audit ) ) {
+			return $this->rollback( $audit );
+		}
+		$state  = $this->state( $revision, true );
+		$commit = $this->commit();
+		return is_wp_error( $commit ) ? $commit : $this->present( $state );
+	}
+
+	private function terms( array $input, int $actor_id ) {
+		$currency = strtoupper( sanitize_text_field( (string) ( $input['currency'] ?? '' ) ) );
+		if ( ! preg_match( '/^[A-Z]{3}$/', $currency ) ) {
+			return new \WP_Error( 'invalid_show_settlement_currency', __( 'Currency must be an uppercase three-letter code.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$terms = array( 'currency' => $currency );
+		foreach ( array( 'ticket_gross_minor', 'door_gross_minor', 'fees_minor', 'taxes_minor', 'refunds_minor', 'venue_expenses_minor', 'production_expenses_minor', 'artist_guarantee_minor', 'artist_split_basis_points' ) as $field ) {
+			if ( ! array_key_exists( $field, $input ) || ! is_int( $input[ $field ] ) ) {
+				return new \WP_Error(
+					'invalid_show_settlement_amount',
+					__( 'Show settlement money and rates must use integers.', 'extrachill-events' ),
+					array(
+						'status' => 400,
+						'field'  => $field,
+					)
+				);
+			}
+			$terms[ $field ] = $input[ $field ];
+		}
+		$adjustments = $input['adjustments'] ?? array();
+		if ( ! is_array( $adjustments ) || 100 < count( $adjustments ) ) {
+			return new \WP_Error( 'invalid_show_settlement_adjustment', __( 'Signed adjustments must be a bounded array.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$terms['adjustments'] = array();
+		foreach ( $adjustments as $adjustment ) {
+			$reason = $this->text( is_array( $adjustment ) ? ( $adjustment['reason'] ?? null ) : null, 'adjustment_reason', 500 );
+			if ( is_wp_error( $reason ) || ! is_array( $adjustment ) || ! is_int( $adjustment['amount_minor'] ?? null ) ) {
+				return is_wp_error( $reason ) ? $reason : new \WP_Error( 'invalid_show_settlement_adjustment', __( 'Every adjustment requires signed integer minor units and a reason.', 'extrachill-events' ), array( 'status' => 400 ) );
+			}
+			$terms['adjustments'][] = array(
+				'amount_minor'      => $adjustment['amount_minor'],
+				'reason'            => $reason,
+				'signed_by_user_id' => $actor_id,
+				'signature_hash'    => self::hash( array( $adjustment['amount_minor'], $reason, $actor_id ) ),
+			);
+		}
+		return $terms;
+	}
+
+	private function attachment_evidence( array $booking, $ids, int $actor_id, bool $required ) {
+		if ( ! is_array( $ids ) || 20 < count( $ids ) || ( $required && empty( $ids ) ) ) {
+			return new \WP_Error( 'show_settlement_evidence_required', __( 'Authorized immutable evidence is required for this settlement operation.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$normalized = array();
+		foreach ( $ids as $id ) {
+			$id = $this->positive_integer( $id, 'attachment_id' );
+			if ( is_wp_error( $id ) || in_array( $id, $normalized, true ) ) {
+				return is_wp_error( $id ) ? $id : new \WP_Error( 'show_settlement_evidence_invalid', __( 'Evidence attachment IDs must be unique.', 'extrachill-events' ), array( 'status' => 400 ) );
+			}
+			$normalized[] = $id;
+		}
+		sort( $normalized, SORT_NUMERIC );
+		$evidence = array();
+		foreach ( $normalized as $id ) {
+			$attachment = $this->attachments->get_for_booking( $booking['id'], $id );
+			if ( is_wp_error( $attachment ) || 'active' !== ( $attachment['state'] ?? '' ) || 'other_private_evidence' !== ( $attachment['purpose'] ?? '' ) ) {
+				return new \WP_Error( 'show_settlement_evidence_invalid', __( 'Settlement evidence is unavailable, inactive, or not approved private evidence.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			$verified = $this->authenticate_attachment( $booking, $attachment, $actor_id );
+			if ( is_wp_error( $verified ) ) {
+				return $verified;
+			}
+			$evidence[] = array(
+				'id'           => $attachment['id'],
+				'public_id'    => $attachment['public_id'],
+				'request_hash' => $attachment['request_hash'],
+				'content_hash' => $attachment['content_hash'],
+				'byte_size'    => $attachment['byte_size'],
+				'mime_type'    => $attachment['mime_type'],
+				'purpose'      => $attachment['purpose'],
+			);
+		}
+		return $evidence;
+	}
+
+	private function authenticate_attachment( array $booking, array $attachment, int $actor_id ) {
+		$descriptor = $this->attachment_service->download_descriptor( $booking['id'], $attachment['id'], $actor_id );
+		if ( is_wp_error( $descriptor ) ) {
+			return new \WP_Error( 'show_settlement_evidence_invalid', __( 'Settlement evidence bytes are unavailable.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$stream = $this->attachment_service->open_download_stream( $booking['id'], $attachment['id'], $descriptor['stream_token'], $actor_id, $descriptor['correlation_id'] );
+		if ( is_wp_error( $stream ) || ! is_resource( $stream ) ) {
+			return new \WP_Error( 'show_settlement_evidence_invalid', __( 'Settlement evidence bytes are unavailable.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$hash  = hash_init( 'sha256' );
+		$bytes = 0;
+		while ( ! feof( $stream ) ) {
+			$chunk = fread( $stream, 8192 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread -- Reads only an authorized private stream.
+			if ( false === $chunk ) {
+				$bytes = -1;
+				break;
+			}
+			$bytes += strlen( $chunk );
+			hash_update( $hash, $chunk );
+			if ( BookingAttachmentPolicy::MAX_BYTES < $bytes || $attachment['byte_size'] < $bytes ) {
+				$bytes = -1;
+				break;
+			}
+		}
+		fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes the approved private stream.
+		$valid  = $bytes === $attachment['byte_size'] && hash_equals( $attachment['content_hash'], hash_final( $hash ) );
+		$logged = $this->attachment_service->record_delivery_outcome( $booking['id'], $attachment['id'], $descriptor['correlation_id'], $valid ? 'completed' : 'failed', $valid ? $bytes : 0, $actor_id );
+		return $valid && ! is_wp_error( $logged ) ? true : new \WP_Error( 'show_settlement_evidence_invalid', __( 'Settlement evidence bytes failed authentication.', 'extrachill-events' ), array( 'status' => 409 ) );
+	}
+
+	private function verify_attachment_snapshot( array $booking, array $snapshot ) {
+		foreach ( $snapshot as $expected ) {
+			$attachment = $this->attachments->get_for_booking( $booking['id'], (int) $expected['id'] );
+			if ( is_wp_error( $attachment ) || 'active' !== ( $attachment['state'] ?? '' ) ) {
+				return new \WP_Error( 'show_settlement_evidence_invalid', __( 'Frozen settlement evidence is missing or inactive.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			foreach ( array( 'public_id', 'request_hash', 'content_hash', 'byte_size', 'mime_type', 'purpose' ) as $field ) {
+				if ( $attachment[ $field ] !== $expected[ $field ] ) {
+					return new \WP_Error( 'show_settlement_evidence_invalid', __( 'Frozen settlement evidence metadata was changed.', 'extrachill-events' ), array( 'status' => 409 ) );
+				}
+			}
+		}
+		return true;
+	}
+
+	private function verify_revision( array $revision, array $booking, int $actor_id, bool $authenticate_bytes ) {
+		if ( $revision['booking_id'] !== $booking['id'] || $revision['event_id'] !== $booking['event_id'] || $revision['venue_term_id'] !== $booking['venue_term_id'] || ! hash_equals( $revision['integrity_hash'], self::hash( self::revision_hashable( $revision ) ) ) ) {
+			return new \WP_Error( 'show_settlement_integrity_failed', __( 'The immutable show-settlement revision failed integrity verification.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$commission = $this->commissions->get( $booking['id'], $actor_id );
+		if ( is_wp_error( $commission ) || $commission['id'] !== $revision['commission_settlement_id'] || ! hash_equals( $commission['integrity_hash'], $revision['commission_integrity_hash'] ) || $commission['currency'] !== $revision['currency'] ) {
+			return new \WP_Error( 'show_settlement_commission_invalid', __( 'The bound Extra Chill commission failed integrity verification.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$calculation = self::calculate_amounts( $revision['terms'], $commission['amount_due_minor'] );
+		if ( is_wp_error( $calculation ) || $calculation !== $revision['calculation'] ) {
+			return new \WP_Error( 'show_settlement_calculation_invalid', __( 'The frozen show-settlement calculation is not reproducible.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$ticket_gross = $this->ticket_gross( $booking, $commission, $actor_id );
+		if ( is_wp_error( $ticket_gross ) || $ticket_gross !== $revision['terms']['ticket_gross_minor'] ) {
+			return is_wp_error( $ticket_gross ) ? $ticket_gross : new \WP_Error( 'show_settlement_ticket_gross_conflict', __( 'Frozen ticket gross no longer matches its reconciled ticket evidence.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$metadata = $this->verify_attachment_snapshot( $booking, $revision['evidence'] );
+		if ( is_wp_error( $metadata ) ) {
+			return $metadata;
+		}
+		if ( $authenticate_bytes ) {
+			foreach ( $revision['evidence'] as $item ) {
+				$attachment = $this->attachments->get_for_booking( $booking['id'], $item['id'] );
+				$verified   = is_array( $attachment ) ? $this->authenticate_attachment( $booking, $attachment, $actor_id ) : $attachment;
+				if ( true !== $verified ) {
+					return is_wp_error( $verified ) ? $verified : new \WP_Error( 'show_settlement_evidence_invalid', __( 'Frozen settlement evidence bytes failed authentication.', 'extrachill-events' ), array( 'status' => 409 ) );
+				}
+			}
+		}
+		$state = $this->state( $revision );
+		if ( is_wp_error( $state ) ) {
+			return $state;
+		}
+		foreach ( $state['actions'] as $action ) {
+			if ( isset( $action['payload']['payout_evidence'] ) ) {
+				$payout = $this->verify_attachment_snapshot( $booking, $action['payload']['payout_evidence'] );
+				if ( is_wp_error( $payout ) ) {
+					return $payout;
+				}
+			}
+		}
+		return $state;
+	}
+
+	private function ticket_gross( array $booking, array $commission, int $actor_id ) {
+		$by_id  = array();
+		$found  = 0;
+		$needed = count( $commission['included_report_ids'] );
+		for ( $offset = 0; $offset < 10000 && $found < $needed; $offset += 200 ) {
+			$reports = $this->commissions->list_sales( $booking['id'], $actor_id, 200, $offset );
+			if ( is_wp_error( $reports ) ) {
+				return $reports;
+			}
+			foreach ( $reports as $report ) {
+				if ( in_array( $report['id'], $commission['included_report_ids'], true ) ) {
+					$by_id[ $report['id'] ] = $report;
+					$found                  = count( $by_id );
+				}
+			}
+			if ( count( $reports ) < 200 ) {
+				break;
+			}
+		}
+		$gross = 0;
+		foreach ( $commission['included_report_ids'] as $report_id ) {
+			if ( ! isset( $by_id[ $report_id ] ) || $by_id[ $report_id ]['currency'] !== $commission['currency'] ) {
+				return new \WP_Error( 'show_settlement_ticket_evidence_invalid', __( 'Frozen ticket evidence is missing from the complete show settlement.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			$gross = self::safe_add( $gross, $by_id[ $report_id ]['gross_minor'] );
+			if ( is_wp_error( $gross ) ) {
+				return $gross;
+			}
+		}
+		return $gross;
+	}
+
+	private function state( array $revision, bool $lock = false ) {
+		global $wpdb;
+		$table = BookingSchema::show_settlement_actions_table();
+		$query = "SELECT * FROM {$table} WHERE show_settlement_id = %d ORDER BY expected_version ASC, id ASC";
+		if ( $lock ) {
+			$query .= ' FOR UPDATE';
+		}
+		$rows = $wpdb->get_results( $wpdb->prepare( $query, $revision['id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Complete immutable lifecycle.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'show_settlement_action_read_failed', __( 'The show-settlement lifecycle could not be read.', 'extrachill-events' ) );
+		}
+		$status  = 'draft';
+		$version = 1;
+		$actions = array();
+		foreach ( (array) $rows as $row ) {
+			$row = $this->hydrate_action( $row );
+			if ( is_wp_error( $row ) || $row['expected_version'] !== $version || $row['show_settlement_id'] !== $revision['id'] ) {
+				return is_wp_error( $row ) ? $row : new \WP_Error( 'show_settlement_action_integrity_failed', __( 'The show-settlement lifecycle chain is invalid.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			$status = $row['action'];
+			++$version;
+			$actions[] = $row;
+		}
+		$revision['status']  = $status;
+		$revision['version'] = $version;
+		$revision['actions'] = $actions;
+		return $revision;
+	}
+
+	private function append_action_row( array $revision, string $action, int $expected_version, array $payload, string $key, int $actor_id, ?string $request_hash = null ) {
+		global $wpdb;
+		$row                   = array(
+			'public_id'          => wp_generate_uuid4(),
+			'booking_id'         => $revision['booking_id'],
+			'venue_term_id'      => $revision['venue_term_id'],
+			'show_settlement_id' => $revision['id'],
+			'action'             => $action,
+			'expected_version'   => $expected_version,
+			'payload'            => wp_json_encode(
+				array(
+					'version' => 1,
+					'data'    => $payload,
+				)
+			),
+			'request_hash'       => $request_hash ? $request_hash : self::hash(
+				array(
+					'revision_id'      => $revision['id'],
+					'expected_version' => $expected_version,
+					'action'           => $action,
+					'payload'          => $payload,
+				)
+			),
+			'idempotency_key'    => $key,
+			'actor_user_id'      => $actor_id,
+			'created_at'         => gmdate( 'Y-m-d H:i:s' ),
+		);
+		$row['integrity_hash'] = self::hash( self::action_hashable( $row ) );
+		return false === $wpdb->insert( BookingSchema::show_settlement_actions_table(), $row ) // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Append-only lifecycle transition.
+			? new \WP_Error( 'show_settlement_action_write_failed', __( 'The show-settlement lifecycle transition could not be recorded.', 'extrachill-events' ) )
+			: $row;
+	}
+
+	private function hydrate_revision( array $row ) {
+		foreach ( array( 'id', 'booking_id', 'event_id', 'venue_term_id', 'revision', 'commission_settlement_id', 'formula_version', 'created_by_user_id' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		$row['corrects_revision_id'] = null === $row['corrects_revision_id'] ? null : (int) $row['corrects_revision_id'];
+		foreach ( array(
+			'terms_payload'       => 'terms',
+			'evidence_payload'    => 'evidence',
+			'calculation_payload' => 'calculation',
+		) as $field => $target ) {
+			$decoded = json_decode( (string) $row[ $field ], true );
+			if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) || 1 !== ( $decoded['version'] ?? null ) || ! is_array( $decoded['data'] ?? null ) ) {
+				return new \WP_Error( 'show_settlement_integrity_failed', __( 'Stored show-settlement data is malformed.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			$row[ $target ] = $decoded['data'];
+			unset( $row[ $field ] );
+		}
+		return $row;
+	}
+
+	private function hydrate_action( array $row ) {
+		foreach ( array( 'id', 'booking_id', 'venue_term_id', 'show_settlement_id', 'expected_version', 'actor_user_id' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		$payload = json_decode( (string) $row['payload'], true );
+		if ( JSON_ERROR_NONE !== json_last_error() || 1 !== ( $payload['version'] ?? null ) || ! is_array( $payload['data'] ?? null ) || ! in_array( $row['action'], self::ACTIONS, true ) ) {
+			return new \WP_Error( 'show_settlement_action_integrity_failed', __( 'Stored show-settlement lifecycle data is malformed.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$row['payload'] = $payload['data'];
+		$hash           = self::hash(
+			array(
+				'revision_id'      => $row['show_settlement_id'],
+				'expected_version' => $row['expected_version'],
+				'action'           => $row['action'],
+				'payload'          => $row['payload'],
+			)
+		);
+		return hash_equals( $row['request_hash'], $hash ) && hash_equals( $row['integrity_hash'], self::hash( self::action_hashable( $row ) ) ) ? $row : new \WP_Error( 'show_settlement_action_integrity_failed', __( 'Stored show-settlement lifecycle data failed integrity verification.', 'extrachill-events' ), array( 'status' => 409 ) );
+	}
+
+	private function latest_revision( int $booking_id, bool $lock = false ) {
+		global $wpdb;
+		$table = BookingSchema::show_settlements_table();
+		$query = "SELECT * FROM {$table} WHERE booking_id = %d ORDER BY revision DESC LIMIT 1" . ( $lock ? ' FOR UPDATE' : '' );
+		$row   = $wpdb->get_row( $wpdb->prepare( $query, $booking_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact latest revision with optional lock.
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'show_settlement_read_failed', __( 'The show settlement could not be read.', 'extrachill-events' ) ) : ( is_array( $row ) ? $this->hydrate_revision( $row ) : null );
+	}
+
+	private function revision_id( int $id, bool $lock = false ) {
+		global $wpdb;
+		$table = BookingSchema::show_settlements_table();
+		$query = "SELECT * FROM {$table} WHERE id = %d LIMIT 1" . ( $lock ? ' FOR UPDATE' : '' );
+		$row   = $wpdb->get_row( $wpdb->prepare( $query, $id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact immutable revision.
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'show_settlement_read_failed', __( 'The show settlement could not be read.', 'extrachill-events' ) ) : ( is_array( $row ) ? $this->hydrate_revision( $row ) : null );
+	}
+
+	private function revision_number( int $booking_id, int $revision ) {
+		global $wpdb;
+		$table = BookingSchema::show_settlements_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE booking_id = %d AND revision = %d LIMIT 1", $booking_id, $revision ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact immutable revision.
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'show_settlement_read_failed', __( 'The show settlement could not be read.', 'extrachill-events' ) ) : ( is_array( $row ) ? $this->hydrate_revision( $row ) : null );
+	}
+
+	private function idempotent_revision( int $booking_id, string $key, bool $lock ) {
+		global $wpdb;
+		$table = BookingSchema::show_settlements_table();
+		$query = "SELECT * FROM {$table} WHERE booking_id = %d AND idempotency_key = %s LIMIT 1" . ( $lock ? ' FOR UPDATE' : '' );
+		$row   = $wpdb->get_row( $wpdb->prepare( $query, $booking_id, $key ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Idempotency lookup.
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'show_settlement_read_failed', __( 'The show settlement could not be read.', 'extrachill-events' ) ) : ( is_array( $row ) ? $this->hydrate_revision( $row ) : null );
+	}
+
+	private function idempotent_action( int $booking_id, string $key, bool $lock ) {
+		global $wpdb;
+		$table = BookingSchema::show_settlement_actions_table();
+		$query = "SELECT * FROM {$table} WHERE booking_id = %d AND idempotency_key = %s LIMIT 1" . ( $lock ? ' FOR UPDATE' : '' );
+		$row   = $wpdb->get_row( $wpdb->prepare( $query, $booking_id, $key ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Idempotency lookup.
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'show_settlement_action_read_failed', __( 'The show-settlement lifecycle could not be read.', 'extrachill-events' ) ) : ( is_array( $row ) ? $this->hydrate_action( $row ) : null );
+	}
+
+	private function begin_authorized( array $booking, int $actor_id ) {
+		global $wpdb;
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Complete financial transaction.
+			return new \WP_Error( 'show_settlement_transaction_start_failed', __( 'The show-settlement transaction could not start.', 'extrachill-events' ) );
+		}
+		$this->transaction_active = true;
+		$table                    = BookingSchema::memberships_table();
+		$members                  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $booking['venue_term_id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks exact venue authority first.
+		$allowed                  = '' === (string) $wpdb->last_error ? $this->authorization->authorize_locked( $actor_id, $booking['venue_term_id'], VenueAuthorization::ACTION_MANAGE_FINANCES, (array) $members ) : false;
+		return true === $allowed ? true : $this->rollback( $this->denied( $allowed ) );
+	}
+
+	private function booking( $id ) {
+		$id = $this->positive_integer( $id, 'booking_id' );
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+		$booking = $this->bookings->get( $id );
+		return is_array( $booking ) && null !== $booking['event_id'] ? $booking : ( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'An event-linked booking was not found.', 'extrachill-events' ), array( 'status' => 404 ) ) );
+	}
+
+	private function append_audit( array $revision, string $kind, int $actor_id ) {
+		return $this->activity->append(
+			array(
+				'booking_id'  => $revision['booking_id'],
+				'kind'        => $kind,
+				'actor_type'  => 'user',
+				'actor_id'    => $actor_id,
+				'external_id' => (string) $revision['id'],
+				'payload'     => array(
+					'show_settlement_id' => $revision['id'],
+					'revision'           => $revision['revision'],
+					'currency'           => $revision['currency'],
+				),
+			)
+		);
+	}
+
+	private function present( array $revision ): array {
+		unset( $revision['idempotency_key'], $revision['request_hash'] );
+		if ( isset( $revision['actions'] ) ) {
+			foreach ( $revision['actions'] as &$action ) {
+				unset( $action['idempotency_key'], $action['request_hash'], $action['integrity_hash'] );
+				if ( isset( $action['payload']['payment_reference'] ) ) {
+					unset( $action['payload']['payment_reference'] );
+					$action['payload']['payment_reference_recorded'] = true;
+				}
+				if ( isset( $action['payload']['payout_evidence'] ) ) {
+					$action['payload']['payout_evidence'] = $this->project_evidence( $action['payload']['payout_evidence'] );
+				}
+			}
+			unset( $action );
+		}
+		$revision['evidence'] = $this->project_evidence( $revision['evidence'] );
+		return $revision;
+	}
+
+	private function project_evidence( array $evidence ): array {
+		return array_map(
+			static function ( array $item ): array {
+				return array(
+					'id'        => $item['id'],
+					'public_id' => $item['public_id'],
+					'mime_type' => $item['mime_type'],
+					'byte_size' => $item['byte_size'],
+				);
+			},
+			$evidence
+		);
+	}
+
+	private static function revision_hashable( array $row ): array {
+		return array(
+			'public_id'                 => $row['public_id'],
+			'booking_id'                => (int) $row['booking_id'],
+			'event_id'                  => (int) $row['event_id'],
+			'venue_term_id'             => (int) $row['venue_term_id'],
+			'revision'                  => (int) $row['revision'],
+			'corrects_revision_id'      => null === $row['corrects_revision_id'] ? null : (int) $row['corrects_revision_id'],
+			'commission_settlement_id'  => (int) $row['commission_settlement_id'],
+			'commission_integrity_hash' => $row['commission_integrity_hash'],
+			'currency'                  => $row['currency'],
+			'formula_version'           => (int) $row['formula_version'],
+			'terms'                     => $row['terms'] ?? json_decode( $row['terms_payload'], true )['data'],
+			'evidence'                  => $row['evidence'] ?? json_decode( $row['evidence_payload'], true )['data'],
+			'calculation'               => $row['calculation'] ?? json_decode( $row['calculation_payload'], true )['data'],
+			'request_hash'              => $row['request_hash'],
+			'idempotency_key'           => $row['idempotency_key'],
+			'created_by_user_id'        => (int) $row['created_by_user_id'],
+			'created_at'                => $row['created_at'],
+		);
+	}
+
+	private static function action_hashable( array $row ): array {
+		$payload = $row['payload'];
+		if ( is_string( $payload ) ) {
+			$payload = json_decode( $payload, true )['data'];
+		}
+		return array(
+			'public_id'          => $row['public_id'],
+			'booking_id'         => (int) $row['booking_id'],
+			'venue_term_id'      => (int) $row['venue_term_id'],
+			'show_settlement_id' => (int) $row['show_settlement_id'],
+			'action'             => $row['action'],
+			'expected_version'   => (int) $row['expected_version'],
+			'payload'            => $payload,
+			'request_hash'       => $row['request_hash'],
+			'idempotency_key'    => $row['idempotency_key'],
+			'actor_user_id'      => (int) $row['actor_user_id'],
+			'created_at'         => $row['created_at'],
+		);
+	}
+
+	private static function safe_add( int $left, int $right ) {
+		if ( ( $right > 0 && $left > PHP_INT_MAX - $right ) || ( $right < 0 && $left < PHP_INT_MIN - $right ) ) {
+			return new \WP_Error( 'show_settlement_amount_out_of_range', __( 'The show-settlement calculation exceeds the supported integer range.', 'extrachill-events' ) );
+		}
+		return $left + $right;
+	}
+
+	private static function safe_subtract( int $left, int $right ) {
+		if ( ( $right > 0 && $left < PHP_INT_MIN + $right ) || ( $right < 0 && $left > PHP_INT_MAX + $right ) ) {
+			return new \WP_Error( 'show_settlement_amount_out_of_range', __( 'The show-settlement calculation exceeds the supported integer range.', 'extrachill-events' ) );
+		}
+		return $left - $right;
+	}
+
+	private static function hash( $value ): string {
+		return hash( 'sha256', wp_json_encode( self::canonicalize( $value ) ) );
+	}
+
+	private static function canonicalize( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+		if ( array() !== $value && array_keys( $value ) !== range( 0, count( $value ) - 1 ) ) {
+			ksort( $value );
+		}
+		foreach ( $value as $key => $item ) {
+			$value[ $key ] = self::canonicalize( $item );
+		}
+		return $value;
+	}
+
+	private function positive_integer( $value, string $field ) {
+		return is_int( $value ) && 0 < $value ? $value : new \WP_Error(
+			'invalid_show_settlement_integer',
+			__( 'A positive integer is required.', 'extrachill-events' ),
+			array(
+				'status' => 400,
+				'field'  => $field,
+			)
+		);
+	}
+
+	private function text( $value, string $field, int $max ) {
+		$value = sanitize_text_field( (string) $value );
+		return '' !== $value && mb_strlen( $value ) <= $max ? $value : new \WP_Error(
+			'invalid_show_settlement_text',
+			__( 'A bounded text value is required.', 'extrachill-events' ),
+			array(
+				'status' => 400,
+				'field'  => $field,
+			)
+		);
+	}
+
+	private function optional_text( $value, int $max ): ?string {
+		$value = sanitize_text_field( (string) $value );
+		return '' === $value ? null : mb_substr( $value, 0, $max );
+	}
+
+	private function date( $value ) {
+		$date = is_string( $value ) ? \DateTimeImmutable::createFromFormat( '!Y-m-d', $value, new \DateTimeZone( 'UTC' ) ) : false;
+		return false !== $date && $date->format( 'Y-m-d' ) === $value ? $value : new \WP_Error( 'invalid_show_settlement_payment_date', __( 'Payment date must use Y-m-d format.', 'extrachill-events' ), array( 'status' => 400 ) );
+	}
+
+	private function denied( $result ): \WP_Error {
+		return is_wp_error( $result ) ? $result : new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to manage this venue settlement.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+
+	private function commit() {
+		global $wpdb;
+		$result                   = $wpdb->query( 'COMMIT' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Complete financial transaction.
+		$this->transaction_active = false;
+		return false === $result ? new \WP_Error( 'show_settlement_commit_uncertain', __( 'The show-settlement transaction outcome could not be confirmed.', 'extrachill-events' ) ) : true;
+	}
+
+	private function rollback( \WP_Error $error ) {
+		global $wpdb;
+		if ( $this->transaction_active ) {
+			$wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Complete financial rollback.
+			$this->transaction_active = false;
+		}
+		return $error;
+	}
+}

--- a/inc/Core/TicketSettlementService.php
+++ b/inc/Core/TicketSettlementService.php
@@ -429,6 +429,24 @@ class TicketSettlementService {
 		return true === $allowed ? $this->get_settlement( $booking['id'] ) : $this->denied( $allowed );
 	}
 
+	/** Read and lock the exact commission inside a caller-owned booking transaction. */
+	public function get_for_update( int $booking_id ) {
+		return $this->get_settlement( $booking_id, true );
+	}
+
+	/** Lock and return the immutable report rows bound to a locked commission. */
+	public function included_reports_for_update( array $settlement ) {
+		$reports = array();
+		foreach ( $settlement['included_report_ids'] ?? array() as $report_id ) {
+			$report = $this->get_report( (int) $report_id, true );
+			if ( ! is_array( $report ) || $report['booking_id'] !== $settlement['booking_id'] || $report['currency'] !== $settlement['currency'] ) {
+				return is_wp_error( $report ) ? $report : new \WP_Error( 'settlement_evidence_integrity_failed', __( 'Frozen settlement evidence is missing or mismatched.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			$reports[] = $report;
+		}
+		return $reports;
+	}
+
 	/** Round a signed basis-point product to nearest minor unit, ties away from zero. */
 	public static function basis_points_amount( int $amount_minor, int $basis_points ) {
 		$out_of_range = $basis_points < 0 || $basis_points > 10000;

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -21,6 +21,7 @@
 			<file>tests/BookingMarketingDelegatedSchemaTest.php</file>
 			<file>tests/TicketSettlementTest.php</file>
 			<file>tests/TicketReconciliationTest.php</file>
+			<file>tests/ShowSettlementTest.php</file>
 			<file>tests/BookingNotificationTest.php</file>
 			<file>tests/LocalSupportNotificationTest.php</file>
 			<file>tests/CanonicalEventPublicationGuardTest.php</file>

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -295,28 +295,28 @@ final class BookingFoundationTest extends BookingTestCase {
 		$this->assertSame( array(), $GLOBALS['ec_artist_test']['dbdelta'] );
 	}
 
-	public function test_stamped_v11_install_adds_settlement_tables_without_disturbing_existing_contracts(): void {
+	public function test_stamped_v14_install_adds_show_settlement_tables_without_disturbing_existing_contracts(): void {
 		$this->assertTrue( BookingSchema::install() );
-		$wpdb        = $GLOBALS['wpdb'];
-		$sales       = BookingSchema::sales_reports_table();
-		$settlements = BookingSchema::settlements_table();
-		unset( $wpdb->schemas[ $sales ], $wpdb->schemas[ $settlements ], $wpdb->engines[ $sales ], $wpdb->engines[ $settlements ], $wpdb->rows[ $sales ], $wpdb->rows[ $settlements ] );
+		$wpdb             = $GLOBALS['wpdb'];
+		$show_settlements = BookingSchema::show_settlements_table();
+		$show_actions     = BookingSchema::show_settlement_actions_table();
+		unset( $wpdb->schemas[ $show_settlements ], $wpdb->schemas[ $show_actions ], $wpdb->engines[ $show_settlements ], $wpdb->engines[ $show_actions ], $wpdb->rows[ $show_settlements ], $wpdb->rows[ $show_actions ] );
 
 		$bookings = BookingSchema::bookings_table();
-		$wpdb->rows[ $bookings ][999] = array( 'id' => 999, 'marker' => 'existing-v11-booking' );
+		$wpdb->rows[ $bookings ][999] = array( 'id' => 999, 'marker' => 'existing-v14-booking' );
 		$existing_schemas              = $wpdb->schemas;
 		$existing_engines              = $wpdb->engines;
-		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '11';
+		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '14';
 
 		$this->assertTrue( BookingSchema::maybe_install() );
-		$this->assertSame( '14', get_option( BookingSchema::VERSION_OPTION ) );
-		$this->assertArrayHasKey( $sales, $wpdb->schemas );
-		$this->assertArrayHasKey( $settlements, $wpdb->schemas );
-		$this->assertSame( 'INNODB', strtoupper( $wpdb->engines[ $sales ] ) );
-		$this->assertSame( 'INNODB', strtoupper( $wpdb->engines[ $settlements ] ) );
+		$this->assertSame( '15', get_option( BookingSchema::VERSION_OPTION ) );
+		$this->assertArrayHasKey( $show_settlements, $wpdb->schemas );
+		$this->assertArrayHasKey( $show_actions, $wpdb->schemas );
+		$this->assertSame( 'INNODB', strtoupper( $wpdb->engines[ $show_settlements ] ) );
+		$this->assertSame( 'INNODB', strtoupper( $wpdb->engines[ $show_actions ] ) );
 		$this->assertSame( $existing_schemas, array_intersect_key( $wpdb->schemas, $existing_schemas ) );
 		$this->assertSame( $existing_engines, array_intersect_key( $wpdb->engines, $existing_engines ) );
-		$this->assertSame( 'existing-v11-booking', $wpdb->rows[ $bookings ][999]['marker'] );
+		$this->assertSame( 'existing-v14-booking', $wpdb->rows[ $bookings ][999]['marker'] );
 		$this->assertTrue( BookingSchema::health() );
 	}
 

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -132,7 +132,7 @@ final class BookingHoldTest extends BookingTestCase {
 	}
 
 	public function test_combined_schema_installs_site_scoped_holds_contract(): void {
-		$this->assertSame( '14', BookingSchema::SCHEMA_VERSION );
+		$this->assertSame( '15', BookingSchema::SCHEMA_VERSION );
 		$this->assertTrue( BookingSchema::install() );
 		$table = BookingSchema::holds_table();
 		$this->assertSame( 'wp_7_ec_booking_holds', $table );

--- a/tests/BookingMutationTest.php
+++ b/tests/BookingMutationTest.php
@@ -118,7 +118,7 @@ final class BookingMutationTest extends BookingTestCase {
 	}
 
 	public function test_schema_and_public_inquiry_separate_requested_from_authoritative_fields(): void {
-		$this->assertSame( '14', BookingSchema::SCHEMA_VERSION );
+		$this->assertSame( '15', BookingSchema::SCHEMA_VERSION );
 		$this->assertTrue( BookingSchema::install() );
 		$columns = $GLOBALS['wpdb']->schemas[ BookingSchema::bookings_table() ]['columns'];
 		foreach ( array( 'requested_space_key', 'performance_start_at', 'performance_end_at', 'production_payload', 'confirmed_deal_payload' ) as $column ) {

--- a/tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
@@ -190,6 +190,60 @@ final class BookingAdmissionConcurrencyMySQLProof extends BookingAttachmentMySQL
 		$this->assertContains( 'show_settlement_version_conflict', $this->race_result_kinds( $payment_race ) );
 	}
 
+	/** Prove commission void serializes before or after every dependent show write. */
+	public function test_commission_void_races_show_create_finalize_and_payment(): void {
+		global $wpdb;
+		$create      = $this->show_commission_race_fixture( 'void-create' );
+		$draft_input = $this->show_revision_input( $create['booking']['id'], $create['commission']['id'], 'void-create-draft' );
+		$this->assert_void_show_race(
+			$create,
+			fn() => ( new ShowSettlementService() )->draft( $draft_input, $this->actor_id )
+		);
+
+		$finalize = $this->show_commission_race_fixture( 'void-finalize' );
+		$draft    = ( new ShowSettlementService() )->draft( $this->show_revision_input( $finalize['booking']['id'], $finalize['commission']['id'], 'void-finalize-draft' ), $this->actor_id );
+		$this->assertIsArray( $draft, is_wp_error( $draft ) ? $draft->get_error_code() : '' );
+		$this->assertNotFalse( $GLOBALS['wpdb']->query( 'COMMIT' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Publishes the draft before contention.
+		$this->assert_void_show_race(
+			$finalize,
+			fn() => ( new ShowSettlementService() )->finalize( array( 'booking_id' => $finalize['booking']['id'], 'revision_id' => $draft['id'], 'expected_version' => $draft['version'], 'idempotency_key' => 'void-finalize-action' ), $this->actor_id )
+		);
+
+		$payment   = $this->show_commission_race_fixture( 'void-payment' );
+		$service   = new ShowSettlementService();
+		$draft     = $service->draft( $this->show_revision_input( $payment['booking']['id'], $payment['commission']['id'], 'void-payment-draft' ), $this->actor_id );
+		$finalized = $service->finalize(
+			array(
+				'booking_id'       => $payment['booking']['id'],
+				'revision_id'      => $draft['id'],
+				'expected_version' => $draft['version'],
+				'idempotency_key'  => 'void-payment-finalize',
+			),
+			$this->actor_id
+		);
+		$bytes = 'void race payout evidence';
+		$wpdb->insert( BookingSchema::attachments_table(), array( 'public_id' => wp_generate_uuid4(), 'booking_id' => $payment['booking']['id'], 'uploader_type' => 'user', 'uploader_user_id' => $this->actor_id, 'uploader_reference' => null, 'artist_term_id' => null, 'artist_profile_id' => null, 'purpose' => 'other_private_evidence', 'original_filename' => 'void-race-payout.txt', 'mime_type' => 'text/plain', 'byte_size' => strlen( $bytes ), 'content_hash' => hash( 'sha256', $bytes ), 'storage_reference' => 'void-race-payout', 'state' => 'active', 'idempotency_key' => 'void-race-payout', 'request_hash' => hash( 'sha256', 'void-race-payout' ), 'replaces_attachment_id' => null, 'retired_at' => null, 'purged_at' => null, 'created_at' => gmdate( 'Y-m-d H:i:s' ), 'updated_at' => gmdate( 'Y-m-d H:i:s' ) ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Seeds disposable payout evidence.
+		$attachment_id = (int) $wpdb->insert_id;
+		$wpdb->update( BookingSchema::bookings_table(), array( 'status' => 'completed', 'version' => $payment['booking']['version'] + 1 ), array( 'id' => $payment['booking']['id'] ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Completes the disposable booking.
+		++$payment['booking']['version'];
+		$this->assertNotFalse( $wpdb->query( 'COMMIT' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Publishes payout fixtures.
+		$this->assert_void_show_race(
+			$payment,
+			fn() => ( new ShowSettlementService( null, null, null, null, new BookingAttachmentRepository(), new ShowSettlementMySQLAttachmentService( $bytes ) ) )->mark_paid(
+				array(
+					'booking_id'                     => $payment['booking']['id'],
+					'revision_id'                    => $finalized['id'],
+					'expected_version'               => $finalized['version'],
+					'idempotency_key'                => 'void-payment-action',
+					'payment_reference'              => 'void-race',
+					'payment_date'                   => gmdate( 'Y-m-d' ),
+					'payout_evidence_attachment_ids' => array( $attachment_id ),
+				),
+				$this->actor_id
+			)
+		);
+	}
+
 	/** Prove the loser replays the completed exact winner without duplicate effects. */
 	public function test_concurrent_exact_inquiry_retry_reuses_one_complete_winner(): void {
 		global $wpdb;
@@ -331,8 +385,83 @@ final class BookingAdmissionConcurrencyMySQLProof extends BookingAttachmentMySQL
 		);
 	}
 
+	/** Build and publish one independent booking plus finalized commission. */
+	private function show_commission_race_fixture( string $key ): array {
+		global $wpdb;
+		$bookings = new BookingRepository();
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'   => defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events',
+				'post_status' => 'publish',
+			)
+		);
+		$booking  = $bookings->create(
+			array(
+				'venue_term_id' => $this->venue_id,
+				'artist_name'   => 'Void Race Artist',
+				'intake'        => array(),
+			)
+		);
+		$booking  = $bookings->claim_event( $booking['id'], $event_id, $booking['version'] );
+		$source   = ( new TicketReconciliationService() )->register_source(
+			array(
+				'booking_id' => $booking['id'],
+				'provider'   => 'manual-certified',
+				'source_key' => $key,
+				'ticket_url' => 'https://tickets.example.test/' . $key,
+			),
+			$this->actor_id
+		);
+		$service  = new TicketSettlementService();
+		$service->record_sales( $this->settlement_report_input( $booking['id'], $key . '-report', $source['id'] ), $this->actor_id );
+		$preview    = $service->calculate(
+			array(
+				'booking_id'       => $booking['id'],
+				'basis'            => 'gross_ticket_sales',
+				'basis_points'     => 2000,
+				'currency'         => 'USD',
+				'adjustment_minor' => 0,
+			),
+			$this->actor_id
+		);
+		$commission = $service->finalize(
+			array(
+				'booking_id'               => $booking['id'],
+				'expected_booking_version' => $preview['booking_version'],
+				'expected_report_ids'      => $preview['included_report_ids'],
+				'expected_evidence_hash'   => $preview['evidence_hash'],
+				'basis'                    => $preview['basis'],
+				'basis_points'             => $preview['basis_points'],
+				'currency'                 => $preview['currency'],
+				'formula_version'          => $preview['formula_version'],
+				'adjustment_minor'         => 0,
+			),
+			$this->actor_id
+		);
+		$this->assertIsArray( $commission, is_wp_error( $commission ) ? $commission->get_error_code() : '' );
+		$this->assertNotFalse( $wpdb->query( 'COMMIT' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Publishes the independent race fixture.
+		return compact( 'booking', 'commission' );
+	}
+
+	/** Race commission void against one dependent operation and verify fail-closed state. */
+	private function assert_void_show_race( array $fixture, callable $show_operation ): void {
+		$void    = array(
+			'booking_id'               => $fixture['booking']['id'],
+			'expected_booking_version' => $fixture['booking']['version'],
+			'expected_version'         => $fixture['commission']['version'],
+			'reason'                   => 'Concurrent commission void.',
+		);
+		$results = $this->race_booking_services( $fixture['booking']['id'], fn() => ( new TicketSettlementService() )->void( $void, $this->actor_id ), $show_operation, false, true );
+		$kinds   = $this->race_result_kinds( $results );
+		$this->assertSame( array( 'result', 'show_settlement_commission_invalid' ), $kinds, 'The queued void must commit before the dependent show write revalidates the commission.' );
+		$commission = ( new TicketSettlementService() )->get( $fixture['booking']['id'], $this->actor_id );
+		$this->assertSame( 'void', $commission['status'] );
+		$show = ( new ShowSettlementService() )->get( $fixture['booking']['id'], $this->actor_id );
+		$this->assertTrue( in_array( $show->get_error_code(), array( 'show_settlement_not_found', 'show_settlement_commission_invalid' ), true ) );
+	}
+
 	/** Run two service calls while both are blocked behind the same booking lock. */
-	private function race_booking_services( int $booking_id, callable $first, callable $second, bool $first_commit_uncertain = false ): array {
+	private function race_booking_services( int $booking_id, callable $first, callable $second, bool $first_commit_uncertain = false, bool $order_first = false ): array {
 		$bookings = BookingSchema::bookings_table();
 		$this->assertTrue( $this->contender->begin_transaction() );
 		$locked = $this->contender->query( "SELECT id FROM {$bookings} WHERE id = {$booking_id} FOR UPDATE" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Independent fixture connection deliberately owns the application lock.
@@ -345,8 +474,31 @@ final class BookingAdmissionConcurrencyMySQLProof extends BookingAttachmentMySQL
 			array( 'ready' => $base . '.first-ready', 'result' => $base . '.first-result' ),
 			array( 'ready' => $base . '.second-ready', 'result' => $base . '.second-result' ),
 		);
-		$pids  = array(
-			$this->fork_service_call( $first, $files[0], $first_commit_uncertain ),
+		$first_pid    = $this->fork_service_call( $first, $files[0], $first_commit_uncertain );
+		$first_queued = ! $order_first;
+		if ( $order_first ) {
+			$deadline = microtime( true ) + 5;
+			while ( ! file_exists( $files[0]['ready'] ) && microtime( true ) < $deadline ) {
+				usleep( 10000 );
+			}
+			if ( file_exists( $files[0]['ready'] ) ) {
+				$thread_id = (int) file_get_contents( $files[0]['ready'] );
+				$deadline  = microtime( true ) + 5;
+				do {
+					$process = $this->contender->query( "SELECT INFO FROM information_schema.PROCESSLIST WHERE COMMAND = 'Query' AND ID = {$thread_id}" );
+					if ( $process instanceof mysqli_result ) {
+						$query = (string) ( $process->fetch_row()[0] ?? '' );
+						$process->free();
+						$first_queued = false !== stripos( $query, $bookings ) && false !== stripos( $query, 'FOR UPDATE' );
+					}
+					if ( ! $first_queued ) {
+						usleep( 10000 );
+					}
+				} while ( ! $first_queued && microtime( true ) < $deadline );
+			}
+		}
+		$pids = array(
+			$first_pid,
 			$this->fork_service_call( $second, $files[1], false ),
 		);
 		$deadline = microtime( true ) + 5;
@@ -394,6 +546,7 @@ final class BookingAdmissionConcurrencyMySQLProof extends BookingAttachmentMySQL
 		}
 
 		$this->assertTrue( $both_ready, 'Both service contenders must reach the held booking lock.' );
+		$this->assertTrue( $first_queued, 'The ordered first contender must enter the production booking lock queue before the second contender starts.' );
 		$this->assertTrue( $both_waiting, 'Both service contenders must overlap in production FOR UPDATE lock acquisition.' );
 		$this->assertTrue( $booking_waiting, 'At least one service contender must block on the production booking row lock.' );
 		$this->assertTrue( $both_blocked, 'A service contender bypassed the held booking lock.' );

--- a/tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/BookingAdmissionConcurrencyMySQLProof.php
@@ -5,13 +5,46 @@ require_once __DIR__ . '/BookingAttachmentMySQLIntegrationTest.php';
 
 use ExtraChillEvents\Core\BookingActivityRepository;
 use ExtraChillEvents\Core\BookingAttachmentRepository;
+use ExtraChillEvents\Core\BookingAttachmentService;
 use ExtraChillEvents\Core\BookingInquiryAdmissionService;
 use ExtraChillEvents\Core\BookingLifecycle;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\ShowSettlementService;
 use ExtraChillEvents\Core\TicketReconciliationService;
 use ExtraChillEvents\Core\TicketSettlementService;
 use ExtraChillEvents\Core\VenueBookingConfig;
+
+/** Serve immutable test bytes without bypassing the show-settlement stream contract. */
+final class ShowSettlementMySQLAttachmentService extends BookingAttachmentService {
+	/** @var string */
+	private $bytes;
+
+	public function __construct( string $bytes ) {
+		$this->bytes = $bytes;
+	}
+
+	public function download_descriptor( int $booking_id, int $attachment_id, ?int $actor_id = null ) {
+		unset( $booking_id, $attachment_id, $actor_id );
+		return array(
+			'stream_token'   => 'mysql-show-evidence',
+			'correlation_id' => '00000000-0000-4000-8000-000000000002',
+		);
+	}
+
+	public function open_download_stream( int $booking_id, int $attachment_id, string $stream_token, int $actor_id, string $correlation_id ) {
+		unset( $booking_id, $attachment_id, $stream_token, $actor_id, $correlation_id );
+		$stream = fopen( 'php://temp', 'w+b' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- In-memory concurrency evidence.
+		fwrite( $stream, $this->bytes ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- In-memory concurrency evidence.
+		rewind( $stream );
+		return $stream;
+	}
+
+	public function record_delivery_outcome( int $booking_id, int $attachment_id, string $correlation_id, string $outcome, int $bytes_sent, int $actor_id ) {
+		unset( $booking_id, $attachment_id, $correlation_id, $outcome, $bytes_sent, $actor_id );
+		return true;
+	}
+}
 
 /** Prove overlapping application processes converge on one complete winner. */
 final class BookingAdmissionConcurrencyMySQLProof extends BookingAttachmentMySQLIntegrationTest {
@@ -101,6 +134,60 @@ final class BookingAdmissionConcurrencyMySQLProof extends BookingAttachmentMySQL
 	/** Prove a resolution racing finalization cannot alter the frozen snapshot. */
 	public function test_resolution_and_finalization_race_freezes_one_consistent_winner(): void {
 		$this->prove_resolution_and_finalization_race_freezes_one_consistent_winner();
+	}
+
+	/** Prove exact/conflicting revisions and lifecycle transitions serialize across sessions. */
+	public function test_show_settlement_revision_finalize_dispute_and_payment_races_serialize(): void {
+		global $wpdb;
+		$bookings = new BookingRepository();
+		$event_id = self::factory()->post->create( array( 'post_type' => defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events', 'post_status' => 'publish' ) );
+		$booking  = $bookings->create( array( 'venue_term_id' => $this->venue_id, 'artist_name' => 'Concurrent Show Artist', 'intake' => array() ) );
+		$booking  = $bookings->claim_event( $booking['id'], $event_id, $booking['version'] );
+		$source   = ( new TicketReconciliationService() )->register_source( array( 'booking_id' => $booking['id'], 'provider' => 'manual-certified', 'source_key' => 'show-concurrency', 'ticket_url' => 'https://tickets.example.test/show-concurrency' ), $this->actor_id );
+		$commission_service = new TicketSettlementService();
+		$this->assertIsArray( $commission_service->record_sales( $this->settlement_report_input( $booking['id'], 'show-concurrency-report', $source['id'] ), $this->actor_id ) );
+		$preview = $commission_service->calculate( array( 'booking_id' => $booking['id'], 'basis' => 'gross_ticket_sales', 'basis_points' => 2000, 'currency' => 'USD', 'adjustment_minor' => 0 ), $this->actor_id );
+		$commission = $commission_service->finalize( array( 'booking_id' => $booking['id'], 'expected_booking_version' => $preview['booking_version'], 'expected_report_ids' => $preview['included_report_ids'], 'expected_evidence_hash' => $preview['evidence_hash'], 'basis' => $preview['basis'], 'basis_points' => $preview['basis_points'], 'currency' => $preview['currency'], 'formula_version' => $preview['formula_version'], 'adjustment_minor' => 0 ), $this->actor_id );
+		$this->assertIsArray( $commission, is_wp_error( $commission ) ? $commission->get_error_code() : '' );
+		$this->assertNotFalse( $wpdb->query( 'COMMIT' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Publishes the cross-process fixture.
+
+		$draft_input = $this->show_revision_input( $booking['id'], $commission['id'], 'show-exact' );
+		$exact = $this->race_booking_services( $booking['id'], fn() => ( new ShowSettlementService() )->draft( $draft_input, $this->actor_id ), fn() => ( new ShowSettlementService() )->draft( $draft_input, $this->actor_id ) );
+		$this->assertSame( array( 'result', 'result' ), $this->race_result_kinds( $exact ) );
+		$draft = ( new ShowSettlementService() )->get( $booking['id'], $this->actor_id );
+		$this->assertSame( 1, $draft['revision'] );
+
+		$conflict_a = $this->show_revision_input( $booking['id'], $commission['id'], 'show-conflict' );
+		$conflict_a['expected_revision_id'] = $draft['id'];
+		$conflict_b = $conflict_a;
+		$conflict_b['fees_minor'] = 1;
+		$conflict = $this->race_booking_services( $booking['id'], fn() => ( new ShowSettlementService() )->revise( $conflict_a, $this->actor_id ), fn() => ( new ShowSettlementService() )->revise( $conflict_b, $this->actor_id ) );
+		$this->assertSame( array( 'result', 'show_settlement_idempotency_conflict' ), $this->race_result_kinds( $conflict ) );
+		$current = ( new ShowSettlementService() )->get( $booking['id'], $this->actor_id );
+
+		$finalize = array( 'booking_id' => $booking['id'], 'revision_id' => $current['id'], 'expected_version' => $current['version'], 'idempotency_key' => 'show-finalize-race' );
+		$revise = $this->show_revision_input( $booking['id'], $commission['id'], 'show-revise-race' );
+		$revise['expected_revision_id'] = $current['id'];
+		$transition_race = $this->race_booking_services( $booking['id'], fn() => ( new ShowSettlementService() )->finalize( $finalize, $this->actor_id ), fn() => ( new ShowSettlementService() )->revise( $revise, $this->actor_id ) );
+		$kinds = $this->race_result_kinds( $transition_race );
+		$this->assertContains( 'result', $kinds );
+		$this->assertTrue( in_array( 'show_settlement_revision_conflict', $kinds, true ) || in_array( 'show_settlement_status_conflict', $kinds, true ) );
+		$current = ( new ShowSettlementService() )->get( $booking['id'], $this->actor_id );
+		if ( 'draft' === $current['status'] ) {
+			$current = ( new ShowSettlementService() )->finalize( array( 'booking_id' => $booking['id'], 'revision_id' => $current['id'], 'expected_version' => $current['version'], 'idempotency_key' => 'show-finalize-after-race' ), $this->actor_id );
+		}
+
+		$bytes       = 'immutable payout evidence';
+		$attachments = BookingSchema::attachments_table();
+		$wpdb->insert( $attachments, array( 'public_id' => wp_generate_uuid4(), 'booking_id' => $booking['id'], 'uploader_type' => 'user', 'uploader_user_id' => $this->actor_id, 'uploader_reference' => null, 'artist_term_id' => null, 'artist_profile_id' => null, 'purpose' => 'other_private_evidence', 'original_filename' => 'payout.txt', 'mime_type' => 'text/plain', 'byte_size' => strlen( $bytes ), 'content_hash' => hash( 'sha256', $bytes ), 'storage_reference' => 'mysql-show-payout', 'state' => 'active', 'idempotency_key' => 'mysql-show-payout', 'request_hash' => hash( 'sha256', 'mysql-show-payout' ), 'replaces_attachment_id' => null, 'retired_at' => null, 'purged_at' => null, 'created_at' => gmdate( 'Y-m-d H:i:s' ), 'updated_at' => gmdate( 'Y-m-d H:i:s' ) ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Seeds immutable private evidence in the disposable database.
+		$attachment_id = (int) $wpdb->insert_id;
+		$wpdb->update( BookingSchema::bookings_table(), array( 'status' => 'completed', 'version' => $booking['version'] + 1 ), array( 'id' => $booking['id'] ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Completes the disposable booking for payment contention.
+		$this->assertNotFalse( $wpdb->query( 'COMMIT' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Publishes payment fixtures.
+		$dispute = array( 'booking_id' => $booking['id'], 'revision_id' => $current['id'], 'expected_version' => $current['version'], 'idempotency_key' => 'show-dispute-race', 'reason' => 'Concurrent dispute.' );
+		$payment = array( 'booking_id' => $booking['id'], 'revision_id' => $current['id'], 'expected_version' => $current['version'], 'idempotency_key' => 'show-payment-race', 'payment_reference' => 'race-payment', 'payment_date' => gmdate( 'Y-m-d' ), 'payout_evidence_attachment_ids' => array( $attachment_id ) );
+		$payment_race = $this->race_booking_services( $booking['id'], fn() => ( new ShowSettlementService() )->dispute( $dispute, $this->actor_id ), fn() => ( new ShowSettlementService( null, null, null, null, new BookingAttachmentRepository(), new ShowSettlementMySQLAttachmentService( $bytes ) ) )->mark_paid( $payment, $this->actor_id ) );
+		$this->assertSame( 1, count( array_filter( $this->race_result_kinds( $payment_race ), static fn( string $kind ): bool => 'result' === $kind ) ) );
+		$this->assertContains( 'show_settlement_version_conflict', $this->race_result_kinds( $payment_race ) );
 	}
 
 	/** Prove the loser replays the completed exact winner without duplicate effects. */
@@ -221,6 +308,27 @@ final class BookingAdmissionConcurrencyMySQLProof extends BookingAttachmentMySQL
 			}
 		}
 		remove_filter( 'extrachill_events_allow_test_booking_file', '__return_true' );
+	}
+
+	/** Build a complete evidence-free door revision for MySQL races. */
+	private function show_revision_input( int $booking_id, int $commission_id, string $key ): array {
+		return array(
+			'booking_id'                     => $booking_id,
+			'commission_settlement_id'       => $commission_id,
+			'currency'                       => 'USD',
+			'ticket_gross_minor'              => 100,
+			'door_gross_minor'                => 0,
+			'fees_minor'                      => 0,
+			'taxes_minor'                     => 0,
+			'refunds_minor'                   => 0,
+			'venue_expenses_minor'            => 0,
+			'production_expenses_minor'       => 0,
+			'artist_guarantee_minor'          => 50,
+			'artist_split_basis_points'       => 5000,
+			'adjustments'                     => array(),
+			'door_report_attachment_ids'      => array(),
+			'idempotency_key'                 => $key,
+		);
 	}
 
 	/** Run two service calls while both are blocked behind the same booking lock. */

--- a/tests/MySQLIntegration/BookingSchemaMultisiteTest.php
+++ b/tests/MySQLIntegration/BookingSchemaMultisiteTest.php
@@ -35,12 +35,14 @@ final class BookingSchemaMultisiteTest extends WP_UnitTestCase {
 				BookingSchema::sales_reports_table(),
 				BookingSchema::sales_resolutions_table(),
 				BookingSchema::settlements_table(),
+				BookingSchema::show_settlements_table(),
+				BookingSchema::show_settlement_actions_table(),
 			);
 
 			$this->assertSame( $prefix, $wpdb->prefix );
 			$this->assertTrue( BookingSchema::is_ready() );
 			$this->assertTrue( BookingSchema::health() );
-			$this->assertCount( 14, $tables );
+			$this->assertCount( 16, $tables );
 			foreach ( $tables as $table ) {
 				$this->assertStringStartsWith( $prefix, $table );
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema integration assertion.
@@ -75,7 +77,7 @@ final class BookingSchemaMultisiteTest extends WP_UnitTestCase {
 			update_option( BookingSchema::VERSION_OPTION, '13', false );
 
 			$this->assertTrue( BookingSchema::maybe_install() );
-			$this->assertSame( '14', get_option( BookingSchema::VERSION_OPTION ) );
+			$this->assertSame( '15', get_option( BookingSchema::VERSION_OPTION ) );
 			$this->assert_v13_snapshots_survive( $fixtures, $snapshots );
 			$this->assert_migrated_financial_graph_readable();
 			$this->assertSame( '73001', $wpdb->get_var( $wpdb->prepare( "SELECT booking_id FROM `{$reports}` WHERE external_report_id = %s", $external_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms migration preserved the fixture.

--- a/tests/ShowSettlementTest.php
+++ b/tests/ShowSettlementTest.php
@@ -1,0 +1,381 @@
+<?php
+/**
+ * Complete show-settlement tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Abilities\ShowSettlementAbilities;
+use ExtraChillEvents\Core\BookingActivityRepository;
+use ExtraChillEvents\Core\BookingAttachmentRepository;
+use ExtraChillEvents\Core\BookingAttachmentService;
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\ShowSettlementService;
+use ExtraChillEvents\Core\TicketReconciliationService;
+use ExtraChillEvents\Core\TicketSettlementService;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
+// Test fixtures intentionally share this file and replace the WordPress database global.
+// phpcs:disable Squiz.Commenting,Generic.Commenting.DocComment.MissingShort,WordPress.Files.FileName,Generic.Files.OneObjectStructurePerFile.MultipleFound,WordPress.WP.GlobalVariablesOverride.Prohibited
+
+/** Supplies authenticated in-memory bytes through the existing service contract. */
+final class ShowSettlementAttachmentService extends BookingAttachmentService {
+	/** @var array<int,string> */
+	public $bytes = array();
+
+	public function download_descriptor( int $booking_id, int $attachment_id, ?int $actor_id = null ) {
+		unset( $booking_id, $actor_id );
+		return array(
+			'stream_token'   => 'stream-' . $attachment_id,
+			'correlation_id' => '00000000-0000-4000-8000-000000000001',
+		);
+	}
+
+	public function open_download_stream( int $booking_id, int $attachment_id, string $stream_token, int $actor_id, string $correlation_id ) {
+		unset( $booking_id, $stream_token, $actor_id, $correlation_id );
+		$stream = fopen( 'php://temp', 'w+b' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- In-memory test evidence stream.
+		fwrite( $stream, $this->bytes[ $attachment_id ] ?? '' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- In-memory test evidence stream.
+		rewind( $stream );
+		return $stream;
+	}
+
+	public function record_delivery_outcome( int $booking_id, int $attachment_id, string $correlation_id, string $outcome, int $bytes_sent, int $actor_id ) {
+		unset( $booking_id, $attachment_id, $correlation_id, $outcome, $bytes_sent, $actor_id );
+		return true;
+	}
+}
+
+final class ShowSettlementTest extends BookingTestCase {
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var BookingTestAuthorization */
+	private $authorization;
+	/** @var TicketSettlementService */
+	private $commissions;
+	/** @var ShowSettlementService */
+	private $service;
+	/** @var ShowSettlementAttachmentService */
+	private $files;
+	/** @var TicketReconciliationService */
+	private $reconciliation;
+
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id'       => 7,
+			'stack'         => array(),
+			'uuid'          => 0,
+			'options'       => array( BookingSchema::VERSION_OPTION => BookingSchema::SCHEMA_VERSION ),
+			'dbdelta'       => array(),
+			'abilities'     => array(),
+			'actions'       => array(),
+			'cache_deletes' => array(),
+			'terms'         => array(
+				7 => array(
+					55 => (object) array(
+						'term_id'  => 55,
+						'taxonomy' => 'venue',
+						'name'     => 'Show Room',
+					),
+				),
+			),
+			'meta'          => array(),
+			'posts'         => array(
+				7 => array(
+					900 => (object) array(
+						'ID'          => 900,
+						'post_type'   => 'data_machine_events',
+						'post_status' => 'publish',
+					),
+				),
+			),
+			'post_meta'     => array(),
+		);
+		$GLOBALS['wpdb']           = new BookingWpdb();
+		$this->bookings            = new BookingRepository();
+		$this->authorization       = new BookingTestAuthorization();
+		$activity                  = new BookingActivityRepository();
+		$this->reconciliation      = new TicketReconciliationService( $this->bookings, $activity, $this->authorization );
+		$this->commissions         = new TicketSettlementService( $this->bookings, $activity, $this->authorization, null, $this->reconciliation );
+		$this->files               = new ShowSettlementAttachmentService();
+		$this->service             = new ShowSettlementService( $this->bookings, $activity, $this->authorization, $this->commissions, new BookingAttachmentRepository(), $this->files );
+	}
+
+	public function test_formula_separates_artist_payout_and_extra_chill_share(): void {
+		$result = ShowSettlementService::calculate_amounts(
+			array(
+				'ticket_gross_minor'        => 100000,
+				'door_gross_minor'          => 20000,
+				'fees_minor'                => 5000,
+				'taxes_minor'               => 3000,
+				'refunds_minor'             => 2000,
+				'venue_expenses_minor'      => 10000,
+				'production_expenses_minor' => 5000,
+				'artist_guarantee_minor'    => 30000,
+				'artist_split_basis_points' => 7000,
+				'adjustments'               => array( array( 'amount_minor' => -1000 ) ),
+			),
+			20000
+		);
+		$this->assertSame( 120000, $result['total_gross_minor'] );
+		$this->assertSame( 25000, $result['total_deductions_minor'] );
+		$this->assertSame( 51800, $result['artist_split_amount_minor'] );
+		$this->assertSame( 51800, $result['artist_payout_minor'] );
+		$this->assertSame( 20000, $result['extra_chill_share_minor'] );
+		$this->assertSame( 22200, $result['venue_net_after_payout_minor'] );
+		$this->assertSame(
+			'show_settlement_amount_out_of_range',
+			ShowSettlementService::calculate_amounts(
+				array(
+					'ticket_gross_minor'        => PHP_INT_MAX,
+					'door_gross_minor'          => 1,
+					'fees_minor'                => 0,
+					'taxes_minor'               => 0,
+					'refunds_minor'             => 0,
+					'venue_expenses_minor'      => 0,
+					'production_expenses_minor' => 0,
+					'artist_guarantee_minor'    => 0,
+					'artist_split_basis_points' => 0,
+					'adjustments'               => array(),
+				),
+				0
+			)->get_error_code()
+		);
+	}
+
+	public function test_schema_adds_revision_and_action_tables_without_changing_commission_contract(): void {
+		$this->assertTrue( BookingSchema::install() );
+		$this->assertTrue( BookingSchema::health() );
+		$revisions = $GLOBALS['wpdb']->schemas[ BookingSchema::show_settlements_table() ];
+		$actions   = $GLOBALS['wpdb']->schemas[ BookingSchema::show_settlement_actions_table() ];
+		$this->assertTrue( $revisions['indexes']['booking_revision']['unique'] );
+		$this->assertTrue( $revisions['indexes']['booking_idempotency']['unique'] );
+		$this->assertArrayHasKey( 'commission_integrity_hash', $revisions['columns'] );
+		$this->assertTrue( $actions['indexes']['revision_version']['unique'] );
+		$this->assertTrue( $GLOBALS['wpdb']->schemas[ BookingSchema::settlements_table() ]['indexes']['booking_id']['unique'] );
+	}
+
+	public function test_complete_lifecycle_is_immutable_idempotent_and_audited(): void {
+		$booking    = $this->booking_with_commission();
+		$commission = $this->commissions->get( $booking['id'], 12 );
+		$input      = $this->draft_input( $booking['id'], $commission['id'], 'draft-one' );
+		$draft      = $this->service->draft( $input, 12 );
+		$this->assertSame( 'draft', $draft['status'] );
+		$this->assertSame( $draft['id'], $this->service->draft( $input, 12 )['id'] );
+		$changed                         = $input;
+		$changed['venue_expenses_minor'] = 99999;
+		$this->assertSame( 'show_settlement_idempotency_conflict', $this->service->draft( $changed, 12 )->get_error_code() );
+		$mismatched                       = $input;
+		$mismatched['idempotency_key']    = 'mismatched-ticket-gross';
+		$mismatched['ticket_gross_minor'] = 99999;
+		$this->assertSame( 'show_settlement_ticket_gross_conflict', $this->service->revise( array_merge( $mismatched, array( 'expected_revision_id' => $draft['id'] ) ), 12 )->get_error_code() );
+
+		$finalized = $this->service->finalize( $this->transition( $booking['id'], $draft, 'finalize-one' ), 12 );
+		$this->assertSame( 'finalized', $finalized['status'] );
+		$this->assertSame( 2, $finalized['version'] );
+		$ack          = $this->transition( $booking['id'], $finalized, 'ack-one' );
+		$ack['note']  = 'Artist representative approved the statement.';
+		$acknowledged = $this->service->acknowledge( $ack, 12 );
+		$this->assertSame( 'acknowledged', $acknowledged['status'] );
+		$dispute           = $this->transition( $booking['id'], $acknowledged, 'dispute-one' );
+		$dispute['reason'] = 'Door count requires correction.';
+		$disputed          = $this->service->dispute( $dispute, 12 );
+		$this->assertSame( 'disputed', $disputed['status'] );
+
+		$correction                               = $this->draft_input( $booking['id'], $commission['id'], 'correction-one' );
+		$correction['expected_revision_id']       = $draft['id'];
+		$correction['expected_version']           = $disputed['version'];
+		$correction['reason']                     = 'Corrected signed door count.';
+		$correction['door_gross_minor']           = 1000;
+		$correction['door_report_attachment_ids'] = array( $this->attachment( $booking['id'], 'door evidence' ) );
+		$corrected                                = $this->service->correct( $correction, 12 );
+		$this->assertSame( 2, $corrected['revision'] );
+		$this->assertSame( $draft['id'], $corrected['corrects_revision_id'] );
+		$this->assertSame( 'corrected', $this->service->get( $booking['id'], 12, 1 )['status'] );
+		$this->assertSame( 'draft', $corrected['status'] );
+		$this->assertSame( $draft['calculation']['extra_chill_share_minor'], $corrected['calculation']['extra_chill_share_minor'] );
+
+		$finalized_two                             = $this->service->finalize( $this->transition( $booking['id'], $corrected, 'finalize-two' ), 12 );
+		$booking_row                               =& $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ];
+		$booking_row['status']                     = 'completed';
+		$booking_row['version']                    = $booking_row['version'] + 1;
+		$payout_id                                 = $this->attachment( $booking['id'], 'payout receipt' );
+		$payment                                   = $this->transition( $booking['id'], $finalized_two, 'payment-one' );
+		$payment['payment_reference']              = 'payout-2026-001';
+		$payment['payment_date']                   = '2026-07-28';
+		$payment['payout_evidence_attachment_ids'] = array( $payout_id );
+		$paid                                      = $this->service->mark_paid( $payment, 12 );
+		$this->assertSame( 'paid', $paid['status'] );
+		$this->assertArrayNotHasKey( 'content_hash', $paid['evidence'][0] );
+		$this->assertArrayNotHasKey( 'request_hash', $paid['actions'][1]['payload']['payout_evidence'][0] );
+		$this->assertArrayNotHasKey( 'payment_reference', $paid['actions'][1]['payload'] );
+		$this->assertTrue( $paid['actions'][1]['payload']['payment_reference_recorded'] );
+		$this->assertSame( $paid['id'], $this->service->mark_paid( $payment, 12 )['id'] );
+		$this->assertSame( 'show_settlement_version_conflict', $this->service->void( array_merge( $this->transition( $booking['id'], $paid, 'void-paid' ), array( 'reason' => 'Not allowed.' ) ), 12 )->get_error_code() );
+		$action_table = BookingSchema::show_settlement_actions_table();
+		$paid_action  = count( $GLOBALS['wpdb']->rows[ $action_table ] );
+		$GLOBALS['wpdb']->rows[ $action_table ][ $paid_action ]['actor_user_id'] = 999;
+		$this->assertSame( 'show_settlement_action_integrity_failed', $this->service->get( $booking['id'], 12 )->get_error_code() );
+		$GLOBALS['wpdb']->rows[ $action_table ][ $paid_action ]['actor_user_id'] = 12;
+
+		$kinds = array_column( ( new BookingActivityRepository() )->list_for_booking( $booking['id'] ), 'kind' );
+		foreach ( array( 'show_settlement_drafted', 'show_settlement_finalized', 'show_settlement_acknowledged', 'show_settlement_disputed', 'show_settlement_corrected', 'show_settlement_paid' ) as $kind ) {
+			$this->assertContains( $kind, $kinds );
+		}
+	}
+
+	public function test_tampered_or_cross_venue_finance_data_fails_closed(): void {
+		$booking    = $this->booking_with_commission();
+		$commission = $this->commissions->get( $booking['id'], 12 );
+		$draft      = $this->service->draft( $this->draft_input( $booking['id'], $commission['id'], 'tamper' ), 12 );
+		$GLOBALS['wpdb']->rows[ BookingSchema::show_settlements_table() ][ $draft['id'] ]['calculation_payload'] = '{"version":1,"data":{"artist_payout_minor":1}}';
+		$this->assertSame( 'show_settlement_integrity_failed', $this->service->get( $booking['id'], 12 )->get_error_code() );
+		$this->authorization->allowed['12:55'] = false;
+		$this->assertSame( 'venue_action_forbidden', $this->service->get( $booking['id'], 12 )->get_error_code() );
+	}
+
+	public function test_abilities_are_private_bounded_and_do_not_accept_account_identity(): void {
+		$abilities = new ShowSettlementAbilities( $this->service, $this->bookings, $this->authorization );
+		$abilities->register();
+		$names      = array( 'draft', 'read', 'revise', 'finalize', 'acknowledge', 'dispute', 'correct', 'mark', 'void' );
+		$registered = array_filter( array_keys( $GLOBALS['ec_artist_test']['abilities'] ), static fn( string $name ): bool => false !== strpos( $name, 'show-settlement' ) || false !== strpos( $name, 'artist-payout' ) );
+		$this->assertCount( count( $names ), $registered );
+		foreach ( $registered as $name ) {
+			$schema = $GLOBALS['ec_artist_test']['abilities'][ $name ]['input_schema'];
+			$this->assertFalse( $schema['additionalProperties'] );
+			$this->assertArrayNotHasKey( 'bank_account', $schema['properties'] );
+			$this->assertArrayNotHasKey( 'tax_identity', $schema['properties'] );
+		}
+	}
+
+	private function booking_with_commission(): array {
+		$booking = $this->bookings->create(
+			array(
+				'venue_term_id' => 55,
+				'artist_name'   => 'Settlement Artist',
+				'intake'        => array(),
+			)
+		);
+		$booking = $this->bookings->claim_event( $booking['id'], 900, $booking['version'] );
+		$source  = $this->reconciliation->register_source(
+			array(
+				'booking_id' => $booking['id'],
+				'provider'   => 'manual',
+				'source_key' => 'primary',
+				'ticket_url' => 'https://tickets.example.test/show',
+			),
+			12
+		);
+		$report  = array(
+			'booking_id'         => $booking['id'],
+			'ticket_source_id'   => $source['id'],
+			'provider'           => 'manual',
+			'external_report_id' => 'show-report',
+			'source_type'        => 'manual',
+			'period_start'       => '2026-07-01 00:00:00',
+			'period_end'         => '2026-07-01 23:59:59',
+			'tickets_sold'       => 100,
+			'tickets_refunded'   => 2,
+			'gross_minor'        => 100000,
+			'fees_minor'         => 5000,
+			'tax_minor'          => 3000,
+			'refunds_minor'      => 2000,
+			'net_minor'          => 90000,
+			'currency'           => 'USD',
+			'source'             => array( 'certificate' => 'show-report' ),
+		);
+		$this->commissions->record_sales( $report, 12 );
+		$preview = $this->commissions->calculate(
+			array(
+				'booking_id'       => $booking['id'],
+				'basis'            => 'gross_ticket_sales',
+				'basis_points'     => 2000,
+				'currency'         => 'USD',
+				'adjustment_minor' => 0,
+			),
+			12
+		);
+		$this->commissions->finalize(
+			array(
+				'booking_id'               => $booking['id'],
+				'expected_booking_version' => $preview['booking_version'],
+				'expected_report_ids'      => $preview['included_report_ids'],
+				'expected_evidence_hash'   => $preview['evidence_hash'],
+				'basis'                    => $preview['basis'],
+				'basis_points'             => $preview['basis_points'],
+				'currency'                 => $preview['currency'],
+				'formula_version'          => $preview['formula_version'],
+				'adjustment_minor'         => 0,
+			),
+			12
+		);
+		return $booking;
+	}
+
+	private function draft_input( int $booking_id, int $commission_id, string $key ): array {
+		return array(
+			'booking_id'                 => $booking_id,
+			'commission_settlement_id'   => $commission_id,
+			'currency'                   => 'USD',
+			'ticket_gross_minor'         => 100000,
+			'door_gross_minor'           => 0,
+			'fees_minor'                 => 5000,
+			'taxes_minor'                => 3000,
+			'refunds_minor'              => 2000,
+			'venue_expenses_minor'       => 10000,
+			'production_expenses_minor'  => 5000,
+			'artist_guarantee_minor'     => 30000,
+			'artist_split_basis_points'  => 7000,
+			'adjustments'                => array(
+				array(
+					'amount_minor' => -1000,
+					'reason'       => 'Signed hospitality adjustment',
+				),
+			),
+			'door_report_attachment_ids' => array(),
+			'idempotency_key'            => $key,
+		);
+	}
+
+	private function transition( int $booking_id, array $revision, string $key ): array {
+		return array(
+			'booking_id'       => $booking_id,
+			'revision_id'      => $revision['id'],
+			'expected_version' => $revision['version'],
+			'idempotency_key'  => $key,
+		);
+	}
+
+	private function attachment( int $booking_id, string $bytes ): int {
+		$table                                  = BookingSchema::attachments_table();
+		$id                                     = count( $GLOBALS['wpdb']->rows[ $table ] ?? array() ) + 1;
+		$GLOBALS['wpdb']->rows[ $table ][ $id ] = array(
+			'id'                     => $id,
+			'public_id'              => sprintf( '00000000-0000-4000-8000-%012d', $id ),
+			'booking_id'             => $booking_id,
+			'uploader_type'          => 'user',
+			'uploader_user_id'       => 12,
+			'uploader_reference'     => null,
+			'artist_term_id'         => null,
+			'artist_profile_id'      => null,
+			'purpose'                => 'other_private_evidence',
+			'original_filename'      => 'evidence.txt',
+			'mime_type'              => 'text/plain',
+			'byte_size'              => strlen( $bytes ),
+			'content_hash'           => hash( 'sha256', $bytes ),
+			'storage_reference'      => 'opaque-' . $id,
+			'state'                  => 'active',
+			'idempotency_key'        => 'evidence-' . $id,
+			'request_hash'           => hash( 'sha256', 'request-' . $id ),
+			'replaces_attachment_id' => null,
+			'retired_at'             => null,
+			'purged_at'              => null,
+			'created_at'             => '2026-07-28 00:00:00',
+			'updated_at'             => '2026-07-28 00:00:00',
+		);
+		$this->files->bytes[ $id ]              = $bytes;
+		return $id;
+	}
+}

--- a/tests/ShowSettlementTest.php
+++ b/tests/ShowSettlementTest.php
@@ -24,9 +24,13 @@ require_once __DIR__ . '/Support/BookingTestHarness.php';
 /** Supplies authenticated in-memory bytes through the existing service contract. */
 final class ShowSettlementAttachmentService extends BookingAttachmentService {
 	/** @var array<int,string> */
-	public $bytes = array();
+	public $bytes       = array();
+	public $descriptors = 0;
+	public $streams     = 0;
+	public $deliveries  = 0;
 
 	public function download_descriptor( int $booking_id, int $attachment_id, ?int $actor_id = null ) {
+		++$this->descriptors;
 		unset( $booking_id, $actor_id );
 		return array(
 			'stream_token'   => 'stream-' . $attachment_id,
@@ -35,6 +39,7 @@ final class ShowSettlementAttachmentService extends BookingAttachmentService {
 	}
 
 	public function open_download_stream( int $booking_id, int $attachment_id, string $stream_token, int $actor_id, string $correlation_id ) {
+		++$this->streams;
 		unset( $booking_id, $stream_token, $actor_id, $correlation_id );
 		$stream = fopen( 'php://temp', 'w+b' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- In-memory test evidence stream.
 		fwrite( $stream, $this->bytes[ $attachment_id ] ?? '' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- In-memory test evidence stream.
@@ -43,8 +48,19 @@ final class ShowSettlementAttachmentService extends BookingAttachmentService {
 	}
 
 	public function record_delivery_outcome( int $booking_id, int $attachment_id, string $correlation_id, string $outcome, int $bytes_sent, int $actor_id ) {
+		++$this->deliveries;
 		unset( $booking_id, $attachment_id, $correlation_id, $outcome, $bytes_sent, $actor_id );
 		return true;
+	}
+}
+
+/** Simulate bounded booking lock read failures after successful preflight. */
+final class ShowSettlementLockFailureRepository extends BookingRepository {
+	public $lock_result;
+
+	public function get_for_update( int $id, bool $include_reservations = false ) {
+		unset( $id, $include_reservations );
+		return $this->lock_result;
 	}
 }
 
@@ -63,16 +79,23 @@ final class ShowSettlementTest extends BookingTestCase {
 	private $reconciliation;
 
 	protected function setUp(): void {
-		$GLOBALS['ec_artist_test'] = array(
-			'blog_id'       => 7,
-			'stack'         => array(),
-			'uuid'          => 0,
-			'options'       => array( BookingSchema::VERSION_OPTION => BookingSchema::SCHEMA_VERSION ),
-			'dbdelta'       => array(),
-			'abilities'     => array(),
-			'actions'       => array(),
-			'cache_deletes' => array(),
-			'terms'         => array(
+		$GLOBALS['ec_artist_test']                                      = array(
+			'blog_id'         => 7,
+			'stack'           => array(),
+			'uuid'            => 0,
+			'options'         => array( BookingSchema::VERSION_OPTION => BookingSchema::SCHEMA_VERSION ),
+			'dbdelta'         => array(),
+			'abilities'       => array(),
+			'actions'         => array(),
+			'cache_deletes'   => array(),
+			'terms'           => array(
+				1 => array(
+					77 => (object) array(
+						'term_id'  => 77,
+						'taxonomy' => 'artist',
+						'name'     => 'Settlement Artist',
+					),
+				),
 				7 => array(
 					55 => (object) array(
 						'term_id'  => 55,
@@ -81,8 +104,16 @@ final class ShowSettlementTest extends BookingTestCase {
 					),
 				),
 			),
-			'meta'          => array(),
-			'posts'         => array(
+			'meta'            => array(),
+			'posts'           => array(
+				4 => array(
+					444 => (object) array(
+						'ID'          => 444,
+						'post_type'   => 'artist_profile',
+						'post_status' => 'publish',
+						'post_title'  => 'Settlement Artist',
+					),
+				),
 				7 => array(
 					900 => (object) array(
 						'ID'          => 900,
@@ -91,16 +122,18 @@ final class ShowSettlementTest extends BookingTestCase {
 					),
 				),
 			),
-			'post_meta'     => array(),
+			'post_meta'       => array( 4 => array( 444 => array( '_artist_term_id' => 77 ) ) ),
+			'artist_managers' => array( 444 => array( 21 => true ) ),
 		);
-		$GLOBALS['wpdb']           = new BookingWpdb();
-		$this->bookings            = new BookingRepository();
-		$this->authorization       = new BookingTestAuthorization();
-		$activity                  = new BookingActivityRepository();
-		$this->reconciliation      = new TicketReconciliationService( $this->bookings, $activity, $this->authorization );
-		$this->commissions         = new TicketSettlementService( $this->bookings, $activity, $this->authorization, null, $this->reconciliation );
-		$this->files               = new ShowSettlementAttachmentService();
-		$this->service             = new ShowSettlementService( $this->bookings, $activity, $this->authorization, $this->commissions, new BookingAttachmentRepository(), $this->files );
+		$GLOBALS['ec_artist_test']['meta'][1][77]['_artist_profile_id'] = 444;
+		$GLOBALS['wpdb']      = new BookingWpdb();
+		$this->bookings       = new BookingRepository();
+		$this->authorization  = new BookingTestAuthorization();
+		$activity             = new BookingActivityRepository();
+		$this->reconciliation = new TicketReconciliationService( $this->bookings, $activity, $this->authorization );
+		$this->commissions    = new TicketSettlementService( $this->bookings, $activity, $this->authorization, null, $this->reconciliation );
+		$this->files          = new ShowSettlementAttachmentService();
+		$this->service        = new ShowSettlementService( $this->bookings, $activity, $this->authorization, $this->commissions, new BookingAttachmentRepository(), $this->files );
 	}
 
 	public function test_formula_separates_artist_payout_and_extra_chill_share(): void {
@@ -175,10 +208,16 @@ final class ShowSettlementTest extends BookingTestCase {
 		$finalized = $this->service->finalize( $this->transition( $booking['id'], $draft, 'finalize-one' ), 12 );
 		$this->assertSame( 'finalized', $finalized['status'] );
 		$this->assertSame( 2, $finalized['version'] );
-		$ack          = $this->transition( $booking['id'], $finalized, 'ack-one' );
-		$ack['note']  = 'Artist representative approved the statement.';
-		$acknowledged = $this->service->acknowledge( $ack, 12 );
+		$ack                         = $this->transition( $booking['id'], $finalized, 'ack-one' );
+		$ack['note']                 = 'Artist representative approved the statement.';
+		$ack['acknowledgement_type'] = 'venue_recorded';
+		$ack['acknowledgement_evidence_attachment_ids'] = array( $this->attachment( $booking['id'], 'signed acknowledgement' ) );
+		$acknowledged                                   = $this->service->acknowledge( $ack, 12 );
 		$this->assertSame( 'acknowledged', $acknowledged['status'] );
+		$this->assertSame( 'venue_recorded', $acknowledged['actions'][1]['payload']['acknowledgement_type'] );
+		$this->assertNull( $acknowledged['actions'][1]['payload']['attested_by_user_id'] );
+		$this->assertSame( 77, $acknowledged['actions'][1]['payload']['counterparty']['artist_term_id'] );
+		$this->assertArrayNotHasKey( 'content_hash', $acknowledged['actions'][1]['payload']['evidence'][0] );
 		$dispute           = $this->transition( $booking['id'], $acknowledged, 'dispute-one' );
 		$dispute['reason'] = 'Door count requires correction.';
 		$disputed          = $this->service->dispute( $dispute, 12 );
@@ -193,7 +232,10 @@ final class ShowSettlementTest extends BookingTestCase {
 		$corrected                                = $this->service->correct( $correction, 12 );
 		$this->assertSame( 2, $corrected['revision'] );
 		$this->assertSame( $draft['id'], $corrected['corrects_revision_id'] );
-		$this->assertSame( 'corrected', $this->service->get( $booking['id'], 12, 1 )['status'] );
+		$prior = $this->service->get( $booking['id'], 12, 1 );
+		$this->assertSame( 'corrected', $prior['status'] );
+		$this->assertSame( 'venue_recorded', $prior['actions'][1]['payload']['acknowledgement_type'], 'Dispute and correction preserve acknowledgement attribution.' );
+		$this->assertSame( 77, $prior['actions'][1]['payload']['counterparty']['artist_term_id'] );
 		$this->assertSame( 'draft', $corrected['status'] );
 		$this->assertSame( $draft['calculation']['extra_chill_share_minor'], $corrected['calculation']['extra_chill_share_minor'] );
 
@@ -236,6 +278,106 @@ final class ShowSettlementTest extends BookingTestCase {
 		$this->assertSame( 'venue_action_forbidden', $this->service->get( $booking['id'], 12 )->get_error_code() );
 	}
 
+	public function test_void_commission_blocks_revision_creation_finalization_and_payment(): void {
+		$create     = $this->booking_with_commission();
+		$commission = $this->commissions->get( $create['id'], 12 );
+		$this->void_commission( $create, $commission );
+		$this->assertSame( 'show_settlement_commission_invalid', $this->service->draft( $this->draft_input( $create['id'], $commission['id'], 'void-create-blocked' ), 12 )->get_error_code() );
+
+		$finalize   = $this->booking_with_commission();
+		$commission = $this->commissions->get( $finalize['id'], 12 );
+		$draft      = $this->service->draft( $this->draft_input( $finalize['id'], $commission['id'], 'void-finalize-draft' ), 12 );
+		$this->void_commission( $finalize, $commission );
+		$this->assertSame( 'show_settlement_commission_invalid', $this->service->finalize( $this->transition( $finalize['id'], $draft, 'void-finalize-blocked' ), 12 )->get_error_code() );
+
+		$payment                = $this->booking_with_commission();
+		$commission             = $this->commissions->get( $payment['id'], 12 );
+		$draft                  = $this->service->draft( $this->draft_input( $payment['id'], $commission['id'], 'void-payment-draft' ), 12 );
+		$finalized              = $this->service->finalize( $this->transition( $payment['id'], $draft, 'void-payment-finalize' ), 12 );
+		$booking_row            =& $GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $payment['id'] ];
+		$booking_row['status']  = 'completed';
+		$booking_row['version'] = $booking_row['version'] + 1;
+		$payment['version']     = $booking_row['version'];
+		$this->void_commission( $payment, $commission );
+		$input = array_merge(
+			$this->transition( $payment['id'], $finalized, 'void-payment-blocked' ),
+			array(
+				'payment_reference'              => 'blocked',
+				'payment_date'                   => '2026-07-28',
+				'payout_evidence_attachment_ids' => array( $this->attachment( $payment['id'], 'blocked payout' ) ),
+			)
+		);
+		$this->assertSame( 'show_settlement_commission_invalid', $this->service->mark_paid( $input, 12 )->get_error_code() );
+	}
+
+	public function test_acknowledgement_attribution_rejects_spoofing_and_revoked_authority(): void {
+		$booking    = $this->booking_with_commission();
+		$commission = $this->commissions->get( $booking['id'], 12 );
+		$draft      = $this->service->draft( $this->draft_input( $booking['id'], $commission['id'], 'attestation-draft' ), 12 );
+		$finalized  = $this->service->finalize( $this->transition( $booking['id'], $draft, 'attestation-finalize' ), 12 );
+		$verified   = array_merge(
+			$this->transition( $booking['id'], $finalized, 'attestation-verified' ),
+			array(
+				'acknowledgement_type'                    => 'counterparty_verified',
+				'acknowledgement_evidence_attachment_ids' => array(),
+				'note'                                    => 'Artist manager accepts the statement.',
+			)
+		);
+		$this->assertSame( 'local_support_forbidden', $this->service->acknowledge( $verified, 12 )->get_error_code(), 'A venue operator cannot spoof direct counterparty attestation.' );
+		$acknowledged = $this->service->acknowledge( $verified, 21 );
+		$this->assertSame( 'acknowledged', $acknowledged['status'] );
+		$this->assertSame( 21, $acknowledged['actions'][1]['payload']['attested_by_user_id'] );
+		$this->assertSame( 444, $acknowledged['actions'][1]['payload']['counterparty']['artist_profile_id'] );
+
+		$second     = $this->booking_with_commission();
+		$commission = $this->commissions->get( $second['id'], 12 );
+		$draft      = $this->service->draft( $this->draft_input( $second['id'], $commission['id'], 'revoked-draft' ), 12 );
+		$finalized  = $this->service->finalize( $this->transition( $second['id'], $draft, 'revoked-finalize' ), 12 );
+		unset( $GLOBALS['ec_artist_test']['artist_managers'][444][21] );
+		$revoked = array_merge(
+			$this->transition( $second['id'], $finalized, 'revoked-attestation' ),
+			array(
+				'acknowledgement_type'                    => 'counterparty_verified',
+				'acknowledgement_evidence_attachment_ids' => array(),
+			)
+		);
+		$this->assertSame( 'local_support_forbidden', $this->service->acknowledge( $revoked, 21 )->get_error_code() );
+	}
+
+	public function test_payment_denial_does_not_consume_private_evidence(): void {
+		$booking       = $this->booking_with_commission();
+		$commission    = $this->commissions->get( $booking['id'], 12 );
+		$draft         = $this->service->draft( $this->draft_input( $booking['id'], $commission['id'], 'denied-payment-draft' ), 12 );
+		$finalized     = $this->service->finalize( $this->transition( $booking['id'], $draft, 'denied-payment-finalize' ), 12 );
+		$payment       = array_merge(
+			$this->transition( $booking['id'], $finalized, 'denied-payment' ),
+			array(
+				'payment_reference'              => 'private',
+				'payment_date'                   => '2026-07-28',
+				'payout_evidence_attachment_ids' => array( $this->attachment( $booking['id'], 'private payout' ) ),
+			)
+		);
+		$before        = array( $this->files->descriptors, $this->files->streams, $this->files->deliveries );
+		$delivery_rows = count( $GLOBALS['wpdb']->rows[ BookingSchema::attachment_deliveries_table() ] ?? array() );
+		$this->assertSame( 'venue_action_forbidden', $this->service->mark_paid( $payment, 99 )->get_error_code() );
+		$this->assertSame( $before, array( $this->files->descriptors, $this->files->streams, $this->files->deliveries ) );
+		$this->assertCount( $delivery_rows, $GLOBALS['wpdb']->rows[ BookingSchema::attachment_deliveries_table() ] ?? array() );
+	}
+
+	public function test_action_booking_lock_failures_rollback_without_indexing_invalid_results(): void {
+		$booking                 = $this->booking_with_commission();
+		$commission              = $this->commissions->get( $booking['id'], 12 );
+		$draft                   = $this->service->draft( $this->draft_input( $booking['id'], $commission['id'], 'lock-failure-draft' ), 12 );
+		$repository              = new ShowSettlementLockFailureRepository();
+		$service                 = new ShowSettlementService( $repository, new BookingActivityRepository(), $this->authorization, $this->commissions, new BookingAttachmentRepository(), $this->files );
+		$repository->lock_result = new WP_Error( 'booking_read_failed' );
+		$error                   = $service->finalize( $this->transition( $booking['id'], $draft, 'lock-error' ), 12 );
+		$this->assertSame( 'show_settlement_booking_lock_failed', $error->get_error_code() );
+		$this->assertSame( array( 'status' => 503 ), $error->get_error_data() );
+		$repository->lock_result = null;
+		$this->assertSame( 'booking_not_found', $service->finalize( $this->transition( $booking['id'], $draft, 'lock-missing' ), 12 )->get_error_code() );
+	}
+
 	public function test_abilities_are_private_bounded_and_do_not_accept_account_identity(): void {
 		$abilities = new ShowSettlementAbilities( $this->service, $this->bookings, $this->authorization );
 		$abilities->register();
@@ -253,9 +395,11 @@ final class ShowSettlementTest extends BookingTestCase {
 	private function booking_with_commission(): array {
 		$booking = $this->bookings->create(
 			array(
-				'venue_term_id' => 55,
-				'artist_name'   => 'Settlement Artist',
-				'intake'        => array(),
+				'venue_term_id'     => 55,
+				'artist_term_id'    => 77,
+				'artist_profile_id' => 444,
+				'artist_name'       => 'Settlement Artist',
+				'intake'            => array(),
 			)
 		);
 		$booking = $this->bookings->claim_event( $booking['id'], 900, $booking['version'] );
@@ -312,6 +456,19 @@ final class ShowSettlementTest extends BookingTestCase {
 			12
 		);
 		return $booking;
+	}
+
+	private function void_commission( array $booking, array $commission ): void {
+		$result = $this->commissions->void(
+			array(
+				'booking_id'               => $booking['id'],
+				'expected_booking_version' => $booking['version'],
+				'expected_version'         => $commission['version'],
+				'reason'                   => 'Commission voided for test.',
+			),
+			12
+		);
+		$this->assertSame( 'void', $result['status'] );
 	}
 
 	private function draft_input( int $booking_id, int $commission_id, string $key ): array {

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -613,6 +613,22 @@ final class BookingWpdb {
 				}
 			}
 		}
+		if ( false !== strpos( $table, 'ec_booking_show_settlements' ) ) {
+			foreach ( $this->rows[ $table ] ?? array() as $existing ) {
+				if ( (int) $existing['booking_id'] === (int) $row['booking_id'] && ( (int) $existing['revision'] === (int) $row['revision'] || $existing['idempotency_key'] === $row['idempotency_key'] ) ) {
+					$this->last_error = 'duplicate show settlement revision';
+					return false;
+				}
+			}
+		}
+		if ( false !== strpos( $table, 'ec_booking_show_settlement_actions' ) ) {
+			foreach ( $this->rows[ $table ] ?? array() as $existing ) {
+				if ( (int) $existing['show_settlement_id'] === (int) $row['show_settlement_id'] && (int) $existing['expected_version'] === (int) $row['expected_version'] || (int) $existing['booking_id'] === (int) $row['booking_id'] && $existing['idempotency_key'] === $row['idempotency_key'] ) {
+					$this->last_error = 'duplicate show settlement action';
+					return false;
+				}
+			}
+		}
 		if ( false !== strpos( $table, 'ec_booking_attachment_deliveries' ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $existing ) {
 				if ( $existing['correlation_id'] === $row['correlation_id'] ) {
@@ -840,17 +856,19 @@ final class BookingWpdb {
 			$table = stripslashes( $match[1] );
 			return isset( $this->engines[ $table ] ) ? array( 'Engine' => $this->engines[ $table ] ) : null;
 		}
-		$is_activity   = false !== strpos( $query, 'ec_booking_activity' );
-		$is_attachment = false !== strpos( $query, 'ec_booking_attachments' );
-		$is_delivery   = false !== strpos( $query, 'ec_booking_attachment_deliveries' );
-		$is_state      = false !== strpos( $query, 'ec_booking_communication_state' );
-		$is_hold       = false !== strpos( $query, 'ec_booking_holds' );
-		$is_sales      = false !== strpos( $query, 'ec_booking_sales_reports' );
-		$is_source     = false !== strpos( $query, 'ec_booking_ticket_sources' );
-		$is_resolution = false !== strpos( $query, 'ec_booking_sales_resolutions' );
-		$is_settlement = false !== strpos( $query, 'ec_booking_settlements' );
-		$is_membership = false !== strpos( $query, 'ec_venue_members' );
-		$database_now  = $this->current_database_time();
+		$is_activity    = false !== strpos( $query, 'ec_booking_activity' );
+		$is_attachment  = false !== strpos( $query, 'ec_booking_attachments' );
+		$is_delivery    = false !== strpos( $query, 'ec_booking_attachment_deliveries' );
+		$is_state       = false !== strpos( $query, 'ec_booking_communication_state' );
+		$is_hold        = false !== strpos( $query, 'ec_booking_holds' );
+		$is_sales       = false !== strpos( $query, 'ec_booking_sales_reports' );
+		$is_source      = false !== strpos( $query, 'ec_booking_ticket_sources' );
+		$is_resolution  = false !== strpos( $query, 'ec_booking_sales_resolutions' );
+		$is_settlement  = false !== strpos( $query, 'ec_booking_settlements' );
+		$is_show        = false !== strpos( $query, 'ec_booking_show_settlements' );
+		$is_show_action = false !== strpos( $query, 'ec_booking_show_settlement_actions' );
+		$is_membership  = false !== strpos( $query, 'ec_venue_members' );
+		$database_now   = $this->current_database_time();
 		if ( null !== $this->reads_before_failure ) {
 			if ( 0 === $this->reads_before_failure ) {
 				$this->last_error = 'simulated delayed row read failure';
@@ -862,7 +880,36 @@ final class BookingWpdb {
 			$this->last_error = 'simulated row read failure';
 			return null;
 		}
-		$table = $is_membership ? $this->prefix . 'ec_venue_members' : ( $is_source ? $this->prefix . 'ec_booking_ticket_sources' : ( $is_resolution ? $this->prefix . 'ec_booking_sales_resolutions' : ( $is_sales ? $this->prefix . 'ec_booking_sales_reports' : ( $is_settlement ? $this->prefix . 'ec_booking_settlements' : ( $is_delivery ? $this->prefix . 'ec_booking_attachment_deliveries' : ( $is_attachment ? $this->prefix . 'ec_booking_attachments' : ( $is_activity ? $this->prefix . 'ec_booking_activity' : ( $is_state ? $this->prefix . 'ec_booking_communication_state' : ( $is_hold ? $this->prefix . 'ec_booking_holds' : $this->prefix . 'ec_bookings' ) ) ) ) ) ) ) ) );
+		$table = $is_show_action ? $this->prefix . 'ec_booking_show_settlement_actions' : ( $is_show ? $this->prefix . 'ec_booking_show_settlements' : ( $is_membership ? $this->prefix . 'ec_venue_members' : ( $is_source ? $this->prefix . 'ec_booking_ticket_sources' : ( $is_resolution ? $this->prefix . 'ec_booking_sales_resolutions' : ( $is_sales ? $this->prefix . 'ec_booking_sales_reports' : ( $is_settlement ? $this->prefix . 'ec_booking_settlements' : ( $is_delivery ? $this->prefix . 'ec_booking_attachment_deliveries' : ( $is_attachment ? $this->prefix . 'ec_booking_attachments' : ( $is_activity ? $this->prefix . 'ec_booking_activity' : ( $is_state ? $this->prefix . 'ec_booking_communication_state' : ( $is_hold ? $this->prefix . 'ec_booking_holds' : $this->prefix . 'ec_bookings' ) ) ) ) ) ) ) ) ) ) );
+		if ( $is_show && preg_match( "/WHERE booking_id = (\d+) AND idempotency_key = '([^']+)'/", $query, $match ) ) {
+			foreach ( $this->rows[ $table ] ?? array() as $row ) {
+				if ( (int) $row['booking_id'] === (int) $match[1] && $row['idempotency_key'] === stripslashes( $match[2] ) ) {
+					return $row;
+				}
+			}
+			return null;
+		}
+		if ( $is_show && preg_match( '/WHERE booking_id = (\d+) AND revision = (\d+)/', $query, $match ) ) {
+			foreach ( $this->rows[ $table ] ?? array() as $row ) {
+				if ( (int) $row['booking_id'] === (int) $match[1] && (int) $row['revision'] === (int) $match[2] ) {
+					return $row;
+				}
+			}
+			return null;
+		}
+		if ( $is_show && preg_match( '/WHERE booking_id = (\d+) ORDER BY revision DESC/', $query, $match ) ) {
+			$rows = array_values( array_filter( $this->rows[ $table ] ?? array(), static fn( array $row ): bool => (int) $row['booking_id'] === (int) $match[1] ) );
+			usort( $rows, static fn( array $left, array $right ): int => (int) $right['revision'] <=> (int) $left['revision'] );
+			return $rows[0] ?? null;
+		}
+		if ( $is_show_action && preg_match( "/WHERE booking_id = (\d+) AND idempotency_key = '([^']+)'/", $query, $match ) ) {
+			foreach ( $this->rows[ $table ] ?? array() as $row ) {
+				if ( (int) $row['booking_id'] === (int) $match[1] && $row['idempotency_key'] === stripslashes( $match[2] ) ) {
+					return $row;
+				}
+			}
+			return null;
+		}
 		if ( $is_membership && preg_match( '/WHERE venue_term_id = (\d+) AND user_id = (\d+)/', $query, $membership ) ) {
 			foreach ( $this->rows[ $table ] ?? array() as $row ) {
 				if ( (int) $row['venue_term_id'] === (int) $membership[1] && (int) $row['user_id'] === (int) $membership[2] ) {
@@ -1027,7 +1074,7 @@ final class BookingWpdb {
 			);
 			return $rows[0] ?? null;
 		}
-		if ( ! $is_attachment && ! $is_delivery && ! $is_activity && ! $is_state && ! $is_hold && ! $is_sales && ! $is_source && ! $is_resolution && ! $is_settlement && ! $is_membership && false !== strpos( $query, 'FOR UPDATE' ) ) {
+		if ( ! $is_attachment && ! $is_delivery && ! $is_activity && ! $is_state && ! $is_hold && ! $is_sales && ! $is_source && ! $is_resolution && ! $is_settlement && ! $is_show && ! $is_show_action && ! $is_membership && false !== strpos( $query, 'FOR UPDATE' ) ) {
 			++$this->booking_lock_queries;
 			if ( is_callable( $this->after_booking_lock ) ) {
 				$callback                 = $this->after_booking_lock;
@@ -1036,7 +1083,7 @@ final class BookingWpdb {
 			}
 		}
 		if ( preg_match( '/WHERE id = (\d+)/', $query, $match ) ) {
-			if ( ! $is_attachment && ! $is_delivery && ! $is_activity && ! $is_state && ! $is_hold && ! $is_sales && ! $is_source && ! $is_resolution && ! $is_settlement && ! $is_membership && false !== strpos( $query, 'FOR UPDATE' ) ) {
+			if ( ! $is_attachment && ! $is_delivery && ! $is_activity && ! $is_state && ! $is_hold && ! $is_sales && ! $is_source && ! $is_resolution && ! $is_settlement && ! $is_show && ! $is_show_action && ! $is_membership && false !== strpos( $query, 'FOR UPDATE' ) ) {
 				$this->lock_sequence[] = 'booking:' . (int) $match[1];
 			}
 			$row = $this->rows[ $table ][ (int) $match[1] ] ?? null;
@@ -1364,6 +1411,16 @@ final class BookingWpdb {
 					);
 				}
 			}
+			return $rows;
+		}
+		if ( false !== strpos( $query, 'ec_booking_show_settlement_actions' ) && preg_match( '/show_settlement_id = (\d+)/', $query, $match ) ) {
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $this->prefix . 'ec_booking_show_settlement_actions' ] ?? array(),
+					static fn( array $row ): bool => (int) $row['show_settlement_id'] === (int) $match[1]
+				)
+			);
+			usort( $rows, static fn( array $left, array $right ): int => (int) $left['expected_version'] <=> (int) $right['expected_version'] ?: (int) $left['id'] <=> (int) $right['id'] );
 			return $rows;
 		}
 		$is_activity   = false !== strpos( $query, 'ec_booking_activity' );
@@ -1983,6 +2040,7 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingInquiryAdmissionService.p
 require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueBookingConfig.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/TicketReconciliationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/TicketSettlementService.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/ShowSettlementService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/CanonicalEventPublicationGuard.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/LocalSupportAbilities.php';
@@ -1993,6 +2051,7 @@ require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingEventAbilities.
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingCommunicationAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingMarketingAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/TicketSettlementAbilities.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Abilities/ShowSettlementAbilities.php';
 
 final class BookingTestAuthorization extends VenueAuthorization {
 	public $calls                     = array();

--- a/tests/TicketReconciliationTest.php
+++ b/tests/TicketReconciliationTest.php
@@ -89,7 +89,7 @@ final class TicketReconciliationTest extends BookingTestCase {
 	public function test_schema_upgrades_v12_without_replacing_settlement_tables(): void {
 		$GLOBALS['ec_artist_test']['options'][ BookingSchema::VERSION_OPTION ] = '12';
 		$this->assertTrue( BookingSchema::maybe_install() );
-		$this->assertSame( '14', get_option( BookingSchema::VERSION_OPTION ) );
+		$this->assertSame( '15', get_option( BookingSchema::VERSION_OPTION ) );
 		$this->assertTrue( BookingSchema::health() );
 		$this->assertArrayHasKey( BookingSchema::ticket_sources_table(), $GLOBALS['wpdb']->schemas );
 		$this->assertArrayHasKey( BookingSchema::sales_resolutions_table(), $GLOBALS['wpdb']->schemas );


### PR DESCRIPTION
## Summary

- add complete immutable show-settlement revisions over the existing frozen Extra Chill commission
- add append-only acknowledgement, dispute, correction, finalization, artist-payout, and void lifecycle records
- authenticate door-report and payout bytes through the existing private booking attachment stream
- expose exact-venue, finance-owner abilities with bounded schemas and redacted evidence/payment projections

Closes #318

## Ownership Boundary

#294 remains the sole owner of `ec_booking_settlements`, Extra Chill commission terms, formula versions 1/2/3, and `amount_due_minor`. #316 remains the owner of ticket-source attribution, signed sales observations, corrections, reconciliation, and certified CSV evidence.

A complete show revision binds the frozen commission row ID and integrity hash, revalidates it through `TicketSettlementService`, pages through its exact `included_report_ids`, and requires recorded ticket gross to equal the overflow-safe signed gross sum. Artist payout is calculated and stored separately and is never written to or inferred from the Extra Chill commission amount.

## Immutable Model And Revision Chain

Schema version 15 adds two site-scoped InnoDB tables without changing any existing table:

- `ec_booking_show_settlements`: append-only draft/revised/corrected financial snapshots with unique booking/revision and booking/idempotency keys
- `ec_booking_show_settlement_actions`: append-only optimistic lifecycle actions with unique revision/version and booking/idempotency keys

Draft revisions are immutable. Revision appends a successor. Correction requires the exact current revision and lifecycle version, appends a linked correction draft, and atomically marks the prior revision corrected. Finalization and all later states are actions rather than edits to frozen terms. Canonical integrity hashes bind identities, inputs, evidence, calculations, idempotency keys, actor, and timestamps.

## Formula

Formula version 1 uses integer minor units and one explicit three-letter currency:

1. `total_gross = ticket_gross + door_gross`
2. `deductions = fees + taxes + refunds + venue_expenses + production_expenses`
3. `adjustment_total = sum(signed_adjustments)`
4. `artist_split_basis = total_gross - deductions + adjustment_total - extra_chill_share`
5. `artist_split = max(0, artist_split_basis) * artist_split_basis_points / 10000`
6. `artist_payout = max(artist_guarantee, artist_split)`
7. `venue_net_after_payout = artist_split_basis - artist_payout`

Basis-point products reuse #294 rounding: nearest minor unit, exact halves away from zero. Every add/subtract/multiply path rejects integer overflow. Adjustments bind signed amount, reason, authenticated actor, and canonical signature hash.

## Evidence And Authorization

Non-zero door gross requires approved `other_private_evidence`; payment requires payout evidence. Draft calculation, finalization, and payment reopen the existing opaque private stream, hash every byte, verify exact size, then recheck frozen metadata under the financial transaction lock. Historical reads use frozen metadata rather than current admission policy, while missing, inactive, or tampered files fail closed.

All operations require the existing exact-venue `manage_finances` policy, including its capability/feature gate and active owner membership. There is no administrator bypass or new role matrix. Raw content hashes, paths, storage references, stream tokens, recipient data, bank/tax identity, and payment references are absent from ability projections.

## Migration

The v14-to-v15 migration uses the existing site advisory lock, `dbDelta`, engine repair, exact health contracts, and stamp-after-verification flow. Unit migration proof snapshots every existing schema/engine and a representative booking row before adding only the two new tables. The managed multisite proof now verifies all 16 site-prefixed tables; the existing v13 fixture continues to preserve and verify every one of the 14 legacy tables plus formula-v2 settlement readability.

## Tests

Passed locally:

- focused show settlement suite: `5 tests, 71 assertions`
- complete booking suite: `408 tests, 4474 assertions`
- production PHPCS: clean
- Homeboy changed-file lint: clean
- PHPStan level 7 with PHP 7.4 target: clean
- Homeboy PR audit: no introduced findings
- PHP syntax and `git diff --check`: clean

The focused suite covers formula components, guarantee/split separation, signed adjustments, refunds/expenses, rounding/overflow, schema contracts, exact retry/conflict, immutable revisions, acknowledgement, dispute, correction, paid/void lifecycle, actor/action tampering, evidence redaction, ticket-gross reconciliation, cross-venue denial, and bounded abilities.

The managed MySQL concurrency workflow adds a genuine two-process proof for concurrent exact/conflicting drafts, finalize vs revise, and dispute vs payment. It also updates the workflow's exact expected test count from 4 to 5. Host execution is unavailable because the managed WordPress/Codebox database bootstrap secrets (`WP_CODEBOX_DB_HOST` et al.) are CI-only; GitHub checks are the authoritative run.

## Residual Exclusions

- no provider-specific ticket or payment adapter
- no bank account, routing, recipient, or tax identity storage
- no payment execution or money movement
- no public settlement projection
- no change to commission formulas 1/2/3 or ticket reconciliation policy
- no release, deployment, plugin version bump, or changelog edit