### PR TITLE
fix: guard unavailable publication timezone transitions

### DIFF
--- a/inc/Core/CanonicalEventPublicationGuard.php
+++ b/inc/Core/CanonicalEventPublicationGuard.php
@@ -612,8 +612,31 @@ class CanonicalEventPublicationGuard {
 		if ( false === $wall || $wall->format( 'Y-m-d H:i:s' ) !== $value ) {
 			return new \WP_Error( 'canonical_event_datetime_invalid', __( 'Event dates must be valid local venue wall times.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
+		$transitions = $timezone->getTransitions( $wall->getTimestamp() - DAY_IN_SECONDS, $wall->getTimestamp() + DAY_IN_SECONDS );
+		if ( ! is_array( $transitions ) ) {
+			return new \WP_Error(
+				'canonical_event_venue_timezone_transitions_unavailable',
+				__( 'The venue timezone cannot be checked safely for publication.', 'extrachill-events' ),
+				array(
+					'status'    => 409,
+					'timezone'  => $timezone->getName(),
+					'wall_time' => $value,
+				)
+			);
+		}
 		$offsets = array();
-		foreach ( (array) $timezone->getTransitions( $wall->getTimestamp() - DAY_IN_SECONDS, $wall->getTimestamp() + DAY_IN_SECONDS ) as $transition ) {
+		foreach ( $transitions as $transition ) {
+			if ( ! is_array( $transition ) || ! array_key_exists( 'offset', $transition ) ) {
+				return new \WP_Error(
+					'canonical_event_venue_timezone_transitions_unavailable',
+					__( 'The venue timezone cannot be checked safely for publication.', 'extrachill-events' ),
+					array(
+						'status'    => 409,
+						'timezone'  => $timezone->getName(),
+						'wall_time' => $value,
+					)
+				);
+			}
 			$offsets[] = (int) $transition['offset'];
 		}
 		$candidates = array();

--- a/tests/CanonicalEventPublicationGuardTest.php
+++ b/tests/CanonicalEventPublicationGuardTest.php
@@ -234,6 +234,22 @@ final class CanonicalEventPublicationGuardTest extends BookingTestCase {
 		$this->assertSame( array(), $GLOBALS['wpdb']->lock_names );
 	}
 
+	public function test_missing_timezone_transitions_fail_closed_with_structured_diagnostic(): void {
+		$GLOBALS['ec_artist_test']['meta'][7][55]['_venue_timezone'] = '+00:00';
+
+		$result = $this->preflight_dme( new CanonicalEventPublicationGuard(), $this->dme_input() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'canonical_event_venue_timezone_transitions_unavailable', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
+		$this->assertSame( '+00:00', $result->get_error_data()['timezone'] );
+		$this->assertSame( array(), $GLOBALS['wpdb']->lock_names );
+		$logs = $GLOBALS['ec_artist_test']['fired_actions']['datamachine_log'];
+		$this->assertSame( 'warning', $logs[0][0] );
+		$this->assertSame( 'canonical_event_venue_timezone_transitions_unavailable', $logs[0][2]['error_code'] );
+		$this->assertSame( '+00:00', $logs[0][2]['error_data']['timezone'] );
+	}
+
 	public function test_release_failure_is_audited_while_every_lock_is_attempted(): void {
 		$guard = new CanonicalEventPublicationGuard();
 		$this->assertTrue( $guard->acquire_for_publication( 55, '2030-08-01 20:00:00', '2030-08-01 23:00:00' ) );


### PR DESCRIPTION
## Summary
- fail closed when PHP cannot provide venue timezone transition rows or returns a malformed transition row
- preserve normal IANA timezone publication and booking-conflict behavior
- emit the existing structured canonical-publication denial diagnostic with timezone and wall-time context

## Root cause
`CanonicalEventPublicationGuard::strict_local_datetime_candidates()` cast the result of `DateTimeZone::getTransitions()` and then assumed every returned value was an array containing `offset`. PHP returns `false` for fixed-offset timezone objects such as `+00:00`, allowing the guard to reach an unsafe offset read in the affected runtime path.

## Behavior after fix
Unavailable or malformed transition data now returns `canonical_event_venue_timezone_transitions_unavailable` with status 409 before any venue lock is acquired. The error flows through the guard's existing denial audit, producing a structured warning with the error code plus timezone and wall-time context. IANA timezone candidates continue through the existing DST-aware calculation and unchanged lock/conflict checks.

## Regression coverage
A fixed-offset venue timezone reproduces the real `getTransitions()` false result and verifies that publication fails closed, acquires no lock, and records the structured diagnostic. The complete standalone guard suite also covers existing successful acquisition, booking conflicts, and DST semantics.

## Verification
- `vendor/bin/phpunit tests/CanonicalEventPublicationGuardTest.php` (passes: 31 tests, 107 assertions)
- `php -l inc/Core/CanonicalEventPublicationGuard.php`
- `php -l tests/CanonicalEventPublicationGuardTest.php`
- `git diff --check`
- `composer test` (repository bootstrap failure: `WP_UnitTestCase` is unavailable while loading `tests/Unit/Abilities/CanonicalLocationsAbilityTest.php`)
- `composer run lint:php` (timed out after 120 seconds while scanning existing repository-wide PHPCS debt; changed-file PHPCS output is baseline-only)

Closes #489