### PR TITLE
refactor: consume public DME booking contracts

### DIFF
--- a/.github/workflows/booking-network-e2e.yml
+++ b/.github/workflows/booking-network-e2e.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           BOOKING_E2E_ARTIFACT_ROOT: ${{ github.workspace }}/artifacts/booking-network-e2e
           BOOKING_E2E_DATA_MACHINE: ${{ github.workspace }}/.ci/data-machine
-          BOOKING_E2E_DATA_MACHINE_REV: dc71db023b09b9d4cd29e9c853678b930384b033
+          BOOKING_E2E_DATA_MACHINE_REV: 25dbfc8e6c7e371afc80b64d58cd7761b902e3ac
           BOOKING_E2E_DATA_MACHINE_EVENTS: ${{ github.workspace }}/.ci/data-machine-events
           BOOKING_E2E_DATA_MACHINE_EVENTS_REV: fb445f87b4133600244d129ed53538cfde7fbb1b
           BOOKING_E2E_EXTRACHILL_API: ${{ github.workspace }}/.ci/extrachill-api

--- a/.github/workflows/booking-network-e2e.yml
+++ b/.github/workflows/booking-network-e2e.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           repository: Extra-Chill/data-machine
-          ref: dc71db023b09b9d4cd29e9c853678b930384b033
+          ref: 25dbfc8e6c7e371afc80b64d58cd7761b902e3ac
           path: .ci/data-machine
 
       - name: Checkout Data Machine Events

--- a/.github/workflows/booking-network-e2e.yml
+++ b/.github/workflows/booking-network-e2e.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           repository: Extra-Chill/data-machine-events
-          ref: fb445f87b4133600244d129ed53538cfde7fbb1b
+          ref: 2fb1839a241c798bff0271f0de0f7412abcd5193
           path: .ci/data-machine-events
 
       - name: Checkout Extra Chill API
@@ -121,7 +121,7 @@ jobs:
           BOOKING_E2E_DATA_MACHINE: ${{ github.workspace }}/.ci/data-machine
           BOOKING_E2E_DATA_MACHINE_REV: 25dbfc8e6c7e371afc80b64d58cd7761b902e3ac
           BOOKING_E2E_DATA_MACHINE_EVENTS: ${{ github.workspace }}/.ci/data-machine-events
-          BOOKING_E2E_DATA_MACHINE_EVENTS_REV: fb445f87b4133600244d129ed53538cfde7fbb1b
+          BOOKING_E2E_DATA_MACHINE_EVENTS_REV: 2fb1839a241c798bff0271f0de0f7412abcd5193
           BOOKING_E2E_EXTRACHILL_API: ${{ github.workspace }}/.ci/extrachill-api
           BOOKING_E2E_EXTRACHILL_API_REV: d449ed353f17b4c81cfd466fcbbefaa5ee637609
           BOOKING_E2E_EXTRACHILL_NETWORK: ${{ github.workspace }}/.ci/extrachill-network

--- a/.github/workflows/internal-booking-calendar-alpha.yml
+++ b/.github/workflows/internal-booking-calendar-alpha.yml
@@ -14,6 +14,7 @@ on:
       - inc/Abilities/VenueMembershipAbilities.php
       - inc/Core/BookingActivityRepository.php
       - inc/Core/BookingEventConversionService.php
+      - inc/Core/BookingEventSyncService.php
       - inc/Core/BookingHoldRepository.php
       - inc/Core/BookingInquiryAdmissionService.php
       - inc/Core/BookingLifecycle.php
@@ -173,7 +174,7 @@ jobs:
           svn export --quiet "https://develop.svn.wordpress.org/tags/${wp_branch}/tests/phpunit/includes" /tmp/wordpress-tests-lib/includes
           svn export --quiet "https://develop.svn.wordpress.org/tags/${wp_branch}/tests/phpunit/data" /tmp/wordpress-tests-lib/data
 
-      - name: Run native overlapping hold proof
+      - name: Run native hold proofs
         env:
           DB_HOST: 127.0.0.1
           DB_PORT: 3306
@@ -186,8 +187,8 @@ jobs:
           DME_PLUGIN_DIR: ${{ github.workspace }}/.ci/data-machine-events
         run: |
           set -euo pipefail
-          vendor/bin/phpunit -c phpunit-booking-alpha-concurrency.xml.dist --filter test_overlapping_public_hold_abilities_allow_one_winner | tee "$RUNNER_TEMP/internal-booking-hold-concurrency.txt"
-          grep -E 'OK \(1 test, [1-9][0-9]* assertions?\)' "$RUNNER_TEMP/internal-booking-hold-concurrency.txt"
+          vendor/bin/phpunit -c phpunit-booking-alpha-concurrency.xml.dist --filter '/test_(overlapping_public_hold_abilities_allow_one_winner|canonical_event_overlap_blocks_public_hold)$/' | tee "$RUNNER_TEMP/internal-booking-hold-concurrency.txt"
+          grep -E 'OK \(2 tests, [1-9][0-9]* assertions?\)' "$RUNNER_TEMP/internal-booking-hold-concurrency.txt"
           if grep -Eiq 'skip|no tests executed|OK, but' "$RUNNER_TEMP/internal-booking-hold-concurrency.txt"; then
             exit 1
           fi

--- a/inc/Core/BookingEventConversionService.php
+++ b/inc/Core/BookingEventConversionService.php
@@ -424,6 +424,7 @@ class BookingEventConversionService {
 			&& self::SOURCE === ( $upstream['source']['name'] ?? null )
 			&& ( $upstream['source']['id'] ?? null ) === $booking['public_id']
 			&& ( $upstream['source']['identity'] ?? null ) === $identity
+			&& 1 === preg_match( '/^[a-f0-9]{64}$/', (string) ( $upstream['fingerprint'] ?? '' ) )
 			&& (int) ( $upstream['normalized']['venue_id'] ?? 0 ) === (int) $booking['venue_term_id']
 			&& 'publish' === ( $upstream['normalized']['post_status'] ?? null )
 			&& ( $upstream['normalized']['start_datetime'] ?? null ) === $expected_start
@@ -440,105 +441,70 @@ class BookingEventConversionService {
 				)
 			);
 		}
-		$fingerprint = $this->event_fingerprint( (int) $upstream['event_id'], $booking, $identity );
-		if ( is_wp_error( $fingerprint ) ) {
-			return $fingerprint;
+		$post      = get_post( (int) $upstream['event_id'] );
+		$type      = defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events';
+		$venue_ids = wp_get_object_terms( (int) $upstream['event_id'], 'venue', array( 'fields' => 'ids' ) );
+		$venue_ids = is_wp_error( $venue_ids ) ? $venue_ids : array_values( array_unique( array_map( 'intval', (array) $venue_ids ) ) );
+		if ( ! $post || ( $post->post_type ?? null ) !== $type || 'publish' !== ( $post->post_status ?? null ) || is_wp_error( $venue_ids ) || array( (int) $booking['venue_term_id'] ) !== $venue_ids ) {
+			return new \WP_Error(
+				'booking_event_upsert_failed',
+				__( 'Canonical event conversion returned an invalid published event.', 'extrachill-events' ),
+				array(
+					'status'        => is_wp_error( $venue_ids ) ? 503 : 502,
+					'retryable'     => true,
+					'upstream_code' => is_wp_error( $venue_ids ) ? $venue_ids->get_error_code() : 'published_event_invalid',
+					'event_id'      => (int) $upstream['event_id'],
+				)
+			);
 		}
 		return array(
 			'event_id'    => (int) $upstream['event_id'],
 			'event_url'   => (string) ( $upstream['event_url'] ?? '' ),
 			'action'      => (string) $upstream['action'],
-			'fingerprint' => $fingerprint,
+			'fingerprint' => (string) $upstream['fingerprint'],
 			'source'      => $upstream['source'],
 		);
 	}
 
-	/** Verify persisted source ownership and fingerprint the canonical event state. */
-	private function event_fingerprint( int $event_id, array $booking, string $identity ) {
-		$post = get_post( $event_id );
-		$type = defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events';
-		if ( ! $post || ( $post->post_type ?? null ) !== $type
-			|| 'publish' !== ( $post->post_status ?? null )
-			|| self::SOURCE !== get_post_meta( $event_id, '_datamachine_event_source', true )
-			|| get_post_meta( $event_id, '_datamachine_event_source_id', true ) !== $booking['public_id']
-			|| get_post_meta( $event_id, '_datamachine_event_source_identity', true ) !== $identity ) {
-			return new \WP_Error(
-				'booking_event_upsert_failed',
-				__( 'Canonical event conversion returned an invalid source-owned event.', 'extrachill-events' ),
-				array(
-					'status'        => 502,
-					'retryable'     => true,
-					'upstream_code' => 'source_event_invalid',
-					'event_id'      => $event_id,
-				)
-			);
-		}
-		$venues = wp_get_object_terms( $event_id, 'venue', array( 'fields' => 'ids' ) );
-		if ( is_wp_error( $venues ) ) {
-			return new \WP_Error(
-				'booking_event_upsert_failed',
-				__( 'Canonical event venue ownership could not be verified.', 'extrachill-events' ),
-				array(
-					'status'        => 503,
-					'retryable'     => true,
-					'upstream_code' => $venues->get_error_code(),
-				)
-			);
-		}
-		$venues = array_values( array_unique( array_map( 'absint', (array) $venues ) ) );
-		sort( $venues, SORT_NUMERIC );
-		if ( array( (int) $booking['venue_term_id'] ) !== $venues ) {
-			return new \WP_Error(
-				'booking_event_upsert_failed',
-				__( 'Canonical event venue ownership did not match the booking.', 'extrachill-events' ),
-				array(
-					'status'        => 502,
-					'retryable'     => true,
-					'upstream_code' => 'source_event_venue_mismatch',
-					'event_id'      => $event_id,
-				)
-			);
-		}
-		$payload = wp_json_encode(
-			array(
-				'event_id'        => $event_id,
-				'post_status'     => $post->post_status,
-				'post_title'      => $post->post_title,
-				'post_content'    => $post->post_content,
-				'venue_ids'       => $venues,
-				'source'          => self::SOURCE,
-				'source_id'       => $booking['public_id'],
-				'source_identity' => $identity,
-			)
-		);
-		return false === $payload ? new \WP_Error(
-			'booking_event_upsert_failed',
-			__( 'Canonical event state could not be fingerprinted.', 'extrachill-events' ),
-			array(
-				'status'        => 503,
-				'retryable'     => true,
-				'upstream_code' => 'fingerprint_failed',
-			)
-		) : hash( 'sha256', $payload );
-	}
-
-	/** Read only DME-established canonical venue metadata. */
+	/** Map DME's supported canonical venue projection to event attributes. */
 	private function venue_metadata( int $venue_id ) {
+		if ( ! function_exists( 'data_machine_events_get_venue_data' ) ) {
+			return new \WP_Error(
+				'booking_event_venue_contract_unavailable',
+				__( 'Canonical venue data is temporarily unavailable.', 'extrachill-events' ),
+				array(
+					'status'    => 503,
+					'retryable' => true,
+				)
+			);
+		}
+		$venue = data_machine_events_get_venue_data( $venue_id );
+		if ( ! is_array( $venue ) ) {
+			return new \WP_Error(
+				'booking_event_venue_contract_invalid',
+				__( 'Canonical venue data returned an invalid result.', 'extrachill-events' ),
+				array(
+					'status'    => 502,
+					'retryable' => true,
+					'venue_id'  => $venue_id,
+				)
+			);
+		}
 		$map    = array(
-			'_venue_address'     => 'venueAddress',
-			'_venue_city'        => 'venueCity',
-			'_venue_state'       => 'venueState',
-			'_venue_zip'         => 'venueZip',
-			'_venue_country'     => 'venueCountry',
-			'_venue_phone'       => 'venuePhone',
-			'_venue_website'     => 'venueWebsite',
-			'_venue_coordinates' => 'venueCoordinates',
-			'_venue_capacity'    => 'venueCapacity',
-			'_venue_timezone'    => 'venueTimezone',
+			'address'     => 'venueAddress',
+			'city'        => 'venueCity',
+			'state'       => 'venueState',
+			'zip'         => 'venueZip',
+			'country'     => 'venueCountry',
+			'phone'       => 'venuePhone',
+			'website'     => 'venueWebsite',
+			'coordinates' => 'venueCoordinates',
+			'capacity'    => 'venueCapacity',
+			'timezone'    => 'venueTimezone',
 		);
 		$output = array();
-		foreach ( $map as $meta_key => $event_key ) {
-			$value = get_term_meta( $venue_id, $meta_key, true );
+		foreach ( $map as $venue_key => $event_key ) {
+			$value = $venue[ $venue_key ] ?? '';
 			if ( '' !== trim( (string) $value ) ) {
 				$output[ $event_key ] = (string) $value;
 			}
@@ -659,20 +625,16 @@ class BookingEventConversionService {
 		} elseif ( 'publish' !== $post->post_status ) {
 			$integrity[] = 'post_status';
 		}
-		if ( self::SOURCE !== get_post_meta( $booking['event_id'], '_datamachine_event_source', true ) ) {
-			$integrity[] = 'source_name';
-		}
-		if ( get_post_meta( $booking['event_id'], '_datamachine_event_source_id', true ) !== $booking['public_id'] ) {
-			$integrity[] = 'source_id';
-		}
-		if ( get_post_meta( $booking['event_id'], '_datamachine_event_source_identity', true ) !== $identity ) {
-			$integrity[] = 'source_identity';
-		}
 		if ( is_wp_error( $venue_ids ) || array_map( 'intval', (array) $venue_ids ) !== array( (int) $booking['venue_term_id'] ) ) {
 			$integrity[] = 'venue';
 		}
 		$completed = is_array( $conversion ) ? $conversion['completed'] : null;
-		if ( ! is_array( $completed ) || (int) ( $completed['payload']['data']['event_id'] ?? 0 ) !== (int) $booking['event_id'] || ( $completed['payload']['data']['source_identity'] ?? null ) !== $identity ) {
+		if ( ! is_array( $completed )
+			|| (int) ( $completed['payload']['data']['event_id'] ?? 0 ) !== (int) $booking['event_id']
+			|| ( $completed['payload']['data']['source'] ?? null ) !== self::SOURCE
+			|| ( $completed['payload']['data']['source_id'] ?? null ) !== $booking['public_id']
+			|| ( $completed['payload']['data']['source_identity'] ?? null ) !== $identity
+			|| 1 !== preg_match( '/^[a-f0-9]{64}$/', (string) ( $completed['payload']['data']['fingerprint'] ?? '' ) ) ) {
 			$integrity[] = 'event_converted_activity';
 		}
 		if ( $integrity ) {

--- a/inc/Core/BookingEventSyncService.php
+++ b/inc/Core/BookingEventSyncService.php
@@ -525,8 +525,29 @@ class BookingEventSyncService {
 
 	/** Map the current booking through the same public conversion rules. */
 	private function authority_from_booking( array $booking ) {
-		$venue    = get_term( $booking['venue_term_id'], 'venue' );
-		$timezone = (string) get_term_meta( $booking['venue_term_id'], '_venue_timezone', true );
+		$venue = get_term( $booking['venue_term_id'], 'venue' );
+		if ( ! function_exists( 'data_machine_events_get_venue_data' ) ) {
+			return new \WP_Error(
+				'booking_event_venue_contract_unavailable',
+				__( 'Canonical venue data is temporarily unavailable.', 'extrachill-events' ),
+				array(
+					'status'    => 503,
+					'retryable' => true,
+				)
+			);
+		}
+		$venue_data = data_machine_events_get_venue_data( (int) $booking['venue_term_id'] );
+		if ( ! is_array( $venue_data ) ) {
+			return new \WP_Error(
+				'booking_event_venue_contract_invalid',
+				__( 'Canonical venue data returned an invalid result.', 'extrachill-events' ),
+				array(
+					'status'    => 502,
+					'retryable' => true,
+				)
+			);
+		}
+		$timezone = (string) ( $venue_data['timezone'] ?? '' );
 		try {
 			$zone = new \DateTimeZone( $timezone );
 		} catch ( \Exception $exception ) {
@@ -561,10 +582,20 @@ class BookingEventSyncService {
 		if ( ! $post || ( $post->post_type ?? '' ) !== $type ) {
 			return new \WP_Error( 'booking_event_existing_invalid', __( 'The linked site-local event is invalid.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
-		$identity = hash( 'sha256', BookingEventConversionService::SOURCE . "\0" . $booking['public_id'] );
-		if ( BookingEventConversionService::SOURCE !== get_post_meta( $booking['event_id'], '_datamachine_event_source', true )
-			|| get_post_meta( $booking['event_id'], '_datamachine_event_source_id', true ) !== $booking['public_id']
-			|| get_post_meta( $booking['event_id'], '_datamachine_event_source_identity', true ) !== $identity ) {
+		$snapshot = $this->activity->latest_event_snapshot( (int) $booking['id'] );
+		if ( is_wp_error( $snapshot ) ) {
+			return $snapshot;
+		}
+		$activity = is_array( $snapshot ) ? ( $snapshot['activity'] ?? null ) : null;
+		$data     = is_array( $activity ) ? ( $activity['payload']['data'] ?? null ) : null;
+		$linked   = is_array( $data ) && (int) ( $data['event_id'] ?? 0 ) === (int) $booking['event_id'];
+		if ( $linked && 'event_converted' === ( $activity['kind'] ?? '' ) ) {
+			$identity = hash( 'sha256', BookingEventConversionService::SOURCE . "\0" . $booking['public_id'] );
+			$linked   = ( $data['source'] ?? null ) === BookingEventConversionService::SOURCE
+				&& ( $data['source_id'] ?? null ) === $booking['public_id']
+				&& ( $data['source_identity'] ?? null ) === $identity;
+		}
+		if ( ! $linked ) {
 			return new \WP_Error( 'booking_event_identity_mismatch', __( 'The linked event does not belong to this immutable booking handoff.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
 		$attrs = array();
@@ -592,7 +623,13 @@ class BookingEventSyncService {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
-		if ( ! is_array( $result ) || true !== ( $result['success'] ?? null ) || ! in_array( $result['action'] ?? '', array( 'updated', 'no_change' ), true ) || 1 !== preg_match( '/^[a-f0-9]{64}$/', (string) ( $result['fingerprint'] ?? '' ) ) ) {
+		if ( ! is_array( $result )
+			|| true !== ( $result['success'] ?? null )
+			|| ! in_array( $result['action'] ?? '', array( 'updated', 'no_change' ), true )
+			|| ! is_int( $result['event_id'] ?? null )
+			|| $result['event_id'] !== $input['event']
+			|| ( $result['previous_fingerprint'] ?? null ) !== $input['expected_fingerprint']
+			|| 1 !== preg_match( '/^[a-f0-9]{64}$/', (string) ( $result['fingerprint'] ?? '' ) ) ) {
 			return new \WP_Error(
 				'booking_event_update_failed',
 				__( 'Canonical event update returned an invalid source-owned result.', 'extrachill-events' ),

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -966,24 +966,112 @@ class BookingHoldRepository {
 		if ( is_array( $row ) ) {
 			return $row;
 		}
-		$timezone_name = get_term_meta( $booking['venue_term_id'], '_venue_timezone', true );
+		if ( ! function_exists( 'data_machine_events_query_venue_interval_overlaps' ) ) {
+			return new \WP_Error(
+				'booking_canonical_overlap_contract_unavailable',
+				__( 'Canonical event conflicts cannot be checked because the overlap service is unavailable.', 'extrachill-events' ),
+				array(
+					'status'    => 503,
+					'retryable' => true,
+				)
+			);
+		}
+		if ( ! function_exists( 'data_machine_events_get_venue_data' ) ) {
+			return new \WP_Error(
+				'booking_canonical_overlap_contract_unavailable',
+				__( 'Canonical event conflicts cannot be checked because venue data is unavailable.', 'extrachill-events' ),
+				array(
+					'status'    => 503,
+					'retryable' => true,
+				)
+			);
+		}
+		$venue_data = data_machine_events_get_venue_data( (int) $booking['venue_term_id'] );
 		try {
-			$timezone = new \DateTimeZone( (string) $timezone_name );
+			$timezone = new \DateTimeZone( is_array( $venue_data ) ? (string) ( $venue_data['timezone'] ?? '' ) : '' );
 		} catch ( \Exception $exception ) {
 			return new \WP_Error( 'booking_venue_timezone_invalid', __( 'The venue timezone is missing or invalid, so conflicts cannot be checked safely.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
-		$window    = $this->canonical_local_window( $booking['performance_start_at'], $booking['performance_end_at'], $timezone );
-		$start     = $window['start'];
-		$end       = $window['end'];
-		$dates     = $wpdb->prefix . 'datamachine_event_dates';
-		$post_type = defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ? DATA_MACHINE_EVENTS_POST_TYPE : 'data_machine_events';
-		// Canonical events have no space identity, so a published venue event safely blocks every configured space.
-		$sql = "SELECT p.ID AS id, 'canonical_event' AS conflict_type FROM {$wpdb->posts} p JOIN {$dates} ed ON p.ID = ed.post_id JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE p.post_type = %s AND p.post_status = 'publish' AND tt.taxonomy = 'venue' AND tt.term_id = %d AND p.ID <> %d AND ed.start_datetime < %s AND ((ed.end_datetime IS NOT NULL AND ed.end_datetime > %s) OR (ed.end_datetime IS NULL AND ed.start_datetime >= %s)) LIMIT 1"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Core/current-prefix tables only.
-		$row = $wpdb->get_row( $wpdb->prepare( $sql, $post_type, $booking['venue_term_id'], (int) $booking['event_id'], $end, $start, $start ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Values prepared.
-		if ( '' !== (string) $wpdb->last_error ) {
-			return new \WP_Error( 'booking_conflict_check_failed', __( 'Canonical event conflicts could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		$utc   = new \DateTimeZone( 'UTC' );
+		$start = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $booking['performance_start_at'], $utc );
+		$end   = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $booking['performance_end_at'], $utc );
+		if ( false === $start || false === $end || $start->format( 'Y-m-d H:i:s' ) !== $booking['performance_start_at'] || $end->format( 'Y-m-d H:i:s' ) !== $booking['performance_end_at'] ) {
+			return new \WP_Error( 'booking_conflict_check_failed', __( 'Canonical event conflicts could not be checked for an invalid booking interval.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
-		return is_array( $row ) ? $row : null;
+		$query  = array(
+			'venue_id' => (int) $booking['venue_term_id'],
+			'start'    => $start->format( 'Y-m-d\TH:i:s\Z' ),
+			'end'      => $end->format( 'Y-m-d\TH:i:s\Z' ),
+			'exclude'  => (int) $booking['event_id'] > 0 ? array( (int) $booking['event_id'] ) : array(),
+			'page'     => 1,
+			'per_page' => 1,
+			'statuses' => array( 'publish' ),
+		);
+		$result = data_machine_events_query_venue_interval_overlaps( $query );
+		if ( is_wp_error( $result ) ) {
+			return new \WP_Error(
+				'booking_conflict_check_failed',
+				__( 'Canonical event conflicts could not be checked.', 'extrachill-events' ),
+				array(
+					'status'        => 503,
+					'retryable'     => true,
+					'upstream_code' => $result->get_error_code(),
+					'upstream_data' => $result->get_error_data(),
+				)
+			);
+		}
+		$interval_start = is_array( $result ) && is_string( $result['interval']['start'] ?? null ) ? \DateTimeImmutable::createFromFormat( '!Y-m-d\TH:i:sP', $result['interval']['start'] ) : false;
+		$interval_end   = is_array( $result ) && is_string( $result['interval']['end'] ?? null ) ? \DateTimeImmutable::createFromFormat( '!Y-m-d\TH:i:sP', $result['interval']['end'] ) : false;
+		$valid_result   = is_array( $result )
+			&& is_int( $result['venue_id'] ?? null )
+			&& $result['venue_id'] === (int) $booking['venue_term_id']
+			&& ( $result['timezone'] ?? null ) === $timezone->getName()
+			&& false !== $interval_start
+			&& false !== $interval_end
+			&& $interval_start->format( DATE_RFC3339 ) === $result['interval']['start']
+			&& $interval_end->format( DATE_RFC3339 ) === $result['interval']['end']
+			&& $interval_start->getTimestamp() === $start->getTimestamp()
+			&& $interval_end->getTimestamp() === $end->getTimestamp()
+			&& 1 === ( $result['page'] ?? null )
+			&& 1 === ( $result['per_page'] ?? null )
+			&& is_bool( $result['has_more'] ?? null )
+			&& isset( $result['events'] )
+			&& is_array( $result['events'] )
+			&& array_is_list( $result['events'] )
+			&& count( $result['events'] ) <= 1
+			&& ( ! empty( $result['events'] ) || false === $result['has_more'] );
+		if ( ! $valid_result ) {
+			return new \WP_Error(
+				'booking_canonical_overlap_contract_invalid',
+				__( 'Canonical event conflict checking returned an invalid result.', 'extrachill-events' ),
+				array(
+					'status'    => 502,
+					'retryable' => true,
+				)
+			);
+		}
+		if ( empty( $result['events'] ) ) {
+			return null;
+		}
+		$event       = $result['events'][0];
+		$event_id    = is_array( $event ) ? ( $event['event_id'] ?? null ) : null;
+		$event_start = is_array( $event ) && is_string( $event['start'] ?? null ) ? \DateTimeImmutable::createFromFormat( '!Y-m-d\TH:i:sP', $event['start'] ) : false;
+		$event_end   = is_array( $event ) && is_string( $event['end'] ?? null ) ? \DateTimeImmutable::createFromFormat( '!Y-m-d\TH:i:sP', $event['end'] ) : false;
+		if ( ! is_int( $event_id ) || $event_id < 1 || $event_id === (int) $booking['event_id'] || 'publish' !== ( $event['status'] ?? null ) || false === $event_start || false === $event_end || $event_start->format( DATE_RFC3339 ) !== $event['start'] || $event_end->format( DATE_RFC3339 ) !== $event['end'] || $event_start >= $event_end ) {
+			return new \WP_Error(
+				'booking_canonical_overlap_contract_invalid',
+				__( 'Canonical event conflict checking returned an invalid event.', 'extrachill-events' ),
+				array(
+					'status'    => 502,
+					'retryable' => true,
+				)
+			);
+		}
+		return array(
+			'id'            => $event_id,
+			'event_id'      => $event_id,
+			'conflict_type' => 'canonical_event',
+		);
 	}
 
 	private function conflict_error( array $conflict ): \WP_Error {
@@ -1242,38 +1330,6 @@ class BookingHoldRepository {
 			return new \WP_Error( 'booking_hold_expiration_check_failed', __( 'The booking hold expiration could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
 		}
 		return null !== $row;
-	}
-
-	private function canonical_local_window( string $start, string $end, \DateTimeZone $timezone ): array {
-		$utc         = new \DateTimeZone( 'UTC' );
-		$start_utc   = new \DateTimeImmutable( $start, $utc );
-		$end_utc     = new \DateTimeImmutable( $end, $utc );
-		$start_local = $start_utc->setTimezone( $timezone );
-		$end_local   = $end_utc->setTimezone( $timezone );
-		$local_start = $start_local->format( 'Y-m-d H:i:s' );
-		$local_end   = $end_local->format( 'Y-m-d H:i:s' );
-		$transitions = $timezone->getTransitions( $start_utc->getTimestamp(), $end_utc->getTimestamp() );
-		if ( is_array( $transitions ) ) {
-			$previous_offset = null;
-			foreach ( $transitions as $transition ) {
-				if ( ! is_array( $transition ) || ! isset( $transition['ts'], $transition['offset'] ) ) {
-					continue;
-				}
-				$new_offset = (int) $transition['offset'];
-				if ( null !== $previous_offset && $new_offset < $previous_offset ) {
-					// The canonical index lacks offsets. Include the entire repeated wall-clock fold conservatively.
-					$fold_start  = gmdate( 'Y-m-d H:i:s', (int) $transition['ts'] + $new_offset );
-					$fold_end    = gmdate( 'Y-m-d H:i:s', (int) $transition['ts'] + $previous_offset );
-					$local_start = min( $local_start, $fold_start );
-					$local_end   = max( $local_end, $fold_end );
-				}
-				$previous_offset = $new_offset;
-			}
-		}
-		return array(
-			'start' => $local_start,
-			'end'   => $local_end,
-		);
 	}
 
 	private function valid_datetime( string $value ): bool {

--- a/tests/BookingEventConversionTest.php
+++ b/tests/BookingEventConversionTest.php
@@ -167,12 +167,6 @@ final class BookingEventConversionTest extends BookingTestCase {
 	}
 
 	private function add_event_source_proof( int $id, array $input, ?int $venue_id = null ): void {
-		$identity = hash( 'sha256', $input['source'] . "\0" . $input['source_id'] );
-		$GLOBALS['ec_artist_test']['post_meta'][7][ $id ] = array(
-			'_datamachine_event_source'          => $input['source'],
-			'_datamachine_event_source_id'       => $input['source_id'],
-			'_datamachine_event_source_identity' => $identity,
-		);
 		$GLOBALS['ec_artist_test']['event_venues'][7][ $id ] = array( null === $venue_id ? 55 : $venue_id );
 		if ( isset( $input['event'] ) ) {
 			$GLOBALS['ec_artist_test']['parsed_blocks'][ 'event-' . $id ] = array(
@@ -215,6 +209,7 @@ final class BookingEventConversionTest extends BookingTestCase {
 			'event_id'  => 901,
 			'event_url' => 'https://events.example/test-band',
 			'action'    => 'created',
+			'fingerprint' => hash( 'sha256', 'event-' . (int) ( $overrides['event_id'] ?? 901 ) ),
 			'source'    => array(
 				'name'     => $input['source'],
 				'id'       => $input['source_id'],
@@ -371,6 +366,7 @@ final class BookingEventConversionTest extends BookingTestCase {
 		$this->assertCount( 2, $activity );
 		$this->assertSame( 'event_converted', $activity[0]['kind'] );
 		$this->assertSame( 901, $activity[0]['payload']['data']['event_id'] );
+		$this->assertSame( hash( 'sha256', 'event-901' ), $activity[0]['payload']['data']['fingerprint'] );
 		$this->assertSame( 2, $activity[0]['payload']['data']['version'] );
 		$this->assertSame( 'event_conversion_started', $activity[1]['kind'] );
 		$this->assertGreaterThanOrEqual( 2, $GLOBALS['wpdb']->booking_lock_queries );
@@ -417,13 +413,13 @@ final class BookingEventConversionTest extends BookingTestCase {
 				$this->assertSame( '15:00', $input['event']['startTime'] );
 				$this->assertSame( 'America/New_York', $input['event']['venueTimezone'] );
 				$this->assertSame( $booking['public_id'], $input['source_id'] );
-				$this->assertSame( $identity, get_post_meta( 291410, '_datamachine_event_source_identity', true ) );
 				$GLOBALS['ec_artist_test']['posts'][7][291410]->post_status = 'publish';
 				return array(
 					'success'    => true,
 					'event_id'   => 291410,
 					'event_url'  => 'https://events.extrachill.com/events/extra-chill-production-smoke-test-at-lo-fi-brewing',
 					'action'     => 'updated',
+					'fingerprint' => hash( 'sha256', 'event-291410' ),
 					'source'     => array(
 						'name'     => BookingEventConversionService::SOURCE,
 						'id'       => $booking['public_id'],
@@ -517,6 +513,9 @@ final class BookingEventConversionTest extends BookingTestCase {
 		unset( $GLOBALS['ec_artist_test']['meta'][7][55]['_venue_address'] );
 		$this->assertSame( 'booking_event_venue_incomplete', $this->service()->convert( $timezone['id'], 1, 12 )->get_error_code() );
 		$GLOBALS['ec_artist_test']['meta'][7][55]['_venue_address'] = '123 King Street';
+		$GLOBALS['ec_artist_test']['venue_projection_result'] = null;
+		$this->assertSame( 'booking_event_venue_contract_invalid', $this->service()->convert( $timezone['id'], 1, 12 )->get_error_code() );
+		unset( $GLOBALS['ec_artist_test']['venue_projection_result'] );
 		unset( $GLOBALS['ec_artist_test']['terms'][7][55] );
 		$this->assertSame( 'booking_event_venue_invalid', $this->service()->convert( $timezone['id'], 1, 12 )->get_error_code() );
 		$this->assertCount( 0, $GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event']->calls );
@@ -704,6 +703,7 @@ final class BookingEventConversionTest extends BookingTestCase {
 			array( 'source' => array( 'name' => 'wrong-source' ) ),
 			array( 'source' => array( 'id' => 'wrong-id' ) ),
 			array( 'source' => array( 'identity' => 'wrong-identity' ) ),
+			array( 'fingerprint' => 'not-a-canonical-fingerprint' ),
 			array( 'normalized' => array( 'venue_id' => 999 ) ),
 			array( 'normalized' => array( 'post_status' => 'draft' ) ),
 		);
@@ -866,7 +866,7 @@ final class BookingEventConversionTest extends BookingTestCase {
 		$this->assertCount( 0, $GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event']->calls );
 	}
 
-	public function test_existing_draft_private_wrong_source_wrong_venue_and_missing_activity_are_rejected(): void {
+	public function test_existing_draft_wrong_venue_and_missing_activity_are_rejected(): void {
 		$booking = $this->booking();
 		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $booking['id'] ]['event_id'] = 901;
 		$input = array( 'source' => 'extrachill-events-booking', 'source_id' => $booking['public_id'] );
@@ -878,10 +878,6 @@ final class BookingEventConversionTest extends BookingTestCase {
 		$GLOBALS['ec_artist_test']['posts'][7][901]->post_status = 'private';
 		$this->assertSame( 'booking_event_existing_invalid', $this->service()->convert( $booking['id'], 1, 12 )->get_error_code() );
 		$GLOBALS['ec_artist_test']['posts'][7][901]->post_status = 'publish';
-		$GLOBALS['ec_artist_test']['post_meta'][7][901]['_datamachine_event_source'] = 'wrong';
-		$error = $this->service()->convert( $booking['id'], 1, 12 );
-		$this->assertContains( 'source_name', $error->get_error_data()['integrity'] );
-		$GLOBALS['ec_artist_test']['post_meta'][7][901]['_datamachine_event_source'] = 'extrachill-events-booking';
 		$GLOBALS['ec_artist_test']['event_venues'][7][901] = array( 999 );
 		$error = $this->service()->convert( $booking['id'], 1, 12 );
 		$this->assertContains( 'venue', $error->get_error_data()['integrity'] );
@@ -995,7 +991,19 @@ final class BookingEventConversionTest extends BookingTestCase {
 
 		$other = $this->booking();
 		$this->service()->convert( $other['id'], 1, 12 );
-		$GLOBALS['ec_artist_test']['post_meta'][7][901]['_datamachine_event_source_id'] = 'another-site-local-source';
+		$snapshot = ( new BookingActivityRepository() )->latest_event_snapshot( $other['id'] );
+		( new BookingActivityRepository() )->append(
+			array(
+				'booking_id'      => $other['id'],
+				'kind'            => 'event_sync_noop',
+				'idempotency_key' => 'event-sync-noop:wrong-linkage',
+				'payload'         => array(
+					'event_id'    => 999,
+					'authority'   => $snapshot['authority'],
+					'fingerprint' => $snapshot['fingerprint'],
+				),
+			)
+		);
 		$error = $sync->reconcile( $other['id'], 2, 12 );
 		$this->assertSame( 'booking_event_identity_mismatch', $error->get_error_code() );
 	}
@@ -1044,6 +1052,27 @@ final class BookingEventConversionTest extends BookingTestCase {
 		$this->assertSame( 'booking_event_manual_divergence', $error->get_error_code() );
 		$this->assertArrayHasKey( 'venue_id', $error->get_error_data()['conflicts'] );
 		$this->assertCount( 0, $ability->calls );
+	}
+
+	public function test_source_update_result_must_match_requested_event_and_previous_fingerprint(): void {
+		foreach ( array( 'event_id', 'previous_fingerprint' ) as $invalid_field ) {
+			$booking = $this->booking();
+			$this->service()->convert( $booking['id'], 1, 12 );
+			$GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/update-source-event'] = new BookingConversionAbilityFake(
+				static function ( array $input ) use ( $invalid_field ): array {
+					return array(
+						'success'              => true,
+						'event_id'             => 'event_id' === $invalid_field ? 999 : $input['event'],
+						'action'               => 'updated',
+						'previous_fingerprint' => 'previous_fingerprint' === $invalid_field ? hash( 'sha256', 'wrong' ) : $input['expected_fingerprint'],
+						'fingerprint'          => hash( 'sha256', 'next-' . $invalid_field ),
+						'updated_fields'       => array( 'performer' ),
+					);
+				}
+			);
+			$error = ( new BookingEventSyncService( null, null, new BookingTestAuthorization() ) )->reconcile( $booking['id'], 2, 12, array( 'performer' => 'Corrected Artist' ) );
+			$this->assertSame( 'booking_event_update_failed', $error->get_error_code() );
+		}
 	}
 
 	public function test_source_owned_update_is_combined_and_scoped_to_active_wrapper(): void {

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -792,17 +792,64 @@ final class BookingHoldTest extends BookingTestCase {
 				'venue_term_id'  => 55,
 				'post_status'    => 'publish',
 				'start_datetime' => '2030-11-03 01:05:00',
-				'end_datetime'   => null,
+				'end_datetime'   => '2030-11-03 01:30:00',
 			),
 		);
 		$dst                          = $this->booking( '2030-11-03 06:00:00', '2030-11-03 07:00:00' );
 		$this->assertSame( 'canonical_event', $holds->create( $dst['id'], 1, 12 )->get_error_data()['conflict']['conflict_type'], '06:00 UTC converts to the repeated 01:00 hour after the DST fallback.' );
 		$crossing_fold = $this->booking( '2030-11-03 05:45:00', '2030-11-03 06:15:00' );
-		$this->assertSame( 'canonical_event', $holds->create( $crossing_fold['id'], 1, 12 )->get_error_data()['conflict']['conflict_type'], 'The local window must include the early segment of the repeated fold.' );
+		$GLOBALS['ec_artist_test']['overlap_result'] = new WP_Error( 'venue_overlap_unrepresentable_interval', 'The canonical index cannot represent this interval.', array( 'status' => 400 ) );
+		$fold_error = $holds->create( $crossing_fold['id'], 1, 12 );
+		$this->assertSame( 'booking_conflict_check_failed', $fold_error->get_error_code() );
+		$this->assertSame( 'venue_overlap_unrepresentable_interval', $fold_error->get_error_data()['upstream_code'] );
 
+		$this->assertSame( array( 'publish' ), $GLOBALS['ec_artist_test']['overlap_calls'][0]['statuses'] );
+		$this->assertSame( '2030-08-01T22:00:00Z', $GLOBALS['ec_artist_test']['overlap_calls'][0]['start'] );
+	}
+
+	public function test_canonical_overlap_contract_errors_fail_closed_and_exclusions_remain_half_open(): void {
+		$holds   = $this->holds();
+		$booking = $this->booking();
+		$GLOBALS['ec_artist_test']['overlap_result'] = new WP_Error( 'venue_overlap_query_failed', 'Unavailable.' );
+		$this->assertSame( 'booking_conflict_check_failed', $holds->create( $booking['id'], 1, 12 )->get_error_code() );
+
+		$GLOBALS['ec_artist_test']['overlap_result'] = array( 'venue_id' => '55', 'events' => array() );
+		$this->assertSame( 'booking_canonical_overlap_contract_invalid', $holds->create( $booking['id'], 1, 12 )->get_error_code() );
+		$GLOBALS['ec_artist_test']['overlap_result'] = array(
+			'venue_id' => 55,
+			'timezone' => 'America/New_York',
+			'interval' => array( 'start' => '2030-08-01T15:00:00-04:00', 'end' => '2030-08-01T19:00:00-04:00' ),
+			'events'   => array(),
+			'page'     => 1,
+			'per_page' => 1,
+			'has_more' => false,
+		);
+		$this->assertSame( 'booking_canonical_overlap_contract_invalid', $holds->create( $booking['id'], 1, 12 )->get_error_code(), 'A response for a different interval must not mean no conflict.' );
+		$GLOBALS['ec_artist_test']['overlap_result']['interval'] = array( 'start' => '2030-08-01T16:00:00-04:00', 'end' => '2030-08-01T19:00:00-04:00' );
+		$GLOBALS['ec_artist_test']['overlap_result']['has_more'] = true;
+		$this->assertSame( 'booking_canonical_overlap_contract_invalid', $holds->create( $booking['id'], 1, 12 )->get_error_code(), 'An empty page cannot hide an asserted additional overlap.' );
+
+		unset( $GLOBALS['ec_artist_test']['overlap_result'] );
 		$GLOBALS['ec_artist_test']['meta'][7][55]['_venue_timezone'] = 'Not/AZone';
-		$next = $this->booking( '2030-09-01 20:00:00', '2030-09-01 22:00:00' );
-		$this->assertSame( 'booking_venue_timezone_invalid', $holds->create( $next['id'], 1, 12 )->get_error_code() );
+		$this->assertSame( 'booking_venue_timezone_invalid', $holds->create( $booking['id'], 1, 12 )->get_error_code() );
+		$GLOBALS['ec_artist_test']['meta'][7][55]['_venue_timezone'] = 'America/New_York';
+		$GLOBALS['wpdb']->event_dates = array(
+			array(
+				'post_id'        => 903,
+				'venue_term_id'  => 55,
+				'post_status'    => 'publish',
+				'start_datetime' => '2030-08-01 15:00:00',
+				'end_datetime'   => '2030-08-01 16:00:00',
+			),
+		);
+		$this->assertSame( 'active', $holds->create( $booking['id'], 1, 12 )['hold']['status'], 'An event ending exactly when the hold starts is adjacent.' );
+
+		$excluded = $this->booking( '2030-08-01 20:00:00', '2030-08-01 23:00:00', 'patio' );
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $excluded['id'] ]['event_id'] = 903;
+		$GLOBALS['wpdb']->event_dates[0]['start_datetime'] = '2030-08-01 16:30:00';
+		$GLOBALS['wpdb']->event_dates[0]['end_datetime']   = '2030-08-01 17:30:00';
+		$this->assertSame( 'active', $holds->create( $excluded['id'], 1, 12 )['hold']['status'], 'The booking-linked canonical event is excluded from self-conflict.' );
+		$this->assertSame( array( 903 ), end( $GLOBALS['ec_artist_test']['overlap_calls'] )['exclude'] );
 	}
 
 	public function test_lifecycle_requires_exact_hold_converts_selected_and_releases_alternatives(): void {

--- a/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
@@ -15,27 +15,7 @@ final class InternalBookingHoldConcurrencyMySQLProof extends BookingAttachmentMy
 		wp_set_current_user( $this->actor_id );
 		$this->assertNotFalse( update_term_meta( $this->venue_id, '_venue_timezone', 'America/New_York' ) );
 		$this->assertTrue( DataMachineEvents\Core\EventDatesTable::table_exists() );
-
-		$config            = wp_get_ability( 'extrachill/get-venue-booking-config' )->execute( array( 'venue_term_id' => $this->venue_id ) );
-		$this->assertIsArray( $config, is_wp_error( $config ) ? $config->get_error_code() : 'Venue config was not returned.' );
-		$revision = (int) $config['revision'];
-		unset( $config['revision'], $config['updated_by_user_id'], $config['updated_at'] );
-		$config['enabled'] = true;
-		$config['spaces']  = array(
-			array(
-				'key'        => 'main-room',
-				'name'       => 'Main Room',
-				'is_default' => true,
-			),
-		);
-		$config = wp_get_ability( 'extrachill/update-venue-booking-config' )->execute(
-			array(
-				'venue_term_id'    => $this->venue_id,
-				'expected_revision' => $revision,
-				'config'           => $config,
-			)
-		);
-		$this->assertIsArray( $config, is_wp_error( $config ) ? $config->get_error_code() : 'Venue config was not committed.' );
+		$this->configure_booking_venue();
 
 		$bookings = array(
 			$this->prepare_booking( 'Native Race One' ),
@@ -117,6 +97,48 @@ final class InternalBookingHoldConcurrencyMySQLProof extends BookingAttachmentMy
 		rmdir( $directory );
 	}
 
+	/** Prove the public hold path consumes DME's real indexed overlap contract. */
+	public function test_canonical_event_overlap_blocks_public_hold(): void {
+		global $wpdb;
+		$this->register_booking_abilities();
+		wp_set_current_user( $this->actor_id );
+		$this->assertNotFalse( update_term_meta( $this->venue_id, '_venue_timezone', 'America/New_York' ) );
+		$this->configure_booking_venue();
+
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'   => DataMachineEvents\Core\Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+				'post_title'  => 'Canonical Venue Blocker',
+			)
+		);
+		$this->assertNotWPError( wp_set_object_terms( $event_id, array( $this->venue_id ), 'venue' ) );
+		$this->assertNotFalse(
+			$wpdb->replace(
+				DataMachineEvents\Core\EventDatesTable::table_name(),
+				array(
+					'post_id'        => $event_id,
+					'start_datetime' => '2031-06-30 21:00:00',
+					'end_datetime'   => '2031-06-30 22:00:00',
+					'post_status'    => 'publish',
+				),
+				array( '%d', '%s', '%s', '%s' )
+			)
+		);
+
+		$booking = $this->prepare_booking( 'Canonical Conflict Probe' );
+		$result  = wp_get_ability( 'extrachill/create-booking-hold' )->execute(
+			array(
+				'booking_id'              => $booking['id'],
+				'expected_booking_version' => $booking['version'],
+			)
+		);
+		$this->assertWPError( $result );
+		$this->assertSame( 'booking_time_conflict', $result->get_error_code() );
+		$this->assertSame( 'canonical_event', $result->get_error_data()['conflict']['conflict_type'] );
+		$this->assertSame( $event_id, $result->get_error_data()['conflict']['event_id'] );
+	}
+
 	/** Prepare one negotiating booking through public lifecycle Abilities. */
 	private function prepare_booking( string $artist_name ): array {
 		$booking = ( new BookingRepository() )->create(
@@ -149,6 +171,30 @@ final class InternalBookingHoldConcurrencyMySQLProof extends BookingAttachmentMy
 		);
 		$this->assertIsArray( $booking, is_wp_error( $booking ) ? $booking->get_error_code() : 'Performance selection failed.' );
 		return $booking;
+	}
+
+	/** Enable one deterministic booking space for this test's venue. */
+	private function configure_booking_venue(): void {
+		$config = wp_get_ability( 'extrachill/get-venue-booking-config' )->execute( array( 'venue_term_id' => $this->venue_id ) );
+		$this->assertIsArray( $config, is_wp_error( $config ) ? $config->get_error_code() : 'Venue config was not returned.' );
+		$revision = (int) $config['revision'];
+		unset( $config['revision'], $config['updated_by_user_id'], $config['updated_at'] );
+		$config['enabled'] = true;
+		$config['spaces']  = array(
+			array(
+				'key'        => 'main-room',
+				'name'       => 'Main Room',
+				'is_default' => true,
+			),
+		);
+		$config = wp_get_ability( 'extrachill/update-venue-booking-config' )->execute(
+			array(
+				'venue_term_id'    => $this->venue_id,
+				'expected_revision' => $revision,
+				'config'            => $config,
+			)
+		);
+		$this->assertIsArray( $config, is_wp_error( $config ) ? $config->get_error_code() : 'Venue config was not committed.' );
 	}
 
 	/** Register booking definitions in Core's public Abilities registry. */

--- a/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
+++ b/tests/MySQLIntegration/InternalBookingHoldConcurrencyMySQLProof.php
@@ -104,6 +104,7 @@ final class InternalBookingHoldConcurrencyMySQLProof extends BookingAttachmentMy
 		wp_set_current_user( $this->actor_id );
 		$this->assertNotFalse( update_term_meta( $this->venue_id, '_venue_timezone', 'America/New_York' ) );
 		$this->configure_booking_venue();
+		$booking = $this->prepare_booking( 'Canonical Conflict Probe' );
 
 		$event_id = self::factory()->post->create(
 			array(
@@ -126,8 +127,7 @@ final class InternalBookingHoldConcurrencyMySQLProof extends BookingAttachmentMy
 			)
 		);
 
-		$booking = $this->prepare_booking( 'Canonical Conflict Probe' );
-		$result  = wp_get_ability( 'extrachill/create-booking-hold' )->execute(
+		$result = wp_get_ability( 'extrachill/create-booking-hold' )->execute(
 			array(
 				'booking_id'              => $booking['id'],
 				'expected_booking_version' => $booking['version'],

--- a/tests/MySQLIntegration/host-wordpress-bootstrap.php
+++ b/tests/MySQLIntegration/host-wordpress-bootstrap.php
@@ -16,9 +16,27 @@ require getenv( 'WP_TESTS_DIR' ) . '/includes/bootstrap.php';
 
 $dme_directory = rtrim( (string) getenv( 'DME_PLUGIN_DIR' ), '/\\' );
 if ( '' !== $dme_directory ) {
-	require_once $dme_directory . '/inc/Core/EventDatesTable.php';
+	foreach (
+		array(
+			'/inc/Core/EventDatesTable.php',
+			'/inc/Core/Event_Post_Type.php',
+			'/inc/Core/Venue_Taxonomy.php',
+			'/inc/Abilities/AbilityCategories.php',
+			'/inc/Abilities/VenueIntervalOverlapAbilities.php',
+			'/inc/public-api.php',
+		) as $relative_path
+	) {
+		$file = $dme_directory . $relative_path;
+		if ( ! is_file( $file ) ) {
+			throw new RuntimeException( 'The native hold proof requires the current DME public overlap contract: ' . $relative_path );
+		}
+		require_once $file;
+	}
 	DataMachineEvents\Core\EventDatesTable::create_table();
 	if ( ! DataMachineEvents\Core\EventDatesTable::table_exists() ) {
 		throw new RuntimeException( 'The native hold proof requires the DME event dates table.' );
+	}
+	if ( ! function_exists( 'data_machine_events_query_venue_interval_overlaps' ) ) {
+		throw new RuntimeException( 'The native hold proof requires the DME venue interval-overlap function.' );
 	}
 }

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -191,6 +191,69 @@ if ( ! function_exists( 'get_term_meta' ) ) {
 		return $state['meta'][ $state['blog_id'] ][ $term_id ][ $key ] ?? '';
 	}
 }
+if ( ! function_exists( 'data_machine_events_get_venue_data' ) ) {
+	function data_machine_events_get_venue_data( int $term_id ) {
+		if ( array_key_exists( 'venue_projection_result', $GLOBALS['ec_artist_test'] ?? array() ) ) {
+			$result = $GLOBALS['ec_artist_test']['venue_projection_result'];
+			return is_callable( $result ) ? $result( $term_id ) : $result;
+		}
+		$meta = $GLOBALS['ec_artist_test']['meta'][ get_current_blog_id() ][ $term_id ] ?? array();
+		return array(
+			'address'     => $meta['_venue_address'] ?? '',
+			'city'        => $meta['_venue_city'] ?? '',
+			'state'       => $meta['_venue_state'] ?? '',
+			'zip'         => $meta['_venue_zip'] ?? '',
+			'country'     => $meta['_venue_country'] ?? '',
+			'phone'       => $meta['_venue_phone'] ?? '',
+			'website'     => $meta['_venue_website'] ?? '',
+			'coordinates' => $meta['_venue_coordinates'] ?? '',
+			'capacity'    => $meta['_venue_capacity'] ?? '',
+			'timezone'    => $meta['_venue_timezone'] ?? '',
+		);
+	}
+}
+if ( ! function_exists( 'data_machine_events_query_venue_interval_overlaps' ) ) {
+	function data_machine_events_query_venue_interval_overlaps( array $params ) {
+		$GLOBALS['ec_artist_test']['overlap_calls'][] = $params;
+		if ( array_key_exists( 'overlap_result', $GLOBALS['ec_artist_test'] ?? array() ) ) {
+			$result = $GLOBALS['ec_artist_test']['overlap_result'];
+			return is_callable( $result ) ? $result( $params ) : $result;
+		}
+		$venue_id  = (int) $params['venue_id'];
+		$projection = data_machine_events_get_venue_data( $venue_id );
+		$timezone  = new DateTimeZone( (string) ( $projection['timezone'] ?? 'UTC' ) );
+		$start     = ( new DateTimeImmutable( $params['start'] ) )->setTimezone( $timezone )->format( 'Y-m-d H:i:s' );
+		$end       = ( new DateTimeImmutable( $params['end'] ) )->setTimezone( $timezone )->format( 'Y-m-d H:i:s' );
+		$excluded  = array_map( 'intval', $params['exclude'] ?? array() );
+		$events    = array();
+		foreach ( $GLOBALS['wpdb']->event_dates ?? array() as $event ) {
+			if ( (int) $event['venue_term_id'] !== $venue_id || in_array( (int) $event['post_id'], $excluded, true ) || 'publish' !== $event['post_status'] || null === $event['end_datetime'] || $event['end_datetime'] <= $event['start_datetime'] ) {
+				continue;
+			}
+			if ( $event['start_datetime'] < $end && $event['end_datetime'] > $start ) {
+				$events[] = array(
+					'event_id' => (int) $event['post_id'],
+					'start'    => DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $event['start_datetime'], $timezone )->format( DATE_RFC3339 ),
+					'end'      => DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $event['end_datetime'], $timezone )->format( DATE_RFC3339 ),
+					'status'   => 'publish',
+				);
+				break;
+			}
+		}
+		return array(
+			'venue_id' => $venue_id,
+			'timezone' => $timezone->getName(),
+			'interval' => array(
+				'start' => ( new DateTimeImmutable( $params['start'] ) )->setTimezone( $timezone )->format( DATE_RFC3339 ),
+				'end'   => ( new DateTimeImmutable( $params['end'] ) )->setTimezone( $timezone )->format( DATE_RFC3339 ),
+			),
+			'events'   => $events,
+			'page'     => 1,
+			'per_page' => 1,
+			'has_more' => false,
+		);
+	}
+}
 if ( ! function_exists( 'update_term_meta' ) ) {
 	function update_term_meta( $term_id, $key, $value ) {
 		if ( isset( $GLOBALS['venue_membership_test'] ) ) {


### PR DESCRIPTION
## Summary
- trust and persist DME's returned source identity and fingerprints instead of reading or recomputing private source metadata
- consume DME's public venue projection and interval-overlap contract with strict fail-closed response validation
- retain Extra Chill-owned hold, confirmed-booking, space, lock, retry, and conflict policy
- extend the native MySQL workflow to prove canonical DME overlaps block public booking holds

## Verification
- `vendor/bin/phpunit -c phpunit-booking.xml.dist` (`435 tests, 4,644 assertions`)
- changed-code PHPCS passed through Homeboy
- PHP syntax and `git diff --check` passed
- independent exact-diff review approved
- native MySQL proof is wired into `internal-booking-calendar-alpha.yml` and must run on GitHub because the host has no disposable WordPress/MySQL test environment

## Tooling
- Homeboy PHPStan still reports the repository-wide baseline (`1,746` findings); no changed-code PHPCS findings remain
- Homeboy audit warnings were existing non-portable artifact observations, not product-code findings

Closes #471