### PR TITLE
fix: collapse venue preferences into one notice

### DIFF
--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -105,29 +105,32 @@
 }
 
 .events-venue-preferences {
-    display: block;
-    padding: 0;
+    align-items: flex-start;
 }
 
-.events-venue-preferences__header {
+.events-venue-preferences__controls,
+.events-venue-preferences__control,
+.events-venue-preferences__label {
     display: flex;
+}
+
+.events-venue-preferences__controls {
+    align-items: flex-end;
+}
+
+.events-venue-preferences__control {
+    align-items: center;
+    gap: var(--spacing-sm);
+}
+
+.events-venue-preferences__label {
     flex-direction: column;
     gap: var(--spacing-xs);
-    padding: var(--spacing-md);
 }
 
-.events-venue-preferences__header span {
+.events-venue-preferences__label span {
     color: var(--muted-text);
     font-size: var(--font-size-sm);
-}
-
-.events-venue-preferences__row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-md);
-    padding: var(--spacing-md);
-    border-top: 1px solid var(--border-color);
 }
 
 /* Progressive homepage router: search, preferred market, sample, directories. */
@@ -221,12 +224,14 @@
         gap: var(--spacing-sm) var(--spacing-md);
     }
 
-    .events-venue-preferences__row {
+    .events-venue-preferences,
+    .events-venue-preferences__controls,
+    .events-venue-preferences__control {
         align-items: stretch;
         flex-direction: column;
     }
 
-    .events-venue-preferences__row .button-1 {
+    .events-venue-preferences__control .button-1 {
         align-self: flex-start;
     }
 

--- a/inc/core/venue-email-sharing.php
+++ b/inc/core/venue-email-sharing.php
@@ -58,8 +58,8 @@ function extrachill_events_render_venue_email_sharing_control(): void {
 		return;
 	}
 	?>
-	<div class="events-venue-preferences__row" data-venue-email-sharing-control>
-		<div class="events-market-context__copy">
+	<div class="events-venue-preferences__control" data-venue-email-sharing-control>
+		<div class="events-venue-preferences__label">
 			<strong><?php esc_html_e( 'Venue email list', 'extrachill-events' ); ?></strong>
 			<span data-venue-email-sharing-status aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-events' ); ?></span>
 		</div>

--- a/inc/core/venue-update-subscriptions.php
+++ b/inc/core/venue-update-subscriptions.php
@@ -60,8 +60,22 @@ function extrachill_events_render_venue_update_control(): void {
 	}
 
 	$archive_url = get_term_link( $term );
+	$docs_url    = function_exists( 'ec_get_site_url' ) ? trailingslashit( ec_get_site_url( 'docs' ) ) . 'events-calendar/venue-preferences/' : '';
 	if ( ! is_user_logged_in() ) {
-		echo '<aside class="events-market-context events-market-context--quiet"><div class="events-market-context__copy"><strong>' . esc_html__( 'Venue preferences', 'extrachill-events' ) . '</strong><span>' . esc_html__( 'Get event notifications and choose whether to share your email with this venue.', 'extrachill-events' ) . '</span></div> <a href="' . esc_url( wp_login_url( $archive_url ) ) . '">' . esc_html__( 'Sign in to manage preferences', 'extrachill-events' ) . '</a></aside>';
+		?>
+		<aside class="events-market-context events-market-context--quiet" data-venue-preferences>
+			<div class="events-market-context__copy">
+				<strong><?php esc_html_e( 'Venue preferences', 'extrachill-events' ); ?></strong>
+				<span>
+					<?php esc_html_e( 'Control event alerts and email access.', 'extrachill-events' ); ?>
+					<?php if ( $docs_url ) : ?>
+						<a href="<?php echo esc_url( $docs_url ); ?>"><?php esc_html_e( 'How preferences work', 'extrachill-events' ); ?></a>
+					<?php endif; ?>
+				</span>
+			</div>
+			<a href="<?php echo esc_url( wp_login_url( $archive_url ) ); ?>"><?php esc_html_e( 'Sign in to manage', 'extrachill-events' ); ?></a>
+		</aside>
+		<?php
 		return;
 	}
 
@@ -71,13 +85,18 @@ function extrachill_events_render_venue_update_control(): void {
 	nocache_headers();
 	?>
 	<aside class="events-market-context events-venue-preferences" data-venue-preferences>
-		<div class="events-venue-preferences__header">
+		<div class="events-market-context__copy">
 			<strong><?php esc_html_e( 'Venue preferences', 'extrachill-events' ); ?></strong>
-			<span><?php esc_html_e( 'Choose how you hear about events and whether this venue can access your email.', 'extrachill-events' ); ?></span>
+			<span>
+				<?php esc_html_e( 'Control event alerts and email access.', 'extrachill-events' ); ?>
+				<?php if ( $docs_url ) : ?>
+					<a href="<?php echo esc_url( $docs_url ); ?>"><?php esc_html_e( 'How preferences work', 'extrachill-events' ); ?></a>
+				<?php endif; ?>
+			</span>
 		</div>
-		<div class="events-venue-preferences__rows">
-			<div class="events-venue-preferences__row" data-venue-update-control>
-				<div class="events-market-context__copy">
+		<div class="events-market-context__actions events-venue-preferences__controls">
+			<div class="events-venue-preferences__control" data-venue-update-control>
+				<div class="events-venue-preferences__label">
 					<strong><?php esc_html_e( 'Event notifications', 'extrachill-events' ); ?></strong>
 					<span data-venue-update-status aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-events' ); ?></span>
 				</div>

--- a/tests/Unit/VenueUpdateSubscriptionsTest.php
+++ b/tests/Unit/VenueUpdateSubscriptionsTest.php
@@ -98,8 +98,9 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		$html = ob_get_clean();
 
 		$this->assertStringContainsString( 'Venue preferences', $html );
-		$this->assertStringContainsString( 'Get event notifications and choose whether to share your email with this venue.', $html );
-		$this->assertStringContainsString( 'Sign in to manage preferences', $html );
+		$this->assertStringContainsString( 'Control event alerts and email access.', $html );
+		$this->assertStringContainsString( 'events-calendar/venue-preferences/', $html );
+		$this->assertStringContainsString( 'Sign in to manage', $html );
 		$this->assertStringNotContainsString( 'data-venue-update-subscription', $html );
 		$this->assertStringNotContainsString( 'data-venue-email-sharing', $html );
 	}
@@ -119,7 +120,7 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'data-slug="the-royal-american"', $html );
 	}
 
-	/** Archive preferences compose two explicit controls in one panel. */
+	/** Archive preferences compose two explicit controls in one notice. */
 	public function test_archive_composes_independent_controls_in_one_panel(): void {
 		$this->venue_archive();
 		wp_set_current_user( self::factory()->user->create() );
@@ -129,7 +130,9 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		$html = ob_get_clean();
 
 		$this->assertSame( 1, substr_count( $html, '<aside' ) );
+		$this->assertSame( 0, substr_count( $html, 'events-venue-preferences__row' ) );
 		$this->assertStringContainsString( 'data-venue-preferences', $html );
+		$this->assertStringContainsString( 'events-calendar/venue-preferences/', $html );
 		$this->assertStringContainsString( 'data-venue-update-subscription', $html );
 		$this->assertStringContainsString( 'data-venue-email-sharing', $html );
 		$this->assertStringContainsString( 'Venue email list', $html );


### PR DESCRIPTION
## Summary
- flatten venue notifications and email sharing into one existing notice surface
- remove nested bordered rows while preserving independent consent controls
- link contextual help through `ec_get_site_url( 'docs' )` to the Events docs path

## Verification
- `npm run test:js -- --runInBand assets/js/venue-update-subscriptions.test.js assets/js/venue-email-sharing.test.js` (8 tests)
- targeted WordPress PHPCS
- `git diff --check`

## Release order
Merge and publish Extra-Chill/extrachill-docs#59 first so the contextual help link is live before this change deploys.

Closes #500