### PR TITLE
fix: simplify venue subscription prompt

### DIFF
--- a/inc/core/venue-update-subscriptions.php
+++ b/inc/core/venue-update-subscriptions.php
@@ -61,7 +61,7 @@ function extrachill_events_render_venue_update_control(): void {
 
 	$archive_url = get_term_link( $term );
 	if ( ! is_user_logged_in() ) {
-		echo '<aside class="events-market-context events-market-context--quiet"><span>' . esc_html__( 'Get a private notification when new events are published at this venue.', 'extrachill-events' ) . '</span> <a href="' . esc_url( wp_login_url( $archive_url ) ) . '">' . esc_html__( 'Sign in to subscribe', 'extrachill-events' ) . '</a></aside>';
+		echo '<aside class="events-market-context events-market-context--quiet"><span>' . esc_html__( 'Get notified when new events are published at this venue.', 'extrachill-events' ) . '</span> <a href="' . esc_url( wp_login_url( $archive_url ) ) . '">' . esc_html__( 'Sign in to subscribe', 'extrachill-events' ) . '</a></aside>';
 		return;
 	}
 

--- a/tests/Unit/VenueUpdateSubscriptionsTest.php
+++ b/tests/Unit/VenueUpdateSubscriptionsTest.php
@@ -97,6 +97,7 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		extrachill_events_render_venue_update_control();
 		$html = ob_get_clean();
 
+		$this->assertStringContainsString( 'Get notified when new events are published at this venue.', $html );
 		$this->assertStringContainsString( 'Sign in to subscribe', $html );
 		$this->assertStringNotContainsString( 'data-venue-update-subscription', $html );
 	}


### PR DESCRIPTION
## Summary
- replace the awkward anonymous venue prompt with direct reader-facing language
- assert the corrected prompt in the existing venue subscription test

## Testing
- `vendor/bin/phpcs --standard=WordPress inc/core/venue-update-subscriptions.php tests/Unit/VenueUpdateSubscriptionsTest.php`
- `git diff --check`
- `vendor/bin/phpunit -c phpunit.xml.dist --filter VenueUpdateSubscriptionsTest` *(blocked by the existing test bootstrap issue: `WP_UnitTestCase` is not loaded)*

Closes #477