### PR TITLE
fix: compose venue preference controls

### DIFF
--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -104,6 +104,32 @@
     flex-shrink: 0;
 }
 
+.events-venue-preferences {
+    display: block;
+    padding: 0;
+}
+
+.events-venue-preferences__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-md);
+}
+
+.events-venue-preferences__header span {
+    color: var(--muted-text);
+    font-size: var(--font-size-sm);
+}
+
+.events-venue-preferences__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+    border-top: 1px solid var(--border-color);
+}
+
 /* Progressive homepage router: search, preferred market, sample, directories. */
 .events-home-router {
     display: grid;
@@ -193,6 +219,15 @@
 
     .events-market-context__actions {
         gap: var(--spacing-sm) var(--spacing-md);
+    }
+
+    .events-venue-preferences__row {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .events-venue-preferences__row .button-1 {
+        align-self: flex-start;
     }
 
     .events-primary-market {

--- a/assets/js/venue-email-sharing.js
+++ b/assets/js/venue-email-sharing.js
@@ -17,14 +17,12 @@
 
 	function setState( subscribed, message ) {
 		button.setAttribute( 'aria-pressed', subscribed ? 'true' : 'false' );
-		button.textContent = subscribed
-			? 'Email shared with venue'
-			: 'Share email with venue';
+		button.textContent = subscribed ? 'Stop sharing' : 'Share email';
 		status.textContent =
 			message ||
 			( subscribed
-				? 'This venue can access your current account email.'
-				: 'This venue cannot access your account email.' );
+				? 'Shared with this venue'
+				: 'Not shared with this venue' );
 	}
 
 	function request( ability, method ) {
@@ -55,13 +53,13 @@
 	}
 
 	request( 'entity-subscription-status', 'GET' )
-		.then( ( data ) => setState( Boolean( data.subscribed ) ) )
+		.then( ( data ) => {
+			setState( Boolean( data.subscribed ) );
+			button.disabled = false;
+		} )
 		.catch( () => {
 			status.textContent =
-				'Email-sharing status is unavailable. Please try again.';
-		} )
-		.finally( () => {
-			button.disabled = false;
+				"Couldn't load this setting. Refresh to try again.";
 		} );
 
 	button.addEventListener( 'click', () => {

--- a/assets/js/venue-email-sharing.test.js
+++ b/assets/js/venue-email-sharing.test.js
@@ -31,6 +31,11 @@ describe( 'Venue email sharing', () => {
 		expect( fetch.mock.calls[ 0 ][ 0 ] ).toContain(
 			'entity-subscription-status'
 		);
+		expect(
+			document.querySelector( '[data-venue-email-sharing-status]' )
+				.textContent
+		).toBe( 'Not shared with this venue' );
+		expect( document.querySelector( 'button' ).disabled ).toBe( false );
 	} );
 
 	it( 'uses only the scoped venue email-sharing identity', async () => {
@@ -57,7 +62,7 @@ describe( 'Venue email sharing', () => {
 			'"entity_type":"venue"'
 		);
 		expect( document.querySelector( 'button' ).textContent ).toBe(
-			'Email shared with venue'
+			'Stop sharing'
 		);
 	} );
 
@@ -80,7 +85,19 @@ describe( 'Venue email sharing', () => {
 			'entity-unsubscribe/run'
 		);
 		expect( document.querySelector( 'button' ).textContent ).toBe(
-			'Share email with venue'
+			'Share email'
 		);
+	} );
+
+	it( 'keeps mutation disabled when status cannot be loaded', async () => {
+		fetch.mockRejectedValue( new Error( 'offline' ) );
+		require( './venue-email-sharing' );
+		await flushPromises();
+
+		expect( document.querySelector( 'button' ).disabled ).toBe( true );
+		expect(
+			document.querySelector( '[data-venue-email-sharing-status]' )
+				.textContent
+		).toBe( "Couldn't load this setting. Refresh to try again." );
 	} );
 } );

--- a/assets/js/venue-update-subscriptions.js
+++ b/assets/js/venue-update-subscriptions.js
@@ -17,12 +17,8 @@
 
 	function setState( subscribed, message ) {
 		button.setAttribute( 'aria-pressed', subscribed ? 'true' : 'false' );
-		button.textContent = subscribed
-			? 'Subscribed to updates'
-			: 'Subscribe to updates';
-		status.textContent =
-			message ||
-			( subscribed ? 'Venue updates are on.' : 'Venue updates are off.' );
+		button.textContent = subscribed ? 'Turn off' : 'Turn on';
+		status.textContent = message || ( subscribed ? 'On' : 'Off' );
 	}
 
 	function request( ability, method ) {
@@ -53,13 +49,13 @@
 	}
 
 	request( 'entity-subscription-status', 'GET' )
-		.then( ( data ) => setState( Boolean( data.subscribed ) ) )
+		.then( ( data ) => {
+			setState( Boolean( data.subscribed ) );
+			button.disabled = false;
+		} )
 		.catch( () => {
 			status.textContent =
-				'Subscription status is unavailable. Please try again.';
-		} )
-		.finally( () => {
-			button.disabled = false;
+				"Couldn't load this setting. Refresh to try again.";
 		} );
 
 	button.addEventListener( 'click', () => {

--- a/assets/js/venue-update-subscriptions.test.js
+++ b/assets/js/venue-update-subscriptions.test.js
@@ -36,7 +36,8 @@ describe( 'Venue update subscriptions', () => {
 		);
 		expect(
 			document.querySelector( '[data-venue-update-status]' ).textContent
-		).toBe( 'Venue updates are off.' );
+		).toBe( 'Off' );
+		expect( document.querySelector( 'button' ).disabled ).toBe( false );
 	} );
 
 	it( 'subscribes with the exact venue identity after a click', async () => {
@@ -63,11 +64,11 @@ describe( 'Venue update subscriptions', () => {
 			slug: 'the-royal-american',
 		} );
 		expect( document.querySelector( 'button' ).textContent ).toBe(
-			'Subscribed to updates'
+			'Turn off'
 		);
 		expect(
 			document.querySelector( '[data-venue-update-status]' ).textContent
-		).toBe( 'Venue updates are on.' );
+		).toBe( 'On' );
 	} );
 
 	it( 'unsubscribes only after an explicit second click', async () => {
@@ -89,7 +90,18 @@ describe( 'Venue update subscriptions', () => {
 			'entity-unsubscribe/run'
 		);
 		expect( document.querySelector( 'button' ).textContent ).toBe(
-			'Subscribe to updates'
+			'Turn on'
 		);
+	} );
+
+	it( 'keeps mutation disabled when status cannot be loaded', async () => {
+		fetch.mockRejectedValue( new Error( 'offline' ) );
+		require( './venue-update-subscriptions' );
+		await flushPromises();
+
+		expect( document.querySelector( 'button' ).disabled ).toBe( true );
+		expect(
+			document.querySelector( '[data-venue-update-status]' ).textContent
+		).toBe( "Couldn't load this setting. Refresh to try again." );
 	} );
 } );

--- a/inc/core/venue-email-sharing.php
+++ b/inc/core/venue-email-sharing.php
@@ -13,7 +13,6 @@ const EXTRACHILL_EVENTS_VENUE_EMAIL_SHARING_PRODUCER = 'extrachill-events-venue-
 function extrachill_events_init_venue_email_sharing(): void {
 	add_filter( 'extrachill_users_entity_subscription_entities', 'extrachill_events_register_venue_email_sharing_identity' );
 	add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_events_authorize_venue_email_sharing_producer', 10, 4 );
-	add_action( 'extrachill_archive_below_description', 'extrachill_events_render_venue_email_sharing_control', 6 );
 	add_action( 'wp_enqueue_scripts', 'extrachill_events_venue_email_sharing_scripts' );
 }
 
@@ -52,31 +51,20 @@ function extrachill_events_authorize_venue_email_sharing_producer( $authorized, 
 		&& 'venue' === ( $entity['taxonomy'] ?? '' );
 }
 
-/** Render a separate explicit email-sharing choice on canonical venue archives. */
+/** Render the explicit email-sharing row inside venue preferences. */
 function extrachill_events_render_venue_email_sharing_control(): void {
 	$term = function_exists( 'extrachill_events_get_venue_archive_term' ) ? extrachill_events_get_venue_archive_term() : null;
-	if ( null === $term ) {
+	if ( null === $term || ! is_user_logged_in() ) {
 		return;
 	}
-
-	$archive_url = get_term_link( $term );
-	if ( ! is_user_logged_in() ) {
-		echo '<aside class="events-market-context events-market-context--quiet"><span>' . esc_html__( 'Share your account email with this venue for its own email list.', 'extrachill-events' ) . '</span> <a href="' . esc_url( wp_login_url( $archive_url ) ) . '">' . esc_html__( 'Sign in to share your email', 'extrachill-events' ) . '</a></aside>';
-		return;
-	}
-
-	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
-		define( 'DONOTCACHEPAGE', true );
-	}
-	nocache_headers();
 	?>
-	<aside class="events-market-context" data-venue-email-sharing-control>
+	<div class="events-venue-preferences__row" data-venue-email-sharing-control>
 		<div class="events-market-context__copy">
 			<strong><?php esc_html_e( 'Venue email list', 'extrachill-events' ); ?></strong>
-			<span data-venue-email-sharing-status><?php esc_html_e( 'Checking your email-sharing choice...', 'extrachill-events' ); ?></span>
+			<span data-venue-email-sharing-status aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-events' ); ?></span>
 		</div>
-		<button class="button-1 button-small" type="button" disabled aria-pressed="false" data-venue-email-sharing data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Share email with venue', 'extrachill-events' ); ?></button>
-	</aside>
+		<button class="button-1 button-small" type="button" disabled aria-pressed="false" data-venue-email-sharing data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Share email', 'extrachill-events' ); ?></button>
+	</div>
 	<?php
 }
 

--- a/inc/core/venue-update-subscriptions.php
+++ b/inc/core/venue-update-subscriptions.php
@@ -61,7 +61,7 @@ function extrachill_events_render_venue_update_control(): void {
 
 	$archive_url = get_term_link( $term );
 	if ( ! is_user_logged_in() ) {
-		echo '<aside class="events-market-context events-market-context--quiet"><span>' . esc_html__( 'Get notified when new events are published at this venue.', 'extrachill-events' ) . '</span> <a href="' . esc_url( wp_login_url( $archive_url ) ) . '">' . esc_html__( 'Sign in to subscribe', 'extrachill-events' ) . '</a></aside>';
+		echo '<aside class="events-market-context events-market-context--quiet"><div class="events-market-context__copy"><strong>' . esc_html__( 'Venue preferences', 'extrachill-events' ) . '</strong><span>' . esc_html__( 'Get event notifications and choose whether to share your email with this venue.', 'extrachill-events' ) . '</span></div> <a href="' . esc_url( wp_login_url( $archive_url ) ) . '">' . esc_html__( 'Sign in to manage preferences', 'extrachill-events' ) . '</a></aside>';
 		return;
 	}
 
@@ -70,12 +70,21 @@ function extrachill_events_render_venue_update_control(): void {
 	}
 	nocache_headers();
 	?>
-	<aside class="events-market-context" data-venue-update-control>
-		<div class="events-market-context__copy">
-			<strong><?php esc_html_e( 'Venue updates', 'extrachill-events' ); ?></strong>
-			<span data-venue-update-status><?php esc_html_e( 'Checking your subscription...', 'extrachill-events' ); ?></span>
+	<aside class="events-market-context events-venue-preferences" data-venue-preferences>
+		<div class="events-venue-preferences__header">
+			<strong><?php esc_html_e( 'Venue preferences', 'extrachill-events' ); ?></strong>
+			<span><?php esc_html_e( 'Choose how you hear about events and whether this venue can access your email.', 'extrachill-events' ); ?></span>
 		</div>
-		<button class="button-1 button-small" type="button" disabled aria-pressed="false" data-venue-update-subscription data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Subscribe to updates', 'extrachill-events' ); ?></button>
+		<div class="events-venue-preferences__rows">
+			<div class="events-venue-preferences__row" data-venue-update-control>
+				<div class="events-market-context__copy">
+					<strong><?php esc_html_e( 'Event notifications', 'extrachill-events' ); ?></strong>
+					<span data-venue-update-status aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-events' ); ?></span>
+				</div>
+				<button class="button-1 button-small" type="button" disabled aria-pressed="false" data-venue-update-subscription data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Turn on', 'extrachill-events' ); ?></button>
+			</div>
+			<?php extrachill_events_render_venue_email_sharing_control(); ?>
+		</div>
 	</aside>
 	<?php
 }

--- a/tests/Unit/VenueUpdateSubscriptionsTest.php
+++ b/tests/Unit/VenueUpdateSubscriptionsTest.php
@@ -97,9 +97,11 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		extrachill_events_render_venue_update_control();
 		$html = ob_get_clean();
 
-		$this->assertStringContainsString( 'Get notified when new events are published at this venue.', $html );
-		$this->assertStringContainsString( 'Sign in to subscribe', $html );
+		$this->assertStringContainsString( 'Venue preferences', $html );
+		$this->assertStringContainsString( 'Get event notifications and choose whether to share your email with this venue.', $html );
+		$this->assertStringContainsString( 'Sign in to manage preferences', $html );
 		$this->assertStringNotContainsString( 'data-venue-update-subscription', $html );
+		$this->assertStringNotContainsString( 'data-venue-email-sharing', $html );
 	}
 
 	/** Authenticated archives progressively load the exact venue identity. */
@@ -112,23 +114,26 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		$html = ob_get_clean();
 
 		$this->assertStringContainsString( 'data-venue-update-subscription', $html );
-		$this->assertStringContainsString( 'Checking your subscription...', $html );
+		$this->assertStringContainsString( 'Event notifications', $html );
+		$this->assertStringContainsString( 'aria-live="polite"', $html );
 		$this->assertStringContainsString( 'data-slug="the-royal-american"', $html );
 	}
 
-	/** Archive email sharing remains a visibly separate explicit control. */
-	public function test_archive_renders_separate_email_sharing_control(): void {
+	/** Archive preferences compose two explicit controls in one panel. */
+	public function test_archive_composes_independent_controls_in_one_panel(): void {
 		$this->venue_archive();
 		wp_set_current_user( self::factory()->user->create() );
 
 		ob_start();
 		extrachill_events_render_venue_update_control();
-		extrachill_events_render_venue_email_sharing_control();
 		$html = ob_get_clean();
 
+		$this->assertSame( 1, substr_count( $html, '<aside' ) );
+		$this->assertStringContainsString( 'data-venue-preferences', $html );
 		$this->assertStringContainsString( 'data-venue-update-subscription', $html );
 		$this->assertStringContainsString( 'data-venue-email-sharing', $html );
-		$this->assertStringContainsString( 'Share email with venue', $html );
+		$this->assertStringContainsString( 'Venue email list', $html );
+		$this->assertStringContainsString( 'Share email', $html );
 	}
 
 	/** First publication deduplicates subscribers across all assigned venues. */


### PR DESCRIPTION
## Summary
- combine event notifications and venue email sharing into one coherent preferences panel
- preserve independent consent identities while clarifying each purpose
- keep controls disabled when their current state cannot be established
- add responsive composition styles and polite status announcements

## Testing
- `npm run test:js -- assets/js/venue-update-subscriptions.test.js assets/js/venue-email-sharing.test.js --runInBand`
- `npm run lint:js -- assets/js/venue-update-subscriptions.js assets/js/venue-update-subscriptions.test.js assets/js/venue-email-sharing.js assets/js/venue-email-sharing.test.js`
- `vendor/bin/phpcs --standard=WordPress inc/core/venue-update-subscriptions.php inc/core/venue-email-sharing.php tests/Unit/VenueUpdateSubscriptionsTest.php`
- `git diff --check`

## Dependency

Successful venue email-sharing status requires the unreleased descriptor support already merged into `extrachill-users/main` under Extra-Chill/extrachill-users#300. This PR intentionally does not work around that generic contract.

Closes #487