### PR TITLE
feat: add scoped venue email consent

### DIFF
--- a/assets/js/venue-email-sharing.js
+++ b/assets/js/venue-email-sharing.js
@@ -1,0 +1,83 @@
+( function () {
+	'use strict';
+
+	const button = document.querySelector( '[data-venue-email-sharing]' );
+	if ( ! button ) {
+		return;
+	}
+
+	const status = button
+		.closest( '[data-venue-email-sharing-control]' )
+		.querySelector( '[data-venue-email-sharing-status]' );
+	const input = {
+		entity_type: 'venue-email-sharing',
+		taxonomy: 'venue',
+		slug: button.dataset.slug,
+	};
+
+	function setState( subscribed, message ) {
+		button.setAttribute( 'aria-pressed', subscribed ? 'true' : 'false' );
+		button.textContent = subscribed
+			? 'Email shared with venue'
+			: 'Share email with venue';
+		status.textContent =
+			message ||
+			( subscribed
+				? 'This venue can access your current account email.'
+				: 'This venue cannot access your account email.' );
+	}
+
+	function request( ability, method ) {
+		let url = button.dataset.endpoint + 'extrachill/' + ability + '/run';
+		const options = {
+			method,
+			credentials: 'same-origin',
+			headers: { 'X-WP-Nonce': button.dataset.nonce },
+		};
+		if ( 'GET' === method ) {
+			const query = new URLSearchParams();
+			Object.keys( input ).forEach( ( key ) =>
+				query.set( `input[${ key }]`, input[ key ] )
+			);
+			url += `?${ query.toString() }`;
+		} else {
+			options.headers[ 'Content-Type' ] = 'application/json';
+			options.body = JSON.stringify( { input } );
+		}
+		return window.fetch( url, options ).then( ( response ) =>
+			response.json().then( ( data ) => {
+				if ( ! response.ok ) {
+					throw new Error( data.message || 'Request failed.' );
+				}
+				return data;
+			} )
+		);
+	}
+
+	request( 'entity-subscription-status', 'GET' )
+		.then( ( data ) => setState( Boolean( data.subscribed ) ) )
+		.catch( () => {
+			status.textContent =
+				'Email-sharing status is unavailable. Please try again.';
+		} )
+		.finally( () => {
+			button.disabled = false;
+		} );
+
+	button.addEventListener( 'click', () => {
+		const subscribed = 'true' === button.getAttribute( 'aria-pressed' );
+		button.disabled = true;
+		request(
+			subscribed ? 'entity-unsubscribe' : 'entity-subscribe',
+			'POST'
+		)
+			.then( ( data ) => setState( Boolean( data.subscribed ) ) )
+			.catch( () => {
+				status.textContent =
+					'Unable to update email sharing. Please try again.';
+			} )
+			.finally( () => {
+				button.disabled = false;
+			} );
+	} );
+} )();

--- a/assets/js/venue-email-sharing.test.js
+++ b/assets/js/venue-email-sharing.test.js
@@ -1,0 +1,86 @@
+/** Scoped venue email-sharing control. */
+/* global beforeEach, describe, expect, it, jest */
+
+async function flushPromises() {
+	await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+}
+
+describe( 'Venue email sharing', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		document.body.innerHTML = `
+			<div data-venue-email-sharing-control>
+				<span data-venue-email-sharing-status></span>
+				<button disabled aria-pressed="false" data-venue-email-sharing
+					data-endpoint="https://example.com/wp-json/wp-abilities/v1/abilities/"
+					data-nonce="nonce" data-slug="the-royal-american"></button>
+			</div>`;
+		global.fetch = jest.fn();
+	} );
+
+	it( 'loads status without granting consent', async () => {
+		fetch.mockResolvedValue( {
+			ok: true,
+			json: () => Promise.resolve( { subscribed: false } ),
+		} );
+		require( './venue-email-sharing' );
+		await flushPromises();
+
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+		expect( fetch.mock.calls[ 0 ][ 1 ].method ).toBe( 'GET' );
+		expect( fetch.mock.calls[ 0 ][ 0 ] ).toContain(
+			'entity-subscription-status'
+		);
+	} );
+
+	it( 'uses only the scoped venue email-sharing identity', async () => {
+		fetch
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: () => Promise.resolve( { subscribed: false } ),
+			} )
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: () => Promise.resolve( { subscribed: true } ),
+			} );
+		require( './venue-email-sharing' );
+		await flushPromises();
+		document.querySelector( 'button' ).click();
+		await flushPromises();
+
+		expect( JSON.parse( fetch.mock.calls[ 1 ][ 1 ].body ).input ).toEqual( {
+			entity_type: 'venue-email-sharing',
+			taxonomy: 'venue',
+			slug: 'the-royal-american',
+		} );
+		expect( fetch.mock.calls[ 1 ][ 1 ].body ).not.toContain(
+			'"entity_type":"venue"'
+		);
+		expect( document.querySelector( 'button' ).textContent ).toBe(
+			'Email shared with venue'
+		);
+	} );
+
+	it( 'revokes only after an explicit second click', async () => {
+		fetch
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: () => Promise.resolve( { subscribed: true } ),
+			} )
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: () => Promise.resolve( { subscribed: false } ),
+			} );
+		require( './venue-email-sharing' );
+		await flushPromises();
+		document.querySelector( 'button' ).click();
+		await flushPromises();
+
+		expect( fetch.mock.calls[ 1 ][ 0 ] ).toContain(
+			'entity-unsubscribe/run'
+		);
+		expect( document.querySelector( 'button' ).textContent ).toBe(
+			'Share email with venue'
+		);
+	} );
+} );

--- a/blocks/venue-settings/src/api.js
+++ b/blocks/venue-settings/src/api.js
@@ -8,6 +8,7 @@ const METHODS = {
 	'extrachill/get-venue-booking-config': 'GET',
 	'extrachill/list-venue-memberships': 'GET',
 	'extrachill/list-venue-invitations': 'GET',
+	'extrachill/list-venue-email-subscribers': 'GET',
 	'extrachill/list-venue-claims': 'GET',
 	'extrachill/list-venue-bookings': 'GET',
 	'extrachill/get-venue-booking': 'GET',

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -57,6 +57,24 @@ const INTAKE_TYPES = [
 	'url',
 ];
 
+export const venueSubscriberCsv = ( subscribers ) =>
+	[
+		[ 'user_id', 'email' ],
+		...subscribers.map( ( subscriber ) => [
+			subscriber.user_id,
+			subscriber.email,
+		] ),
+	]
+		.map( ( row ) =>
+			row
+				.map(
+					( value ) =>
+						`"${ String( value ).replaceAll( '"', '""' ) }"`
+				)
+				.join( ',' )
+		)
+		.join( '\r\n' );
+
 const profileInputType = ( key ) => {
 	if ( key === 'website' ) {
 		return 'url';
@@ -649,7 +667,7 @@ function IntakeTab( { config, setConfig } ) {
 	);
 }
 
-function TeamTab( { venueId, members, invitations, onRefresh } ) {
+function TeamTab( { venueId, members, invitations, subscribers, onRefresh } ) {
 	const [ email, setEmail ] = useState( '' );
 	const [ owner, setOwner ] = useState( false );
 	const [ action, setAction ] = useState( null );
@@ -687,8 +705,53 @@ function TeamTab( { venueId, members, invitations, onRefresh } ) {
 			setOwner( false );
 		}
 	};
+	const exportSubscribers = () => {
+		const url = window.URL.createObjectURL(
+			new window.Blob( [ venueSubscriberCsv( subscribers ) ], {
+				type: 'text/csv;charset=utf-8',
+			} )
+		);
+		const link = document.createElement( 'a' );
+		link.href = url;
+		link.download = `venue-${ venueId }-email-subscribers.csv`;
+		link.click();
+		window.URL.revokeObjectURL( url );
+	};
 	return (
 		<div className="ec-venue-settings__stack">
+			<Panel>
+				<PanelHeader
+					title="Venue email list"
+					description="Only accounts that explicitly share email access with this venue appear here. Addresses always reflect the current account email."
+				/>
+				{ subscribers.length === 0 ? (
+					<p>
+						No accounts currently share email access with this
+						venue.
+					</p>
+				) : (
+					<>
+						<ul className="ec-venue-settings__records">
+							{ subscribers.map( ( subscriber ) => (
+								<li key={ subscriber.user_id }>
+									<a href={ `mailto:${ subscriber.email }` }>
+										{ subscriber.email }
+									</a>
+								</li>
+							) ) }
+						</ul>
+						<ActionRow>
+							<button
+								type="button"
+								className="button-2"
+								onClick={ exportSubscribers }
+							>
+								Download CSV
+							</button>
+						</ActionRow>
+					</>
+				) }
+			</Panel>
 			<Panel>
 				<PanelHeader
 					title="Invite a teammate"
@@ -1033,6 +1096,7 @@ export function VenueSettingsApp( { context } ) {
 	const [ configRevision, setConfigRevision ] = useState( 0 );
 	const [ members, setMembers ] = useState( [] );
 	const [ invitations, setInvitations ] = useState( [] );
+	const [ subscribers, setSubscribers ] = useState( [] );
 	const [ claims, setClaims ] = useState( [] );
 	const [ profileStatus, setProfileStatus ] = useState( null );
 	const [ configStatus, setConfigStatus ] = useState( null );
@@ -1054,25 +1118,33 @@ export function VenueSettingsApp( { context } ) {
 		if ( ! selected || ! context.can_manage ) {
 			return;
 		}
-		const [ memberResult, invitationResult ] = await Promise.allSettled( [
-			runAbility( 'extrachill/list-venue-memberships', {
-				venue_term_id: selected.id,
-			} ),
-			runAbility( 'extrachill/list-venue-invitations', {
-				venue_term_id: selected.id,
-			} ),
-		] );
+		const [ memberResult, invitationResult, subscriberResult ] =
+			await Promise.allSettled( [
+				runAbility( 'extrachill/list-venue-memberships', {
+					venue_term_id: selected.id,
+				} ),
+				runAbility( 'extrachill/list-venue-invitations', {
+					venue_term_id: selected.id,
+				} ),
+				runAbility( 'extrachill/list-venue-email-subscribers', {
+					venue_term_id: selected.id,
+				} ),
+			] );
 		if ( memberResult.status === 'fulfilled' ) {
 			setMembers( memberResult.value );
 		}
 		if ( invitationResult.status === 'fulfilled' ) {
 			setInvitations( invitationResult.value );
 		}
+		if ( subscriberResult.status === 'fulfilled' ) {
+			setSubscribers( subscriberResult.value.subscribers || [] );
+		}
 		setLoadErrors( ( current ) => ( {
 			...current,
 			team:
 				memberResult.status === 'rejected' ||
-				invitationResult.status === 'rejected'
+				invitationResult.status === 'rejected' ||
+				subscriberResult.status === 'rejected'
 					? 'Some team records could not be loaded.'
 					: null,
 		} ) );
@@ -1359,6 +1431,7 @@ export function VenueSettingsApp( { context } ) {
 						venueId={ selected.id }
 						members={ members }
 						invitations={ invitations }
+						subscribers={ subscribers }
 						onRefresh={ loadTeam }
 					/>
 				</>

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -14,7 +14,7 @@ import { act } from 'react';
 /**
  * Internal dependencies
  */
-import { VenueSettingsApp } from './view';
+import { VenueSettingsApp, venueSubscriberCsv } from './view';
 
 jest.mock( '@wordpress/api-fetch', () => ( {
 	__esModule: true,
@@ -293,7 +293,54 @@ describe( 'venue settings authorization-facing states', () => {
 				request.path.includes( 'list-venue-memberships' )
 			)
 		).toBe( false );
+		expect(
+			apiFetch.mock.calls.some( ( [ request ] ) =>
+				request.path.includes( 'list-venue-email-subscribers' )
+			)
+		).toBe( false );
 		await act( async () => root.unmount() );
+	} );
+
+	it( 'shows exact current venue email subscribers only to owners', async () => {
+		apiFetch.mockImplementation( ( request ) => {
+			const input = requestInput( request.path );
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'list-venue-email-subscribers' ) ) {
+				return Promise.resolve( {
+					venue_term_id: input.venue_term_id,
+					total: 1,
+					subscribers: [
+						{ user_id: 12, email: 'current@example.com' },
+					],
+				} );
+			}
+			return Promise.resolve( [] );
+		} );
+		const { container, root } = await renderApp(
+			context( { can_manage: true } )
+		);
+		await act( async () => buttonByText( container, 'Team' ).click() );
+
+		expect( container.textContent ).toContain( 'current@example.com' );
+		expect( container.textContent ).toContain( 'Download CSV' );
+		const request = apiFetch.mock.calls.find( ( [ call ] ) =>
+			call.path.includes( 'list-venue-email-subscribers' )
+		)[ 0 ];
+		expect( requestInput( request.path ) ).toEqual( { venue_term_id: 44 } );
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'exports only the resolved user ID and current email', () => {
+		expect(
+			venueSubscriberCsv( [
+				{ user_id: 12, email: 'current@example.com' },
+			] )
+		).toBe( '"user_id","email"\r\n"12","current@example.com"' );
 	} );
 
 	it( 'lets administrators review claims without active venue access', async () => {

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -333,6 +333,8 @@ class ExtraChillEvents {
 		extrachill_events_init_local_scene_digest();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/venue-update-subscriptions.php';
 		extrachill_events_init_venue_update_subscriptions();
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/venue-email-sharing.php';
+		extrachill_events_init_venue_email_sharing();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/near-me.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/discovery-pages.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/router-pages.php';
@@ -401,6 +403,9 @@ class ExtraChillEvents {
 		if ( \ExtraChillEvents\Core\BookingSchema::is_ready() ) {
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueMembershipAbilities.php';
 			new \ExtraChillEvents\Abilities\VenueMembershipAbilities();
+
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueEmailSharingAbilities.php';
+			new \ExtraChillEvents\Abilities\VenueEmailSharingAbilities();
 
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VenueOnboardingAbilities.php';
 			new \ExtraChillEvents\Abilities\VenueOnboardingAbilities();

--- a/inc/Abilities/VenueEmailSharingAbilities.php
+++ b/inc/Abilities/VenueEmailSharingAbilities.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Venue email-sharing audience ability.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+use ExtraChillEvents\Core\VenueAuthorization;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Registers the verified-owner venue email audience surface. */
+class VenueEmailSharingAbilities {
+
+	/** Whether ability registration has already been hooked. */
+	private static bool $registered = false;
+
+	/**
+	 * Venue authorization service.
+	 *
+	 * @var VenueAuthorization
+	 */
+	private $authorization;
+
+	/**
+	 * Build the ability with the canonical venue authorization service.
+	 *
+	 * @param VenueAuthorization|null $authorization Venue authorization service.
+	 */
+	public function __construct( ?VenueAuthorization $authorization = null ) {
+		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
+		if ( ! self::$registered ) {
+			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+			self::$registered = true;
+		}
+	}
+
+	/** Register the private current-email listing contract. */
+	public function register(): void {
+		wp_register_ability(
+			'extrachill/list-venue-email-subscribers',
+			array(
+				'label'               => __( 'List Venue Email Subscribers', 'extrachill-events' ),
+				'description'         => __( 'List current account emails explicitly shared with one managed venue.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'venue_term_id' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+					),
+					'required'             => array( 'venue_term_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'venue_term_id' => array( 'type' => 'integer' ),
+						'total'         => array( 'type' => 'integer' ),
+						'subscribers'   => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'user_id' => array( 'type' => 'integer' ),
+									'email'   => array( 'type' => 'string' ),
+								),
+							),
+						),
+					),
+				),
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => array( $this, 'can_manage_venue' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'   => true,
+						'idempotent' => true,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Require verified owner authority for the exact venue.
+	 *
+	 * @param array $input Ability input.
+	 * @return true|\WP_Error
+	 */
+	public function can_manage_venue( array $input ) {
+		return $this->authorization->authorize( get_current_user_id(), absint( $input['venue_term_id'] ?? 0 ), VenueAuthorization::ACTION_MANAGE_MEMBERS );
+	}
+
+	/**
+	 * Resolve consenting IDs and map only valid current account emails.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public function execute( array $input ) {
+		$venue_term_id = absint( $input['venue_term_id'] ?? 0 );
+		$authorized    = $this->can_manage_venue( $input );
+		if ( true !== $authorized ) {
+			return $authorized;
+		}
+
+		$venue = get_term( $venue_term_id, 'venue' );
+		if ( ! is_object( $venue ) || 'venue' !== ( $venue->taxonomy ?? '' ) || empty( $venue->slug ) || ! function_exists( 'extrachill_users_entity_subscription_recipients' ) ) {
+			return new \WP_Error( 'venue_email_subscribers_unavailable', __( 'Venue email subscribers are unavailable.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+
+		$user_ids = extrachill_users_entity_subscription_recipients(
+			EXTRACHILL_EVENTS_VENUE_EMAIL_SHARING_PRODUCER,
+			'venue-email-sharing',
+			'venue',
+			$venue->slug,
+			'email'
+		);
+		if ( is_wp_error( $user_ids ) ) {
+			return $user_ids;
+		}
+
+		$subscribers = array();
+		foreach ( array_values( array_unique( array_filter( array_map( 'absint', (array) $user_ids ) ) ) ) as $user_id ) {
+			$user  = get_userdata( $user_id );
+			$email = $user instanceof \WP_User ? sanitize_email( $user->user_email ) : '';
+			if ( '' === $email || ! is_email( $email ) ) {
+				continue;
+			}
+			$subscribers[] = array(
+				'user_id' => $user_id,
+				'email'   => $email,
+			);
+		}
+
+		return array(
+			'venue_term_id' => $venue_term_id,
+			'total'         => count( $subscribers ),
+			'subscribers'   => $subscribers,
+		);
+	}
+}

--- a/inc/core/venue-email-sharing.php
+++ b/inc/core/venue-email-sharing.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Scoped venue email-sharing consent.
+ *
+ * @package ExtraChillEvents
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EXTRACHILL_EVENTS_VENUE_EMAIL_SHARING_PRODUCER = 'extrachill-events-venue-email-sharing';
+
+/** Register the feature-owned identity, archive control, and private producer. */
+function extrachill_events_init_venue_email_sharing(): void {
+	add_filter( 'extrachill_users_entity_subscription_entities', 'extrachill_events_register_venue_email_sharing_identity' );
+	add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_events_authorize_venue_email_sharing_producer', 10, 4 );
+	add_action( 'extrachill_archive_below_description', 'extrachill_events_render_venue_email_sharing_control', 6 );
+	add_action( 'wp_enqueue_scripts', 'extrachill_events_venue_email_sharing_scripts' );
+}
+
+/**
+ * Register the venue email-sharing purpose independently of venue updates.
+ *
+ * @param array $entities Entity identity definitions.
+ * @return array
+ */
+function extrachill_events_register_venue_email_sharing_identity( array $entities ): array {
+	$entities['venue-email-sharing'] = array(
+		'taxonomy'                           => 'venue',
+		'uses_notification_email_preference' => false,
+	);
+
+	return $entities;
+}
+
+/**
+ * Authorize only the exact private venue email-sharing resolution contract.
+ *
+ * @param bool   $authorized Existing authorization decision.
+ * @param string $producer   Requesting producer.
+ * @param array  $entity     Normalized entity identity.
+ * @param string $delivery   Delivery channel.
+ * @return bool
+ */
+function extrachill_events_authorize_venue_email_sharing_producer( $authorized, $producer, $entity, $delivery ): bool {
+	if ( EXTRACHILL_EVENTS_VENUE_EMAIL_SHARING_PRODUCER !== $producer ) {
+		return (bool) $authorized;
+	}
+
+	return 'email' === $delivery
+		&& is_array( $entity )
+		&& 'venue-email-sharing' === ( $entity['entity_type'] ?? '' )
+		&& 'venue' === ( $entity['taxonomy'] ?? '' );
+}
+
+/** Render a separate explicit email-sharing choice on canonical venue archives. */
+function extrachill_events_render_venue_email_sharing_control(): void {
+	$term = function_exists( 'extrachill_events_get_venue_archive_term' ) ? extrachill_events_get_venue_archive_term() : null;
+	if ( null === $term ) {
+		return;
+	}
+
+	$archive_url = get_term_link( $term );
+	if ( ! is_user_logged_in() ) {
+		echo '<aside class="events-market-context events-market-context--quiet"><span>' . esc_html__( 'Share your account email with this venue for its own email list.', 'extrachill-events' ) . '</span> <a href="' . esc_url( wp_login_url( $archive_url ) ) . '">' . esc_html__( 'Sign in to share your email', 'extrachill-events' ) . '</a></aside>';
+		return;
+	}
+
+	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+		define( 'DONOTCACHEPAGE', true );
+	}
+	nocache_headers();
+	?>
+	<aside class="events-market-context" data-venue-email-sharing-control>
+		<div class="events-market-context__copy">
+			<strong><?php esc_html_e( 'Venue email list', 'extrachill-events' ); ?></strong>
+			<span data-venue-email-sharing-status><?php esc_html_e( 'Checking your email-sharing choice...', 'extrachill-events' ); ?></span>
+		</div>
+		<button class="button-1 button-small" type="button" disabled aria-pressed="false" data-venue-email-sharing data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Share email with venue', 'extrachill-events' ); ?></button>
+	</aside>
+	<?php
+}
+
+/** Enqueue the progressive control only for authenticated venue archives. */
+function extrachill_events_venue_email_sharing_scripts(): void {
+	if ( ! function_exists( 'extrachill_events_get_venue_archive_term' ) || null === extrachill_events_get_venue_archive_term() || ! is_user_logged_in() ) {
+		return;
+	}
+
+	wp_enqueue_script( 'extrachill-events-venue-email-sharing', EXTRACHILL_EVENTS_PLUGIN_URL . 'assets/js/venue-email-sharing.js', array(), EXTRACHILL_EVENTS_VERSION, true );
+}

--- a/tests/Unit/VenueUpdateSubscriptionsTest.php
+++ b/tests/Unit/VenueUpdateSubscriptionsTest.php
@@ -9,6 +9,7 @@
 
 require_once dirname( __DIR__ ) . '/Support/venue-update-subscription-stubs.php';
 require_once dirname( __DIR__, 2 ) . '/inc/core/venue-update-subscriptions.php';
+require_once dirname( __DIR__, 2 ) . '/inc/core/venue-email-sharing.php';
 
 /** Verify archive consent UI and first-publication delivery behavior. */
 final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
@@ -72,6 +73,21 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		$this->assertFalse( extrachill_events_authorize_venue_update_producer( false, 'untrusted', $venue, 'notification' ) );
 	}
 
+	/** Email sharing is a separate descriptor and private producer purpose. */
+	public function test_registers_and_authorizes_only_exact_email_sharing_contract(): void {
+		$entities = extrachill_events_register_venue_email_sharing_identity( array( 'venue' => 'venue' ) );
+		$sharing  = array(
+			'entity_type' => 'venue-email-sharing',
+			'taxonomy'    => 'venue',
+		);
+
+		$this->assertSame( 'venue', $entities['venue-email-sharing']['taxonomy'] );
+		$this->assertFalse( $entities['venue-email-sharing']['uses_notification_email_preference'] );
+		$this->assertTrue( extrachill_events_authorize_venue_email_sharing_producer( false, EXTRACHILL_EVENTS_VENUE_EMAIL_SHARING_PRODUCER, $sharing, 'email' ) );
+		$this->assertFalse( extrachill_events_authorize_venue_email_sharing_producer( false, EXTRACHILL_EVENTS_VENUE_EMAIL_SHARING_PRODUCER, $sharing, 'notification' ) );
+		$this->assertFalse( extrachill_events_authorize_venue_email_sharing_producer( false, EXTRACHILL_EVENTS_VENUE_EMAIL_SHARING_PRODUCER, array( 'entity_type' => 'venue', 'taxonomy' => 'venue' ), 'email' ) );
+	}
+
 	/** Anonymous archives offer sign-in without exposing a mutation control. */
 	public function test_anonymous_archive_renders_sign_in_without_mutation_control(): void {
 		$this->venue_archive();
@@ -97,6 +113,21 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'data-venue-update-subscription', $html );
 		$this->assertStringContainsString( 'Checking your subscription...', $html );
 		$this->assertStringContainsString( 'data-slug="the-royal-american"', $html );
+	}
+
+	/** Archive email sharing remains a visibly separate explicit control. */
+	public function test_archive_renders_separate_email_sharing_control(): void {
+		$this->venue_archive();
+		wp_set_current_user( self::factory()->user->create() );
+
+		ob_start();
+		extrachill_events_render_venue_update_control();
+		extrachill_events_render_venue_email_sharing_control();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'data-venue-update-subscription', $html );
+		$this->assertStringContainsString( 'data-venue-email-sharing', $html );
+		$this->assertStringContainsString( 'Share email with venue', $html );
 	}
 
 	/** First publication deduplicates subscribers across all assigned venues. */

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -6,6 +6,7 @@
  */
 
 use ExtraChillEvents\Abilities\VenueMembershipAbilities;
+use ExtraChillEvents\Abilities\VenueEmailSharingAbilities;
 use ExtraChillEvents\Abilities\VenueBookingConfigAbilities;
 use ExtraChillEvents\Abilities\VenueProfileAbilities;
 use ExtraChillEvents\Core\BookingSchema;
@@ -139,6 +140,13 @@ if ( ! function_exists( 'get_term' ) ) {
 if ( ! function_exists( 'get_userdata' ) ) {
 	function get_userdata( $user_id ) {
 		return $GLOBALS['venue_membership_test']['users'][ $user_id ] ?? false;
+	}
+}
+if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) ) {
+	/** Resolve configured scoped audience fixtures. */
+	function extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug, $delivery = 'notification' ) {
+		$GLOBALS['venue_membership_test']['email_recipient_resolutions'][] = compact( 'producer', 'entity_type', 'taxonomy', 'slug', 'delivery' );
+		return $GLOBALS['venue_membership_test']['email_recipient_ids'][ $slug ] ?? array();
 	}
 }
 if ( ! function_exists( 'get_user_by' ) ) {
@@ -844,6 +852,8 @@ require_once dirname( __DIR__ ) . '/inc/Core/BookingRepository.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueBookingConfig.php';
 require_once dirname( __DIR__ ) . '/inc/Core/VenueProfile.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueMembershipAbilities.php';
+require_once dirname( __DIR__ ) . '/inc/core/venue-email-sharing.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/VenueEmailSharingAbilities.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueBookingConfigAbilities.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/VenueProfileAbilities.php';
 
@@ -943,12 +953,14 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 					'term_id'     => 55,
 					'taxonomy'    => 'venue',
 					'name'        => 'The Royal American',
+					'slug'        => 'the-royal-american',
 					'description' => 'Neighborhood venue.',
 				),
 				56 => (object) array(
 					'term_id'     => 56,
 					'taxonomy'    => 'venue',
 					'name'        => 'Music Farm',
+					'slug'        => 'music-farm',
 					'description' => '',
 				),
 				57 => (object) array(
@@ -995,6 +1007,8 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 			'permission_boundary_failures' => array(),
 			'doing_action'      => '',
 			'rollback_attempts' => array(),
+			'email_recipient_ids' => array(),
+			'email_recipient_resolutions' => array(),
 			'reset_key_calls'   => 0,
 			'fail_reset_key'    => false,
 			'fail_delivery'     => false,
@@ -1294,6 +1308,50 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 			)
 		);
 		$this->assertSame( 'venue_action_forbidden', $denied->get_error_code() );
+	}
+
+	/** Venue email listing is owner-scoped and resolves current consent and emails. */
+	public function test_venue_email_subscriber_ability_enforces_owner_scope_and_current_resolution(): void {
+		$this->create_member( 55, 2, true );
+		$this->create_member( 55, 3, false );
+		$this->create_member( 56, 4, true );
+		$GLOBALS['venue_membership_test']['current_user_id'] = 2;
+		$this->set_current_user( 2 );
+		$GLOBALS['venue_membership_test']['email_recipient_ids']['the-royal-american'] = array( 3, 4 );
+
+		$abilities = new VenueEmailSharingAbilities();
+		$abilities->register();
+		$this->assertTrue( $abilities->can_manage_venue( array( 'venue_term_id' => 55 ) ) );
+		$this->assertSame( 'venue_action_forbidden', $abilities->can_manage_venue( array( 'venue_term_id' => 56 ) )->get_error_code() );
+
+		$first = $abilities->execute( array( 'venue_term_id' => 55 ) );
+		$this->assertSame( array( 'member3@example.com', 'member4@example.com' ), array_column( $first['subscribers'], 'email' ) );
+		$this->assertSame(
+			array(
+				'producer'    => EXTRACHILL_EVENTS_VENUE_EMAIL_SHARING_PRODUCER,
+				'entity_type' => 'venue-email-sharing',
+				'taxonomy'    => 'venue',
+				'slug'        => 'the-royal-american',
+				'delivery'    => 'email',
+			),
+			$GLOBALS['venue_membership_test']['email_recipient_resolutions'][0]
+		);
+
+		$GLOBALS['venue_membership_test']['email_recipient_ids']['the-royal-american'] = array( 4 );
+		$GLOBALS['venue_membership_test']['users'][4]->user_email = 'changed@example.com';
+		if ( $this->original_wpdb ) {
+			$this->original_wpdb->update( $this->original_wpdb->users, array( 'user_email' => 'changed@example.com' ), array( 'ID' => 4 ) );
+			clean_user_cache( 4 );
+		}
+		$after_revocation = $abilities->execute( array( 'venue_term_id' => 55 ) );
+		$this->assertSame( array( array( 'user_id' => 4, 'email' => 'changed@example.com' ) ), $after_revocation['subscribers'] );
+
+		$this->assertSame( 'venue_action_forbidden', $abilities->execute( array( 'venue_term_id' => 56 ) )->get_error_code() );
+		$this->assertCount( 2, $GLOBALS['venue_membership_test']['email_recipient_resolutions'] );
+
+		$GLOBALS['venue_membership_test']['current_user_id'] = 3;
+		$this->set_current_user( 3 );
+		$this->assertSame( 'venue_action_forbidden', $abilities->execute( array( 'venue_term_id' => 55 ) )->get_error_code() );
 	}
 
 	public function test_claim_submission_is_idempotent_and_approval_bootstraps_exact_owner(): void {


### PR DESCRIPTION
## Summary
- register the feature-owned `venue-email-sharing/venue/<slug>` descriptor with notification-email preference independence
- add a separate explicit venue archive email-sharing control alongside, but independent from, `venue/venue/<slug>` update subscriptions
- add a verified-owner venue settings list/CSV export backed by current Users consent and account data

## Identity and UI separation
Venue email sharing uses the exact canonical identity `entity_type=venue-email-sharing`, `taxonomy=venue`, and the canonical venue term slug. Events registers the Users descriptor with `uses_notification_email_preference=false`, so the account notification-email preference neither grants nor suppresses this consent.

The archive renders and mutates email sharing through its own progressive control. It never reads or changes venue update subscriptions, Local Scene state, attendance, bookings, submissions, visits, or any follower relationship.

## Privacy and authorization
`extrachill/list-venue-email-subscribers` reuses the existing verified venue owner permission (`VenueAuthorization::ACTION_MANAGE_MEMBERS`) for the exact requested venue and rechecks that authorization during execution. Cross-venue and active non-owner access fail closed.

The ability invokes Users' private producer-authorized recipient resolver with `extrachill-events-venue-email-sharing`, `venue-email-sharing/venue/<slug>`, and `delivery=email`. It receives user IDs, then resolves and validates current account emails on every read. Revocations and account email changes therefore take effect immediately. The REST response and CSV are available only behind the venue-scoped owner permission.

## Storage decision
No Events consent table, copied account emails, follower model, anonymous venue mailing-list substrate, or migration was added. Users remains the canonical consent store. Any future direct/anonymous venue subscribers remain product-owned and can be combined only at read time with normalized-email deduplication.

## Verification
- `homeboy review lint --changed-only --summary` (PHPCS, ESLint, PHPStan level 7): passed
- `homeboy review audit --changed-since=origin/main --json-summary`: passed with no introduced findings
- `./vendor/bin/phpunit -c phpunit-venue-unit.xml.dist`: 45 tests, 330 assertions passed
- `npm run test:js -- --runInBand`: 14 suites, 70 tests passed
- `npm run lint:js`: passed
- `npm run build`: passed
- `php -l` on new and changed PHP coverage plus `git diff --check`: passed
- Managed WordPress `homeboy review test --skip-lint`: runner stopped before PHPUnit because `WP_CODEBOX_DB_HOST` was unavailable; no product test result was produced by that gate

Closes #409