### PR TITLE
refactor: migrate event notifications to receipts

### DIFF
--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -60,6 +60,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class ArtistUrlImportAbilities {
+	/** Feature-owned producer for submitter moderation notifications. */
+	private const NOTIFICATION_PRODUCER = 'extrachill-events-artist-url-import';
 
 	/**
 	 * Registered event-import handler slug consumed for the preview probe.
@@ -1818,12 +1820,13 @@ class ArtistUrlImportAbilities {
 	 * @param int    $item_id    Optional related object ID.
 	 */
 	private function notifySubmitter( array $submission, string $type, string $title, string $link, int $item_id = 0 ): void {
-		if ( ! function_exists( 'ec_users_notify' ) ) {
+		if ( ! function_exists( 'ec_users_notify_with_receipts' ) ) {
 			return;
 		}
 
-		$submitter_id = isset( $submission['user_id'] ) ? (int) $submission['user_id'] : 0;
-		if ( $submitter_id <= 0 ) {
+		$submitter_id  = isset( $submission['user_id'] ) ? (int) $submission['user_id'] : 0;
+		$submission_id = isset( $submission['id'] ) ? (int) $submission['id'] : 0;
+		if ( $submitter_id <= 0 || $submission_id <= 0 ) {
 			return;
 		}
 
@@ -1847,18 +1850,20 @@ class ArtistUrlImportAbilities {
 		}
 
 		$data = array(
-			'actor_id' => $actor_id,
-			'type'     => $type,
-			'title'    => $title,
-			'link'     => $link,
+			'actor_id'        => $actor_id,
+			'type'            => $type,
+			'title'           => $title,
+			'link'            => $link,
+			'producer'        => self::NOTIFICATION_PRODUCER,
+			'idempotency_key' => 'submission:' . $submission_id . ':' . $type,
 		);
 		if ( $item_id > 0 ) {
 			$data['item_id'] = $item_id;
 		}
 
-		$inserted = 0;
+		$receipt = null;
 		try {
-			$inserted = ec_users_notify( $submitter_id, $data );
+			$receipt = ec_users_notify_with_receipts( array( $submitter_id ), $data );
 		} catch ( \Throwable $e ) {
 			do_action(
 				'datamachine_log',
@@ -1874,15 +1879,16 @@ class ArtistUrlImportAbilities {
 			return;
 		}
 
-		if ( 0 === $inserted ) {
+		if ( ! is_array( $receipt ) || 0 < absint( $receipt['failed'] ?? 1 ) ) {
 			do_action(
 				'datamachine_log',
 				'warning',
-				'ArtistUrlImportAbilities: submitter notification was not inserted',
+				'ArtistUrlImportAbilities: submitter notification failed',
 				array(
 					'type'     => $type,
 					'user_id'  => $submitter_id,
 					'actor_id' => $actor_id,
+					'receipt'  => is_array( $receipt ) ? $receipt : array( 'result' => $receipt ),
 				)
 			);
 		}

--- a/inc/core/data-machine-events/festival-notifications.php
+++ b/inc/core/data-machine-events/festival-notifications.php
@@ -61,7 +61,7 @@ function extrachill_events_notify_festival_subscribers( $new_status, $old_status
 		return;
 	}
 
-	if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify' ) ) {
+	if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify_with_receipts' ) ) {
 		return;
 	}
 
@@ -105,46 +105,49 @@ function extrachill_events_notify_festival_subscribers( $new_status, $old_status
 		return;
 	}
 
-	$expected_deliveries = 0;
-	$delivered           = 0;
+	$failed_receipts = 0;
 
 	if ( ! empty( $general_recipient_ids ) ) {
-		$expected_deliveries += count( $general_recipient_ids );
-		$delivered           += ec_users_notify(
+		$receipt          = ec_users_notify_with_receipts(
 			$general_recipient_ids,
 			array(
-				'actor_id' => (int) $post->post_author,
-				'type'     => 'festival_event_published',
+				'actor_id'        => (int) $post->post_author,
+				'type'            => 'festival_event_published',
 				/* translators: %s: event title. */
-				'title'    => sprintf( __( 'New event: %s', 'extrachill-events' ), get_the_title( $post ) ),
-				'link'     => get_permalink( $post ),
-				'item_id'  => (int) $post->ID,
+				'title'           => sprintf( __( 'New event: %s', 'extrachill-events' ), get_the_title( $post ) ),
+				'link'            => get_permalink( $post ),
+				'item_id'         => (int) $post->ID,
+				'producer'        => EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER,
+				'idempotency_key' => 'event:' . (int) $post->ID . ':festival_event_published',
 			)
 		);
+		$failed_receipts += is_array( $receipt ) ? absint( $receipt['failed'] ?? count( $general_recipient_ids ) ) : count( $general_recipient_ids );
 	}
 
 	if ( empty( $nearby_recipient_ids ) ) {
-		if ( $delivered < $expected_deliveries ) {
+		if ( 0 < $failed_receipts ) {
 			delete_post_meta( $post->ID, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META );
 		}
 
 		return;
 	}
 
-	$expected_deliveries += count( $nearby_recipient_ids );
-	$delivered           += ec_users_notify(
+	$receipt          = ec_users_notify_with_receipts(
 		$nearby_recipient_ids,
 		array(
-			'actor_id' => (int) $post->post_author,
-			'type'     => EXTRACHILL_EVENTS_NEARBY_ARTIST_EVENT_NOTIFICATION,
+			'actor_id'        => (int) $post->post_author,
+			'type'            => EXTRACHILL_EVENTS_NEARBY_ARTIST_EVENT_NOTIFICATION,
 			/* translators: %s: event title. */
-			'title'    => sprintf( __( 'Nearby show: %s', 'extrachill-events' ), get_the_title( $post ) ),
-			'link'     => get_permalink( $post ),
-			'item_id'  => (int) $post->ID,
+			'title'           => sprintf( __( 'Nearby show: %s', 'extrachill-events' ), get_the_title( $post ) ),
+			'link'            => get_permalink( $post ),
+			'item_id'         => (int) $post->ID,
+			'producer'        => EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER,
+			'idempotency_key' => 'event:' . (int) $post->ID . ':' . EXTRACHILL_EVENTS_NEARBY_ARTIST_EVENT_NOTIFICATION,
 		)
 	);
+	$failed_receipts += is_array( $receipt ) ? absint( $receipt['failed'] ?? count( $nearby_recipient_ids ) ) : count( $nearby_recipient_ids );
 
-	if ( $delivered < $expected_deliveries ) {
+	if ( 0 < $failed_receipts ) {
 		delete_post_meta( $post->ID, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META );
 	}
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,7 @@
 			<file>tests/Unit/Abilities/EventsByTermTaxonomyContextTest.php</file>
 			<file>tests/Unit/Abilities/EventsByArtistAbilityTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalAdapterContractsTest.php</file>
+			<file>tests/Unit/Abilities/ArtistUrlImportNotificationTest.php</file>
 			<file>tests/Unit/Core/VenueExpansionPlanTest.php</file>
 			<file>tests/Unit/Core/VenueExpansionRunnerTest.php</file>
 			<file>tests/Unit/Core/VenueExpansionSystemTaskTest.php</file>

--- a/tests/Unit/Abilities/ArtistUrlImportNotificationTest.php
+++ b/tests/Unit/Abilities/ArtistUrlImportNotificationTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests for artist URL import submitter notification receipts.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+// phpcs:disable -- This isolated unit fixture intentionally declares WordPress test doubles.
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id() {
+		return $GLOBALS['artist_import_notification_actor_id'] ?? 0;
+	}
+}
+
+if ( ! function_exists( 'get_userdata' ) ) {
+	function get_userdata( $user_id ) {
+		return 0 < (int) $user_id ? (object) array( 'ID' => (int) $user_id ) : false;
+	}
+}
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ) {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! function_exists( 'ec_users_notify_with_receipts' ) ) {
+	function ec_users_notify_with_receipts( $user_ids, array $data ) {
+		$GLOBALS['artist_import_notification_calls'][] = compact( 'user_ids', 'data' );
+		return $GLOBALS['artist_import_notification_receipt'];
+	}
+}
+
+require_once dirname( __DIR__, 3 ) . '/inc/Abilities/ArtistUrlImportAbilities.php';
+
+use ExtraChillEvents\Abilities\ArtistUrlImportAbilities;
+
+/** Verify the feature's receipt and replay contracts. */
+final class ArtistUrlImportNotificationTest extends PHPUnit\Framework\TestCase {
+	/** Reset notification fixtures. */
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['artist_import_notification_actor_id'] = 31;
+		$GLOBALS['artist_import_notification_calls']    = array();
+		$GLOBALS['artist_import_notification_receipt']  = array(
+			'requested'  => 1,
+			'inserted'   => 0,
+			'existing'   => 1,
+			'failed'     => 0,
+			'recipients' => array( 22 => array( 'status' => 'existing' ) ),
+		);
+		$GLOBALS['ec_artist_test']                      = array( 'fired_actions' => array() );
+	}
+
+	/**
+	 * Invoke the private delivery helper through reflection.
+	 *
+	 * @param array  $submission Submission fixture.
+	 * @param string $type       Notification type.
+	 * @param int    $item_id    Related object ID.
+	 */
+	private function notify_submitter( array $submission, string $type, int $item_id ): void {
+		$reflection = new ReflectionClass( ArtistUrlImportAbilities::class );
+		$instance   = $reflection->newInstanceWithoutConstructor();
+		$method     = $reflection->getMethod( 'notifySubmitter' );
+		$method->setAccessible( true );
+		$method->invoke( $instance, $submission, $type, 'Moderation result', 'https://events.example/artist/', $item_id );
+	}
+
+	/** Existing receipts succeed and use the immutable submission row identity. */
+	public function test_existing_receipt_uses_submission_id_and_type_as_replay_key(): void {
+		$this->notify_submitter(
+			array(
+				'id'             => 456,
+				'user_id'        => 22,
+				'artist_term_id' => 999,
+			),
+			'artist_import_approved',
+			999
+		);
+
+		$this->assertCount( 1, $GLOBALS['artist_import_notification_calls'] );
+		$call = $GLOBALS['artist_import_notification_calls'][0];
+		$this->assertSame( array( 22 ), $call['user_ids'] );
+		$this->assertSame( 'extrachill-events-artist-url-import', $call['data']['producer'] );
+		$this->assertSame( 'submission:456:artist_import_approved', $call['data']['idempotency_key'] );
+		$this->assertSame( 999, $call['data']['item_id'] );
+		$this->assertArrayNotHasKey( 'datamachine_log', $GLOBALS['ec_artist_test']['fired_actions'] );
+	}
+
+	/** Failed receipt status preserves warning logging. */
+	public function test_failed_receipt_is_logged(): void {
+		$GLOBALS['artist_import_notification_receipt'] = array(
+			'requested'  => 1,
+			'inserted'   => 0,
+			'existing'   => 0,
+			'failed'     => 1,
+			'recipients' => array(
+				22 => array(
+					'status' => 'failed',
+					'error'  => 'insert_failed',
+				),
+			),
+		);
+
+		$this->notify_submitter(
+			array(
+				'id'      => 457,
+				'user_id' => 22,
+			),
+			'artist_import_rejected',
+			457
+		);
+
+		$this->assertCount( 1, $GLOBALS['ec_artist_test']['fired_actions']['datamachine_log'] );
+		$log = $GLOBALS['ec_artist_test']['fired_actions']['datamachine_log'][0];
+		$this->assertSame( 'warning', $log[0] );
+		$this->assertSame( 'ArtistUrlImportAbilities: submitter notification failed', $log[1] );
+		$this->assertSame( 1, $log[2]['receipt']['failed'] );
+	}
+}

--- a/tests/Unit/FestivalNotificationsTest.php
+++ b/tests/Unit/FestivalNotificationsTest.php
@@ -91,14 +91,25 @@ if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) ) {
 	}
 }
 
-if ( ! function_exists( 'ec_users_notify' ) ) {
-	function ec_users_notify( $user_ids, array $data ) {
+if ( ! function_exists( 'ec_users_notify_with_receipts' ) ) {
+	function ec_users_notify_with_receipts( $user_ids, array $data ) {
 		$GLOBALS['festival_notification_calls'][] = array(
 			'user_ids' => $user_ids,
 			'data'     => $data,
 		);
 
-		return array_shift( $GLOBALS['festival_notification_delivery_results'] ) ?? count( $user_ids );
+		$result = array_shift( $GLOBALS['festival_notification_delivery_results'] ) ?? count( $user_ids );
+		if ( is_array( $result ) ) {
+			return $result;
+		}
+
+		return array(
+			'requested'  => count( $user_ids ),
+			'inserted'   => $result,
+			'existing'   => 0,
+			'failed'     => count( $user_ids ) - $result,
+			'recipients' => array(),
+		);
 	}
 }
 
@@ -217,6 +228,8 @@ class FestivalNotificationsTest extends WP_UnitTestCase {
 		$this->assert_same_ids( array( 7, 9, 11 ), $GLOBALS['festival_notification_calls'][0]['user_ids'] );
 		$this->assertSame( 'New event: The Big Show', $GLOBALS['festival_notification_calls'][0]['data']['title'] );
 		$this->assertSame( get_permalink( $post ), $GLOBALS['festival_notification_calls'][0]['data']['link'] );
+		$this->assertSame( EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER, $GLOBALS['festival_notification_calls'][0]['data']['producer'] );
+		$this->assertSame( 'event:' . $post->ID . ':festival_event_published', $GLOBALS['festival_notification_calls'][0]['data']['idempotency_key'] );
 	}
 
 	public function test_notifies_artist_subscribers_and_deduplicates_across_entity_terms(): void {
@@ -283,6 +296,8 @@ class FestivalNotificationsTest extends WP_UnitTestCase {
 		$this->assert_same_ids( array( 7 ), $GLOBALS['festival_notification_calls'][1]['user_ids'] );
 		$this->assertSame( EXTRACHILL_EVENTS_NEARBY_ARTIST_EVENT_NOTIFICATION, $GLOBALS['festival_notification_calls'][1]['data']['type'] );
 		$this->assertSame( 'Nearby show: The Big Show', $GLOBALS['festival_notification_calls'][1]['data']['title'] );
+		$this->assertSame( EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_PRODUCER, $GLOBALS['festival_notification_calls'][1]['data']['producer'] );
+		$this->assertSame( 'event:' . $post->ID . ':' . EXTRACHILL_EVENTS_NEARBY_ARTIST_EVENT_NOTIFICATION, $GLOBALS['festival_notification_calls'][1]['data']['idempotency_key'] );
 	}
 
 	public function test_does_not_notify_for_published_post_updates(): void {
@@ -352,6 +367,28 @@ class FestivalNotificationsTest extends WP_UnitTestCase {
 		extrachill_events_notify_festival_subscribers( 'publish', 'draft', $post );
 
 		$this->assertCount( 2, $GLOBALS['festival_notification_calls'] );
+		$this->assertNotEmpty( get_post_meta( $post->ID, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META, true ) );
+	}
+
+	public function test_existing_receipts_count_as_success_and_keep_the_claim(): void {
+		$GLOBALS['festival_notification_terms']['festival'] = array( 'summer-jam' );
+		$GLOBALS['festival_notification_recipients']        = array(
+			'summer-jam' => array( 7 ),
+		);
+		$GLOBALS['festival_notification_delivery_results']  = array(
+			array(
+				'requested'  => 1,
+				'inserted'   => 0,
+				'existing'   => 1,
+				'failed'     => 0,
+				'recipients' => array( 7 => array( 'status' => 'existing' ) ),
+			),
+		);
+		$post = $this->event_post();
+
+		extrachill_events_notify_festival_subscribers( 'publish', 'draft', $post );
+
+		$this->assertCount( 1, $GLOBALS['festival_notification_calls'] );
 		$this->assertNotEmpty( get_post_meta( $post->ID, EXTRACHILL_EVENTS_FESTIVAL_NOTIFICATION_SENT_META, true ) );
 	}
 }


### PR DESCRIPTION
## Summary
- migrate festival and nearby-artist event notifications to canonical receipts
- migrate artist URL import moderation notifications with immutable submission identities
- preserve inserted/existing success and partial-failure retries

## Verification
- Artist URL notification suite: 2 tests, 10 assertions
- festival notification source tests updated for receipt replay
- changed PHP syntax and focused PHPCS passed
- `git diff --check` passed

The full legacy Artist URL class still carries pre-existing repository PHPCS naming debt.

## Rollout
Merge and deploy this consumer before Extra-Chill/extrachill-users#309 removes the legacy wrapper.

Closes #504