### PR TITLE
fix: simplify venue subscription status

### DIFF
--- a/assets/js/venue-update-subscriptions.js
+++ b/assets/js/venue-update-subscriptions.js
@@ -22,9 +22,7 @@
 			: 'Subscribe to updates';
 		status.textContent =
 			message ||
-			( subscribed
-				? 'Private venue updates are on.'
-				: 'Private venue updates are off.' );
+			( subscribed ? 'Venue updates are on.' : 'Venue updates are off.' );
 	}
 
 	function request( ability, method ) {

--- a/assets/js/venue-update-subscriptions.test.js
+++ b/assets/js/venue-update-subscriptions.test.js
@@ -34,6 +34,9 @@ describe( 'Venue update subscriptions', () => {
 		expect( fetch.mock.calls[ 0 ][ 0 ] ).not.toContain(
 			'entity-subscribe/run'
 		);
+		expect(
+			document.querySelector( '[data-venue-update-status]' ).textContent
+		).toBe( 'Venue updates are off.' );
 	} );
 
 	it( 'subscribes with the exact venue identity after a click', async () => {
@@ -62,6 +65,9 @@ describe( 'Venue update subscriptions', () => {
 		expect( document.querySelector( 'button' ).textContent ).toBe(
 			'Subscribed to updates'
 		);
+		expect(
+			document.querySelector( '[data-venue-update-status]' ).textContent
+		).toBe( 'Venue updates are on.' );
 	} );
 
 	it( 'unsubscribes only after an explicit second click', async () => {


### PR DESCRIPTION
## Summary
- remove the internal \"private\" qualifier from authenticated venue subscription states
- verify both on and off status copy in the existing JavaScript tests

## Testing
- `npm run test:js -- assets/js/venue-update-subscriptions.test.js --runInBand`
- `npm run lint:js -- assets/js/venue-update-subscriptions.js assets/js/venue-update-subscriptions.test.js`
- `git diff --check`

Closes #479