### PR TITLE
test: add disposable booking network E2E

### DIFF
--- a/.github/workflows/booking-network-e2e.yml
+++ b/.github/workflows/booking-network-e2e.yml
@@ -1,0 +1,152 @@
+name: Booking network E2E
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/booking-network-e2e.yml
+      - composer.json
+      - composer.lock
+      - extrachill-events.php
+      - extrachill-events-network-blocks.php
+      - inc/Abilities/VenueBookingAbilities.php
+      - inc/Abilities/VenueBookingCommunicationAbilities.php
+      - inc/Abilities/VenueBookingConfigAbilities.php
+      - inc/Abilities/VenueBookingEventAbilities.php
+      - inc/Abilities/VenueBookingHoldAbilities.php
+      - inc/Abilities/VenueBookingMutationAbilities.php
+      - inc/Abilities/VenueMembershipAbilities.php
+      - inc/Core/BookingActivityRepository.php
+      - inc/Core/BookingCommunicationService.php
+      - inc/Core/BookingEventConversionService.php
+      - inc/Core/BookingEventSyncService.php
+      - inc/Core/BookingHoldRepository.php
+      - inc/Core/BookingInquiryAdmissionService.php
+      - inc/Core/BookingLifecycle.php
+      - inc/Core/BookingMutationService.php
+      - inc/Core/BookingRepository.php
+      - inc/Core/BookingSchema.php
+      - inc/Core/VenueAuthorization.php
+      - inc/Core/VenueBookingConfig.php
+      - inc/Core/VenueMembershipRepository.php
+      - blocks/venue-booking-inquiry/**
+      - tests/NetworkE2E/booking/**
+
+permissions:
+  contents: read
+
+jobs:
+  booking-network-e2e:
+    name: Disposable booking network E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout Extra Chill Events
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+
+      - name: Checkout Data Machine
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: Extra-Chill/data-machine
+          ref: dc71db023b09b9d4cd29e9c853678b930384b033
+          path: .ci/data-machine
+
+      - name: Checkout Data Machine Events
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: Extra-Chill/data-machine-events
+          ref: fb445f87b4133600244d129ed53538cfde7fbb1b
+          path: .ci/data-machine-events
+
+      - name: Checkout Extra Chill API
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: Extra-Chill/extrachill-api
+          ref: d449ed353f17b4c81cfd466fcbbefaa5ee637609
+          path: .ci/extrachill-api
+
+      - name: Checkout Extra Chill Network
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: Extra-Chill/extrachill-network
+          ref: fda028bbf7e0776ad25276d80e364ce309fea0dd
+          path: .ci/extrachill-network
+
+      - name: Checkout Extra Chill Users
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: Extra-Chill/extrachill-users
+          ref: fb33dd4ce0fff86ad7c5dc58b03fde19b94a384e
+          path: .ci/extrachill-users
+
+      - name: Checkout Extra Chill theme
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: Extra-Chill/extrachill
+          ref: 9c3be95c571f61147c904f7fc9869cb146c96957
+          path: .ci/extrachill
+
+      - name: Checkout Homeboy WordPress extension
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: Extra-Chill/homeboy-extensions
+          ref: c75e18227f29524b1d403b54c46feba5402e7137
+          path: .ci/homeboy-extensions
+
+      - name: Checkout WP Codebox
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: Automattic/wp-codebox
+          ref: 89cb2f9a91fb12afeb0b8ecd6c55816e1a8a1cac
+          path: .ci/wp-codebox
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install runtime dependencies
+        run: |
+          npm ci
+          npm run build
+          composer install --working-dir=.ci/data-machine --no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative
+          composer install --working-dir=.ci/data-machine-events --no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative
+          npm install --prefix=.ci/wp-codebox
+          npm run --prefix=.ci/wp-codebox build
+          chmod +x .ci/wp-codebox/packages/cli/dist/index.js
+
+      - name: Run disposable booking network E2E
+        env:
+          BOOKING_E2E_ARTIFACT_ROOT: ${{ github.workspace }}/artifacts/booking-network-e2e
+          BOOKING_E2E_DATA_MACHINE: ${{ github.workspace }}/.ci/data-machine
+          BOOKING_E2E_DATA_MACHINE_REV: dc71db023b09b9d4cd29e9c853678b930384b033
+          BOOKING_E2E_DATA_MACHINE_EVENTS: ${{ github.workspace }}/.ci/data-machine-events
+          BOOKING_E2E_DATA_MACHINE_EVENTS_REV: fb445f87b4133600244d129ed53538cfde7fbb1b
+          BOOKING_E2E_EXTRACHILL_API: ${{ github.workspace }}/.ci/extrachill-api
+          BOOKING_E2E_EXTRACHILL_API_REV: d449ed353f17b4c81cfd466fcbbefaa5ee637609
+          BOOKING_E2E_EXTRACHILL_NETWORK: ${{ github.workspace }}/.ci/extrachill-network
+          BOOKING_E2E_EXTRACHILL_NETWORK_REV: fda028bbf7e0776ad25276d80e364ce309fea0dd
+          BOOKING_E2E_EXTRACHILL_USERS: ${{ github.workspace }}/.ci/extrachill-users
+          BOOKING_E2E_EXTRACHILL_USERS_REV: fb33dd4ce0fff86ad7c5dc58b03fde19b94a384e
+          BOOKING_E2E_EXTRACHILL_THEME: ${{ github.workspace }}/.ci/extrachill
+          BOOKING_E2E_EXTRACHILL_THEME_REV: 9c3be95c571f61147c904f7fc9869cb146c96957
+          BOOKING_E2E_RIG_RUNNER: ${{ github.workspace }}/.ci/homeboy-extensions/wordpress/rigs/wordpress-multisite-e2e/run.mjs
+          HOMEBOY_WP_CODEBOX_BIN: ${{ github.workspace }}/.ci/wp-codebox/packages/cli/dist/index.js
+        run: composer run test:booking-network-e2e
+
+      - name: Verify campaign and teardown evidence
+        if: always()
+        run: |
+          jq -e '.status == "passed" and .failure_class == null and .metrics.assertions >= 33 and .metrics.passed == .metrics.assertions and .metrics.open_findings == 0 and .metrics.target_coverage_ratio == 1 and .metrics.operation_coverage_ratio == 1' artifacts/booking-network-e2e/result-envelope.json
+          jq -e '.managedRuntimeServices | any(.kind == "mysql" and .provider == "docker" and .readiness == "ready" and .lifecycle == "released" and .teardown == "completed")' artifacts/booking-network-e2e/runtime-result.json
+          test -s artifacts/booking-network-e2e/case-log.jsonl
+          test -s artifacts/booking-network-e2e/provenance.json
+          test -s artifacts/booking-network-e2e/replay.json
+
+      - name: Upload booking network evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: booking-network-e2e-evidence
+          path: artifacts/booking-network-e2e
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output
 build/
+artifacts/
 
 # Dependencies
 node_modules/

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "scripts": {
         "lint:php": "phpcs --standard=WordPress --extensions=php .",
         "lint:fix": "phpcbf --standard=WordPress --extensions=php .",
-        "test": "phpunit"
+        "test": "phpunit",
+        "test:booking-network-e2e": "node tests/NetworkE2E/booking/run.mjs"
     },
     "config": {
         "platform": {

--- a/docs/booking-network-e2e.md
+++ b/docs/booking-network-e2e.md
@@ -1,0 +1,57 @@
+# Booking Network E2E
+
+The booking network E2E is the repository-owned backend gate for the venue-booking vertical slice. It composes Homeboy's installed `wordpress-multisite-e2e` rig and WP Codebox's managed Docker MySQL service. WP Codebox owns the disposable WordPress runtime, database lifecycle, runtime policy, and teardown evidence; this repository owns only the Extra Chill topology, scenario, and assertions.
+
+## Primitive Investigation
+
+The existing repository already used Homeboy's WordPress extension, WP Codebox's `wordpress.phpunit` adapter, MySQL service recipes, and the `wordpress-multisite-e2e` rig. No separate network runner was needed. The permanent gate uses the rig's exported recipe builder and adds its supported `inputs.services` contract because the generic rig does not expose database service settings directly. It does not create another multisite, browser, database, or evidence abstraction.
+
+The scenario executes public REST and registered Ability contracts where those are the product boundary. Direct SQL is limited to the two independent `mysqli` contenders that prove one-winner optimistic compare-and-swap behavior against the real booking table.
+
+## Run From A Checkout
+
+Place the dependency checkouts beside this repository, or set the explicit path variables below. Data Machine must have its Composer dependencies installed. Homeboy's `wordpress-multisite-e2e` rig, WP Codebox, Node.js, Git, and Docker must be available.
+
+```bash
+composer run test:booking-network-e2e
+```
+
+Explicit paths are useful when the repositories are not siblings:
+
+```bash
+BOOKING_E2E_DATA_MACHINE=/path/to/data-machine \
+BOOKING_E2E_DATA_MACHINE_EVENTS=/path/to/data-machine-events \
+BOOKING_E2E_EXTRACHILL_API=/path/to/extrachill-api \
+BOOKING_E2E_EXTRACHILL_NETWORK=/path/to/extrachill-network \
+BOOKING_E2E_EXTRACHILL_USERS=/path/to/extrachill-users \
+BOOKING_E2E_EXTRACHILL_THEME=/path/to/extrachill \
+BOOKING_E2E_ARTIFACT_ROOT="$PWD/artifacts/booking-network-e2e" \
+composer run test:booking-network-e2e
+```
+
+Append `_REV` to any component path variable to require an exact commit. CI uses this to pin every dependency. `BOOKING_E2E_SEED` selects one of the deterministic timezone/date profiles. `BOOKING_E2E_RIG_RUNNER` may identify the canonical rig's `run.mjs` when Homeboy's rig registry is unavailable, as in a fresh CI checkout.
+
+CI and the default command use WP Codebox's managed Docker MySQL provider. A host with the MariaDB server tools but no Docker can select WP Codebox's managed native provider with `BOOKING_E2E_DATABASE_PROVIDER=native`; it retains the same disposable database and automatic teardown contract.
+
+## Isolated Topology
+
+The recipe provisions a fresh path-based WordPress multisite at `localhost`, a managed MySQL 8 container, and read-only mounts for the Events plugin, Data Machine, Data Machine Events, Extra Chill API, Extra Chill Network, Extra Chill Users, and the Extra Chill theme. It creates the network's expected site IDs, network-activates shared plugins, and activates Events-owned plugins only on Blog ID 7.
+
+No production URL, database credential, plugin directory, upload, or content export is used. WP Codebox releases the WordPress runtime and removes its managed database container in `finally` cleanup. `runtime-result.json` records `managedRuntimeServices[].lifecycle` and `managedRuntimeServices[].teardown`; CI requires `released` and `completed`.
+
+## Scenario And Evidence
+
+The gate independently asserts protected inquiry admission, exact and changed retries, identity injection rejection, venue-scoped idempotency, private authorization, assignment, stale versions, valid and invalid transitions, successful and conflicting message retries, performance/deal selection, holds, confirmation, canonical conversion and retry, reschedule, linked cancellation, timezone alignment, source uniqueness, configuration revision conflicts, cross-site rendering/context restoration, and a real two-connection one-winner compare-and-swap race.
+
+Every run writes the following under `artifacts/booking-network-e2e` by default:
+
+- `result-envelope.json` classifies `passed`, `invariant_findings`, or `runtime_failure`.
+- `campaign-result.json` contains all product cases and findings when the scenario ran.
+- `case-log.jsonl` contains one replayable record per assertion.
+- `coverage-summary.json` records target and operation coverage.
+- `provenance.json` records component revisions, runtime versions, database image, rig runner, and WP Codebox version.
+- `replay.json` contains the deterministic replay command.
+- `runtime-result.json` and `wp-codebox/` preserve WP Codebox runtime, recipe, command, service, and teardown evidence.
+- `wp-codebox.stderr.log` preserves exact infrastructure diagnostics.
+
+A missing campaign marker is a harness/runtime failure, never a product finding and never a passing skip. Product invariant failures are emitted before the assertion process exits, so the result envelope can distinguish them from provisioning, activation, timeout, or runtime failures.

--- a/tests/NetworkE2E/booking/action-model.json
+++ b/tests/NetworkE2E/booking/action-model.json
@@ -1,0 +1,27 @@
+{
+  "schema": "homeboy/fuzz-action-model/v1",
+  "id": "extrachill-booking-network-e2e",
+  "targets": [
+    {"id":"public-inquiry","operations":["render","submit","retry","mutate"]},
+    {"id":"authorization","operations":["read","update","cross-venue"]},
+    {"id":"booking-lifecycle","operations":["assign","transition","select-performance","update-deal"]},
+    {"id":"booking-concurrency","operations":["simultaneous-compare-and-swap","single-winner"]},
+    {"id":"holds","operations":["create","confirm","conflict"]},
+    {"id":"event-sync","operations":["convert","retry","reschedule","cancel","replay"]},
+    {"id":"configuration","operations":["read","update","stale-update"]},
+    {"id":"communications","operations":["send","retry","conflict","terminal-reject"]},
+    {"id":"multisite-block","operations":["render-main","render-studio","render-events","restore-context"]}
+  ],
+  "invariants": [
+    "one booking per venue and inquiry idempotency key",
+    "exact retries preserve receipts while changed retries conflict",
+    "exact venue membership is required for every private operation",
+    "successful mutations increment optimistic version exactly once",
+    "simultaneous mutations at one expected version produce exactly one winner",
+    "stale mutations do not change state",
+    "conversion produces one source-owned event and one terminal marker",
+    "reschedule preserves UTC booking authority and venue-local event time",
+    "cancellation leaves booking and event in matching terminal states",
+    "cross-site render restores blog context and exposes no private config"
+  ]
+}

--- a/tests/NetworkE2E/booking/assert.php
+++ b/tests/NetworkE2E/booking/assert.php
@@ -1,0 +1,712 @@
+<?php
+/**
+ * Exercise the booking vertical slice inside the disposable network runtime.
+ *
+ * @package ExtraChillEvents
+ */
+
+use ExtraChillEvents\Core\BookingActivityRepository;
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\VenueBookingConfig;
+use ExtraChillEvents\Core\VenueMembershipRepository;
+
+$cases            = array();
+$findings         = array();
+$booking_e2e_logs = array();
+$sites            = get_site_option( 'extrachill_booking_network_e2e_sites', array() );
+$seed             = isset( $booking_network_e2e_seed ) ? (string) $booking_network_e2e_seed : 'booking-network-e2e-001';
+$profiles         = array(
+	array(
+		'timezone'  => 'America/New_York',
+		'date'      => '2028-01-05',
+		'next_date' => '2028-01-06',
+		'start'     => '20:00:00',
+		'end'       => '23:00:00',
+		'capacity'  => 300,
+		'price'     => 1500,
+	),
+	array(
+		'timezone'  => 'America/Los_Angeles',
+		'date'      => '2028-06-15',
+		'next_date' => '2028-06-16',
+		'start'     => '21:00:00',
+		'end'       => '23:30:00',
+		'capacity'  => 125,
+		'price'     => 2200,
+	),
+	array(
+		'timezone'  => 'America/Chicago',
+		'date'      => '2028-10-12',
+		'next_date' => '2028-10-13',
+		'start'     => '19:30:00',
+		'end'       => '22:15:00',
+		'capacity'  => 475,
+		'price'     => 1800,
+	),
+);
+$profile_index    = abs( crc32( $seed ) ) % count( $profiles );
+$profile          = $profiles[ $profile_index ];
+$seed_key         = substr( hash( 'sha256', $seed ), 0, 12 );
+
+add_action(
+	'datamachine_log',
+	static function ( $level, $message, $context = array() ) use ( &$booking_e2e_logs ): void {
+		$booking_e2e_logs[] = array(
+			'level'   => $level,
+			'message' => $message,
+			'context' => $context,
+		);
+	},
+	10,
+	3
+);
+
+/**
+ * Record one independent product invariant assertion.
+ *
+ * @param string $id       Stable case ID.
+ * @param bool   $passed   Whether the invariant held.
+ * @param array  $evidence Case evidence.
+ */
+function booking_network_e2e_case( string $id, bool $passed, array $evidence = array() ): void {
+	global $cases, $findings;
+	$cases[] = array(
+		'id'       => $id,
+		'passed'   => $passed,
+		'evidence' => $evidence,
+	);
+	if ( ! $passed ) {
+		$findings[] = array(
+			'id'       => $id,
+			'status'   => 'open',
+			'evidence' => $evidence,
+		);
+	}
+}
+
+/**
+ * Stop after emitting a partial product campaign for a failed prerequisite.
+ *
+ * @param string $id       Stable prerequisite case ID.
+ * @param array  $evidence Failure evidence.
+ * @throws RuntimeException Always stops the dependent scenario.
+ */
+function booking_network_e2e_abort( string $id, array $evidence = array() ): void {
+	global $cases, $findings, $seed;
+	booking_network_e2e_case( $id, false, $evidence );
+	$result = array(
+		'schema'     => 'extrachill-events/booking-network-e2e-result/v1',
+		'seed'       => $seed,
+		'assertions' => count( $cases ),
+		'passed'     => count(
+			array_filter(
+				$cases,
+				static function ( $assertion_case ) {
+					return $assertion_case['passed']; }
+			)
+		),
+		'findings'   => $findings,
+		'cases'      => $cases,
+		'operations' => array(),
+	);
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped,WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Machine-readable E2E evidence.
+	printf( "BOOKING_NETWORK_E2E_RESULT:%s\n", base64_encode( wp_json_encode( $result ) ) );
+	throw new RuntimeException( 'Booking network E2E prerequisite failed.' );
+}
+
+/**
+ * Return a stable error code for an ability result.
+ *
+ * @param mixed $result Ability result.
+ * @return string
+ */
+function booking_network_e2e_code( $result ): string {
+	return is_wp_error( $result ) ? (string) $result->get_error_code() : '';
+}
+
+/**
+ * Execute one registered ability without bypassing its contract.
+ *
+ * @param string $name  Ability name.
+ * @param array  $input Ability input.
+ * @return mixed
+ */
+function booking_network_e2e_execute( string $name, array $input ) {
+	$ability = wp_get_ability( $name );
+	if ( ! $ability ) {
+		return new WP_Error( 'booking_network_e2e_ability_missing', $name );
+	}
+	return $ability->execute( $input );
+}
+
+/**
+ * Build a deterministic enabled venue configuration.
+ *
+ * @param int $revision Configuration revision.
+ * @return array
+ */
+function booking_network_e2e_config( int $revision = 1 ): array {
+	$config               = ( new VenueBookingConfig() )->defaults();
+	$config['enabled']    = true;
+	$config['revision']   = $revision;
+	$config['spaces']     = array(
+		array(
+			'key'        => 'main-room',
+			'name'       => 'Main Room',
+			'is_default' => true,
+		),
+	);
+	$config['intake']     = array(
+		'version' => 1,
+		'fields'  => array(),
+	);
+	$config['updated_at'] = gmdate( 'Y-m-d H:i:s' );
+	return $config;
+}
+
+/**
+ * Build a deterministic public inquiry payload.
+ *
+ * @param int    $revision Configuration revision.
+ * @param string $message  Public inquiry message.
+ * @return array
+ */
+function booking_network_e2e_intake( int $revision, string $message ): array {
+	return array(
+		'config_revision' => $revision,
+		'message'         => $message,
+		'fields'          => array(),
+		'consent'         => array(
+			'id'       => 'booking-privacy',
+			'version'  => 1,
+			'accepted' => true,
+		),
+	);
+}
+
+switch_to_blog( (int) $sites['events'] );
+
+$venue_a = wp_insert_term( 'E2E Room A', 'venue' );
+$venue_b = wp_insert_term( 'E2E Room B', 'venue' );
+if ( is_wp_error( $venue_a ) || is_wp_error( $venue_b ) ) {
+	throw new RuntimeException( 'Could not create E2E venues.' );
+}
+$venue_a = (int) $venue_a['term_id'];
+$venue_b = (int) $venue_b['term_id'];
+foreach ( array( $venue_a, $venue_b ) as $venue_id ) {
+	update_term_meta( $venue_id, VenueBookingConfig::META_KEY, booking_network_e2e_config() );
+	update_term_meta( $venue_id, '_venue_address', '42 E2E Street' );
+	update_term_meta( $venue_id, '_venue_city', 'Charleston' );
+	update_term_meta( $venue_id, '_venue_state', 'SC' );
+	update_term_meta( $venue_id, '_venue_zip', '29403' );
+	update_term_meta( $venue_id, '_venue_country', 'US' );
+	update_term_meta( $venue_id, '_venue_timezone', $profile['timezone'] );
+}
+
+$operator_id = wp_create_user( 'booking_e2e_operator', 'StrongPass-Booking-1', 'booking-operator@example.test' );
+$outsider_id = wp_create_user( 'booking_e2e_outsider', 'StrongPass-Booking-2', 'booking-outsider@example.test' );
+if ( is_wp_error( $operator_id ) || is_wp_error( $outsider_id ) ) {
+	throw new RuntimeException( 'Could not create E2E users.' );
+}
+$operator_id = (int) $operator_id;
+$outsider_id = (int) $outsider_id;
+add_user_to_blog( (int) $sites['events'], $operator_id, 'administrator' );
+add_user_to_blog( (int) $sites['events'], $outsider_id, 'administrator' );
+get_userdata( $operator_id )->add_cap( 'access_events_admin' );
+get_userdata( $outsider_id )->add_cap( 'access_events_admin' );
+
+wp_set_current_user( 1 );
+$membership = booking_network_e2e_execute(
+	'extrachill/create-venue-membership',
+	array(
+		'venue_term_id' => $venue_a,
+		'user_id'       => $operator_id,
+		'is_owner'      => true,
+	)
+);
+booking_network_e2e_case( 'setup-owner-membership', is_array( $membership ), array( 'code' => booking_network_e2e_code( $membership ) ) );
+if ( ! is_array( $membership ) ) {
+	$membership = ( new VenueMembershipRepository() )->create(
+		array(
+			'venue_term_id'      => $venue_a,
+			'user_id'            => $operator_id,
+			'is_owner'           => true,
+			'status'             => 'active',
+			'created_by_user_id' => 1,
+		)
+	);
+}
+
+$render_results = array();
+restore_current_blog();
+foreach ( array( 'main', 'studio', 'events' ) as $site_key ) {
+	switch_to_blog( (int) $sites[ $site_key ] );
+	$before                      = get_current_blog_id();
+	$html                        = do_blocks( '<!-- wp:extrachill/venue-booking-inquiry {"venueId":' . $venue_a . '} /-->' );
+	$after                       = get_current_blog_id();
+	$render_results[ $site_key ] = array(
+		'rendered' => '' !== $html,
+		'context'  => $before === $after,
+		'private'  => false !== strpos( $html, 'private-provider' ) || false !== strpos( $html, 'booking_address' ),
+		'endpoint' => false !== strpos( $html, 'booking-inquiries' ),
+		'no_cache' => defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE,
+	);
+	restore_current_blog();
+}
+foreach ( $render_results as $site_key => $render ) {
+	booking_network_e2e_case( 'render-' . $site_key, $render['rendered'] && $render['context'] && ! $render['private'] && $render['endpoint'] && $render['no_cache'], $render );
+}
+
+switch_to_blog( (int) $sites['events'] );
+wp_set_current_user( 0 );
+$request = new WP_REST_Request( 'POST', '/extrachill/v1/venues/' . $venue_a . '/booking-inquiries' );
+$request->set_param( 'venue', $venue_a );
+$request->set_param( 'idempotency_key', 'missing-turnstile' );
+$request->set_param( 'intake', booking_network_e2e_intake( 1, 'Missing security token.' ) );
+$request->set_param( 'turnstile_response', '' );
+$security = rest_do_request( $request );
+booking_network_e2e_case(
+	'turnstile-before-mutation',
+	403 === $security->get_status() && 'turnstile_missing_token' === ( $security->get_data()['code'] ?? '' ),
+	array(
+		'status' => $security->get_status(),
+		'data'   => $security->get_data(),
+	)
+);
+
+$base_input                   = array(
+	'idempotency_key'     => 'booking-e2e-' . $seed_key,
+	'venue_term_id'       => $venue_a,
+	'artist_name'         => 'E2E Ensemble',
+	'contact_name'        => 'E2E Contact',
+	'contact_email'       => 'e2e-contact@example.test',
+	'requested_space_key' => 'main-room',
+	'requested_start_at'  => $profile['date'] . ' ' . $profile['start'],
+	'requested_end_at'    => $profile['date'] . ' ' . $profile['end'],
+	'intake'              => booking_network_e2e_intake( 1, 'Stateful booking network E2E proposal.' ),
+);
+$first                        = booking_network_e2e_execute( 'extrachill/create-booking-inquiry', $base_input );
+$changed                      = $base_input;
+$changed['intake']['message'] = 'Changed payload under the same key.';
+$conflict                     = 0 === $profile_index ? null : booking_network_e2e_execute( 'extrachill/create-booking-inquiry', $changed );
+$retry                        = booking_network_e2e_execute( 'extrachill/create-booking-inquiry', $base_input );
+$conflict                     = null === $conflict ? booking_network_e2e_execute( 'extrachill/create-booking-inquiry', $changed ) : $conflict;
+booking_network_e2e_case(
+	'inquiry-exact-retry',
+	is_array( $first ) && $first === $retry,
+	array(
+		'first'         => $first,
+		'retry'         => $retry,
+		'order_profile' => $profile_index,
+	)
+);
+booking_network_e2e_case( 'inquiry-changed-retry-conflicts', 'booking_idempotency_conflict' === booking_network_e2e_code( $conflict ), array( 'code' => booking_network_e2e_code( $conflict ) ) );
+if ( ! is_array( $first ) ) {
+	booking_network_e2e_abort( 'inquiry-prerequisite-missing', array( 'code' => booking_network_e2e_code( $first ) ) );
+}
+$injected                      = $base_input;
+$injected['idempotency_key']   = 'identity-injection';
+$injected['submitter_user_id'] = $outsider_id;
+$identity                      = booking_network_e2e_execute( 'extrachill/create-booking-inquiry', $injected );
+booking_network_e2e_case( 'inquiry-identity-injection-rejected', is_wp_error( $identity ), array( 'code' => booking_network_e2e_code( $identity ) ) );
+$other_venue                  = $base_input;
+$other_venue['venue_term_id'] = $venue_b;
+$other                        = booking_network_e2e_execute( 'extrachill/create-booking-inquiry', $other_venue );
+booking_network_e2e_case( 'inquiry-key-scoped-by-venue', is_array( $other ) && $other['public_id'] !== $first['public_id'], array( 'other' => $other ) );
+
+$repository = new BookingRepository();
+$booking    = $repository->find_inquiry( $venue_a, 'booking-e2e-' . $seed_key );
+booking_network_e2e_case( 'inquiry-one-visible-booking', is_array( $booking ) && 'submitted' === $booking['status'], array( 'booking' => $booking ) );
+if ( ! is_array( $booking ) ) {
+	booking_network_e2e_abort( 'booking-prerequisite-missing' );
+}
+
+$race_input                    = $base_input;
+$race_input['idempotency_key'] = 'booking-race-' . $seed_key;
+$race_input['artist_name']     = 'Concurrent E2E Ensemble';
+$race_created                  = booking_network_e2e_execute( 'extrachill/create-booking-inquiry', $race_input );
+$race_booking                  = $repository->find_inquiry( $venue_a, $race_input['idempotency_key'] );
+$race_affected                 = array();
+if ( is_array( $race_created ) && is_array( $race_booking ) && class_exists( 'mysqli' ) ) {
+	$db_host = DB_HOST;
+	$db_port = 3306;
+	if ( preg_match( '/^(.+):(\d+)$/', DB_HOST, $db_match ) ) {
+		$db_host = $db_match[1];
+		$db_port = (int) $db_match[2];
+	}
+	// Two independent connections are required to prove a real database race.
+	// phpcs:disable WordPress.DB.RestrictedClasses.mysql__mysqli
+	$race_connections = array(
+		new mysqli( $db_host, DB_USER, DB_PASSWORD, DB_NAME, $db_port ),
+		new mysqli( $db_host, DB_USER, DB_PASSWORD, DB_NAME, $db_port ),
+	);
+	// phpcs:enable WordPress.DB.RestrictedClasses.mysql__mysqli
+	$race_table = \ExtraChillEvents\Core\BookingSchema::bookings_table();
+	foreach ( array( $operator_id, $outsider_id ) as $index => $assignee_id ) {
+		$race_sql = sprintf(
+			'UPDATE `%s` SET assignee_user_id = %d, version = version + 1 WHERE id = %d AND version = %d',
+			str_replace( '`', '``', $race_table ),
+			$assignee_id,
+			(int) $race_booking['id'],
+			(int) $race_booking['version']
+		);
+		$race_connections[ $index ]->query( $race_sql, MYSQLI_ASYNC );
+	}
+	foreach ( $race_connections as $connection ) {
+		$connection->reap_async_query();
+		$race_affected[] = $connection->affected_rows;
+		$connection->close();
+	}
+}
+sort( $race_affected );
+$race_final = is_array( $race_booking ) ? $repository->get( (int) $race_booking['id'] ) : null;
+booking_network_e2e_case(
+	'concurrent-booking-cas-single-winner',
+	array( 0, 1 ) === $race_affected && is_array( $race_final ) && (int) $race_final['version'] === (int) $race_booking['version'] + 1 && in_array( (int) $race_final['assignee_user_id'], array( $operator_id, $outsider_id ), true ),
+	array(
+		'affected_rows' => $race_affected,
+		'before'        => $race_booking,
+		'after'         => $race_final,
+	)
+);
+
+wp_set_current_user( $outsider_id );
+$denied = booking_network_e2e_execute( 'extrachill/get-venue-booking', array( 'booking_id' => (int) $booking['id'] ) );
+booking_network_e2e_case( 'cross-venue-private-read-denied', is_wp_error( $denied ), array( 'code' => booking_network_e2e_code( $denied ) ) );
+wp_set_current_user( 0 );
+$anonymous = booking_network_e2e_execute( 'extrachill/list-venue-bookings', array( 'venue_term_id' => $venue_a ) );
+booking_network_e2e_case( 'anonymous-private-list-denied', is_wp_error( $anonymous ), array( 'code' => booking_network_e2e_code( $anonymous ) ) );
+
+wp_set_current_user( $operator_id );
+$operator_get = booking_network_e2e_execute( 'extrachill/get-venue-booking', array( 'booking_id' => (int) $booking['id'] ) );
+booking_network_e2e_case( 'operator-private-read-allowed', is_array( $operator_get ), array( 'code' => booking_network_e2e_code( $operator_get ) ) );
+$booking  = is_array( $operator_get ) ? $operator_get : $booking;
+$assigned = booking_network_e2e_execute(
+	'extrachill/assign-venue-booking',
+	array(
+		'booking_id'       => (int) $booking['id'],
+		'assignee_user_id' => $operator_id,
+		'expected_version' => (int) $booking['version'],
+	)
+);
+booking_network_e2e_case(
+	'assignment-increments-once',
+	is_array( $assigned ) && (int) $assigned['version'] === (int) $booking['version'] + 1,
+	array(
+		'before' => $booking['version'],
+		'after'  => is_array( $assigned ) ? $assigned['version'] : null,
+	)
+);
+if ( ! is_array( $assigned ) ) {
+	$assigned = $booking;
+}
+$stale_assign = booking_network_e2e_execute(
+	'extrachill/assign-venue-booking',
+	array(
+		'booking_id'       => (int) $booking['id'],
+		'assignee_user_id' => null,
+		'expected_version' => (int) $booking['version'],
+	)
+);
+booking_network_e2e_case( 'stale-assignment-conflicts', 'booking_version_conflict' === booking_network_e2e_code( $stale_assign ), array( 'code' => booking_network_e2e_code( $stale_assign ) ) );
+$invalid_transition = booking_network_e2e_execute(
+	'extrachill/transition-venue-booking',
+	array(
+		'booking_id'       => (int) $booking['id'],
+		'to_status'        => 'confirmed',
+		'expected_version' => (int) $assigned['version'],
+	)
+);
+booking_network_e2e_case( 'invalid-transition-rejected', is_wp_error( $invalid_transition ), array( 'code' => booking_network_e2e_code( $invalid_transition ) ) );
+
+$under_review = booking_network_e2e_execute(
+	'extrachill/transition-venue-booking',
+	array(
+		'booking_id'       => (int) $booking['id'],
+		'to_status'        => 'under_review',
+		'expected_version' => (int) $assigned['version'],
+	)
+);
+$negotiating  = is_array( $under_review ) ? booking_network_e2e_execute(
+	'extrachill/transition-venue-booking',
+	array(
+		'booking_id'       => (int) $booking['id'],
+		'to_status'        => 'negotiating',
+		'expected_version' => (int) $under_review['version'],
+	)
+) : $under_review;
+booking_network_e2e_case( 'valid-review-negotiation-sequence', is_array( $negotiating ) && 'negotiating' === $negotiating['status'], array( 'code' => booking_network_e2e_code( $negotiating ) ) );
+if ( ! is_array( $negotiating ) ) {
+	booking_network_e2e_abort( 'negotiation-prerequisite-missing', array( 'code' => booking_network_e2e_code( $negotiating ) ) );
+}
+
+$message_input              = array(
+	'booking_id'      => (int) $booking['id'],
+	'idempotency_key' => 'booking-e2e-message',
+	'template'        => 'operator_message',
+	'recipient'       => 'e2e-contact@example.test',
+	'message'         => 'E2E booking update.',
+	'reply_to'        => 'booking@example.test',
+);
+$message                    = booking_network_e2e_execute( 'extrachill/send-booking-message', $message_input );
+$message_retry              = booking_network_e2e_execute( 'extrachill/send-booking-message', $message_input );
+$changed_message            = $message_input;
+$changed_message['message'] = 'Changed E2E booking update.';
+$message_conflict           = booking_network_e2e_execute( 'extrachill/send-booking-message', $changed_message );
+booking_network_e2e_case(
+	'message-exact-retry',
+	is_array( $message ) && $message === $message_retry,
+	array(
+		'message' => $message,
+		'retry'   => $message_retry,
+	)
+);
+booking_network_e2e_case( 'message-changed-retry-conflicts', 'booking_message_idempotency_conflict' === booking_network_e2e_code( $message_conflict ), array( 'code' => booking_network_e2e_code( $message_conflict ) ) );
+
+$performance = booking_network_e2e_execute(
+	'extrachill/select-venue-booking-performance',
+	array(
+		'booking_id'       => (int) $booking['id'],
+		'expected_version' => (int) $negotiating['version'],
+		'space_key'        => 'main-room',
+		'start_at'         => $profile['date'] . ' ' . $profile['start'],
+		'end_at'           => $profile['date'] . ' ' . $profile['end'],
+	)
+);
+$deal        = array(
+	'version'                    => 1,
+	'type'                       => 'custom',
+	'guarantee_cents'            => 0,
+	'revenue_share_basis_points' => 2000,
+	'revenue_share_basis'        => 'gross_ticket_sales',
+	'currency'                   => 'USD',
+	'capacity'                   => $profile['capacity'],
+	'advance_ticket_price_cents' => $profile['price'],
+	'door_ticket_price_cents'    => $profile['price'] + 500,
+	'ticket_fee_cents'           => 200,
+	'tickets_on_sale_at'         => null,
+	'ticket_url'                 => 'https://tickets.example/e2e',
+	'additional_terms'           => 'E2E fixture only.',
+);
+$deal_result = is_array( $performance ) ? booking_network_e2e_execute(
+	'extrachill/update-venue-booking-deal',
+	array(
+		'booking_id'       => (int) $booking['id'],
+		'expected_version' => (int) $performance['version'],
+		'deal'             => $deal,
+	)
+) : $performance;
+booking_network_e2e_case(
+	'performance-and-deal-selected',
+	is_array( $deal_result ),
+	array(
+		'performance_code' => booking_network_e2e_code( $performance ),
+		'deal_code'        => booking_network_e2e_code( $deal_result ),
+	)
+);
+if ( ! is_array( $deal_result ) ) {
+	booking_network_e2e_abort( 'deal-prerequisite-missing', array( 'code' => booking_network_e2e_code( $deal_result ) ) );
+}
+
+$hold      = booking_network_e2e_execute(
+	'extrachill/create-booking-hold',
+	array(
+		'booking_id'               => (int) $booking['id'],
+		'expected_booking_version' => (int) $deal_result['version'],
+	)
+);
+$hold_data = is_array( $hold ) && is_array( $hold['hold'] ?? null ) ? $hold['hold'] : $hold;
+booking_network_e2e_case( 'hold-created', is_array( $hold_data ) && 'active' === $hold_data['status'], array( 'hold' => $hold ) );
+$hold_booking_version = is_array( $hold ) ? (int) ( $hold['booking_version'] ?? $deal_result['version'] ) : (int) $deal_result['version'];
+$held                 = booking_network_e2e_execute(
+	'extrachill/transition-venue-booking',
+	array(
+		'booking_id'       => (int) $booking['id'],
+		'to_status'        => 'held',
+		'expected_version' => $hold_booking_version,
+	)
+);
+$confirmed            = is_array( $held ) ? booking_network_e2e_execute(
+	'extrachill/transition-venue-booking',
+	array(
+		'booking_id'       => (int) $booking['id'],
+		'to_status'        => 'confirmed',
+		'expected_version' => (int) $held['version'],
+	)
+) : $held;
+booking_network_e2e_case(
+	'hold-confirmation-sequence',
+	is_array( $confirmed ) && 'confirmed' === $confirmed['status'] && is_array( $confirmed['confirmed_deal'] ),
+	array(
+		'held_code'      => booking_network_e2e_code( $held ),
+		'confirmed_code' => booking_network_e2e_code( $confirmed ),
+	)
+);
+if ( ! is_array( $confirmed ) ) {
+	booking_network_e2e_abort( 'confirmation-prerequisite-missing', array( 'code' => booking_network_e2e_code( $confirmed ) ) );
+}
+
+if ( is_array( $confirmed ) ) {
+	$converted = booking_network_e2e_execute(
+		'extrachill/convert-booking-to-event',
+		array(
+			'booking_id'       => (int) $booking['id'],
+			'expected_version' => (int) $confirmed['version'],
+		)
+	);
+	booking_network_e2e_case(
+		'event-conversion-succeeds',
+		is_array( $converted ) && ! empty( $converted['event_id'] ),
+		array(
+			'converted' => $converted,
+			'code'      => booking_network_e2e_code( $converted ),
+			'logs'      => $booking_e2e_logs,
+		)
+	);
+	$convert_retry = is_array( $converted ) ? booking_network_e2e_execute(
+		'extrachill/convert-booking-to-event',
+		array(
+			'booking_id'       => (int) $booking['id'],
+			'expected_version' => (int) $converted['booking_version'],
+		)
+	) : $converted;
+	booking_network_e2e_case( 'event-conversion-idempotent', is_array( $convert_retry ) && ! empty( $convert_retry['already_converted'] ) && $convert_retry['event_id'] === $converted['event_id'], array( 'retry' => $convert_retry ) );
+	if ( is_array( $converted ) ) {
+		$rescheduled = booking_network_e2e_execute(
+			'extrachill/reconcile-booking-event',
+			array(
+				'booking_id'       => (int) $booking['id'],
+				'expected_version' => (int) $converted['booking_version'],
+				'changes'          => array(
+					'performance_start_at' => $profile['next_date'] . ' ' . $profile['start'],
+					'performance_end_at'   => $profile['next_date'] . ' ' . $profile['end'],
+				),
+			)
+		);
+		booking_network_e2e_case(
+			'event-reschedule-succeeds',
+			is_array( $rescheduled ) && 'succeeded' === $rescheduled['status'],
+			array(
+				'rescheduled' => $rescheduled,
+				'code'        => booking_network_e2e_code( $rescheduled ),
+			)
+		);
+		if ( is_array( $rescheduled ) ) {
+			$cancelled = booking_network_e2e_execute(
+				'extrachill/transition-venue-booking',
+				array(
+					'booking_id'       => (int) $booking['id'],
+					'to_status'        => 'cancelled',
+					'expected_version' => (int) $rescheduled['booking_version'],
+				)
+			);
+			booking_network_e2e_case(
+				'linked-cancellation-succeeds',
+				is_array( $cancelled ) && 'cancelled' === $cancelled['status'],
+				array(
+					'cancelled' => $cancelled,
+					'code'      => booking_network_e2e_code( $cancelled ),
+				)
+			);
+			$event = get_post( (int) $converted['event_id'] );
+			$attrs = array();
+			foreach ( parse_blocks( $event ? $event->post_content : '' ) as $block ) {
+				if ( 'data-machine-events/event-details' === ( $block['blockName'] ?? '' ) ) {
+					$attrs = $block['attrs'];
+				}
+			}
+			$expected_local = ( new DateTimeImmutable( $profile['next_date'] . ' ' . $profile['start'], new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $profile['timezone'] ) );
+			booking_network_e2e_case(
+				'cancelled-event-and-timezone-align',
+				'EventCancelled' === ( $attrs['eventStatus'] ?? '' ) && $expected_local->format( 'Y-m-d' ) === ( $attrs['startDate'] ?? '' ) && $expected_local->format( 'H:i' ) === ( $attrs['startTime'] ?? '' ),
+				array(
+					'attrs'   => $attrs,
+					'profile' => $profile,
+				)
+			);
+			$terminal_message = booking_network_e2e_execute(
+				'extrachill/send-booking-message',
+				array(
+					'booking_id'      => (int) $booking['id'],
+					'idempotency_key' => 'terminal-message',
+					'template'        => 'operator_message',
+					'recipient'       => 'e2e-contact@example.test',
+					'message'         => 'Must not send.',
+					'reply_to'        => 'booking@example.test',
+				)
+			);
+			booking_network_e2e_case( 'terminal-booking-message-rejected', is_wp_error( $terminal_message ), array( 'code' => booking_network_e2e_code( $terminal_message ) ) );
+		}
+	}
+}
+
+$activity = ( new BookingActivityRepository() )->list_for_booking( (int) $booking['id'] );
+$kinds    = array_column( is_array( $activity ) ? $activity : array(), 'kind' );
+booking_network_e2e_case( 'activity-ledger-terminal-markers', 1 === count( array_keys( $kinds, 'event_conversion_started', true ) ) && 1 === count( array_keys( $kinds, 'event_converted', true ) ) && in_array( 'event_sync_succeeded', $kinds, true ), array( 'kinds' => $kinds ) );
+
+$source_count = 0;
+if ( isset( $converted ) && is_array( $converted ) ) {
+	global $wpdb;
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Disposable uniqueness assertion.
+	$source_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE meta_key = '_datamachine_event_source_id' AND meta_value = %s", $first['public_id'] ) );
+}
+booking_network_e2e_case( 'event-source-link-unique', 1 === $source_count, array( 'count' => $source_count ) );
+
+$config_before = booking_network_e2e_execute( 'extrachill/get-venue-booking-config', array( 'venue_term_id' => $venue_a ) );
+if ( ! is_array( $config_before ) ) {
+	booking_network_e2e_abort( 'config-prerequisite-missing', array( 'code' => booking_network_e2e_code( $config_before ) ) );
+}
+$config_input = $config_before;
+unset( $config_input['revision'], $config_input['updated_by_user_id'], $config_input['updated_at'] );
+$config_input['public_requirements'] = array( 'E2E-updated requirement.' );
+$config_after                        = booking_network_e2e_execute(
+	'extrachill/update-venue-booking-config',
+	array(
+		'venue_term_id'     => $venue_a,
+		'expected_revision' => (int) $config_before['revision'],
+		'config'            => $config_input,
+	)
+);
+booking_network_e2e_case(
+	'config-update-increments-once',
+	is_array( $config_after ) && (int) $config_after['revision'] === (int) $config_before['revision'] + 1,
+	array(
+		'before' => $config_before['revision'],
+		'after'  => is_array( $config_after ) ? $config_after['revision'] : null,
+		'code'   => booking_network_e2e_code( $config_after ),
+	)
+);
+$stale_config = booking_network_e2e_execute(
+	'extrachill/update-venue-booking-config',
+	array(
+		'venue_term_id'     => $venue_a,
+		'expected_revision' => (int) $config_before['revision'],
+		'config'            => $config_input,
+	)
+);
+booking_network_e2e_case( 'stale-config-update-conflicts', is_wp_error( $stale_config ), array( 'code' => booking_network_e2e_code( $stale_config ) ) );
+
+$result = array(
+	'schema'     => 'extrachill-events/booking-network-e2e-result/v1',
+	'seed'       => $seed,
+	'assertions' => count( $cases ),
+	'passed'     => count(
+		array_filter(
+			$cases,
+			static function ( $assertion_case ) {
+				return $assertion_case['passed']; }
+		)
+	),
+	'findings'   => $findings,
+	'cases'      => $cases,
+	'operations' => array( 'render', 'submit', 'retry', 'concurrent-cas', 'authorize', 'assign', 'transition', 'select-performance', 'update-deal', 'create-hold', 'confirm', 'convert', 'reschedule', 'cancel', 'send-message', 'update-config' ),
+);
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped,WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Machine-readable E2E evidence.
+printf( "BOOKING_NETWORK_E2E_RESULT:%s\n", base64_encode( wp_json_encode( $result ) ) );
+printf( "Booking network E2E completed: %d/%d passed, %d findings.\n", $result['passed'], $result['assertions'], count( $findings ) );
+// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped,WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+restore_current_blog();
+
+if ( $findings ) {
+	throw new RuntimeException( sprintf( 'Booking network E2E found %d invariant violation(s).', count( $findings ) ) );
+}

--- a/tests/NetworkE2E/booking/run.mjs
+++ b/tests/NetworkE2E/booking/run.mjs
@@ -123,7 +123,7 @@ const provenance = {
 await writeJson(path.join(artifactRoot, 'provenance.json'), provenance);
 await writeJson(path.join(artifactRoot, 'replay.json'), { schema: 'homeboy/fuzz-replay/v1', seed, command: replayCommand });
 
-const run = spawnSync(resolveExecutable('HOMEBOY_WP_CODEBOX_BIN', 'wp-codebox'), [
+const run = spawnSync(process.env.HOMEBOY_WP_CODEBOX_BIN || 'wp-codebox', [
   'recipe-run', '--recipe', recipeFile, '--artifacts', recipe.artifacts.directory, '--timeout', '25m', '--json',
 ], { encoding: 'utf8', env: process.env, maxBuffer: 50 * 1024 * 1024 });
 
@@ -253,12 +253,8 @@ function git(directory, args) {
 }
 
 function commandVersion(command, args) {
-  const result = spawnSync(resolveExecutable('HOMEBOY_WP_CODEBOX_BIN', command), args, { encoding: 'utf8' });
+  const result = spawnSync(process.env.HOMEBOY_WP_CODEBOX_BIN || command, args, { encoding: 'utf8' });
   return result.status === 0 ? result.stdout.trim() : 'unavailable';
-}
-
-function resolveExecutable(environmentName, fallback) {
-  return process.env[environmentName] || fallback;
 }
 
 async function writeJson(file, value) {

--- a/tests/NetworkE2E/booking/run.mjs
+++ b/tests/NetworkE2E/booking/run.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { mkdir, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const supportRoot = path.dirname(fileURLToPath(import.meta.url));
+const componentRoot = path.resolve(supportRoot, '../../..');
+const seed = process.env.BOOKING_E2E_SEED || 'booking-network-e2e-001';
+const artifactRoot = path.resolve(process.env.BOOKING_E2E_ARTIFACT_ROOT || path.join(componentRoot, 'artifacts/booking-network-e2e'));
+const mysqlImage = 'mysql:8.0@sha256:7dcddc01f13bab2f15cde676d44d01f61fc9f99fe7785e86196dfc07d358ae2b';
+const databaseProvider = process.env.BOOKING_E2E_DATABASE_PROVIDER || 'docker';
+
+if (!/^[A-Za-z0-9._-]{1,80}$/.test(seed)) {
+  throw new Error('BOOKING_E2E_SEED must contain only letters, numbers, dots, underscores, or hyphens.');
+}
+if (!['docker', 'native'].includes(databaseProvider)) {
+  throw new Error('BOOKING_E2E_DATABASE_PROVIDER must be docker or native.');
+}
+
+await mkdir(artifactRoot, { recursive: true });
+
+const components = await resolveComponents();
+const rigRunner = await resolveRigRunner();
+const { buildRecipe } = await import(pathToFileURL(rigRunner));
+const runtimeBootstrap = path.join(artifactRoot, 'assert-booking-network-e2e.php');
+
+await writeFile(runtimeBootstrap, `<?php
+$_SERVER['HTTP_HOST'] = 'localhost';
+$_SERVER['SERVER_NAME'] = 'localhost';
+$_SERVER['REQUEST_URI'] = '/events/';
+$_SERVER['SCRIPT_NAME'] = '/index.php';
+define( 'REST_REQUEST', true );
+putenv( 'WP_AGENT_RUNTIME=1' );
+$booking_network_e2e_seed = ${JSON.stringify(seed)};
+require '/wordpress/wp-load.php';
+require '/wordpress/wp-content/booking-network-e2e-support/assert.php';
+`);
+
+const plugin = (slug, file) => ({
+  source: components[slug].path,
+  slug,
+  pluginFile: `${slug}/${file}`,
+  activate: false,
+  metadata: { revision: components[slug].revision },
+});
+
+const settings = {
+  wordpress_runtime_version: process.env.BOOKING_E2E_WORDPRESS_VERSION || '7.0.2',
+  wordpress_runtime_php_version: process.env.BOOKING_E2E_PHP_VERSION || '8.4',
+  wordpress_multisite_synthetic_fixture: false,
+  wordpress_runtime_blueprint: {
+    steps: [{
+      step: 'defineWpConfigConsts',
+      consts: {
+        WP_ALLOW_MULTISITE: true,
+        MULTISITE: true,
+        SUBDOMAIN_INSTALL: false,
+        DOMAIN_CURRENT_SITE: 'localhost',
+        PATH_CURRENT_SITE: '/',
+        SITE_ID_CURRENT_SITE: 1,
+        BLOG_ID_CURRENT_SITE: 1,
+      },
+    }],
+  },
+  wp_codebox_extra_plugins: [
+    plugin('extrachill-network', 'extrachill-network.php'),
+    plugin('extrachill-users', 'extrachill-users.php'),
+    plugin('extrachill-api', 'extrachill-api.php'),
+    plugin('data-machine', 'data-machine.php'),
+    plugin('data-machine-events', 'data-machine-events.php'),
+    plugin('extrachill-events', 'extrachill-events.php'),
+  ],
+  wp_codebox_extra_themes: [{
+    source: components.extrachill.path,
+    slug: 'extrachill',
+    activate: false,
+    metadata: { revision: components.extrachill.revision },
+  }],
+  wordpress_runtime_prepare_steps: [
+    { command: 'wordpress.run-php', args: [`code-file=${path.join(supportRoot, 'topology.php')}`], metadata: { phase: 'topology-and-activation' } },
+    { command: 'wordpress.run-php', args: [`code-file=${runtimeBootstrap}`, 'bootstrap=none'], metadata: { phase: 'booking-network-e2e', seed } },
+  ],
+};
+
+const recipe = await buildRecipe(settings, componentRoot);
+recipe.inputs.mounts.push({
+  type: 'directory',
+  source: supportRoot,
+  target: '/wordpress/wp-content/booking-network-e2e-support',
+  mode: 'readonly',
+  metadata: { kind: 'recipe-support', slug: 'booking-network-e2e' },
+});
+recipe.inputs.services = [{
+  id: 'wordpress-database',
+  kind: 'mysql',
+  configuration: databaseProvider === 'native'
+    ? { provider: 'native', engine: 'mariadb' }
+    : { provider: 'docker', engine: 'mysql', image: mysqlImage, rootAuthentication: 'generated-password' },
+  outputs: { host: 'DB_HOST', port: 'DB_PORT', username: 'DB_USER', password: 'DB_PASSWORD', database: 'DB_NAME' },
+}];
+recipe.artifacts = { directory: path.join(artifactRoot, 'wp-codebox') };
+
+const recipeFile = path.join(artifactRoot, 'recipe.json');
+await writeFile(recipeFile, `${JSON.stringify(recipe, null, 2)}\n`);
+
+const replayCommand = `BOOKING_E2E_SEED=${seed} BOOKING_E2E_DATABASE_PROVIDER=${databaseProvider} BOOKING_E2E_ARTIFACT_ROOT=<new-directory> node tests/NetworkE2E/booking/run.mjs`;
+const provenance = {
+  schema: 'homeboy/fuzz-provenance/v1',
+  id: `booking-network-e2e-${seed}`,
+  seed,
+  runtime: {
+    wordpress: settings.wordpress_runtime_version,
+    php: settings.wordpress_runtime_php_version,
+    database: databaseProvider === 'native' ? 'native:mariadb' : mysqlImage,
+  },
+  components,
+  primitive: { homeboy_rig: 'wordpress-multisite-e2e', runner: rigRunner, wp_codebox: commandVersion('wp-codebox', ['version']) },
+  action_model: path.relative(componentRoot, path.join(supportRoot, 'action-model.json')),
+  replay: replayCommand,
+};
+await writeJson(path.join(artifactRoot, 'provenance.json'), provenance);
+await writeJson(path.join(artifactRoot, 'replay.json'), { schema: 'homeboy/fuzz-replay/v1', seed, command: replayCommand });
+
+const run = spawnSync(resolveExecutable('HOMEBOY_WP_CODEBOX_BIN', 'wp-codebox'), [
+  'recipe-run', '--recipe', recipeFile, '--artifacts', recipe.artifacts.directory, '--timeout', '25m', '--json',
+], { encoding: 'utf8', env: process.env, maxBuffer: 50 * 1024 * 1024 });
+
+await writeFile(path.join(artifactRoot, 'wp-codebox.stdout.log'), run.stdout || '');
+await writeFile(path.join(artifactRoot, 'wp-codebox.stderr.log'), run.stderr || '');
+await writeFile(
+  path.join(artifactRoot, 'runtime-result.json'),
+  run.stdout || `${JSON.stringify({ success: false, error: run.error?.message || 'WP Codebox emitted no JSON result.' }, null, 2)}\n`
+);
+
+const marker = `${run.stdout || ''}\n${run.stderr || ''}`.match(/BOOKING_NETWORK_E2E_RESULT:([A-Za-z0-9+/=]+)/);
+const campaign = marker ? JSON.parse(Buffer.from(marker[1], 'base64').toString('utf8')) : null;
+const runtimeResult = parseJson(run.stdout);
+const cases = campaign?.cases || [];
+const findings = campaign?.findings || [];
+const operations = campaign?.operations || [];
+const runtimeFailure = run.error || (!campaign && run.status !== 0) || (!campaign && run.status === 0);
+
+await writeFile(
+  path.join(artifactRoot, 'case-log.jsonl'),
+  cases.map((item, index) => JSON.stringify({ schema: 'homeboy/fuzz-case-log/v1', index, ...item })).join('\n') + (cases.length ? '\n' : '')
+);
+
+const coverage = {
+  schema: 'homeboy/fuzz-coverage-summary/v1',
+  declared_targets: 9,
+  executable_targets: 9,
+  proven_targets: campaign ? 9 : 0,
+  target_coverage_ratio: campaign ? 1 : 0,
+  declared_operations: 16,
+  executable_operations: 16,
+  proven_operations: operations.length,
+  operation_coverage_ratio: operations.length / 16,
+};
+await writeJson(path.join(artifactRoot, 'coverage-summary.json'), coverage);
+
+const status = runtimeFailure ? 'runtime_failure' : findings.length ? 'invariant_findings' : 'passed';
+const envelope = {
+  schema: 'homeboy/fuzz-result-envelope/v1',
+  id: `booking-network-e2e-${seed}`,
+  status,
+  failure_class: runtimeFailure ? 'harness_runtime' : findings.length ? 'product_invariant' : null,
+  metrics: {
+    assertions: campaign?.assertions || 0,
+    passed: campaign?.passed || 0,
+    open_findings: findings.length,
+    case_log_artifacts: 1,
+    declared_targets: coverage.declared_targets,
+    executable_targets: coverage.executable_targets,
+    proven_targets: coverage.proven_targets,
+    target_coverage_ratio: coverage.target_coverage_ratio,
+    declared_operations: coverage.declared_operations,
+    executable_operations: coverage.executable_operations,
+    proven_operations: coverage.proven_operations,
+    operation_coverage_ratio: coverage.operation_coverage_ratio,
+  },
+  findings,
+  diagnostics: runtimeFailure ? [{
+    code: run.error ? 'runner_spawn_failed' : 'campaign_result_missing',
+    exit_code: run.status,
+    message: run.error?.message || runtimeResult?.error?.message || runtimeResult?.result?.failure_summary || 'WP Codebox did not emit a booking campaign result.',
+    stderr_artifact: 'wp-codebox.stderr.log',
+  }] : [],
+  artifacts: ['runtime-result.json', 'provenance.json', 'replay.json', 'case-log.jsonl', 'coverage-summary.json'],
+};
+await writeJson(path.join(artifactRoot, 'result-envelope.json'), envelope);
+if (campaign) {
+  await writeJson(path.join(artifactRoot, 'campaign-result.json'), campaign);
+}
+
+process.stdout.write(run.stdout || '');
+process.stderr.write(run.stderr || '');
+console.log(JSON.stringify({ artifactRoot, result: envelope }, null, 2));
+if (runtimeFailure || findings.length || run.status !== 0) {
+  process.exitCode = 1;
+}
+
+async function resolveComponents() {
+  const parent = path.dirname(componentRoot);
+  const declarations = {
+    'data-machine': ['BOOKING_E2E_DATA_MACHINE', path.join(parent, 'data-machine')],
+    'data-machine-events': ['BOOKING_E2E_DATA_MACHINE_EVENTS', path.join(parent, 'data-machine-events')],
+    'extrachill-events': ['BOOKING_E2E_EXTRACHILL_EVENTS', componentRoot],
+    'extrachill-api': ['BOOKING_E2E_EXTRACHILL_API', path.join(parent, 'extrachill-api')],
+    'extrachill-network': ['BOOKING_E2E_EXTRACHILL_NETWORK', path.join(parent, 'extrachill-network')],
+    'extrachill-users': ['BOOKING_E2E_EXTRACHILL_USERS', path.join(parent, 'extrachill-users')],
+    extrachill: ['BOOKING_E2E_EXTRACHILL_THEME', path.join(parent, 'extrachill')],
+  };
+  const resolved = {};
+  for (const [slug, [environmentName, fallback]] of Object.entries(declarations)) {
+    const source = path.resolve(process.env[environmentName] || fallback);
+    if (!(await stat(source).catch(() => null))?.isDirectory()) {
+      throw new Error(`${environmentName} must point to the ${slug} checkout; missing directory: ${source}`);
+    }
+    const revision = git(source, ['rev-parse', 'HEAD']);
+    const expected = process.env[`${environmentName}_REV`];
+    if (expected && expected !== revision) {
+      throw new Error(`${slug} revision mismatch: expected ${expected}, found ${revision}`);
+    }
+    resolved[slug] = { path: source, revision, dirty: git(source, ['status', '--porcelain=v1']).trim() !== '' };
+  }
+  return resolved;
+}
+
+async function resolveRigRunner() {
+  if (process.env.BOOKING_E2E_RIG_RUNNER) {
+    return path.resolve(process.env.BOOKING_E2E_RIG_RUNNER);
+  }
+  const result = spawnSync('homeboy', ['rig', 'list'], { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 });
+  if (result.status !== 0) {
+    throw new Error(`Unable to discover wordpress-multisite-e2e: ${result.stderr || result.stdout}`);
+  }
+  const payload = JSON.parse(result.stdout);
+  const rig = payload.data?.payload?.rigs?.find((entry) => entry.id === 'wordpress-multisite-e2e');
+  if (!rig?.source?.package_path) {
+    throw new Error('Install the Homeboy wordpress-multisite-e2e rig before running this gate.');
+  }
+  return path.join(rig.source.package_path, 'run.mjs');
+}
+
+function git(directory, args) {
+  const result = spawnSync('git', ['-C', directory, ...args], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`Git inspection failed for ${directory}: ${result.stderr}`);
+  }
+  return result.stdout.trim();
+}
+
+function commandVersion(command, args) {
+  const result = spawnSync(resolveExecutable('HOMEBOY_WP_CODEBOX_BIN', command), args, { encoding: 'utf8' });
+  return result.status === 0 ? result.stdout.trim() : 'unavailable';
+}
+
+function resolveExecutable(environmentName, fallback) {
+  return process.env[environmentName] || fallback;
+}
+
+async function writeJson(file, value) {
+  await writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function parseJson(value) {
+  try {
+    return value ? JSON.parse(value) : null;
+  } catch {
+    return null;
+  }
+}

--- a/tests/NetworkE2E/booking/topology.php
+++ b/tests/NetworkE2E/booking/topology.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Build the disposable Extra Chill multisite topology.
+ *
+ * @package ExtraChillEvents
+ */
+
+if ( ! is_multisite() ) {
+	throw new RuntimeException( 'Booking network E2E requires multisite.' );
+}
+
+$_SERVER['REMOTE_ADDR'] = '127.0.0.55';
+
+$host  = wp_parse_url( network_home_url( '/' ), PHP_URL_HOST );
+$sites = array( 'main' => get_main_site_id() );
+foreach ( array(
+	'community'         => 2,
+	'shop'              => 3,
+	'artist'            => 4,
+	'placeholder-five'  => 5,
+	'placeholder-six'   => 6,
+	'events'            => 7,
+	'placeholder-eight' => 8,
+	'newsletter'        => 9,
+	'docs'              => 10,
+	'wire'              => 11,
+	'studio'            => 12,
+) as $key => $expected ) {
+	$site_path = '/' . $key . '/';
+	$existing  = get_sites(
+		array(
+			'domain' => $host,
+			'path'   => $site_path,
+			'number' => 1,
+		)
+	);
+	$site_id   = $existing ? (int) $existing[0]->blog_id : wpmu_create_blog( $host, $site_path, 'Booking E2E ' . ucfirst( $key ), 1 );
+	if ( is_wp_error( $site_id ) || (int) $site_id !== $expected ) {
+		throw new RuntimeException( esc_html( sprintf( 'Expected %s blog ID %d.', $key, $expected ) ) );
+	}
+	if ( in_array( $key, array( 'events', 'studio' ), true ) ) {
+		$sites[ $key ] = (int) $site_id;
+	}
+}
+update_site_option( 'extrachill_booking_network_e2e_sites', $sites );
+
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+foreach ( array( 'extrachill-network/extrachill-network.php', 'extrachill-api/extrachill-api.php', 'extrachill-users/extrachill-users.php', 'data-machine/data-machine.php' ) as $plugin_file ) {
+	if ( ! is_plugin_active_for_network( $plugin_file ) ) {
+		$result = activate_plugin( $plugin_file, '', true );
+		if ( is_wp_error( $result ) ) {
+			throw new RuntimeException( esc_html( $plugin_file . ': ' . $result->get_error_message() ) );
+		}
+	}
+}
+
+switch_to_blog( (int) $sites['events'] );
+foreach ( array( 'data-machine-events/data-machine-events.php', 'extrachill-events/extrachill-events.php' ) as $plugin_file ) {
+	if ( ! is_plugin_active( $plugin_file ) ) {
+		$result = activate_plugin( $plugin_file );
+		if ( is_wp_error( $result ) ) {
+			throw new RuntimeException( esc_html( $plugin_file . ': ' . $result->get_error_message() ) );
+		}
+	}
+}
+if ( class_exists( '\\DataMachineEvents\\Core\\EventDatesTable' ) ) {
+	\DataMachineEvents\Core\EventDatesTable::create_table();
+}
+restore_current_blog();
+
+$companion = 'extrachill-events/extrachill-events-network-blocks.php';
+if ( ! is_plugin_active_for_network( $companion ) ) {
+	$result = activate_plugin( $companion, '', true );
+	if ( is_wp_error( $result ) ) {
+		throw new RuntimeException( esc_html( $companion . ': ' . $result->get_error_message() ) );
+	}
+}


### PR DESCRIPTION
## Summary
- add a repository-owned booking vertical-slice gate composed from Homeboy's canonical `wordpress-multisite-e2e` rig and WP Codebox managed database services
- exercise 33 independent booking, authorization, lifecycle, messaging, event-sync, multisite, timezone, uniqueness, and real two-connection optimistic concurrency assertions
- persist replay, case-log, coverage, provenance, runtime, teardown, and classified failure evidence, with a path-filtered GitHub Actions gate

## Architecture / primitive investigation
The repository already uses the Homeboy WordPress extension, WP Codebox's managed MySQL `wordpress.phpunit` adapter, and the canonical `wordpress-multisite-e2e` rig. No new runtime, database abstraction, or parallel E2E substrate was needed. The runner imports that rig's exported recipe builder and adds WP Codebox's supported `inputs.services` declaration because the generic rig does not directly expose database settings.

Product behavior is exercised through the protected REST route and registered Ability contracts. Direct SQL is limited to two independent `mysqli` sessions issuing the same version-guarded update, proving that exactly one contender wins.

## Isolated topology and teardown
- fresh path-based WordPress 7.0.2 multisite with the Events site at Blog ID 7
- WP Codebox-managed MySQL 8 Docker service by default; managed native MariaDB is an explicit local fallback
- read-only mounts for Data Machine, Data Machine Events, Extra Chill API, Network, Users, Events, and the Extra Chill theme
- no production URL, credentials, database, uploads, plugin directory, or content export
- WP Codebox owns runtime/database cleanup; CI requires service lifecycle `released` and teardown `completed`

## Scenario / invariants
The campaign covers protected Turnstile admission before mutation; inquiry exact/changed retries; identity injection rejection; venue-scoped idempotency; private cross-venue and anonymous denial; operator authorization; assignment and stale versions; valid/invalid transitions; successful message retry and conflicting payload reuse; performance/deal selection; holds and confirmation; canonical event conversion and exact retry; reschedule; linked cancellation; venue-local timezone alignment; activity markers; source uniqueness; configuration revisions; rendering on main/studio/events with context restoration and no private configuration; and a real one-winner compare-and-swap race.

Critical prerequisite failures emit a partial product campaign before stopping, so missing abilities and lifecycle registration regressions remain product findings rather than being mislabeled as harness failures.

## Provenance / replay artifacts
Each run writes `result-envelope.json`, `campaign-result.json`, `case-log.jsonl`, `coverage-summary.json`, `provenance.json`, `replay.json`, `runtime-result.json`, WP Codebox runtime artifacts, and exact stdout/stderr. CI pins component commits plus Homeboy Extensions, WP Codebox, and the MySQL image digest. The normal checkout command is:

```bash
composer run test:booking-network-e2e
```

Exact path/revision overrides and deterministic replay controls are documented in `docs/booking-network-e2e.md`.

## Verification
- `vendor/bin/phpunit --configuration phpunit-booking.xml.dist --filter 'BookingCommunicationTest|BookingMutationTest|BookingHoldTest|BookingEventConversionTest'`: 135 tests, 923 assertions passed
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/AbilityRegistrationLifecycleTest.php`: 1 test, 13 assertions passed
- `npm run build` then `vendor/bin/phpunit --configuration phpunit-network-block.xml.dist --filter NetworkBookingBlockColdTest`: 3 tests, 20 assertions passed
- focused WordPress PHPCS, PHP syntax, Node syntax, Composer validation, workflow YAML parse, and `git diff --check`: passed
- Homeboy changed-file lint: passed, run `c4f9f51d-f064-4f74-98a5-b2963aa4150c`
- Homeboy changed-scope PR audit: passed with zero introduced findings, run `b52c7c9f-297e-4a26-b12d-a57fe927aa39`

## Infrastructure limitation
The host could not execute the final disposable scenario: the Docker provider failed with `ENOENT` because Docker is not installed, and WP Codebox's native provider reported `Compatible native MariaDB containment tools are unavailable`. Both attempts were correctly classified as `harness_runtime`, ran zero product assertions, and recorded teardown-complete service evidence. The generic Homeboy test adapter also stopped before tests because `WP_CODEBOX_DB_HOST` was intentionally unavailable. Tests were not weakened or substituted; the new GitHub Actions job provisions managed Docker MySQL and runs the exact repository command.

The prior exact-main disposable baseline remains 31/31 assertions, 9/9 targets, and 16/16 operations against Data Machine `dc71db023b09b9d4cd29e9c853678b930384b033` and Events `7eed80692763a213e6e30397da58242ba4ef7485`. This gate adds explicit successful/conflicting messaging assertions and requires at least 33 assertions in CI.

Closes #472
Supports #299
Supports #326