### PR TITLE
Refactor booking surfaces onto shared components and tokens

### DIFF
--- a/blocks/venue-booking-inquiry/src/style.scss
+++ b/blocks/venue-booking-inquiry/src/style.scss
@@ -1,20 +1,16 @@
 @use "@extrachill/components/styles/components.scss";
 
-.ec-venue-booking-inquiry { margin-block: var(--wp--preset--spacing--50, 2rem); }
-.ec-booking-inquiry__identity { align-items: start; display: flex; gap: 1rem; justify-content: space-between; }
-.ec-booking-inquiry__identity h3 { margin: .15rem 0; }
-.ec-booking-inquiry__eyebrow { color: var(--wp--preset--color--primary, #2563eb); font-size: .75rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
-.ec-booking-inquiry__signed-in { background: var(--wp--preset--color--base-2, #f1f5f9); border-radius: 999px; font-size: .8rem; padding: .35rem .65rem; }
+.ec-venue-booking-inquiry { margin-block: var(--spacing-xl); }
+.ec-booking-inquiry__identity { align-items: start; }
+.ec-booking-inquiry__identity .ec-panel-header__title { display: grid; gap: var(--spacing-xs); }
 .ec-booking-inquiry__description { font-size: 1.05rem; max-width: 70ch; }
 .ec-booking-inquiry__requirements { display: grid; gap: .5rem; margin-bottom: 0; }
 .ec-booking-inquiry__form { display: grid; gap: 1.25rem; margin-top: 1.5rem; }
-.ec-booking-inquiry__grid { display: grid; gap: 1rem; grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .ec-booking-inquiry__checkbox, .ec-booking-inquiry__consent { align-items: start; display: flex; gap: .55rem; line-height: 1.45; }
 .ec-booking-inquiry__checkbox input, .ec-booking-inquiry__consent input { flex: 0 0 auto; margin-top: .25rem; }
 .ec-booking-inquiry__turnstile { min-height: 65px; }
-.ec-booking-inquiry__privacy { color: var(--wp--preset--color--contrast-2, #475569); font-size: .85rem; max-width: 36rem; }
-.ec-booking-inquiry__result:focus { outline: 3px solid var(--wp--preset--color--primary, #2563eb); outline-offset: .35rem; }
+.ec-booking-inquiry__privacy { color: var(--muted-text); font-size: .85rem; max-width: 36rem; }
+.ec-booking-inquiry__result:focus { outline: 3px solid var(--focus-border-color); outline-offset: .35rem; }
 .ec-booking-inquiry__reference { display: inline-block; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
 .ec-venue-booking-editor { border: 1px dashed currentColor; padding: 1.5rem; }
-@media (max-width: 700px) { .ec-booking-inquiry__grid { grid-template-columns: 1fr; } .ec-booking-inquiry__identity { display: grid; } }
 @media (prefers-reduced-motion: reduce) { .ec-venue-booking-inquiry * { scroll-behavior: auto !important; transition: none !important; } }

--- a/blocks/venue-booking-inquiry/src/style.test.js
+++ b/blocks/venue-booking-inquiry/src/style.test.js
@@ -7,6 +7,7 @@ import { readFileSync } from 'fs';
 import path from 'path';
 
 const styles = readFileSync( path.resolve( __dirname, 'style.scss' ), 'utf8' );
+const view = readFileSync( path.resolve( __dirname, 'view.js' ), 'utf8' );
 
 describe( 'venue booking inquiry styles', () => {
 	it( 'composes the canonical shared component stylesheet', () => {
@@ -15,15 +16,24 @@ describe( 'venue booking inquiry styles', () => {
 		);
 	} );
 
-	it( 'retains inquiry-specific responsive and accessibility behavior', () => {
-		expect( styles ).toContain( '.ec-booking-inquiry__grid' );
-		expect( styles ).toContain(
-			'grid-template-columns: repeat(2, minmax(0, 1fr))'
+	it( 'composes canonical form, identity, and status primitives', () => {
+		expect( view ).toContain( 'Grid minColumnWidth="16rem"' );
+		expect( view ).toContain( '<PanelHeader' );
+		expect( view ).toContain( '<Badge tone="success">Now booking</Badge>' );
+		expect( view ).toContain(
+			'<Badge tone="info">Signed-in inquiry</Badge>'
 		);
-		expect( styles ).toContain( '@media (max-width: 700px)' );
-		expect( styles ).toContain( 'grid-template-columns: 1fr' );
+	} );
+
+	it( 'keeps unique accessibility behavior token-driven', () => {
 		expect( styles ).toContain( '.ec-booking-inquiry__result:focus' );
+		expect( styles ).toContain( 'var(--focus-border-color)' );
 		expect( styles ).toContain( '@media (prefers-reduced-motion: reduce)' );
 		expect( styles ).toContain( 'transition: none !important' );
+	} );
+
+	it( 'does not reintroduce local colors or arbitrary breakpoints', () => {
+		expect( styles ).not.toMatch( /#[0-9a-f]{3,8}\b/i );
+		expect( styles ).not.toMatch( /max-width:\s*(?:700|720)px/ );
 	} );
 } );

--- a/blocks/venue-booking-inquiry/src/view.js
+++ b/blocks/venue-booking-inquiry/src/view.js
@@ -8,12 +8,15 @@ import { createRoot, useEffect, useRef, useState } from '@wordpress/element';
  */
 import {
 	ActionRow,
+	Badge,
 	BlockShell,
 	BlockShellHeader,
 	BlockShellInner,
 	FieldGroup,
+	Grid,
 	InlineStatus,
 	Panel,
+	PanelHeader,
 } from '@extrachill/components';
 
 /**
@@ -210,9 +213,7 @@ function BookingInquiry( { config, wrapper } ) {
 							tabIndex="-1"
 							role="status"
 						>
-							<p className="ec-booking-inquiry__eyebrow">
-								Inquiry received
-							</p>
+							<Badge tone="success">Inquiry received</Badge>
 							<h3>
 								Thanks for reaching out to { config.venue.name }
 								.
@@ -237,22 +238,21 @@ function BookingInquiry( { config, wrapper } ) {
 				description={ `Send a performance inquiry directly to ${ config.venue.name }.` }
 			/>
 			<BlockShellInner>
-				<div className="ec-booking-inquiry__identity">
-					<div>
-						<span className="ec-booking-inquiry__eyebrow">
-							Now booking
-						</span>
-						<h3>{ config.venue.name }</h3>
-						{ config.venue.address && (
-							<p>{ config.venue.address }</p>
-						) }
-					</div>
-					{ config.authenticated && (
-						<span className="ec-booking-inquiry__signed-in">
-							Signed-in inquiry
-						</span>
-					) }
-				</div>
+				<PanelHeader
+					className="ec-booking-inquiry__identity"
+					title={
+						<>
+							<Badge tone="success">Now booking</Badge>
+							<span>{ config.venue.name }</span>
+						</>
+					}
+					description={ config.venue.address }
+					actions={
+						config.authenticated ? (
+							<Badge tone="info">Signed-in inquiry</Badge>
+						) : null
+					}
+				/>
 				{ config.venue.description && (
 					<p className="ec-booking-inquiry__description">
 						{ config.venue.description }
@@ -273,7 +273,7 @@ function BookingInquiry( { config, wrapper } ) {
 					onSubmit={ submit }
 					noValidate={ false }
 				>
-					<div className="ec-booking-inquiry__grid">
+					<Grid minColumnWidth="16rem" maxColumns={ 2 }>
 						<FieldGroup
 							label="Artist or project name"
 							htmlFor={ `${ prefix }-artist` }
@@ -410,7 +410,7 @@ function BookingInquiry( { config, wrapper } ) {
 								}
 							/>
 						) ) }
-					</div>
+					</Grid>
 					<FieldGroup
 						label="Performance details"
 						htmlFor={ `${ prefix }-message` }

--- a/blocks/venue-settings/src/booking-console.js
+++ b/blocks/venue-settings/src/booking-console.js
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
  */
 import {
 	ActionRow,
+	Badge,
 	FieldGroup,
 	Grid,
 	InlineStatus,
@@ -45,6 +46,19 @@ const STATUS_LABELS = {
 	withdrawn: 'Withdrawn',
 	cancelled: 'Cancelled',
 	completed: 'Completed',
+};
+
+const STATUS_TONES = {
+	submitted: 'info',
+	needs_info: 'error',
+	under_review: 'info',
+	negotiating: 'warning',
+	held: 'warning',
+	confirmed: 'success',
+	declined: 'error',
+	withdrawn: 'error',
+	cancelled: 'error',
+	completed: 'success',
 };
 
 const pad = ( value ) => String( value ).padStart( 2, '0' );
@@ -562,10 +576,9 @@ function ActivityTimeline( { operations } ) {
 
 function BookingStatus( { status } ) {
 	return (
-		<span className={ `ec-booking-status ec-booking-status--${ status }` }>
-			<span className="ec-booking-status__mark" aria-hidden="true" />
+		<Badge tone={ STATUS_TONES[ status ] || 'default' }>
 			{ statusLabel( status ) }
-		</span>
+		</Badge>
 	);
 }
 
@@ -588,7 +601,9 @@ function BookingCard( { booking, active, holds, onSelect } ) {
 	return (
 		<button
 			type="button"
-			className={ `ec-booking-card${ active ? ' is-active' : '' }` }
+			className={ `ec-panel ec-booking-card${
+				active ? ' is-active' : ''
+			}` }
 			onClick={ () => onSelect( booking.id ) }
 			aria-pressed={ active }
 		>
@@ -636,40 +651,39 @@ function Calendar( { bookings, holds, month, onMonthChange, onSelect } ) {
 
 	return (
 		<Panel>
-			<div className="ec-booking-calendar__heading">
-				<div>
-					<h2>{ heading }</h2>
-					<p>
-						Requests, holds, and confirmed shows share one canonical
-						calendar.
-					</p>
-				</div>
-				<ActionRow>
-					<button
-						type="button"
-						className="button-2"
-						onClick={ () =>
-							onMonthChange( moveMonth( month, -1 ) )
-						}
-					>
-						Previous
-					</button>
-					<button
-						type="button"
-						className="button-2"
-						onClick={ () => onMonthChange( monthKey() ) }
-					>
-						Today
-					</button>
-					<button
-						type="button"
-						className="button-2"
-						onClick={ () => onMonthChange( moveMonth( month, 1 ) ) }
-					>
-						Next
-					</button>
-				</ActionRow>
-			</div>
+			<PanelHeader
+				title={ heading }
+				description="Requests, holds, and confirmed shows share one canonical calendar."
+				actions={
+					<ActionRow>
+						<button
+							type="button"
+							className="button-2"
+							onClick={ () =>
+								onMonthChange( moveMonth( month, -1 ) )
+							}
+						>
+							Previous
+						</button>
+						<button
+							type="button"
+							className="button-2"
+							onClick={ () => onMonthChange( monthKey() ) }
+						>
+							Today
+						</button>
+						<button
+							type="button"
+							className="button-2"
+							onClick={ () =>
+								onMonthChange( moveMonth( month, 1 ) )
+							}
+						>
+							Next
+						</button>
+					</ActionRow>
+				}
+			/>
 			<div className="ec-booking-calendar__weekdays" aria-hidden="true">
 				{ [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ].map(
 					( day ) => (
@@ -967,18 +981,25 @@ function BookingDetail( {
 
 	return (
 		<Panel className="ec-booking-detail">
-			<div className="ec-booking-detail__header">
-				<div>
-					<BookingStatus status={ booking.status } />
-					<h2>{ booking.artist_name }</h2>
-					<p>
-						Booking #{ booking.id } · version { booking.version }
-					</p>
-				</div>
-				<button type="button" className="button-2" onClick={ onClose }>
-					Close detail
-				</button>
-			</div>
+			<PanelHeader
+				className="ec-booking-detail__header"
+				title={
+					<>
+						<BookingStatus status={ booking.status } />
+						<span>{ booking.artist_name }</span>
+					</>
+				}
+				description={ `Booking #${ booking.id } · version ${ booking.version }` }
+				actions={
+					<button
+						type="button"
+						className="button-2"
+						onClick={ onClose }
+					>
+						Close detail
+					</button>
+				}
+			/>
 			{ status && (
 				<InlineStatus tone={ status.tone }>
 					{ status.message }
@@ -1510,7 +1531,11 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 
 	return (
 		<div className="ec-booking-console">
-			<div className="ec-booking-console__toolbar">
+			<Grid
+				className="ec-booking-console__toolbar"
+				minColumnWidth="12rem"
+				maxColumns={ 3 }
+			>
 				<SearchBox
 					value={ search }
 					onSearch={ setSearch }
@@ -1549,7 +1574,7 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 						</option>
 					</select>
 				</label>
-			</div>
+			</Grid>
 			{ error && <ErrorState message={ error } onRetry={ loadList } /> }
 			{ loading ? (
 				<Panel>
@@ -1572,7 +1597,11 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 								description="A bounded venue-authorized list. Filters are reapplied by canonical abilities."
 							/>
 							{ visible.length ? (
-								<div className="ec-booking-console__list">
+								<Grid
+									className="ec-booking-console__list"
+									minColumnWidth="15rem"
+									gap="0.75rem"
+								>
 									{ visible.map( ( booking ) => (
 										<BookingCard
 											key={ booking.id }
@@ -1584,7 +1613,7 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 											onSelect={ selectBooking }
 										/>
 									) ) }
-								</div>
+								</Grid>
 							) : (
 								<EmptyState>
 									No bookings match this venue and filter.

--- a/blocks/venue-settings/src/style.scss
+++ b/blocks/venue-settings/src/style.scss
@@ -5,8 +5,6 @@
 }
 
 .ec-venue-settings {
-	--venue-accent: var(--wp--preset--color--primary, #1f6f5b);
-
 	input:not([type="checkbox"]):not([type="radio"]),
 	select,
 	textarea {
@@ -24,7 +22,7 @@
 	input:focus-visible,
 	select:focus-visible,
 	textarea:focus-visible {
-		outline: 3px solid color-mix(in srgb, var(--venue-accent) 55%, white);
+		outline: 3px solid var(--focus-border-color);
 		outline-offset: 2px;
 	}
 }
@@ -46,8 +44,8 @@
 	gap: 0.8rem;
 	margin: 0 0 1rem;
 	padding: 1rem;
-	border: 1px solid var(--wp--preset--color--contrast-3, #ccd4d1);
-	border-radius: 0.5rem;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
 }
 
 .ec-venue-settings__repeater legend {
@@ -69,7 +67,7 @@
 	justify-content: space-between;
 	gap: 1rem;
 	padding-block: 1rem;
-	border-bottom: 1px solid var(--wp--preset--color--contrast-3, #d9dfdc);
+	border-bottom: 1px solid var(--border-color);
 }
 
 .ec-venue-settings__records li:last-child {
@@ -79,7 +77,7 @@
 .ec-venue-settings__dirty {
 	font-size: 0.9rem;
 	font-weight: 600;
-	color: var(--wp--preset--color--contrast-2, #67520b);
+	color: var(--warning-color);
 }
 
 .ec-venue-settings__save-note {
@@ -98,10 +96,11 @@
 }
 
 .ec-booking-console__toolbar {
-	display: grid;
-	grid-template-columns: minmax(14rem, 2fr) repeat(2, minmax(10rem, 1fr));
-	gap: 0.75rem;
 	align-items: end;
+}
+
+.ec-booking-console__toolbar .ec-search-box {
+	margin-bottom: 0;
 }
 
 .ec-booking-console__toolbar label {
@@ -111,87 +110,23 @@
 	font-weight: 700;
 }
 
-.ec-booking-console__list {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
-	gap: 0.75rem;
-}
-
 .ec-booking-card {
-	display: grid;
-	gap: 0.45rem;
-	padding: 1rem;
-	border: 1px solid var(--wp--preset--color--contrast-3, #ccd4d1);
-	border-radius: 0.5rem;
-	background: var(--wp--preset--color--base, #fff);
+	width: 100%;
 	color: inherit;
+	font: inherit;
 	text-align: left;
 	cursor: pointer;
 }
 
 .ec-booking-card:hover,
 .ec-booking-card.is-active {
-	border-color: var(--venue-accent);
-	box-shadow: 0 0 0 2px color-mix(in srgb, var(--venue-accent) 18%, transparent);
+	border-color: var(--focus-border-color);
+	box-shadow: 0 0 0 2px color-mix(in srgb, var(--focus-border-color) 18%, transparent);
 }
 
 .ec-booking-card__title {
 	font-size: 1.05rem;
 	font-weight: 750;
-}
-
-.ec-booking-status {
-	display: inline-flex;
-	align-items: center;
-	gap: 0.35rem;
-	width: fit-content;
-	font-size: 0.82rem;
-	font-weight: 750;
-	text-transform: uppercase;
-	letter-spacing: 0.035em;
-}
-
-.ec-booking-status__mark {
-	width: 0.65rem;
-	height: 0.65rem;
-	border: 2px solid currentcolor;
-	border-radius: 50%;
-	background: transparent;
-}
-
-.ec-booking-status--confirmed,
-.ec-booking-status--completed {
-	color: #17633f;
-}
-
-.ec-booking-status--held,
-.ec-booking-status--negotiating {
-	color: #8a5700;
-}
-
-.ec-booking-status--needs_info,
-.ec-booking-status--declined,
-.ec-booking-status--withdrawn,
-.ec-booking-status--cancelled {
-	color: #9f2d25;
-}
-
-.ec-booking-status--under_review,
-.ec-booking-status--submitted {
-	color: #315f88;
-}
-
-.ec-booking-calendar__heading {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 1rem;
-	margin-block-end: 1rem;
-}
-
-.ec-booking-calendar__heading h2,
-.ec-booking-calendar__heading p {
-	margin: 0;
 }
 
 .ec-booking-calendar__weekdays,
@@ -209,21 +144,21 @@
 }
 
 .ec-booking-calendar {
-	border-block-start: 1px solid var(--wp--preset--color--contrast-3, #ccd4d1);
-	border-inline-start: 1px solid var(--wp--preset--color--contrast-3, #ccd4d1);
+	border-block-start: 1px solid var(--border-color);
+	border-inline-start: 1px solid var(--border-color);
 }
 
 .ec-booking-calendar__day {
 	min-height: 8.5rem;
 	padding: 0.35rem;
-	border-block-end: 1px solid var(--wp--preset--color--contrast-3, #ccd4d1);
-	border-inline-end: 1px solid var(--wp--preset--color--contrast-3, #ccd4d1);
-	background: var(--wp--preset--color--base, #fff);
+	border-block-end: 1px solid var(--border-color);
+	border-inline-end: 1px solid var(--border-color);
+	background: var(--background-color);
 }
 
 .ec-booking-calendar__day.is-outside {
-	background: color-mix(in srgb, var(--wp--preset--color--contrast, #111) 3%, transparent);
-	color: var(--wp--preset--color--contrast-2, #68716e);
+	background: color-mix(in srgb, var(--text-color) 3%, transparent);
+	color: var(--muted-text);
 }
 
 .ec-booking-calendar__date {
@@ -243,10 +178,10 @@
 	width: 100%;
 	padding: 0.35rem 0.45rem;
 	border: 0;
-	border-left: 4px solid #315f88;
-	border-radius: 0.2rem;
-	background: color-mix(in srgb, #315f88 12%, white);
-	color: #17212a;
+	border-left: 4px solid var(--info-color);
+	border-radius: var(--border-radius-sm);
+	background: var(--info-bg);
+	color: var(--text-color);
 	font-size: 0.76rem;
 	line-height: 1.2;
 	text-align: left;
@@ -255,22 +190,22 @@
 
 .ec-booking-calendar__item--held,
 .ec-booking-calendar__item--negotiating {
-	border-left-color: #b36f00;
-	background: #fff4d7;
+	border-left-color: var(--warning-color);
+	background: var(--warning-bg);
 }
 
 .ec-booking-calendar__item--confirmed,
 .ec-booking-calendar__item--completed {
-	border-left-color: #17633f;
-	background: #e1f4e9;
+	border-left-color: var(--success-color);
+	background: color-mix(in srgb, var(--success-color) 10%, transparent);
 }
 
 .ec-booking-calendar__item--needs_info,
 .ec-booking-calendar__item--declined,
 .ec-booking-calendar__item--withdrawn,
 .ec-booking-calendar__item--cancelled {
-	border-left-color: #9f2d25;
-	background: #fbe8e6;
+	border-left-color: var(--error-color);
+	background: color-mix(in srgb, var(--error-color) 10%, transparent);
 }
 
 .ec-booking-calendar__item span {
@@ -278,23 +213,18 @@
 }
 
 .ec-booking-detail__header {
-	display: flex;
 	align-items: flex-start;
-	justify-content: space-between;
-	gap: 1rem;
-	padding-block-end: 1rem;
-	border-block-end: 1px solid var(--wp--preset--color--contrast-3, #ccd4d1);
 }
 
-.ec-booking-detail__header h2,
-.ec-booking-detail__header p {
-	margin: 0.25rem 0 0;
+.ec-booking-detail__header .ec-panel-header__title {
+	display: grid;
+	gap: var(--spacing-xs);
 }
 
 .ec-booking-detail__section {
 	margin-block-start: 1.5rem;
 	padding-block-start: 1.25rem;
-	border-block-start: 1px solid var(--wp--preset--color--contrast-3, #ccd4d1);
+	border-block-start: 1px solid var(--border-color);
 }
 
 .ec-booking-detail__section h3 {
@@ -310,8 +240,8 @@
 
 .ec-booking-detail__facts > div {
 	padding: 0.75rem;
-	border-radius: 0.35rem;
-	background: color-mix(in srgb, var(--venue-accent) 5%, transparent);
+	border-radius: var(--border-radius-sm);
+	background: var(--card-background);
 }
 
 .ec-booking-detail__facts dt {
@@ -342,8 +272,8 @@
 	justify-content: space-between;
 	gap: 0.75rem;
 	padding: 0.7rem;
-	border-left: 3px solid var(--venue-accent);
-	background: color-mix(in srgb, var(--venue-accent) 5%, transparent);
+	border-left: 3px solid var(--focus-border-color);
+	background: var(--card-background);
 }
 
 .ec-booking-console__form {
@@ -354,21 +284,13 @@
 
 .ec-booking-console__empty {
 	padding: 2rem 1rem;
-	border: 1px dashed var(--wp--preset--color--contrast-3, #ccd4d1);
+	border: 1px dashed var(--border-color);
+	border-radius: var(--border-radius-md);
+	color: var(--muted-text);
 	text-align: center;
 }
 
-@media (max-width: 720px) {
-	.ec-booking-console__toolbar {
-		grid-template-columns: 1fr;
-	}
-
-	.ec-booking-calendar__heading,
-	.ec-booking-detail__header {
-		align-items: stretch;
-		flex-direction: column;
-	}
-
+@media screen and (max-width: 480px) {
 	.ec-booking-calendar__weekdays {
 		display: none;
 	}
@@ -384,7 +306,7 @@
 		display: grid;
 		grid-template-columns: 2.5rem minmax(0, 1fr);
 		min-height: 0;
-		border: 1px solid var(--wp--preset--color--contrast-3, #ccd4d1);
+		border: 1px solid var(--border-color);
 	}
 
 	.ec-booking-calendar__day.is-outside,

--- a/blocks/venue-settings/src/style.test.js
+++ b/blocks/venue-settings/src/style.test.js
@@ -1,0 +1,39 @@
+/* global describe, expect, it */
+
+/**
+ * External dependencies
+ */
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const styles = readFileSync( path.resolve( __dirname, 'style.scss' ), 'utf8' );
+const consoleSource = readFileSync(
+	path.resolve( __dirname, 'booking-console.js' ),
+	'utf8'
+);
+
+describe( 'venue booking workspace composition', () => {
+	it( 'loads and composes the canonical shared primitives', () => {
+		expect( styles ).toContain(
+			'@use "@extrachill/components/styles/components.scss";'
+		);
+		expect( consoleSource ).toContain( '<Badge tone=' );
+		expect( consoleSource ).toContain( '<PanelHeader' );
+		expect( consoleSource ).toContain(
+			'className="ec-booking-console__toolbar"'
+		);
+		expect( consoleSource ).toContain( '`ec-panel ec-booking-card${' );
+	} );
+
+	it( 'uses canonical semantic tokens for unique calendar states', () => {
+		[ 'info', 'warning', 'success', 'error' ].forEach( ( tone ) => {
+			expect( styles ).toContain( `var(--${ tone }-color)` );
+		} );
+	} );
+
+	it( 'does not reintroduce local colors or arbitrary breakpoints', () => {
+		expect( styles ).not.toMatch( /#[0-9a-f]{3,8}\b/i );
+		expect( styles ).not.toMatch( /max-width:\s*(?:700|720)px/ );
+		expect( styles ).toContain( '@media screen and (max-width: 480px)' );
+	} );
+} );


### PR DESCRIPTION
## Summary
- compose booking inquiry and venue workspace surfaces from shared `Badge`, `PanelHeader`, `Grid`, `Panel`, and `ActionRow` primitives
- replace local status/calendar colors with canonical `--success-*`, `--warning-*`, `--error-*`, `--info-*`, focus, surface, border, spacing, and radius tokens
- remove divergent `700px` and `720px` rules in favor of shared auto-fit grids and the established `480px` mobile convention

## Component Audit
Reused primitives: `Badge` for booking and inquiry states, `PanelHeader` for venue identity/calendar/detail headers, `Grid` for inquiry fields/toolbars/card collections, existing `Panel`/`ActionRow` composition, and shared `.ec-panel` chrome for semantic booking-card buttons.

Retained local styles only where no shared equivalent exists: seven-day booking-calendar geometry and its mobile agenda transformation, interactive booking-card selection behavior, booking fact lists, activity/correspondence timelines, and the bounded empty state. These remain token-driven.

Removed hard-coded booking colors including `#17633f`, `#8a5700`, `#9f2d25`, `#315f88`, `#b36f00`, `#fff4d7`, `#e1f4e9`, and `#fbe8e6`; focused tests reject any future hex colors in both booking stylesheets.

## Verification
- `npx wp-scripts lint-js blocks/venue-settings/src/booking-console.js blocks/venue-settings/src/style.test.js blocks/venue-booking-inquiry/src/view.js blocks/venue-booking-inquiry/src/style.test.js` passed
- all venue settings and booking inquiry unit tests passed: 7 suites, 44 tests
- `npm run build:venue-settings` and `npm run build:venue-booking-inquiry` passed; required block files copied, with no tracked generated drift
- `git diff --check` passed
- no repository baseline failures encountered
- screenshots/browser evidence not produced because the repository has no deterministic booking browser harness; its available browser script targets the unrelated Local Support flow

Closes #510