### PR TITLE
feat: expose managed venue voices

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -410,6 +410,9 @@ class ExtraChillEvents {
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueProfileAbilities.php';
 			new \ExtraChillEvents\Abilities\VenueProfileAbilities();
 
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/ManagedVenueVoicesAbilities.php';
+			new \ExtraChillEvents\Abilities\ManagedVenueVoicesAbilities();
+
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueBookingAbilities.php';
 			new \ExtraChillEvents\Abilities\VenueBookingAbilities();
 

--- a/inc/Abilities/ManagedVenueVoicesAbilities.php
+++ b/inc/Abilities/ManagedVenueVoicesAbilities.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Self-scoped public venue voice projection.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+use ExtraChillEvents\Core\VenueMembershipRepository;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Registers the bounded current-user venue representation contract. */
+class ManagedVenueVoicesAbilities {
+
+	/**
+	 * Canonical membership reader.
+	 *
+	 * @var VenueMembershipRepository
+	 */
+	private $memberships;
+
+	/**
+	 * Construct the ability registrar.
+	 *
+	 * @param VenueMembershipRepository|null $memberships Optional membership reader.
+	 */
+	public function __construct( ?VenueMembershipRepository $memberships = null ) {
+		$this->memberships = $memberships ? $memberships : new VenueMembershipRepository();
+		add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+	}
+
+	/** Register the REST-exposed read-only ability. */
+	public function register(): void {
+		wp_register_ability(
+			'extrachill/get-managed-venue-voices',
+			array(
+				'label'               => __( 'Get Managed Venue Voices', 'extrachill-events' ),
+				'description'         => __( 'Returns public venue identities represented by the current authenticated user.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'voices' => array(
+							'type'  => 'array',
+							'items' => $this->voice_schema(),
+						),
+					),
+					'required'             => array( 'voices' ),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => array( $this, 'authorize' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => true,
+						'idempotent'  => true,
+						'destructive' => false,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Require an authenticated runtime identity and reject identity claims.
+	 *
+	 * @param array $input Ability input, which must be empty.
+	 * @return true|\WP_Error Authorization result.
+	 */
+	public function authorize( array $input ) {
+		if ( ! empty( $input ) ) {
+			return new \WP_Error( 'managed_venue_voice_identity_claim_forbidden', __( 'Managed venue voices are scoped to the current user.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		if ( get_current_user_id() < 1 ) {
+			return new \WP_Error( 'managed_venue_voice_authentication_required', __( 'Authentication is required.', 'extrachill-events' ), array( 'status' => 401 ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return active managed venues as a narrow public projection.
+	 *
+	 * @param array $input Ability input, which must be empty.
+	 * @return array|\WP_Error Public voices or an error.
+	 */
+	public function execute( array $input ) {
+		$allowed = $this->authorize( $input );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+
+		$user_id        = get_current_user_id();
+		$events_blog_id = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'events' ) ) : 0;
+		if ( $events_blog_id < 1 ) {
+			return new \WP_Error( 'events_site_unresolved', __( 'Could not resolve the Events site.', 'extrachill-events' ), array( 'status' => 500 ) );
+		}
+
+		$switched = get_current_blog_id() !== $events_blog_id;
+		if ( $switched ) {
+			switch_to_blog( $events_blog_id );
+		}
+
+		try {
+			$venue_ids = $this->memberships->list_active_venue_ids_for_user( $user_id );
+			if ( is_wp_error( $venue_ids ) ) {
+				return $venue_ids;
+			}
+
+			$voices = array();
+			foreach ( $venue_ids as $venue_id ) {
+				$term = get_term( $venue_id, 'venue' );
+				if ( ! $term || is_wp_error( $term ) || 'venue' !== $term->taxonomy ) {
+					continue;
+				}
+
+				$url = get_term_link( $term );
+				if ( is_wp_error( $url ) ) {
+					continue;
+				}
+
+				$voices[] = array(
+					'reference'   => 'venue:' . (int) $term->term_id,
+					'term_id'     => (int) $term->term_id,
+					'name'        => sanitize_text_field( (string) $term->name ),
+					'slug'        => sanitize_title( (string) $term->slug ),
+					'url'         => esc_url_raw( $url ),
+					'description' => wp_strip_all_tags( (string) $term->description ),
+				);
+			}
+
+			return array( 'voices' => $voices );
+		} finally {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+		}
+	}
+
+	/** Return the exact public consumer contract for one venue voice. */
+	private function voice_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'reference'   => array(
+					'type'    => 'string',
+					'pattern' => '^venue:[1-9][0-9]*$',
+				),
+				'term_id'     => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'name'        => array( 'type' => 'string' ),
+				'slug'        => array( 'type' => 'string' ),
+				'url'         => array(
+					'type'   => 'string',
+					'format' => 'uri',
+				),
+				'description' => array( 'type' => 'string' ),
+			),
+			'required'             => array( 'reference', 'term_id', 'name', 'slug', 'url', 'description' ),
+			'additionalProperties' => false,
+		);
+	}
+}

--- a/inc/Abilities/ManagedVenueVoicesAbilities.php
+++ b/inc/Abilities/ManagedVenueVoicesAbilities.php
@@ -45,6 +45,7 @@ class ManagedVenueVoicesAbilities {
 					'type'                 => 'object',
 					'properties'           => array(),
 					'additionalProperties' => false,
+					'default'              => array(),
 				),
 				'output_schema'       => array(
 					'type'                 => 'object',

--- a/inc/Core/VenueMembershipRepository.php
+++ b/inc/Core/VenueMembershipRepository.php
@@ -134,6 +134,28 @@ class VenueMembershipRepository {
 		return VenueAuthorization::STATUS_ACTIVE === $membership['status'] ? $membership : null;
 	}
 
+	/**
+	 * List canonical venue IDs actively represented by one network user.
+	 *
+	 * @param int $user_id Network user ID.
+	 * @return int[]|\WP_Error Canonical venue term IDs or a database error.
+	 */
+	public function list_active_venue_ids_for_user( int $user_id ) {
+		global $wpdb;
+
+		if ( $user_id < 1 ) {
+			return array();
+		}
+
+		$table = BookingSchema::memberships_table();
+		$ids   = $wpdb->get_col( $wpdb->prepare( "SELECT venue_term_id FROM {$table} WHERE user_id = %d AND status = %s ORDER BY venue_term_id ASC", $user_id, VenueAuthorization::STATUS_ACTIVE ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private authority table, reduced to canonical public IDs.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'venue_membership_list_failed', __( 'Managed venues could not be read.', 'extrachill-events' ), array( 'status' => 500 ) );
+		}
+
+		return array_map( 'intval', (array) $ids );
+	}
+
 	/** List memberships for one venue with bounded filters. */
 	public function list_for_venue( int $venue_term_id, array $filters = array(), int $actor_user_id = 0 ) {
 		global $wpdb;

--- a/phpunit-managed.xml.dist
+++ b/phpunit-managed.xml.dist
@@ -15,6 +15,7 @@
 			<file>tests/Unit/Abilities/CanonicalLocationsAbilityTest.php</file>
 			<file>tests/Unit/Abilities/EventsByTermTaxonomyContextTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalAdapterContractsTest.php</file>
+			<file>tests/Unit/Abilities/ManagedVenueVoicesRestTest.php</file>
 			<file>tests/Unit/FestivalNotificationsTest.php</file>
 			<file>tests/Unit/VenueUpdateSubscriptionsTest.php</file>
 			<file>tests/Unit/SingleEventNetworkBridgeTest.php</file>

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -150,12 +150,21 @@ if ( ! function_exists( 'get_current_blog_id' ) ) {
 }
 if ( ! function_exists( 'switch_to_blog' ) ) {
 	function switch_to_blog( $blog_id ) {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			$GLOBALS['venue_membership_test']['blog_stack'][]  = $GLOBALS['venue_membership_test']['current_blog_id'];
+			$GLOBALS['venue_membership_test']['current_blog_id'] = (int) $blog_id;
+			return;
+		}
 		$GLOBALS['ec_artist_test']['stack'][] = $GLOBALS['ec_artist_test']['blog_id'];
 		$GLOBALS['ec_artist_test']['blog_id'] = (int) $blog_id;
 	}
 }
 if ( ! function_exists( 'restore_current_blog' ) ) {
 	function restore_current_blog() {
+		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
+			$GLOBALS['venue_membership_test']['current_blog_id'] = array_pop( $GLOBALS['venue_membership_test']['blog_stack'] );
+			return;
+		}
 		$GLOBALS['ec_artist_test']['blog_id'] = array_pop( $GLOBALS['ec_artist_test']['stack'] ); }
 }
 if ( ! function_exists( 'get_term' ) ) {
@@ -359,7 +368,7 @@ if ( ! function_exists( 'get_permalink' ) ) {
 if ( ! function_exists( 'get_term_link' ) ) {
 	function get_term_link( $term, $taxonomy = '' ) {
 		unset( $taxonomy );
-		return 'https://events.example/venue/' . (int) $term;
+		return 'https://events.example/venue/' . ( is_object( $term ) ? $term->slug : (int) $term );
 	}
 }
 if ( ! function_exists( 'ec_events_resolve_booking_console_destination' ) ) {

--- a/tests/Unit/Abilities/ManagedVenueVoicesRestTest.php
+++ b/tests/Unit/Abilities/ManagedVenueVoicesRestTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Managed venue voices REST contract coverage.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Abilities
+ */
+
+use ExtraChillEvents\Abilities\ManagedVenueVoicesAbilities;
+use ExtraChillEvents\Core\BookingSchema;
+
+require_once dirname( __DIR__, 3 ) . '/inc/Core/BookingSchema.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Core/VenueAuthorization.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Core/VenueMembershipRepository.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Abilities/ManagedVenueVoicesAbilities.php';
+
+/** Proves zero-input GET execution through the WordPress Abilities route. */
+final class ManagedVenueVoicesRestTest extends WP_UnitTestCase {
+
+	private int $member_user_id;
+	private int $venue_term_id;
+	private string $venue_url;
+
+	/** Create one active canonical venue membership on the Events site. */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->member_user_id = self::factory()->user->create();
+		switch_to_blog( 7 );
+		try {
+			if ( ! taxonomy_exists( 'venue' ) ) {
+				register_taxonomy( 'venue', 'data_machine_events', array( 'public' => true ) );
+			}
+			$this->venue_term_id = self::factory()->term->create(
+				array(
+					'taxonomy'    => 'venue',
+					'name'        => 'Route Contract Hall',
+					'slug'        => 'route-contract-hall',
+					'description' => '<strong>Public venue description.</strong>',
+				)
+			);
+			$this->venue_url = get_term_link( $this->venue_term_id, 'venue' );
+
+			global $wpdb;
+			$created = gmdate( 'Y-m-d H:i:s' );
+			$this->assertSame(
+				1,
+				$wpdb->insert(
+					BookingSchema::memberships_table(),
+					array(
+						'venue_term_id'      => $this->venue_term_id,
+						'user_id'            => $this->member_user_id,
+						'is_owner'           => 0,
+						'status'             => 'active',
+						'version'            => 1,
+						'created_by_user_id' => $this->member_user_id,
+						'created_at'         => $created,
+						'updated_at'         => $created,
+						'revoked_at'         => null,
+					)
+				)
+			); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Disposable integration fixture.
+		} finally {
+			restore_current_blog();
+		}
+
+		if ( ! wp_get_ability( 'extrachill/get-managed-venue-voices' ) ) {
+			$abilities = new ManagedVenueVoicesAbilities();
+			$abilities->register();
+		}
+	}
+
+	/** Verify omitted GET input defaults to an empty object across the REST boundary. */
+	public function test_zero_input_get_denies_anonymous_and_returns_authenticated_voice(): void {
+		$route = '/wp-abilities/v1/abilities/extrachill/get-managed-venue-voices/run';
+
+		wp_set_current_user( 0 );
+		$anonymous = rest_do_request( new WP_REST_Request( 'GET', $route ) );
+		$this->assertSame( 401, $anonymous->get_status() );
+		$this->assertSame( 'managed_venue_voice_authentication_required', $anonymous->get_data()['code'] );
+
+		wp_set_current_user( $this->member_user_id );
+		$authenticated = rest_do_request( new WP_REST_Request( 'GET', $route ) );
+		$this->assertSame( 200, $authenticated->get_status() );
+		$this->assertSame(
+			array(
+				'voices' => array(
+					array(
+						'reference'   => 'venue:' . $this->venue_term_id,
+						'term_id'     => $this->venue_term_id,
+						'name'        => 'Route Contract Hall',
+						'slug'        => 'route-contract-hall',
+						'url'         => $this->venue_url,
+						'description' => 'Public venue description.',
+					),
+				),
+			),
+			$authenticated->get_data()
+		);
+		$this->assertSame( 1, get_current_blog_id() );
+	}
+}

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -1960,6 +1960,7 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertTrue( $ability['meta']['show_in_rest'] );
 		$this->assertTrue( $ability['meta']['annotations']['readonly'] );
 		$this->assertFalse( $ability['input_schema']['additionalProperties'] );
+		$this->assertSame( array(), $ability['input_schema']['default'] );
 		$this->assertSame(
 			array(
 				'reference'   => 'venue:55',

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -7,6 +7,7 @@
 
 use ExtraChillEvents\Abilities\VenueMembershipAbilities;
 use ExtraChillEvents\Abilities\VenueBookingConfigAbilities;
+use ExtraChillEvents\Abilities\ManagedVenueVoicesAbilities;
 use ExtraChillEvents\Abilities\VenueProfileAbilities;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\VenueAuthorization;
@@ -134,6 +135,11 @@ if ( ! function_exists( 'get_term' ) ) {
 	function get_term( $term_id, $taxonomy = '' ) {
 		$term = $GLOBALS['venue_membership_test']['terms'][ $term_id ] ?? null;
 		return $term && ( '' === $taxonomy || $taxonomy === $term->taxonomy ) ? $term : null;
+	}
+}
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $value ) {
+		return strip_tags( (string) $value );
 	}
 }
 if ( ! function_exists( 'get_userdata' ) ) {
@@ -651,6 +657,26 @@ final class VenueMembershipWpdb {
 		return $rows;
 	}
 
+	public function get_col( $query ) {
+		$this->last_error = '';
+		$rows             = array_values( $this->rows[ $this->prefix . 'ec_venue_members' ] ?? array() );
+		if ( preg_match( '/user_id = (\d+)/', $query, $user_match ) ) {
+			$rows = $this->filter_rows( $rows, 'user_id', (int) $user_match[1] );
+		}
+		if ( preg_match( "/status = '([^']+)'/", $query, $status_match ) ) {
+			$status = stripslashes( $status_match[1] );
+			$rows   = array_values(
+				array_filter(
+					$rows,
+					static fn( $row ) => $status === $row['status']
+				)
+			);
+		}
+		$ids = array_map( static fn( $row ) => (int) $row['venue_term_id'], $rows );
+		sort( $ids );
+		return $ids;
+	}
+
 	public function query( $query ) {
 		if ( $this->wordpress_wpdb && ( false !== strpos( $query, $this->users ) || false !== strpos( $query, $this->usermeta ) || false !== strpos( $query, $this->options ) ) ) {
 			return $this->wordpress_wpdb->query( $query );
@@ -846,6 +872,7 @@ require_once dirname( __DIR__ ) . '/inc/Core/VenueProfile.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueMembershipAbilities.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueBookingConfigAbilities.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueProfileAbilities.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/ManagedVenueVoicesAbilities.php';
 
 /**
  * Venue membership and profile composition coverage uses isolated WP doubles.
@@ -943,12 +970,14 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 					'term_id'     => 55,
 					'taxonomy'    => 'venue',
 					'name'        => 'The Royal American',
+					'slug'        => 'the-royal-american',
 					'description' => 'Neighborhood venue.',
 				),
 				56 => (object) array(
 					'term_id'     => 56,
 					'taxonomy'    => 'venue',
 					'name'        => 'Music Farm',
+					'slug'        => 'music-farm',
 					'description' => '',
 				),
 				57 => (object) array(
@@ -977,6 +1006,7 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 			'feature_available' => true,
 			'current_user_id'   => 1,
 			'current_blog_id'   => 7,
+			'blog_stack'        => array(),
 			'actions'           => array(),
 			'abilities'         => array(),
 			'options'           => array( BookingSchema::VERSION_OPTION => BookingSchema::SCHEMA_VERSION ),
@@ -1914,6 +1944,71 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$GLOBALS['venue_membership_test']['current_user_id'] = 1;
 		$this->set_current_user( 1 );
 		$this->assertSame( 'venue_action_forbidden', call_user_func( $get['execute_callback'], array( 'venue_term_id' => 55 ) )->get_error_code() );
+	}
+
+	public function test_managed_venue_voices_are_self_scoped_public_and_rest_exposed(): void {
+		$this->create_member( 55, 2, true );
+		$this->create_member( 56, 3, true );
+		$GLOBALS['venue_membership_test']['current_user_id'] = 2;
+		$this->set_current_user( 2 );
+
+		$abilities = new ManagedVenueVoicesAbilities();
+		$abilities->register();
+		$ability = $GLOBALS['venue_membership_test']['abilities']['extrachill/get-managed-venue-voices'];
+		$result  = call_user_func( $ability['execute_callback'], array() );
+
+		$this->assertTrue( $ability['meta']['show_in_rest'] );
+		$this->assertTrue( $ability['meta']['annotations']['readonly'] );
+		$this->assertFalse( $ability['input_schema']['additionalProperties'] );
+		$this->assertSame(
+			array(
+				'reference'   => 'venue:55',
+				'term_id'     => 55,
+				'name'        => 'The Royal American',
+				'slug'        => 'the-royal-american',
+				'url'         => 'https://events.example/venue/the-royal-american',
+				'description' => 'Neighborhood venue.',
+			),
+			$result['voices'][0]
+		);
+		$this->assertCount( 1, $result['voices'] );
+		$this->assertSame( array( 'reference', 'term_id', 'name', 'slug', 'url', 'description' ), array_keys( $result['voices'][0] ) );
+	}
+
+	public function test_managed_venue_voices_reject_anonymous_and_spoofed_identity(): void {
+		$abilities = new ManagedVenueVoicesAbilities();
+		$GLOBALS['venue_membership_test']['current_user_id'] = 0;
+		$this->set_current_user( 0 );
+
+		$this->assertSame( 'managed_venue_voice_authentication_required', $abilities->execute( array() )->get_error_code() );
+		$GLOBALS['venue_membership_test']['current_user_id'] = 2;
+		$this->set_current_user( 2 );
+		$this->assertSame( 'managed_venue_voice_identity_claim_forbidden', $abilities->authorize( array( 'user_id' => 3 ) )->get_error_code() );
+		$this->assertSame( 'managed_venue_voice_identity_claim_forbidden', $abilities->execute( array( 'user_id' => 3 ) )->get_error_code() );
+	}
+
+	public function test_managed_venue_voices_exclude_invited_and_revoked_memberships(): void {
+		$this->create_member( 55, 2, true, VenueAuthorization::STATUS_REVOKED );
+		$this->create_member( 56, 2, true, VenueAuthorization::STATUS_INVITED );
+		$GLOBALS['venue_membership_test']['current_user_id'] = 2;
+		$this->set_current_user( 2 );
+
+		$result = ( new ManagedVenueVoicesAbilities() )->execute( array() );
+
+		$this->assertSame( array(), $result['voices'] );
+	}
+
+	public function test_managed_venue_voices_restore_multisite_context(): void {
+		$this->create_member( 55, 2, true );
+		$GLOBALS['venue_membership_test']['current_user_id'] = 2;
+		$GLOBALS['venue_membership_test']['current_blog_id'] = 1;
+		$this->set_current_user( 2 );
+
+		$result = ( new ManagedVenueVoicesAbilities() )->execute( array() );
+
+		$this->assertSame( 'venue:55', $result['voices'][0]['reference'] );
+		$this->assertSame( 1, get_current_blog_id() );
+		$this->assertSame( array(), $GLOBALS['venue_membership_test']['blog_stack'] );
 	}
 
 	public function test_profile_read_delegates_to_dme_after_authorization(): void {


### PR DESCRIPTION
## Summary
- expose `extrachill/get-managed-venue-voices` as a read-only REST ability for cross-site consumers
- project active `ec_venue_members` authority into canonical public venue identities without adding grants or storage
- restore Events multisite context after every projection

## Authorization And Privacy
- identity is bound exclusively to `get_current_user_id()`; the empty input schema and runtime checks reject arbitrary user claims
- anonymous, invited, and revoked memberships do not qualify
- administrators receive no synthetic representation authority
- output is limited to `reference`, `term_id`, `name`, `slug`, canonical `url`, and plain-text `description`
- membership rows, owner flags, contacts, booking/finance/invitation/claim data, and database diagnostics are not exposed

## Cross-Site Contract
Consumers call the standard ability REST execution surface on the Events site through `ec_cross_site_rest_request()` and receive:

```json
{
  "voices": [
    {
      "reference": "venue:55",
      "term_id": 55,
      "name": "The Royal American",
      "slug": "the-royal-american",
      "url": "https://events.extrachill.com/venue/the-royal-american/",
      "description": "Neighborhood venue."
    }
  ]
}
```

## Tests
- `vendor/bin/phpunit --configuration phpunit-venue-unit.xml.dist --filter managed_venue_voices` (4 tests, 13 assertions)
- `vendor/bin/phpunit --configuration phpunit-venue-unit.xml.dist` (48 tests, 335 assertions)
- `homeboy --placement local review lint extrachill-events --path . --changed-only --errors-only --summary` (passed: PHPCS and PHPStan)
- `homeboy --placement local review audit extrachill-events --path . --profile pr --changed-since origin/main` (passed: no introduced findings)
- Homeboy managed integration tests could not bootstrap because `WP_CODEBOX_DB_HOST` is unavailable in this runtime; no test assertions ran in that gate

Closes #463