### PR TITLE
fix: register Events abilities before early registry initialization

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -215,7 +215,7 @@ class ExtraChillEvents {
 		add_filter( 'ec_feature_ceilings', array( $this, 'register_feature_ceilings' ) );
 		add_action( 'init', array( $this, 'load_textdomain' ) );
 		add_action( 'init', array( $this, 'init_data_machine_handlers' ), 20 );
-		add_action( 'init', array( $this, 'init_abilities' ), 25 );
+		add_action( 'plugins_loaded', array( $this, 'init_abilities' ), 25 );
 		add_action( 'plugins_loaded', array( $this, 'maybe_install_schema' ), 20 );
 
 		// Artist URL Import moderation queue admin screen (migrated from

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,7 @@
 			<file>tests/Unit/SingleEventNetworkBridgeTest.php</file>
 			<file>tests/Unit/ConcertStatsPublicProfileRenderTest.php</file>
 			<file>tests/Unit/VenueBookingInquiryRenderTest.php</file>
+			<file>tests/AbilityRegistrationLifecycleTest.php</file>
 		</testsuite>
 		<testsuite name="venue-membership-authorization">
 			<file>tests/VenueMembershipAuthorizationTest.php</file>

--- a/tests/AbilityRegistrationLifecycleTest.php
+++ b/tests/AbilityRegistrationLifecycleTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Ability registration lifecycle regression coverage.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Abilities\PriorityVenueAbilities;
+use ExtraChillEvents\Abilities\TicketSettlementAbilities;
+use ExtraChillEvents\Abilities\VenueBookingAbilities;
+use ExtraChillEvents\Abilities\VenueBookingCommunicationAbilities;
+use ExtraChillEvents\Abilities\VenueBookingEventAbilities;
+use ExtraChillEvents\Abilities\VenueBookingHoldAbilities;
+use ExtraChillEvents\Abilities\VenueMembershipAbilities;
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VenueMembershipService.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/VenueMembershipAbilities.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/PriorityVenueAbilities.php';
+
+/** Covers Events ability hooks when the registry initializes early on init. */
+final class AbilityRegistrationLifecycleTest extends BookingTestCase {
+
+	/** Prepare the minimal booking runtime. */
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'abilities' => array(),
+			'actions'   => array(),
+			'blog_id'   => 7,
+			'options'   => array(),
+		);
+		$GLOBALS['wpdb']           = new BookingWpdb(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Isolated test database double.
+	}
+
+	/**
+	 * Full-runtime registry resolution must retain every representative surface.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_full_runtime_early_registry_keeps_events_abilities_registered(): void {
+		$bootstrap = file_get_contents( dirname( __DIR__ ) . '/extrachill-events.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local test fixture.
+
+		$this->assertIsString( $bootstrap );
+		$this->assertStringContainsString( "add_action( 'plugins_loaded', array( \$this, 'init_abilities' ), 25 );", $bootstrap );
+		$this->assertStringNotContainsString( "add_action( 'init', array( \$this, 'init_abilities' ), 25 );", $bootstrap );
+		$this->assertStringContainsString( 'BookingSchema::is_ready()', $bootstrap );
+		$this->assertStringContainsString( 'LocalSupportSchema::is_ready()', $bootstrap );
+
+		new VenueBookingAbilities();
+		new VenueMembershipAbilities();
+		new VenueBookingHoldAbilities();
+		new VenueBookingEventAbilities();
+		new VenueBookingCommunicationAbilities();
+		new TicketSettlementAbilities();
+		new PriorityVenueAbilities();
+
+		new VenueBookingAbilities();
+		new VenueMembershipAbilities();
+		new VenueBookingHoldAbilities();
+		new VenueBookingEventAbilities();
+		new VenueBookingCommunicationAbilities();
+		new TicketSettlementAbilities();
+		new PriorityVenueAbilities();
+
+		$this->assertCount( 7, $GLOBALS['ec_test_filters']['wp_abilities_api_init'][10] );
+
+		define( 'WP_AGENT_RUNTIME', true );
+		add_action(
+			'init',
+			static function (): void {
+				do_action( 'wp_abilities_api_init' );
+			},
+			10
+		);
+		do_action( 'init' );
+
+		foreach (
+			array(
+				'extrachill/assign-venue-booking',
+				'extrachill/create-venue-membership',
+				'extrachill/create-booking-hold',
+				'extrachill/convert-booking-to-event',
+				'extrachill/send-booking-message',
+				'extrachill/finalize-booking-settlement',
+				'extrachill/list-priority-venues',
+			) as $ability_name
+		) {
+			$this->assertArrayHasKey( $ability_name, $GLOBALS['ec_artist_test']['abilities'] );
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- attach Events ability owners at `plugins_loaded:25`, immediately after schema installation at priority 20 and before any valid post-`init` ability-registry resolution
- preserve the existing `BookingSchema::is_ready()` and `LocalSupportSchema::is_ready()` gates
- add an early/full-runtime lifecycle regression covering booking assignment, membership, holds, event conversion, communication, settlement, and an existing non-booking ability, including duplicate-construction protection

## Root cause
WordPress initializes `WP_Abilities_Registry` lazily. Its first valid resolution after `init` fires the one-shot `wp_abilities_api_init` action. Extra Chill Events did not instantiate its ability owners and attach their callbacks until `init:25`, so a full Data Machine runtime resolving an ability earlier on `init` permanently initialized the registry without Events-owned callbacks.

## Lifecycle ordering
Booking and local-support schema installation remains at `plugins_loaded:20`. Events now runs `init_abilities` at `plugins_loaded:25`, after those readiness checks can succeed but before WordPress permits the registry to initialize. Ability classes continue registering only from `wp_abilities_api_init`, and their existing static guards prevent duplicate callback attachment.

## Test coverage
- `./vendor/bin/phpunit tests/AbilityRegistrationLifecycleTest.php`
- `./vendor/bin/phpunit --testsuite venue-membership-authorization`
- focused booking foundation, hold, conversion, communication, and ticket-settlement test files
- `homeboy review lint --changed-since origin/main` passes
- `homeboy review test --changed-since origin/main` was attempted but the WP Codebox adapter is blocked before test execution because `WP_CODEBOX_DB_HOST` is unavailable in the current environment
- the repository-wide plain PHPUnit command remains blocked by the documented missing WordPress test bootstrap (`WP_UnitTestCase` unavailable)

Closes #468