### PR TITLE
feat: add booking performance reporting abilities

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -306,6 +306,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/TicketReconciliationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/TicketSettlementService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ShowSettlementService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingReportingService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueProfile.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/CanonicalEventPublicationGuard.php';
 		\ExtraChillEvents\Core\BookingHoldRepository::register();
@@ -447,6 +448,9 @@ class ExtraChillEvents {
 
 			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/ShowSettlementAbilities.php';
 			new \ExtraChillEvents\Abilities\ShowSettlementAbilities();
+
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/BookingReportingAbilities.php';
+			new \ExtraChillEvents\Abilities\BookingReportingAbilities();
 		}
 
 		if ( \ExtraChillEvents\Core\LocalSupportSchema::is_ready() ) {

--- a/inc/Abilities/BookingReportingAbilities.php
+++ b/inc/Abilities/BookingReportingAbilities.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Venue booking performance and finance reporting abilities.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+// Repository convention uses PSR-4 class names and concise method comments.
+// phpcs:disable WordPress.Files.FileName,Generic.Commenting,Squiz.Commenting
+
+use ExtraChillEvents\Core\BookingReportingService;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Registers stable read-only reports over canonical booking records. */
+class BookingReportingAbilities {
+	private static bool $registered = false;
+	/** @var BookingReportingService */
+	private $service;
+
+	public function __construct( ?BookingReportingService $service = null ) {
+		$this->service = $service ? $service : new BookingReportingService();
+		if ( ! self::$registered ) {
+			// @phpstan-ignore arguments.count
+			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+			self::$registered = true;
+		}
+	}
+
+	/** Register operational and finance projections. */
+	public function register(): void {
+		$this->register_ability( 'extrachill/get-venue-booking-performance-report', __( 'Get Venue Booking Performance Report', 'extrachill-events' ), 'operations', 'can_read_operations', $this->operations_schema() );
+		$this->register_ability( 'extrachill/get-venue-booking-revenue-report', __( 'Get Venue Booking Revenue Report', 'extrachill-events' ), 'finance', 'can_read_finance', $this->finance_schema() );
+	}
+
+	private function register_ability( string $name, string $label, string $execute, string $permission, array $output ): void {
+		wp_register_ability(
+			$name,
+			array(
+				'label'               => $label,
+				'description'         => $label,
+				'category'            => 'extrachill-events',
+				'input_schema'        => $this->input_schema( 'finance' === $execute ),
+				'output_schema'       => $output,
+				'execute_callback'    => array( $this, $execute ),
+				'permission_callback' => array( $this, $permission ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => true,
+						'idempotent'  => true,
+						'destructive' => false,
+					),
+				),
+			)
+		);
+	}
+
+	public function operations( array $input ) {
+		return $this->service->operations( $input, get_current_user_id() );
+	}
+
+	public function finance( array $input ) {
+		return $this->service->finance( $input, get_current_user_id() );
+	}
+
+	public function can_read_operations( array $input ) {
+		$result = $this->service->authorize_operations( $input, get_current_user_id() );
+		return $result instanceof \WP_Error ? $result : true;
+	}
+
+	public function can_read_finance( array $input ) {
+		$result = $this->service->authorize_finance( $input, get_current_user_id() );
+		return $result instanceof \WP_Error ? $result : true;
+	}
+
+	private function input_schema( bool $finance ): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'venue_term_ids' => array(
+					'type'        => 'array',
+					'minItems'    => 1,
+					'maxItems'    => BookingReportingService::MAX_VENUES,
+					'uniqueItems' => true,
+					'items'       => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+					),
+				),
+				'from'           => $this->datetime(),
+				'to'             => $this->datetime(),
+				'limit'          => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+					'maximum' => $finance ? BookingReportingService::MAX_FINANCE_BOOKINGS : BookingReportingService::MAX_BOOKINGS,
+				),
+			),
+			'required'             => array( 'venue_term_ids', 'from', 'to' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function operations_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'scope'        => $this->scope_schema(),
+				'state'        => array(
+					'type' => 'string',
+					'enum' => array( 'empty', 'incomplete', 'complete' ),
+				),
+				'bounded'      => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
+				'availability' => array(
+					'type'                 => 'object',
+					'additionalProperties' => array( 'type' => 'string' ),
+				),
+				'funnel'       => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
+				'operations'   => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
+				'marketing'    => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
+			),
+			'required'             => array( 'scope', 'state', 'bounded', 'availability', 'funnel', 'operations', 'marketing' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function finance_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'scope'                    => $this->scope_schema(),
+				'state'                    => array(
+					'type' => 'string',
+					'enum' => array( 'empty', 'incomplete', 'corrected', 'finalized' ),
+				),
+				'bounded'                  => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
+				'coverage'                 => array(
+					'type'                 => 'object',
+					'additionalProperties' => array( 'type' => 'integer' ),
+				),
+				'commission_statuses'      => array(
+					'type'                 => 'object',
+					'additionalProperties' => array( 'type' => 'integer' ),
+				),
+				'show_settlement_statuses' => array(
+					'type'                 => 'object',
+					'additionalProperties' => array( 'type' => 'integer' ),
+				),
+				'currencies'               => array(
+					'type'                 => 'object',
+					'additionalProperties' => array(
+						'type'                 => 'object',
+						'additionalProperties' => array( 'type' => 'integer' ),
+					),
+				),
+			),
+			'required'             => array( 'scope', 'state', 'bounded', 'coverage', 'commission_statuses', 'show_settlement_statuses', 'currencies' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function scope_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'venue_term_ids' => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'integer' ),
+				),
+				'from'           => $this->datetime(),
+				'to'             => $this->datetime(),
+				'timezone'       => array(
+					'type' => 'string',
+					'enum' => array( 'UTC' ),
+				),
+				'interval'       => array(
+					'type' => 'string',
+					'enum' => array( 'half_open' ),
+				),
+				'basis'          => array(
+					'type' => 'string',
+					'enum' => array( 'inquiry_created_at', 'performance_start_at' ),
+				),
+				'outcomes_as_of' => $this->datetime(),
+			),
+			'required'             => array( 'venue_term_ids', 'from', 'to', 'timezone', 'interval', 'basis', 'outcomes_as_of' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	private function datetime(): array {
+		return array(
+			'type'    => 'string',
+			'pattern' => '^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$',
+		);
+	}
+}

--- a/inc/Core/BookingReportingService.php
+++ b/inc/Core/BookingReportingService.php
@@ -1,0 +1,553 @@
+<?php
+/**
+ * Bounded reporting projections over canonical venue-booking records.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+// Repository convention uses PSR-4 class names and concise method comments.
+// phpcs:disable WordPress.Files.FileName,Generic.Commenting,Squiz.Commenting
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Builds private venue reports without introducing another analytics store. */
+class BookingReportingService {
+	public const MAX_VENUES           = 20;
+	public const MAX_RANGE_DAYS       = 366;
+	public const MAX_BOOKINGS         = 200;
+	public const MAX_FINANCE_BOOKINGS = 25;
+	private const MAX_ACTIVITIES      = 5000;
+	private const REPORTING_KINDS     = array(
+		'inquiry_submitted',
+		'status_changed',
+		'deal_confirmed',
+		'event_conversion_started',
+		'event_conversion_failed',
+		'event_converted',
+		'event_sync_started',
+		'event_sync_retryable',
+		'event_sync_failed',
+		'event_sync_conflict',
+		'event_sync_succeeded',
+		'event_sync_noop',
+		'marketing_operation_submitted',
+		'marketing_operation_failed',
+		'marketing_operation_approval_failed',
+		'marketing_operation_trigger_failed',
+		'marketing_operation_denied',
+	);
+
+	/** @var VenueAuthorization */
+	private $authorization;
+	/** @var TicketSettlementService */
+	private $commissions;
+	/** @var ShowSettlementService */
+	private $shows;
+	/** @var callable|null */
+	private $snapshot_reader;
+
+	public function __construct( ?VenueAuthorization $authorization = null, ?TicketSettlementService $commissions = null, ?ShowSettlementService $shows = null, ?callable $snapshot_reader = null ) {
+		$this->authorization   = $authorization ? $authorization : new VenueAuthorization();
+		$this->commissions     = $commissions ? $commissions : new TicketSettlementService();
+		$this->shows           = $shows ? $shows : new ShowSettlementService();
+		$this->snapshot_reader = $snapshot_reader;
+	}
+
+	/** Authorize and normalize an operations-report request. */
+	public function authorize_operations( array $input, int $actor_id ) {
+		return $this->authorize( $input, $actor_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+	}
+
+	/** Authorize and normalize a finance-report request. */
+	public function authorize_finance( array $input, int $actor_id ) {
+		return $this->authorize( $input, $actor_id, VenueAuthorization::ACTION_MANAGE_FINANCES );
+	}
+
+	/** Return the canonical booking funnel and operational projection. */
+	public function operations( array $input, int $actor_id ) {
+		$request = $this->authorize_operations( $input, $actor_id );
+		if ( $request instanceof \WP_Error ) {
+			return $request;
+		}
+		$snapshot = $this->snapshot( 'operations', $request, $actor_id );
+		if ( $snapshot instanceof \WP_Error ) {
+			return $snapshot;
+		}
+		return $this->project_operations( $request, $snapshot );
+	}
+
+	/** Return role-gated commission, show-settlement, and artist-payout totals. */
+	public function finance( array $input, int $actor_id ) {
+		$request = $this->authorize_finance( $input, $actor_id );
+		if ( $request instanceof \WP_Error ) {
+			return $request;
+		}
+		$snapshot = $this->snapshot( 'finance', $request, $actor_id );
+		if ( $snapshot instanceof \WP_Error ) {
+			return $snapshot;
+		}
+		return $this->project_finance( $request, $snapshot );
+	}
+
+	/** Enforce exact venue membership and an additional administrator gate for aggregation. */
+	private function authorize( array $input, int $actor_id, string $action ) {
+		$request = $this->normalize_request( $input );
+		if ( $request instanceof \WP_Error ) {
+			return $request;
+		}
+		if ( count( $request['venue_term_ids'] ) > 1 && ! $this->authorization->is_administrator( $actor_id ) ) {
+			return $this->denied();
+		}
+		if ( VenueAuthorization::ACTION_MANAGE_FINANCES === $action ) {
+			$request['limit'] = min( $request['limit'], self::MAX_FINANCE_BOOKINGS );
+		}
+		foreach ( $request['venue_term_ids'] as $venue_term_id ) {
+			$allowed = $this->authorization->authorize( $actor_id, $venue_term_id, $action );
+			if ( true !== $allowed ) {
+				return $this->denied();
+			}
+		}
+		return $request;
+	}
+
+	/** Validate a half-open UTC period and bounded scope. */
+	private function normalize_request( array $input ) {
+		$venues = array_values( array_unique( array_map( 'absint', is_array( $input['venue_term_ids'] ?? null ) ? $input['venue_term_ids'] : array() ) ) );
+		if ( empty( $venues ) || count( $venues ) > self::MAX_VENUES || in_array( 0, $venues, true ) ) {
+			return new \WP_Error( 'invalid_booking_report_venues', __( 'One to twenty unique venue identifiers are required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$from = $this->datetime( $input['from'] ?? null );
+		$to   = $this->datetime( $input['to'] ?? null );
+		if ( $from instanceof \WP_Error || $to instanceof \WP_Error ) {
+			return $from instanceof \WP_Error ? $from : $to;
+		}
+		$seconds = $to->getTimestamp() - $from->getTimestamp();
+		if ( $seconds <= 0 || $seconds > self::MAX_RANGE_DAYS * DAY_IN_SECONDS ) {
+			return new \WP_Error( 'invalid_booking_report_range', __( 'The report period must be positive and no longer than 366 days.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return array(
+			'venue_term_ids' => $venues,
+			'from'           => $from->format( 'Y-m-d H:i:s' ),
+			'to'             => $to->format( 'Y-m-d H:i:s' ),
+			'limit'          => max( 1, min( self::MAX_BOOKINGS, absint( $input['limit'] ?? 100 ) ) ),
+		);
+	}
+
+	private function datetime( $value ) {
+		$date = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', (string) $value, new \DateTimeZone( 'UTC' ) );
+		return $date && $date->format( 'Y-m-d H:i:s' ) === $value
+			? $date
+			: new \WP_Error( 'invalid_booking_report_datetime', __( 'Report timestamps must use UTC Y-m-d H:i:s format.', 'extrachill-events' ), array( 'status' => 400 ) );
+	}
+
+	private function snapshot( string $kind, array $request, int $actor_id ) {
+		if ( $this->snapshot_reader ) {
+			return call_user_func( $this->snapshot_reader, $kind, $request, $actor_id );
+		}
+		return 'finance' === $kind ? $this->read_finance_snapshot( $request, $actor_id ) : $this->read_operations_snapshot( $request );
+	}
+
+	/** Read only bounded, non-contact operational columns from canonical tables. */
+	private function read_operations_snapshot( array $request, bool $finance = false ) {
+		global $wpdb;
+		$venues       = implode( ', ', array_map( 'intval', $request['venue_term_ids'] ) );
+		$bookings     = BookingSchema::bookings_table();
+		$limit        = $request['limit'] + 1;
+		$date_column  = $finance ? 'performance_start_at' : 'created_at';
+		$booking_rows = $wpdb->get_results( $wpdb->prepare( "SELECT id, public_id, venue_term_id, status, event_id, created_at, updated_at FROM {$bookings} WHERE venue_term_id IN ({$venues}) AND status <> 'admission_pending' AND {$date_column} >= %s AND {$date_column} < %s ORDER BY {$date_column} ASC, id ASC LIMIT %d", $request['from'], $request['to'], $limit ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Internal fixed date column, table name, and integer venue list; bounded report snapshot.
+		if ( ! empty( $wpdb->last_error ) || ! is_array( $booking_rows ) ) {
+			return new \WP_Error( 'booking_report_read_failed', __( 'The booking report could not be read.', 'extrachill-events' ) );
+		}
+		$truncated    = count( $booking_rows ) > $request['limit'];
+		$booking_rows = array_slice( $booking_rows, 0, $request['limit'] );
+		foreach ( $booking_rows as &$booking ) {
+			foreach ( array( 'id', 'venue_term_id' ) as $field ) {
+				$booking[ $field ] = (int) $booking[ $field ];
+			}
+			$booking['event_id'] = null === $booking['event_id'] ? null : (int) $booking['event_id'];
+		}
+		unset( $booking );
+		$snapshot = array(
+			'bookings'             => $booking_rows,
+			'activities'           => array(),
+			'holds'                => array(),
+			'sales_reports'        => array(),
+			'sales_resolutions'    => array(),
+			'truncated'            => $truncated,
+			'activities_truncated' => false,
+			'evidence_truncated'   => false,
+			'database_now'         => gmdate( 'Y-m-d H:i:s' ),
+		);
+		if ( empty( $booking_rows ) ) {
+			return $snapshot;
+		}
+		$ids               = array_column( $booking_rows, 'id' );
+		$id_placeholders   = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );
+		$kind_placeholders = implode( ', ', array_fill( 0, count( self::REPORTING_KINDS ), '%s' ) );
+		$activity          = BookingSchema::activity_table();
+		$activity_query    = $wpdb->prepare( "SELECT id, booking_id, kind, channel, external_id, payload, occurred_at FROM {$activity} WHERE booking_id IN ({$id_placeholders}) AND kind IN ({$kind_placeholders}) ORDER BY occurred_at ASC, id ASC LIMIT %d", array_merge( $ids, self::REPORTING_KINDS, array( self::MAX_ACTIVITIES + 1 ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Internal table and bounded placeholder counts; all values prepared.
+		$activity_rows     = $wpdb->get_results( $activity_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Query prepared above.
+		if ( ! empty( $wpdb->last_error ) || ! is_array( $activity_rows ) ) {
+			return new \WP_Error( 'booking_report_activity_read_failed', __( 'Booking report activity could not be read.', 'extrachill-events' ) );
+		}
+		$snapshot['activities_truncated'] = count( $activity_rows ) > self::MAX_ACTIVITIES;
+		$activity_rows                    = array_slice( $activity_rows, 0, self::MAX_ACTIVITIES );
+		$repository                       = new BookingActivityRepository();
+		foreach ( $activity_rows as $row ) {
+			$row['actor_id'] = null;
+			$item            = $repository->hydrate( $row );
+			if ( $item instanceof \WP_Error ) {
+				return $item;
+			}
+			$snapshot['activities'][] = $item;
+		}
+		$holds_table = BookingSchema::holds_table();
+		$holds_query = $wpdb->prepare( "SELECT booking_id, status, expires_at FROM {$holds_table} WHERE booking_id IN ({$id_placeholders}) ORDER BY id ASC LIMIT 1001", $ids ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Internal table and bounded placeholder count; all IDs prepared.
+		$hold_rows   = $wpdb->get_results( $holds_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Query prepared above.
+		if ( ! empty( $wpdb->last_error ) || ! is_array( $hold_rows ) ) {
+			return new \WP_Error( 'booking_report_evidence_read_failed', __( 'Booking hold evidence could not be read.', 'extrachill-events' ) );
+		}
+		$snapshot['holds'] = $hold_rows;
+		$reports_table     = BookingSchema::sales_reports_table();
+		$reports_query     = $wpdb->prepare( "SELECT id, booking_id, corrects_report_id FROM {$reports_table} WHERE booking_id IN ({$id_placeholders}) ORDER BY id ASC LIMIT 1001", $ids ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Internal table and bounded placeholder count; all IDs prepared.
+		$report_rows       = $wpdb->get_results( $reports_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Query prepared above.
+		if ( ! empty( $wpdb->last_error ) || ! is_array( $report_rows ) ) {
+			return new \WP_Error( 'booking_report_evidence_read_failed', __( 'Booking ticket evidence could not be read.', 'extrachill-events' ) );
+		}
+		$snapshot['sales_reports'] = $report_rows;
+		$resolutions_table         = BookingSchema::sales_resolutions_table();
+		$resolutions_query         = $wpdb->prepare( "SELECT report_id, decision, version FROM {$resolutions_table} WHERE booking_id IN ({$id_placeholders}) ORDER BY report_id ASC, version ASC LIMIT 1001", $ids ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Internal table and bounded placeholder count; all IDs prepared.
+		$resolution_rows           = $wpdb->get_results( $resolutions_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Query prepared above.
+		if ( ! empty( $wpdb->last_error ) || ! is_array( $resolution_rows ) ) {
+			return new \WP_Error( 'booking_report_evidence_read_failed', __( 'Booking ticket evidence could not be read.', 'extrachill-events' ) );
+		}
+		$snapshot['sales_resolutions'] = $resolution_rows;
+		foreach ( array( 'holds', 'sales_reports', 'sales_resolutions' ) as $key ) {
+			if ( count( $snapshot[ $key ] ) > 1000 ) {
+				$snapshot['evidence_truncated'] = true;
+				$snapshot[ $key ]               = array_slice( $snapshot[ $key ], 0, 1000 );
+			}
+		}
+		return $snapshot;
+	}
+
+	/** Verify finance records through their owning services before aggregation. */
+	private function read_finance_snapshot( array $request, int $actor_id ) {
+		$operations = $this->read_operations_snapshot( $request, true );
+		if ( $operations instanceof \WP_Error ) {
+			return $operations;
+		}
+		$operations['commissions']                    = array();
+		$operations['shows']                          = array();
+		$operations['finance_verification_truncated'] = false;
+		foreach ( $operations['bookings'] as $booking ) {
+			$commission = $this->commissions->get( $booking['id'], $actor_id );
+			if ( $commission instanceof \WP_Error ) {
+				return $commission;
+			}
+			if ( is_array( $commission ) ) {
+				$operations['commissions'][] = $commission;
+			}
+			$show = $this->shows->get_for_reporting( $booking['id'], $actor_id, 200 );
+			if ( $show instanceof \WP_Error && 'show_settlement_reporting_limit_exceeded' === $show->get_error_code() ) {
+				$operations['finance_verification_truncated'] = true;
+				continue;
+			}
+			if ( $show instanceof \WP_Error && 'show_settlement_not_found' !== $show->get_error_code() ) {
+				return $show;
+			}
+			if ( is_array( $show ) ) {
+				$operations['shows'][] = $show;
+			}
+		}
+		return $operations;
+	}
+
+	private function project_operations( array $request, array $snapshot ): array {
+		$bookings      = array_values( $snapshot['bookings'] ?? array() );
+		$status_counts = array_fill_keys( BookingRepository::STATUSES, 0 );
+		$booking_refs  = array();
+		foreach ( $bookings as $booking ) {
+			$status = (string) ( $booking['status'] ?? '' );
+			if ( isset( $status_counts[ $status ] ) ) {
+				++$status_counts[ $status ];
+			}
+			$booking_refs[ (int) $booking['id'] ] = (string) $booking['public_id'];
+		}
+		$stage_entries      = array_fill_keys( BookingRepository::STATUSES, 0 );
+		$submitted_at       = array();
+		$confirmation_times = array();
+		$decline_note_count = 0;
+		$event_states       = array_fill_keys( array( 'none', 'pending', 'completed', 'failed', 'retryable', 'conflict', 'no_change', 'succeeded' ), 0 );
+		$latest_event_state = array();
+		$marketing_latest   = array();
+		$marketing_failures = 0;
+		foreach ( (array) ( $snapshot['activities'] ?? array() ) as $activity ) {
+			$id       = (int) ( $activity['booking_id'] ?? 0 );
+			$kind     = (string) ( $activity['kind'] ?? '' );
+			$data     = is_array( $activity['payload']['data'] ?? null ) ? $activity['payload']['data'] : array();
+			$occurred = (string) ( $activity['occurred_at'] ?? '' );
+			if ( 'inquiry_submitted' === $kind ) {
+				++$stage_entries['submitted'];
+				$submitted_at[ $id ] = $occurred;
+			} elseif ( 'status_changed' === $kind && isset( $stage_entries[ $data['to_status'] ?? '' ] ) ) {
+				++$stage_entries[ $data['to_status'] ];
+				$decline_note_count += 'declined' === $data['to_status'] && '' !== trim( (string) ( $data['note'] ?? '' ) ) ? 1 : 0;
+			} elseif ( 'deal_confirmed' === $kind ) {
+				++$stage_entries['confirmed'];
+				if ( isset( $submitted_at[ $id ] ) ) {
+					$confirmation_times[] = max( 0, strtotime( $occurred . ' UTC' ) - strtotime( $submitted_at[ $id ] . ' UTC' ) );
+				}
+			}
+			$state = $this->event_state( $kind );
+			if ( null !== $state ) {
+				$latest_event_state[ $id ] = $state;
+			}
+			if ( 'marketing_operation_submitted' === $kind && ! empty( $activity['external_id'] ) ) {
+				$marketing_latest[ (string) $activity['external_id'] ] = array(
+					'booking_ref'    => $booking_refs[ $id ] ?? '',
+					'channel'        => (string) ( $activity['channel'] ?? '' ),
+					'operation_ref'  => (string) $activity['external_id'],
+					'status'         => (string) ( $data['status'] ?? 'failed' ),
+					'classification' => $data['projection']['classification'] ?? null,
+					'effect_count'   => max( 0, (int) ( $data['projection']['effect_count'] ?? 0 ) ),
+					'outcome_refs'   => $this->marketing_refs( $data['projection'] ?? array() ),
+				);
+			} elseif ( 0 === strpos( $kind, 'marketing_operation_' ) && false !== strpos( $kind, 'failed' ) ) {
+				++$marketing_failures;
+			}
+		}
+		foreach ( $bookings as $booking ) {
+			$state = $latest_event_state[ (int) $booking['id'] ] ?? ( null === $booking['event_id'] ? 'none' : 'completed' );
+			++$event_states[ $state ];
+		}
+		$holds = array_fill_keys( array( 'active', 'released', 'expired', 'converted' ), 0 );
+		$now   = (string) ( $snapshot['database_now'] ?? gmdate( 'Y-m-d H:i:s' ) );
+		foreach ( (array) ( $snapshot['holds'] ?? array() ) as $hold ) {
+			$status = (string) ( $hold['status'] ?? '' );
+			if ( 'active' === $status && (string) ( $hold['expires_at'] ?? '' ) <= $now ) {
+				$status = 'expired';
+			}
+			if ( isset( $holds[ $status ] ) ) {
+				++$holds[ $status ];
+			}
+		}
+		$reports     = (array) ( $snapshot['sales_reports'] ?? array() );
+		$resolutions = array();
+		foreach ( (array) ( $snapshot['sales_resolutions'] ?? array() ) as $resolution ) {
+			$resolutions[ (int) $resolution['report_id'] ] = (string) $resolution['decision'];
+		}
+		$decision_counts = array(
+			'admit'                   => 0,
+			'exclude'                 => 0,
+			'not_explicitly_resolved' => 0,
+		);
+		foreach ( $reports as $report ) {
+			$decision = $resolutions[ (int) $report['id'] ] ?? 'not_explicitly_resolved';
+			++$decision_counts[ $decision ];
+		}
+		$confirmation = $this->duration_summary( $confirmation_times );
+		return array(
+			'scope'        => $this->scope( $request, 'inquiry_created_at', (string) ( $snapshot['database_now'] ?? gmdate( 'Y-m-d H:i:s' ) ) ),
+			'state'        => empty( $bookings ) ? 'empty' : ( ! empty( $snapshot['truncated'] ) || ! empty( $snapshot['activities_truncated'] ) || ! empty( $snapshot['evidence_truncated'] ) ? 'incomplete' : 'complete' ),
+			'bounded'      => array(
+				'booking_limit'        => $request['limit'],
+				'booking_count'        => count( $bookings ),
+				'truncated'            => ! empty( $snapshot['truncated'] ),
+				'activity_limit'       => self::MAX_ACTIVITIES,
+				'activities_truncated' => ! empty( $snapshot['activities_truncated'] ),
+				'evidence_limit'       => 1000,
+				'evidence_truncated'   => ! empty( $snapshot['evidence_truncated'] ),
+			),
+			'availability' => array(
+				'inquiry_source'       => 'not_recorded',
+				'decline_reason_codes' => 'not_recorded',
+				'first_response_time'  => 'not_recorded',
+				'time_to_confirmation' => 0 < $confirmation['sample_size'] ? 'available' : 'no_observations',
+				'marketing_outcomes'   => empty( $marketing_latest ) ? 'no_observations' : 'available',
+			),
+			'funnel'       => array(
+				'inquiries'                    => count( $bookings ),
+				'current_stage_counts'         => $status_counts,
+				'stage_entry_counts'           => $stage_entries,
+				'conversion_basis_points'      => $this->conversion_rates( $stage_entries, count( $bookings ) ),
+				'declines'                     => array(
+					'count'                  => $stage_entries['declined'],
+					'note_recorded_count'    => $decline_note_count,
+					'reason_codes_available' => false,
+				),
+				'first_response_seconds'       => null,
+				'time_to_confirmation_seconds' => $confirmation,
+			),
+			'operations'   => array(
+				'holds'           => $holds,
+				'confirmed_shows' => $stage_entries['confirmed'],
+				'event_states'    => $event_states,
+				'ticket_evidence' => array(
+					'reports_recorded'           => count( $reports ),
+					'corrections_recorded'       => count( array_filter( $reports, static fn( array $row ): bool => ! empty( $row['corrects_report_id'] ) ) ),
+					'latest_explicit_decisions'  => $decision_counts,
+					'diagnostic_state_available' => false,
+				),
+			),
+			'marketing'    => array(
+				'operations'    => array_values( $marketing_latest ),
+				'failure_count' => $marketing_failures,
+			),
+		);
+	}
+
+	private function project_finance( array $request, array $snapshot ): array {
+		$bookings            = array_values( $snapshot['bookings'] ?? array() );
+		$commissions         = array_values( $snapshot['commissions'] ?? array() );
+		$shows               = array_values( $snapshot['shows'] ?? array() );
+		$commission_statuses = array_fill_keys( array( 'finalized', 'paid', 'void' ), 0 );
+		$show_statuses       = array_fill_keys( array_merge( array( 'draft' ), ShowSettlementService::ACTIONS ), 0 );
+		$currencies          = array();
+		foreach ( $commissions as $commission ) {
+			$status = (string) $commission['status'];
+			++$commission_statuses[ $status ];
+			$currency                = (string) $commission['currency'];
+			$currencies[ $currency ] = $currencies[ $currency ] ?? $this->money_totals();
+			if ( in_array( $status, array( 'finalized', 'paid' ), true ) ) {
+				$currencies[ $currency ]['extra_chill_share_due_minor'] += (int) $commission['amount_due_minor'];
+			}
+			if ( 'paid' === $status ) {
+				$currencies[ $currency ]['extra_chill_share_paid_minor'] += (int) $commission['amount_due_minor'];
+			}
+		}
+		$has_correction = false;
+		foreach ( $shows as $show ) {
+			$status = (string) $show['status'];
+			++$show_statuses[ $status ];
+			$currency                = (string) $show['currency'];
+			$currencies[ $currency ] = $currencies[ $currency ] ?? $this->money_totals();
+			$calculation             = (array) ( $show['calculation'] ?? array() );
+			if ( in_array( $status, array( 'finalized', 'acknowledged', 'paid' ), true ) ) {
+				$currencies[ $currency ]['artist_payout_committed_minor'] += (int) ( $calculation['artist_payout_minor'] ?? 0 );
+				$currencies[ $currency ]['venue_net_after_payout_minor']  += (int) ( $calculation['venue_net_after_payout_minor'] ?? 0 );
+			}
+			if ( 'paid' === $status ) {
+				$currencies[ $currency ]['artist_payout_paid_minor'] += (int) ( $calculation['artist_payout_minor'] ?? 0 );
+			}
+			$has_correction = $has_correction || null !== ( $show['corrects_revision_id'] ?? null );
+		}
+		$frozen = ! empty( $shows )
+			&& count( $shows ) === count( $bookings )
+			&& count( $commissions ) === count( $bookings )
+			&& empty( $snapshot['truncated'] )
+			&& empty( $snapshot['finance_verification_truncated'] )
+			&& count( $shows ) === count( array_filter( $shows, static fn( array $show ): bool => in_array( $show['status'], array( 'finalized', 'acknowledged', 'paid' ), true ) ) );
+		$state  = empty( $bookings ) ? 'empty' : ( $frozen ? ( $has_correction ? 'corrected' : 'finalized' ) : 'incomplete' );
+		return array(
+			'scope'                    => $this->scope( $request, 'performance_start_at', (string) ( $snapshot['database_now'] ?? gmdate( 'Y-m-d H:i:s' ) ) ),
+			'state'                    => $state,
+			'bounded'                  => array(
+				'booking_limit'                        => $request['limit'],
+				'booking_count'                        => count( $bookings ),
+				'truncated'                            => ! empty( $snapshot['truncated'] ),
+				'financial_evidence_limit_per_booking' => 200,
+				'financial_verification_truncated'     => ! empty( $snapshot['finance_verification_truncated'] ),
+			),
+			'coverage'                 => array(
+				'bookings'                       => count( $bookings ),
+				'commission_settlements'         => count( $commissions ),
+				'show_settlements'               => count( $shows ),
+				'missing_commission_settlements' => count( $bookings ) - count( $commissions ),
+				'missing_show_settlements'       => count( $bookings ) - count( $shows ),
+			),
+			'commission_statuses'      => $commission_statuses,
+			'show_settlement_statuses' => $show_statuses,
+			'currencies'               => $currencies,
+		);
+	}
+
+	private function event_state( string $kind ): ?string {
+		$map = array(
+			'event_conversion_started' => 'pending',
+			'event_conversion_failed'  => 'failed',
+			'event_converted'          => 'completed',
+			'event_sync_started'       => 'pending',
+			'event_sync_retryable'     => 'retryable',
+			'event_sync_failed'        => 'failed',
+			'event_sync_conflict'      => 'conflict',
+			'event_sync_succeeded'     => 'succeeded',
+			'event_sync_noop'          => 'no_change',
+		);
+		return $map[ $kind ] ?? null;
+	}
+
+	private function marketing_refs( array $projection ): array {
+		$refs = array();
+		foreach ( array_slice( (array) ( $projection['share_refs'] ?? array() ), 0, 20 ) as $ref ) {
+			if ( is_array( $ref ) && ! empty( $ref['channel'] ) && ! empty( $ref['platform_post_id'] ) ) {
+				$refs[] = array(
+					'type'    => 'social',
+					'channel' => (string) $ref['channel'],
+					'id'      => (string) $ref['platform_post_id'],
+				);
+			}
+		}
+		$record = $projection['record'] ?? null;
+		if ( is_array( $record ) && ! empty( $record['campaign_id'] ) ) {
+			$refs[] = array(
+				'type'    => 'newsletter',
+				'channel' => 'newsletter',
+				'id'      => (string) $record['campaign_id'],
+			);
+		}
+		return $refs;
+	}
+
+	private function conversion_rates( array $entries, int $inquiries ): array {
+		$rates = array();
+		foreach ( $entries as $stage => $count ) {
+			$rates[ $stage ] = $inquiries > 0 ? (int) round( min( $count, $inquiries ) * 10000 / $inquiries ) : null;
+		}
+		return $rates;
+	}
+
+	private function duration_summary( array $values ): array {
+		return empty( $values ) ? array(
+			'sample_size' => 0,
+			'minimum'     => null,
+			'maximum'     => null,
+			'average'     => null,
+		) : array(
+			'sample_size' => count( $values ),
+			'minimum'     => min( $values ),
+			'maximum'     => max( $values ),
+			'average'     => (int) round( array_sum( $values ) / count( $values ) ),
+		);
+	}
+
+	private function money_totals(): array {
+		return array(
+			'extra_chill_share_due_minor'   => 0,
+			'extra_chill_share_paid_minor'  => 0,
+			'artist_payout_committed_minor' => 0,
+			'artist_payout_paid_minor'      => 0,
+			'venue_net_after_payout_minor'  => 0,
+		);
+	}
+
+	private function scope( array $request, string $basis, string $outcomes_as_of ): array {
+		return array(
+			'venue_term_ids' => $request['venue_term_ids'],
+			'from'           => $request['from'],
+			'to'             => $request['to'],
+			'timezone'       => 'UTC',
+			'interval'       => 'half_open',
+			'basis'          => $basis,
+			'outcomes_as_of' => $outcomes_as_of,
+		);
+	}
+
+	private function denied(): \WP_Error {
+		return new \WP_Error( 'venue_action_forbidden', __( 'You are not authorized to perform this venue action.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+}

--- a/inc/Core/ShowSettlementService.php
+++ b/inc/Core/ShowSettlementService.php
@@ -8,7 +8,7 @@
 namespace ExtraChillEvents\Core;
 
 // Repository convention uses concise method comments.
-// phpcs:disable Generic.Commenting.DocComment.MissingShort,Squiz.Commenting.FunctionComment.Missing,Squiz.Commenting.FunctionComment.MissingParamTag
+// phpcs:disable WordPress.Files.FileName,Generic.Commenting.DocComment.MissingShort,Squiz.Commenting.FunctionComment.Missing,Squiz.Commenting.FunctionComment.MissingParamTag
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -68,6 +68,15 @@ class ShowSettlementService {
 
 	/** Read one revision or the latest revision with derived lifecycle state. */
 	public function get( int $booking_id, int $actor_id, ?int $revision = null ) {
+		return $this->read( $booking_id, $actor_id, $revision, 10000 );
+	}
+
+	/** Read one revision with a strict ticket-evidence scan budget for reporting. */
+	public function get_for_reporting( int $booking_id, int $actor_id, int $max_sales_reports = 200 ) {
+		return $this->read( $booking_id, $actor_id, null, max( 1, min( 1000, $max_sales_reports ) ) );
+	}
+
+	private function read( int $booking_id, int $actor_id, ?int $revision, int $max_sales_reports ) {
 		$booking = $this->booking( $booking_id );
 		if ( is_wp_error( $booking ) ) {
 			return $booking;
@@ -80,7 +89,7 @@ class ShowSettlementService {
 		if ( ! is_array( $row ) ) {
 			return is_wp_error( $row ) ? $row : new \WP_Error( 'show_settlement_not_found', __( 'The show settlement was not found.', 'extrachill-events' ), array( 'status' => 404 ) );
 		}
-		$verified = $this->verify_revision( $row, $booking, $actor_id, false );
+		$verified = $this->verify_revision( $row, $booking, $actor_id, false, false, $max_sales_reports );
 		return is_wp_error( $verified ) ? $verified : $this->present( $verified );
 	}
 
@@ -664,7 +673,7 @@ class ShowSettlementService {
 		return true;
 	}
 
-	private function verify_revision( array $revision, array $booking, int $actor_id, bool $authenticate_bytes, bool $lock_commission = false ) {
+	private function verify_revision( array $revision, array $booking, int $actor_id, bool $authenticate_bytes, bool $lock_commission = false, int $max_sales_reports = 10000 ) {
 		if ( $revision['booking_id'] !== $booking['id'] || $revision['event_id'] !== $booking['event_id'] || $revision['venue_term_id'] !== $booking['venue_term_id'] || ! hash_equals( $revision['integrity_hash'], self::hash( self::revision_hashable( $revision ) ) ) ) {
 			return new \WP_Error( 'show_settlement_integrity_failed', __( 'The immutable show-settlement revision failed integrity verification.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
@@ -676,7 +685,7 @@ class ShowSettlementService {
 		if ( is_wp_error( $calculation ) || $calculation !== $revision['calculation'] ) {
 			return new \WP_Error( 'show_settlement_calculation_invalid', __( 'The frozen show-settlement calculation is not reproducible.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
-		$ticket_gross = $this->ticket_gross( $booking, $commission, $actor_id, $lock_commission );
+		$ticket_gross = $this->ticket_gross( $booking, $commission, $actor_id, $lock_commission, $max_sales_reports );
 		if ( is_wp_error( $ticket_gross ) || $ticket_gross !== $revision['terms']['ticket_gross_minor'] ) {
 			return is_wp_error( $ticket_gross ) ? $ticket_gross : new \WP_Error( 'show_settlement_ticket_gross_conflict', __( 'Frozen ticket gross no longer matches its reconciled ticket evidence.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
@@ -714,12 +723,14 @@ class ShowSettlementService {
 		return $state;
 	}
 
-	private function ticket_gross( array $booking, array $commission, int $actor_id, bool $lock = false ) {
-		$by_id  = array();
-		$found  = 0;
-		$needed = count( $commission['included_report_ids'] );
-		for ( $offset = 0; $offset < 10000 && $found < $needed; $offset += 200 ) {
-			$reports = $lock ? $this->commissions->included_reports_for_update( $commission ) : $this->commissions->list_sales( $booking['id'], $actor_id, 200, $offset );
+	private function ticket_gross( array $booking, array $commission, int $actor_id, bool $lock = false, int $max_sales_reports = 10000 ) {
+		$by_id     = array();
+		$found     = 0;
+		$needed    = count( $commission['included_report_ids'] );
+		$exhausted = false;
+		for ( $offset = 0; $offset < $max_sales_reports && $found < $needed; $offset += 200 ) {
+			$page_limit = min( 200, $max_sales_reports - $offset );
+			$reports    = $lock ? $this->commissions->included_reports_for_update( $commission ) : $this->commissions->list_sales( $booking['id'], $actor_id, $page_limit, $offset );
 			if ( is_wp_error( $reports ) ) {
 				return $reports;
 			}
@@ -729,12 +740,16 @@ class ShowSettlementService {
 					$found                  = count( $by_id );
 				}
 			}
-			if ( count( $reports ) < 200 ) {
+			if ( count( $reports ) < $page_limit ) {
+				$exhausted = true;
 				break;
 			}
 			if ( $lock ) {
 				break;
 			}
+		}
+		if ( $found < $needed && ! $lock && ! $exhausted ) {
+			return new \WP_Error( 'show_settlement_reporting_limit_exceeded', __( 'The show settlement exceeds the bounded reporting evidence limit.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
 		$gross = 0;
 		foreach ( $commission['included_report_ids'] as $report_id ) {

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -23,6 +23,7 @@
 			<file>tests/TicketSettlementTest.php</file>
 			<file>tests/TicketReconciliationTest.php</file>
 			<file>tests/ShowSettlementTest.php</file>
+			<file>tests/BookingReportingTest.php</file>
 			<file>tests/BookingNotificationTest.php</file>
 			<file>tests/LocalSupportNotificationTest.php</file>
 			<file>tests/CanonicalEventPublicationGuardTest.php</file>

--- a/tests/AbilityRegistrationLifecycleTest.php
+++ b/tests/AbilityRegistrationLifecycleTest.php
@@ -7,6 +7,7 @@
 
 use ExtraChillEvents\Abilities\PriorityVenueAbilities;
 use ExtraChillEvents\Abilities\TicketSettlementAbilities;
+use ExtraChillEvents\Abilities\BookingReportingAbilities;
 use ExtraChillEvents\Abilities\VenueBookingAbilities;
 use ExtraChillEvents\Abilities\VenueBookingCommunicationAbilities;
 use ExtraChillEvents\Abilities\VenueBookingEventAbilities;
@@ -53,6 +54,7 @@ final class AbilityRegistrationLifecycleTest extends BookingTestCase {
 		new VenueBookingEventAbilities();
 		new VenueBookingCommunicationAbilities();
 		new TicketSettlementAbilities();
+		new BookingReportingAbilities();
 		new PriorityVenueAbilities();
 
 		new VenueBookingAbilities();
@@ -61,9 +63,10 @@ final class AbilityRegistrationLifecycleTest extends BookingTestCase {
 		new VenueBookingEventAbilities();
 		new VenueBookingCommunicationAbilities();
 		new TicketSettlementAbilities();
+		new BookingReportingAbilities();
 		new PriorityVenueAbilities();
 
-		$this->assertCount( 7, $GLOBALS['ec_test_filters']['wp_abilities_api_init'][10] );
+		$this->assertCount( 8, $GLOBALS['ec_test_filters']['wp_abilities_api_init'][10] );
 
 		define( 'WP_AGENT_RUNTIME', true );
 		add_action(
@@ -83,6 +86,7 @@ final class AbilityRegistrationLifecycleTest extends BookingTestCase {
 				'extrachill/convert-booking-to-event',
 				'extrachill/send-booking-message',
 				'extrachill/finalize-booking-settlement',
+				'extrachill/get-venue-booking-performance-report',
 				'extrachill/list-priority-venues',
 			) as $ability_name
 		) {

--- a/tests/BookingReportingTest.php
+++ b/tests/BookingReportingTest.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * Canonical venue booking reporting tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Abilities\BookingReportingAbilities;
+use ExtraChillEvents\Core\BookingReportingService;
+use ExtraChillEvents\Core\BookingSchema;
+
+// Repository tests use PSR-4 filenames and concise method names as descriptions.
+// phpcs:disable WordPress.Files.FileName,Generic.Commenting,Squiz.Commenting
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
+/** Covers bounded projections, honest gaps, and exact venue authority. */
+final class BookingReportingTest extends BookingTestCase {
+	/** @var BookingTestAuthorization */
+	private $authorization;
+
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'abilities'       => array(),
+			'actions'         => array(),
+			'blog_id'         => 7,
+			'current_user_id' => 12,
+			'options'         => array( BookingSchema::VERSION_OPTION => BookingSchema::SCHEMA_VERSION ),
+			'user_caps'       => array(),
+		);
+		$GLOBALS['wpdb']           = new BookingWpdb(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Isolated test database double.
+		$this->authorization       = new BookingTestAuthorization();
+	}
+
+	public function test_empty_period_is_explicit_and_unavailable_metrics_are_not_fabricated(): void {
+		$service = $this->service( $this->snapshot() );
+		$report  = $service->operations( $this->input(), 12 );
+
+		$this->assertSame( 'empty', $report['state'] );
+		$this->assertSame( 0, $report['funnel']['inquiries'] );
+		$this->assertSame( 'not_recorded', $report['availability']['inquiry_source'] );
+		$this->assertSame( 'not_recorded', $report['availability']['first_response_time'] );
+		$this->assertNull( $report['funnel']['first_response_seconds'] );
+		$this->assertSame( 0, $report['funnel']['time_to_confirmation_seconds']['sample_size'] );
+	}
+
+	public function test_operations_derive_stages_holds_evidence_and_marketing_without_private_data(): void {
+		$snapshot                      = $this->snapshot();
+		$snapshot['bookings']          = array(
+			array(
+				'id'            => 1,
+				'public_id'     => 'booking-one',
+				'venue_term_id' => 55,
+				'status'        => 'confirmed',
+				'event_id'      => 900,
+				'created_at'    => '2026-07-01 10:00:00',
+				'updated_at'    => '2026-07-03 10:00:00',
+			),
+			array(
+				'id'            => 2,
+				'public_id'     => 'booking-two',
+				'venue_term_id' => 55,
+				'status'        => 'declined',
+				'event_id'      => null,
+				'created_at'    => '2026-07-02 10:00:00',
+				'updated_at'    => '2026-07-02 11:00:00',
+			),
+		);
+		$snapshot['activities']        = array(
+			$this->activity( 1, 'inquiry_submitted', '2026-07-01 10:00:00' ),
+			$this->activity( 1, 'status_changed', '2026-07-01 11:00:00', array( 'to_status' => 'negotiating' ) ),
+			$this->activity( 1, 'deal_confirmed', '2026-07-03 10:00:00' ),
+			$this->activity( 1, 'event_converted', '2026-07-03 10:01:00' ),
+			$this->activity( 2, 'inquiry_submitted', '2026-07-02 10:00:00' ),
+			$this->activity(
+				2,
+				'status_changed',
+				'2026-07-02 11:00:00',
+				array(
+					'to_status' => 'declined',
+					'note'      => 'Routing conflict.',
+				)
+			),
+			$this->activity(
+				1,
+				'marketing_operation_submitted',
+				'2026-07-03 10:02:00',
+				array(
+					'status'     => 'executed',
+					'projection' => array(
+						'classification' => 'success',
+						'effect_count'   => 1,
+						'share_refs'     => array(
+							array(
+								'channel'          => 'instagram',
+								'platform_post_id' => 'post-1',
+							),
+						),
+					),
+				),
+				array(
+					'channel'     => 'social',
+					'external_id' => 'dop_' . str_repeat( 'a', 64 ),
+				)
+			),
+		);
+		$snapshot['holds']             = array(
+			array(
+				'booking_id' => 1,
+				'status'     => 'active',
+				'expires_at' => '2026-07-04 00:00:00',
+			),
+			array(
+				'booking_id' => 1,
+				'status'     => 'converted',
+				'expires_at' => '2026-07-10 00:00:00',
+			),
+		);
+		$snapshot['sales_reports']     = array(
+			array(
+				'id'                 => 10,
+				'booking_id'         => 1,
+				'corrects_report_id' => null,
+			),
+			array(
+				'id'                 => 11,
+				'booking_id'         => 1,
+				'corrects_report_id' => 10,
+			),
+		);
+		$snapshot['sales_resolutions'] = array(
+			array(
+				'report_id' => 10,
+				'decision'  => 'exclude',
+				'version'   => 1,
+			),
+		);
+
+		$report = $this->service( $snapshot )->operations( $this->input(), 12 );
+		$this->assertSame( 'complete', $report['state'] );
+		$this->assertSame( 2, $report['funnel']['inquiries'] );
+		$this->assertSame( 1, $report['funnel']['current_stage_counts']['confirmed'] );
+		$this->assertSame( 1, $report['funnel']['stage_entry_counts']['confirmed'] );
+		$this->assertSame( 1, $report['funnel']['declines']['note_recorded_count'] );
+		$this->assertFalse( $report['funnel']['declines']['reason_codes_available'] );
+		$this->assertSame( 172800, $report['funnel']['time_to_confirmation_seconds']['average'] );
+		$this->assertSame( 1, $report['operations']['holds']['expired'], 'Stored active holds use effective database-time state.' );
+		$this->assertSame( 1, $report['operations']['holds']['converted'] );
+		$this->assertSame( 1, $report['operations']['ticket_evidence']['corrections_recorded'] );
+		$this->assertSame( 1, $report['operations']['ticket_evidence']['latest_explicit_decisions']['not_explicitly_resolved'] );
+		$this->assertSame( 'post-1', $report['marketing']['operations'][0]['outcome_refs'][0]['id'] );
+		$this->assertArrayNotHasKey( 'contact_email', $report );
+	}
+
+	public function test_range_and_cross_venue_authorization_fail_closed_before_reading(): void {
+		$reads         = 0;
+		$service       = new BookingReportingService(
+			$this->authorization,
+			null,
+			null,
+			static function () use ( &$reads ): array {
+				++$reads;
+				return array();
+			}
+		);
+		$invalid       = $this->input();
+		$invalid['to'] = '2028-01-01 00:00:00';
+		$this->assertSame( 'invalid_booking_report_range', $service->operations( $invalid, 12 )->get_error_code() );
+
+		$aggregate                             = $this->input();
+		$aggregate['venue_term_ids']           = array( 55, 66 );
+		$this->authorization->allowed['12:66'] = true;
+		$this->assertSame( 'venue_action_forbidden', $service->operations( $aggregate, 12 )->get_error_code() );
+		$this->assertSame( 0, $reads );
+
+		$GLOBALS['ec_artist_test']['user_caps'][12]['manage_options'] = true;
+		$result = $service->operations( $aggregate, 12 );
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $reads );
+	}
+
+	public function test_finance_requires_exact_authority_and_reports_incomplete_corrected_and_finalized_states(): void {
+		$snapshot                              = $this->snapshot();
+		$snapshot['bookings']                  = array(
+			array(
+				'id'            => 1,
+				'public_id'     => 'one',
+				'venue_term_id' => 55,
+				'status'        => 'completed',
+				'event_id'      => 900,
+				'created_at'    => '2026-07-01 00:00:00',
+				'updated_at'    => '2026-07-02 00:00:00',
+			),
+		);
+		$service                               = $this->service( $snapshot );
+		$this->authorization->allowed['99:55'] = false;
+		$this->assertSame( 'venue_action_forbidden', $service->finance( $this->input(), 99 )->get_error_code() );
+		$this->assertSame( 'incomplete', $service->finance( $this->input(), 12 )['state'] );
+
+		$snapshot['shows'] = array(
+			array(
+				'status'               => 'draft',
+				'currency'             => 'USD',
+				'corrects_revision_id' => null,
+				'calculation'          => array(
+					'artist_payout_minor'          => 50000,
+					'venue_net_after_payout_minor' => 30000,
+				),
+			),
+		);
+		$draft             = $this->service( $snapshot )->finance( $this->input(), 12 );
+		$this->assertSame( 0, $draft['currencies']['USD']['artist_payout_committed_minor'] );
+		$this->assertSame( 0, $draft['currencies']['USD']['venue_net_after_payout_minor'] );
+
+		$snapshot['commissions'] = array(
+			array(
+				'status'           => 'paid',
+				'currency'         => 'USD',
+				'amount_due_minor' => 20000,
+			),
+		);
+		$snapshot['shows']       = array(
+			array(
+				'status'               => 'finalized',
+				'currency'             => 'USD',
+				'corrects_revision_id' => null,
+				'calculation'          => array(
+					'artist_payout_minor'          => 50000,
+					'venue_net_after_payout_minor' => 30000,
+				),
+			),
+		);
+		$finalized               = $this->service( $snapshot )->finance( $this->input(), 12 );
+		$this->assertSame( 'finalized', $finalized['state'] );
+		$this->assertSame( 20000, $finalized['currencies']['USD']['extra_chill_share_paid_minor'] );
+		$this->assertSame( 50000, $finalized['currencies']['USD']['artist_payout_committed_minor'] );
+		$this->assertSame( 0, $finalized['currencies']['USD']['artist_payout_paid_minor'] );
+		$snapshot['truncated'] = true;
+		$this->assertSame( 'incomplete', $this->service( $snapshot )->finance( $this->input(), 12 )['state'] );
+		$snapshot['truncated']                      = false;
+		$snapshot['finance_verification_truncated'] = true;
+		$bounded                                    = $this->service( $snapshot )->finance( $this->input(), 12 );
+		$this->assertSame( 'incomplete', $bounded['state'] );
+		$this->assertTrue( $bounded['bounded']['financial_verification_truncated'] );
+		$snapshot['finance_verification_truncated'] = false;
+		$snapshot['bookings'][]                     = array_merge(
+			$snapshot['bookings'][0],
+			array(
+				'id'        => 2,
+				'public_id' => 'two',
+			)
+		);
+		$this->assertSame( 'incomplete', $this->service( $snapshot )->finance( $this->input(), 12 )['state'] );
+		array_pop( $snapshot['bookings'] );
+
+		$snapshot['shows'][0]['status']               = 'paid';
+		$snapshot['shows'][0]['corrects_revision_id'] = 4;
+		$corrected                                    = $this->service( $snapshot )->finance( $this->input(), 12 );
+		$this->assertSame( 'corrected', $corrected['state'] );
+		$this->assertSame( 50000, $corrected['currencies']['USD']['artist_payout_paid_minor'] );
+	}
+
+	public function test_abilities_are_readonly_bounded_and_do_not_accept_caller_identity(): void {
+		$abilities = new BookingReportingAbilities( $this->service( $this->snapshot() ) );
+		$abilities->register();
+		foreach ( array( 'extrachill/get-venue-booking-performance-report', 'extrachill/get-venue-booking-revenue-report' ) as $name ) {
+			$definition = $GLOBALS['ec_artist_test']['abilities'][ $name ];
+			$this->assertTrue( $definition['meta']['annotations']['readonly'] );
+			$this->assertFalse( $definition['meta']['annotations']['destructive'] );
+			$this->assertFalse( $definition['input_schema']['additionalProperties'] );
+			$this->assertArrayNotHasKey( 'user_id', $definition['input_schema']['properties'] );
+			$expected_limit = false !== strpos( $name, 'revenue' ) ? BookingReportingService::MAX_FINANCE_BOOKINGS : BookingReportingService::MAX_BOOKINGS;
+			$this->assertSame( $expected_limit, $definition['input_schema']['properties']['limit']['maximum'] );
+		}
+	}
+
+	private function service( array $snapshot ): BookingReportingService {
+		return new BookingReportingService( $this->authorization, null, null, static fn(): array => $snapshot );
+	}
+
+	private function input(): array {
+		return array(
+			'venue_term_ids' => array( 55 ),
+			'from'           => '2026-07-01 00:00:00',
+			'to'             => '2026-08-01 00:00:00',
+			'limit'          => 100,
+		);
+	}
+
+	private function snapshot(): array {
+		return array(
+			'bookings'             => array(),
+			'activities'           => array(),
+			'holds'                => array(),
+			'sales_reports'        => array(),
+			'sales_resolutions'    => array(),
+			'commissions'          => array(),
+			'shows'                => array(),
+			'truncated'            => false,
+			'activities_truncated' => false,
+			'database_now'         => '2026-07-05 00:00:00',
+		);
+	}
+
+	private function activity( int $booking_id, string $kind, string $occurred_at, array $data = array(), array $extra = array() ): array {
+		return array_merge(
+			array(
+				'booking_id'  => $booking_id,
+				'kind'        => $kind,
+				'occurred_at' => $occurred_at,
+				'channel'     => null,
+				'external_id' => null,
+				'payload'     => array(
+					'version' => 1,
+					'data'    => $data,
+				),
+			),
+			$extra
+		);
+	}
+}

--- a/tests/ShowSettlementTest.php
+++ b/tests/ShowSettlementTest.php
@@ -207,6 +207,7 @@ final class ShowSettlementTest extends BookingTestCase {
 
 		$finalized = $this->service->finalize( $this->transition( $booking['id'], $draft, 'finalize-one' ), 12 );
 		$this->assertSame( 'finalized', $finalized['status'] );
+		$this->assertSame( $finalized['id'], $this->service->get_for_reporting( $booking['id'], 12, 200 )['id'] );
 		$this->assertSame( 2, $finalized['version'] );
 		$ack                         = $this->transition( $booking['id'], $finalized, 'ack-one' );
 		$ack['note']                 = 'Artist representative approved the statement.';

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -2062,6 +2062,8 @@ require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingCommunicationAb
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/VenueBookingMarketingAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/TicketSettlementAbilities.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Abilities/ShowSettlementAbilities.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingReportingService.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Abilities/BookingReportingAbilities.php';
 
 final class BookingTestAuthorization extends VenueAuthorization {
 	public $calls                     = array();


### PR DESCRIPTION
## Summary
- add read-only venue booking performance and revenue report abilities over canonical booking records
- enforce exact venue membership for every requested venue, owner-level finance authority for revenue, and an additional administrator gate for multi-venue aggregation
- expose explicit empty, incomplete, corrected, and finalized states with bounded cohort/query behavior and honest unavailable metrics

## Abilities

### `extrachill/get-venue-booking-performance-report`

Inputs:
- `venue_term_ids`: 1-20 unique venue term IDs
- `from`, `to`: strict UTC `Y-m-d H:i:s`, half-open period, maximum 366 days
- `limit`: 1-200 booking cohorts

Outputs:
- scope and cohort basis (`inquiry_created_at`) plus `outcomes_as_of`
- bounded/truncation metadata and `empty|incomplete|complete` state
- inquiry count, current lifecycle stages, stage entries, conversion basis points, decline/note counts, and time-to-confirmation summary
- effective hold state, confirmed shows, conversion/synchronization state, ticket evidence/correction references, and explicit reconciliation availability
- bounded marketing execution status, classifications, effect counts, and opaque owner-approved outcome references

### `extrachill/get-venue-booking-revenue-report`

Inputs:
- same strict venue/range contract
- `limit`: 1-25 performance cohorts

Outputs:
- scope and cohort basis (`performance_start_at`) plus `outcomes_as_of`
- `empty|incomplete|corrected|finalized` state and exact settlement coverage
- commission and show-settlement lifecycle counts
- currency-separated Extra Chill share due/paid, committed/paid artist payout, and venue net after payout
- explicit booking, truncation, and 200-row-per-booking financial verification bounds

## Canonical Source Map

| Metric | Canonical source |
| --- | --- |
| Inquiry cohort | `ec_bookings.created_at`, excluding `admission_pending` |
| Current stage | `ec_bookings.status` |
| Stage entries and declines | `ec_booking_activity` `inquiry_submitted`, `status_changed`, and `deal_confirmed` records |
| Decline note availability | bounded presence check on canonical `status_changed.payload.data.note`; note text is never returned |
| Time to confirmation | `inquiry_submitted.occurred_at` to `deal_confirmed.occurred_at` |
| Holds | `ec_booking_holds`, including effective expiration against database time |
| Confirmed shows | canonical `deal_confirmed` activity |
| Event conversion/sync | canonical conversion and synchronization activity markers |
| Ticket evidence | `ec_booking_sales_reports` IDs/correction links and latest explicit `ec_booking_sales_resolutions` decisions; no source payload or money is exposed in operations |
| Marketing execution/outcomes | `marketing_operation_submitted` and failure activity using the bounded owner-approved projection and opaque operation refs |
| Extra Chill revenue share | integrity-verified `ec_booking_settlements` through `TicketSettlementService` |
| Show settlement and artist payout | integrity-verified latest `ec_booking_show_settlements` plus lifecycle actions through `ShowSettlementService` |
| Corrected/finalized state | latest immutable show revision, correction link, lifecycle state, complete coverage, and truncation flags |

No reporting table, rollup store, generic analytics substrate, or private Data Machine Events storage was added.

## Authorization And Privacy

| Report | Single venue | Multiple venues | Excluded data |
| --- | --- | --- | --- |
| Performance | authenticated caller must pass existing exact `access_venue` membership policy | caller must additionally have explicit administrator authority and pass exact membership for every venue | contacts, correspondence content, attachments, invitation/member data, intake/deal payloads, resolution reasons, and unrelated venues |
| Revenue | authenticated caller must pass existing exact `manage_finances` owner policy | caller must additionally have explicit administrator authority and pass finance authority for every venue | payment references, payout evidence, attachment metadata/bytes, actor identities, source payloads, and unrelated venues |

Both permission and execution paths resolve identity with `get_current_user_id()` and reauthorize. No caller-supplied user identity is accepted. Authorization failures use the existing non-enumerating `venue_action_forbidden` response.

## Bounded Query Behavior
- maximum 366-day half-open UTC range
- maximum 20 venues, 200 performance cohorts, and 25 finance cohorts
- maximum 5,000 relevant activity records per performance report
- maximum 1,000 hold, sales-report, and resolution references per projection; overflow returns `incomplete`
- finance verification scans at most 200 ticket evidence rows per booking; overflow returns `incomplete`
- every dynamic ID/kind list is prepared, and each evidence query fails immediately rather than silently undercounting
- finance records are verified by their owning settlement services before aggregation

## Honest Unavailable Metrics
- inquiry acquisition source: `not_recorded`
- typed decline reason codes: `not_recorded`; only decline and note-presence counts are returned
- first response/delivery/reply timing: `not_recorded`; queued communication is not treated as delivery or response evidence
- automatic ticket diagnostic state: unavailable in this aggregate; explicit decisions and raw evidence/correction counts are returned without fabricating admission state
- marketing outcomes: `no_observations` when no owner-approved projection exists

## Tests
- `vendor/bin/phpunit --configuration phpunit-booking.xml.dist`: **OK, 430 tests, 4,616 assertions**
- focused reporting suite: authorization, multi-venue admin gate, strict ranges, empty/unavailable metrics, stale holds, lifecycle conversion, corrections, marketing refs, finance denial, incomplete/truncated coverage, corrected/finalized periods, draft exclusion, schemas, and ability annotations
- `vendor/bin/phpcs --standard=WordPress` on changed implementation/tests: **pass**
- Homeboy lint/PHPStan on both new reporting files: **pass, 0 findings**
- Homeboy PR audit: **pass, no introduced findings** (one known contextual test-harness size info finding)
- full file-level PHPStan on touched legacy bootstrap/settlement files still reports pre-existing test-stub signature and bootstrap typing noise; no new reporting-file findings remain

Closes #320