### PR TITLE
fix: preview disabled Local Scene digest dry runs

### DIFF
--- a/inc/Steps/LocalSceneDigest/LocalSceneDigestSystemTask.php
+++ b/inc/Steps/LocalSceneDigest/LocalSceneDigestSystemTask.php
@@ -63,7 +63,7 @@ class LocalSceneDigestSystemTask extends SystemTask {
 	 * @param array $params Digest parameters.
 	 */
 	public function executeTask( int $jobId, array $params ): void {
-		if ( ! (bool) PluginSettings::get( 'extrachill_local_scene_digest_enabled', false ) ) {
+		if ( empty( $params['dry_run'] ) && ! (bool) PluginSettings::get( 'extrachill_local_scene_digest_enabled', false ) ) {
 			$this->completeJob(
 				$jobId,
 				array(

--- a/tests/Unit/Core/LocalSceneDigestSystemTaskTest.php
+++ b/tests/Unit/Core/LocalSceneDigestSystemTaskTest.php
@@ -40,7 +40,7 @@ class LocalSceneDigestSystemTaskTest extends TestCase {
 		};
 		$task->executeTask( 41, array( 'dry_run' => true ) );
 
-		$this->assertSame( array( 'extrachill_local_scene_digest_enabled', false ), $GLOBALS['ec_test_plugin_settings_reads'][0] );
+		$this->assertEmpty( $GLOBALS['ec_test_plugin_settings_reads'] );
 		$this->assertSame( 'failJob', $GLOBALS['ec_test_systemtask_calls'][0]['method'] );
 		$this->assertSame( 'Local Scene digest encountered a retryable delivery failure.', $GLOBALS['ec_test_systemtask_calls'][0]['message'] );
 		$this->assertStringNotContainsString( 'location', strtolower( $GLOBALS['ec_test_systemtask_calls'][0]['message'] ) );
@@ -63,6 +63,57 @@ class LocalSceneDigestSystemTaskTest extends TestCase {
 		$this->assertSame( 'completeJob', $GLOBALS['ec_test_systemtask_calls'][0]['method'] );
 		$this->assertFalse( $GLOBALS['ec_test_systemtask_calls'][0]['data']['retryable_failure'] );
 		$this->assertSame( 1, $GLOBALS['ec_test_systemtask_calls'][0]['data']['counts']['candidate_queries_truncated'] );
+	}
+
+	public function test_disabled_dry_run_executes_preview(): void {
+		$GLOBALS['ec_test_systemtask_calls']      = array();
+		$GLOBALS['ec_test_plugin_settings_reads'] = array();
+		$GLOBALS['ec_test_plugin_settings']       = array( 'extrachill_local_scene_digest_enabled' => false );
+		$GLOBALS['ec_test_digest_params']         = array();
+		$task = new class() extends \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask {
+			protected function runDigest( array $params ): array {
+				$GLOBALS['ec_test_digest_params'][] = $params;
+				return array(
+					'dry_run'           => true,
+					'counts'            => array( 'qualified_events' => 3, 'recipients' => 2 ),
+					'failures'          => array(),
+					'retryable_failure' => false,
+				);
+			}
+		};
+		$task->executeTask( 43, array( 'days' => 7, 'limit' => 8, 'dry_run' => true ) );
+
+		$this->assertEmpty( $GLOBALS['ec_test_plugin_settings_reads'], 'Dry runs must not depend on the live sender setting.' );
+		$this->assertSame( array( 'days' => 7, 'limit' => 8, 'dry_run' => true ), $GLOBALS['ec_test_digest_params'][0] );
+		$this->assertSame( 'completeJob', $GLOBALS['ec_test_systemtask_calls'][0]['method'] );
+		$this->assertTrue( $GLOBALS['ec_test_systemtask_calls'][0]['data']['dry_run'] );
+		$this->assertSame( 3, $GLOBALS['ec_test_systemtask_calls'][0]['data']['counts']['qualified_events'] );
+		$this->assertSame( 2, $GLOBALS['ec_test_systemtask_calls'][0]['data']['counts']['recipients'] );
+	}
+
+	public function test_disabled_live_run_remains_skipped(): void {
+		$GLOBALS['ec_test_systemtask_calls']      = array();
+		$GLOBALS['ec_test_plugin_settings_reads'] = array();
+		$GLOBALS['ec_test_plugin_settings']       = array( 'extrachill_local_scene_digest_enabled' => false );
+		$GLOBALS['ec_test_digest_params']         = array();
+		$task = new class() extends \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask {
+			protected function runDigest( array $params ): array {
+				$GLOBALS['ec_test_digest_params'][] = $params;
+				return array();
+			}
+		};
+		$task->executeTask( 44, array( 'dry_run' => false ) );
+
+		$this->assertSame( array( array( 'extrachill_local_scene_digest_enabled', false ) ), $GLOBALS['ec_test_plugin_settings_reads'] );
+		$this->assertEmpty( $GLOBALS['ec_test_digest_params'] );
+		$this->assertSame( 'completeJob', $GLOBALS['ec_test_systemtask_calls'][0]['method'] );
+		$this->assertSame(
+			array(
+				'skipped' => true,
+				'reason'  => 'Weekly Local Scene digest disabled.',
+			),
+			$GLOBALS['ec_test_systemtask_calls'][0]['data']
+		);
 	}
 
 	public function test_recurring_schedule_is_default_disabled_and_explicitly_delivers(): void {

--- a/tests/Unit/Core/LocalSceneDigestTest.php
+++ b/tests/Unit/Core/LocalSceneDigestTest.php
@@ -605,6 +605,27 @@ class LocalSceneDigestTest extends TestCase {
 		$this->assertEmpty( $GLOBALS['local_scene_releases'] );
 	}
 
+	public function test_dry_run_previews_qualified_recipients_without_mutation(): void {
+		$tomorrow = new DateTimeImmutable( 'tomorrow', wp_timezone() );
+		$GLOBALS['local_scene_posts'] = array( new WP_Post( array( 'ID' => 8, 'post_status' => 'publish', 'post_title' => 'Qualified Show' ) ) );
+		$GLOBALS['local_scene_terms'][8] = array( 'location' => array( 44 ), 'venue' => array( $this->term( 10, 'club', 'Club' ) ), 'artist' => array( 3 ) );
+		$GLOBALS['local_scene_event_data'][8] = array( 'startDate' => $tomorrow->format( 'Y-m-d' ), 'startTime' => '20:00:00', 'venueTimezone' => 'America/New_York' );
+		$GLOBALS['local_scene_recipients'] = array( 'notification' => array( 7 ), 'email' => array( 7 ) );
+		$GLOBALS['local_scene_scenes'][7] = array( 'slug' => 'austin' );
+
+		$result = extrachill_events_run_local_scene_digest( array( 'dry_run' => true ) );
+
+		$this->assertTrue( $result['dry_run'] );
+		$this->assertSame( 1, $result['counts']['qualified_events'] );
+		$this->assertSame( 1, $result['counts']['recipients'] );
+		$this->assertSame( 0, $result['counts']['notifications_inserted'] );
+		$this->assertSame( 0, $result['counts']['emails_queued'] );
+		$this->assertEmpty( $GLOBALS['local_scene_notifications'] );
+		$this->assertEmpty( $GLOBALS['local_scene_emails'] );
+		$this->assertEmpty( $GLOBALS['local_scene_releases'] );
+		$this->assertEmpty( $GLOBALS['local_scene_unsubscribes'] );
+	}
+
 	public function test_runner_marks_location_and_recipient_resolution_failures_retryable(): void {
 		$GLOBALS['local_scene_locations'] = new WP_Error( 'location_query_failed' );
 		$location_failure = extrachill_events_run_local_scene_digest();


### PR DESCRIPTION
## Summary
- let Data Machine dry-runs enter the existing bounded Local Scene digest preview while the live sender setting remains disabled
- preserve the disabled live-send skip and existing recurring schedule defaults
- cover preview counts and prove that dry-runs do not call notification, email, receipt-release, or unsubscribe mutation paths

## Root Cause
`LocalSceneDigestSystemTask::executeTask()` checked `extrachill_local_scene_digest_enabled` before inspecting Data Machine's normalized `dry_run` task parameter. That caused safe manual previews to return the live sender's disabled result before recipient qualification or event selection could run, blocking rollout verification.

## Behavior
- Disabled + `dry_run=true`: bypasses only the live sender enablement gate, runs the existing bounded digest preview, and returns its aggregate `qualified_events` and `recipients` counts.
- Disabled + live/non-dry-run: remains skipped with `Weekly Local Scene digest disabled.` and never invokes the digest runner.

## No-Mutation Evidence
The existing runner stops before `extrachill_events_deliver_local_scene_digest()` whenever `dry_run` is true. The new runner-level test resolves one qualified event and recipient while asserting zero notification inserts, email queue calls, receipt releases, and subscription unsubscribe calls. The task does not write or enable `extrachill_local_scene_digest_enabled`.

## Tests
- `vendor/bin/phpunit --configuration phpunit-local-scene-unit.xml.dist` - PASS: 28 tests, 184 assertions.
- `php -l inc/Steps/LocalSceneDigest/LocalSceneDigestSystemTask.php && php -l tests/Unit/Core/LocalSceneDigestSystemTaskTest.php && php -l tests/Unit/Core/LocalSceneDigestTest.php` - PASS.
- `git diff --check` - PASS.
- `vendor/bin/phpunit` - unable to bootstrap the repository's default suite in this worktree because `WP_UnitTestCase` is unavailable; it exits before running tests at `CanonicalLocationsAbilityTest.php`.
- `vendor/bin/phpcs --standard=WordPress inc/Steps/LocalSceneDigest/LocalSceneDigestSystemTask.php tests/Unit/Core/LocalSceneDigestSystemTaskTest.php tests/Unit/Core/LocalSceneDigestTest.php` - reports the existing test fixture's broad WordPress-standard violations; no automatic formatting was applied.

## Post-Merge Verification
```bash
wp --url=https://events.extrachill.com datamachine system run extrachill_local_scene_digest --dry-run --params='{"days":7,"limit":8}' --wait --format=json
```

Confirm the child result has `dry_run: true`, useful `counts.qualified_events` / `counts.recipients` evidence, and zero delivery counts while `extrachill_local_scene_digest_enabled` remains disabled.

Closes #492