### PR TITLE
fix: restore composed booking inquiry layout

### DIFF
--- a/blocks/venue-booking-inquiry/src/style.scss
+++ b/blocks/venue-booking-inquiry/src/style.scss
@@ -1,16 +1,86 @@
 @use "@extrachill/components/styles/components.scss";
 
-.ec-venue-booking-inquiry { margin-block: var(--spacing-xl); }
-.ec-booking-inquiry__identity { align-items: start; }
-.ec-booking-inquiry__identity .ec-panel-header__title { display: grid; gap: var(--spacing-xs); }
-.ec-booking-inquiry__description { font-size: 1.05rem; max-width: 70ch; }
-.ec-booking-inquiry__requirements { display: grid; gap: .5rem; margin-bottom: 0; }
-.ec-booking-inquiry__form { display: grid; gap: 1.25rem; margin-top: 1.5rem; }
-.ec-booking-inquiry__checkbox, .ec-booking-inquiry__consent { align-items: start; display: flex; gap: .55rem; line-height: 1.45; }
-.ec-booking-inquiry__checkbox input, .ec-booking-inquiry__consent input { flex: 0 0 auto; margin-top: .25rem; }
-.ec-booking-inquiry__turnstile { min-height: 65px; }
-.ec-booking-inquiry__privacy { color: var(--muted-text); font-size: .85rem; max-width: 36rem; }
-.ec-booking-inquiry__result:focus { outline: 3px solid var(--focus-border-color); outline-offset: .35rem; }
-.ec-booking-inquiry__reference { display: inline-block; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
-.ec-venue-booking-editor { border: 1px dashed currentColor; padding: 1.5rem; }
-@media (prefers-reduced-motion: reduce) { .ec-venue-booking-inquiry * { scroll-behavior: auto !important; transition: none !important; } }
+.ec-venue-booking-inquiry {
+	margin-block: var(--spacing-xl);
+}
+
+.ec-booking-inquiry__identity {
+	align-items: start;
+}
+
+.ec-booking-inquiry__identity .ec-panel-header__title {
+	display: grid;
+	gap: var(--spacing-xs);
+}
+
+.ec-booking-inquiry__description {
+	font-size: 1.05rem;
+	max-width: 70ch;
+}
+
+.ec-booking-inquiry__requirements {
+	display: grid;
+	gap: 0.5rem;
+	margin-bottom: 0;
+}
+
+.ec-booking-inquiry__form {
+	display: grid;
+	gap: 1.25rem;
+	margin-top: 1.5rem;
+	min-width: 0;
+	width: 100%;
+}
+
+.ec-booking-inquiry__form > .ec-card-grid {
+	min-width: 0;
+	width: 100%;
+}
+
+.ec-booking-inquiry__checkbox,
+.ec-booking-inquiry__consent {
+	align-items: start;
+	display: flex;
+	gap: 0.55rem;
+	line-height: 1.45;
+}
+
+.ec-booking-inquiry__checkbox input,
+.ec-booking-inquiry__consent input {
+	flex: 0 0 auto;
+	margin-top: 0.25rem;
+}
+
+.ec-booking-inquiry__turnstile {
+	min-height: 65px;
+}
+
+.ec-booking-inquiry__privacy {
+	color: var(--muted-text);
+	font-size: 0.85rem;
+	max-width: 36rem;
+}
+
+.ec-booking-inquiry__result:focus {
+	outline: 3px solid var(--focus-border-color);
+	outline-offset: 0.35rem;
+}
+
+.ec-booking-inquiry__reference {
+	display: inline-block;
+	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	overflow-wrap: anywhere;
+}
+
+.ec-venue-booking-editor {
+	border: 1px dashed currentcolor;
+	padding: 1.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+	.ec-venue-booking-inquiry * {
+		scroll-behavior: auto !important;
+		transition: none !important;
+	}
+}

--- a/blocks/venue-booking-inquiry/src/style.test.js
+++ b/blocks/venue-booking-inquiry/src/style.test.js
@@ -17,11 +17,23 @@ describe( 'venue booking inquiry styles', () => {
 	} );
 
 	it( 'composes canonical form, identity, and status primitives', () => {
+		expect( view ).toContain(
+			'<BlockShellInner className="ec-panel ec-booking-inquiry__panel">'
+		);
 		expect( view ).toContain( 'Grid minColumnWidth="16rem"' );
 		expect( view ).toContain( '<PanelHeader' );
 		expect( view ).toContain( '<Badge tone="success">Now booking</Badge>' );
 		expect( view ).toContain(
 			'<Badge tone="info">Signed-in inquiry</Badge>'
+		);
+	} );
+
+	it( 'contains the shared grid within the booking panel', () => {
+		expect( styles ).toMatch(
+			/\.ec-booking-inquiry__form\s*\{[^}]*min-width:\s*0;[^}]*width:\s*100%;[^}]*\}/
+		);
+		expect( styles ).toMatch(
+			/\.ec-booking-inquiry__form > \.ec-card-grid\s*\{[^}]*min-width:\s*0;[^}]*width:\s*100%;[^}]*\}/
 		);
 	} );
 

--- a/blocks/venue-booking-inquiry/src/view.js
+++ b/blocks/venue-booking-inquiry/src/view.js
@@ -237,7 +237,7 @@ function BookingInquiry( { config, wrapper } ) {
 				title={ config.heading }
 				description={ `Send a performance inquiry directly to ${ config.venue.name }.` }
 			/>
-			<BlockShellInner>
+			<BlockShellInner className="ec-panel ec-booking-inquiry__panel">
 				<PanelHeader
 					className="ec-booking-inquiry__identity"
 					title={

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"start:concert-stats": "wp-scripts start blocks/concert-stats/src/index.js blocks/concert-stats/src/view.js --output-path=build/concert-stats",
 		"test:js": "wp-scripts test-unit-js",
 		"test:browser": "node tests/browser/local-support.evidence.js",
+		"test:browser:booking-inquiry": "node tests/browser/booking-inquiry.evidence.js",
 		"lint:js": "wp-scripts lint-js",
 		"lint:js:fix": "wp-scripts lint-js --fix"
 	},

--- a/tests/browser/booking-inquiry.evidence.js
+++ b/tests/browser/booking-inquiry.evidence.js
@@ -1,0 +1,243 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+const assert = require( 'node:assert/strict' );
+const fs = require( 'node:fs' );
+const os = require( 'node:os' );
+const path = require( 'node:path' );
+const { chromium } = require( 'playwright' );
+
+const root = path.resolve( __dirname, '../..' );
+const artifacts =
+	process.env.BOOKING_INQUIRY_ARTIFACT_DIR ||
+	path.join( os.tmpdir(), 'extrachill-events-booking-inquiry' );
+
+const config = {
+	instanceId: 'ec-booking-browser-proof',
+	endpoint: '/booking-inquiries',
+	restNonce: 'booking-proof-nonce',
+	authenticated: true,
+	heading: 'Booking inquiries',
+	buttonLabel: 'Send booking inquiry',
+	revision: 7,
+	venue: {
+		id: 55,
+		name: 'The Room',
+		description:
+			'An independent room presenting touring and local artists.',
+		address: '123 King Street, Charleston, SC',
+	},
+	requirements: [ 'Include a recent live performance link.' ],
+	spaces: [ { key: 'main', name: 'Main Room', is_default: true } ],
+	fields: [
+		{
+			key: 'website',
+			label: 'Artist website',
+			type: 'url',
+			required: false,
+			options: [],
+		},
+		{
+			key: 'format',
+			label: 'Performance format',
+			type: 'select',
+			required: true,
+			options: [ 'Full band', 'Solo' ],
+		},
+	],
+	consent: {
+		required: true,
+		label: 'I agree that this venue may use these details to review and respond to my booking inquiry.',
+	},
+};
+
+const fixture = `<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width,initial-scale=1">
+		<title>Booking Inquiry Evidence</title>
+	</head>
+	<body>
+		<main>
+			<section class="wp-block-extrachill-venue-booking-inquiry ec-venue-booking-inquiry">
+				<div data-booking-app></div>
+				<script type="application/json">${ JSON.stringify( config ) }</script>
+				<div data-booking-turnstile><div class="cf-turnstile">Security check</div></div>
+			</section>
+		</main>
+	</body>
+</html>`;
+
+const fixtureStyles = `
+	* { box-sizing: border-box; }
+	html, body { margin: 0; }
+	body { color: #111; font: 16px/1.5 Arial, sans-serif; }
+	main { margin-inline: auto; max-width: 1120px; padding-inline: var(--spacing-md, 1rem); }
+	button { padding: .75rem 1rem; }
+`;
+
+const measure = ( page ) =>
+	page.evaluate( () => {
+		const bounds = ( selector ) => {
+			const rect = document
+				.querySelector( selector )
+				.getBoundingClientRect();
+			return {
+				left: rect.left,
+				right: rect.right,
+				width: rect.width,
+			};
+		};
+		const shell = bounds( '.ec-block-shell' );
+		const form = bounds( '.ec-booking-inquiry__form' );
+		const controls = Array.from(
+			document.querySelectorAll( 'input, select, textarea, button' )
+		).map( ( control ) => {
+			const rect = control.getBoundingClientRect();
+			return { left: rect.left, right: rect.right };
+		} );
+
+		return {
+			viewportWidth: document.documentElement.clientWidth,
+			scrollWidth: document.documentElement.scrollWidth,
+			shell,
+			panel: bounds( '.ec-booking-inquiry__panel' ),
+			form,
+			grid: bounds( '.ec-booking-inquiry__form > .ec-card-grid' ),
+			turnstile: bounds( '.ec-booking-inquiry__turnstile' ),
+			actions: bounds( '.ec-action-row' ),
+			inlineGutter: form.left - shell.left,
+			controlsInsideViewport: controls.every(
+				( control ) =>
+					control.left >= 0 &&
+					control.right <= document.documentElement.clientWidth
+			),
+		};
+	} );
+
+( async () => {
+	fs.mkdirSync( artifacts, { recursive: true } );
+	const browser = await chromium.launch( { headless: true } );
+	try {
+		const page = await browser.newPage( {
+			viewport: { width: 1280, height: 900 },
+		} );
+		await page.setContent( fixture );
+		await page.addStyleTag( { content: fixtureStyles } );
+		await page.addStyleTag( {
+			path: path.join(
+				root,
+				'build/venue-booking-inquiry/style-index.css'
+			),
+		} );
+		await page.addScriptTag( {
+			path: path.join(
+				root,
+				'node_modules/react/umd/react.production.min.js'
+			),
+		} );
+		await page.addScriptTag( {
+			path: path.join(
+				root,
+				'node_modules/react-dom/umd/react-dom.production.min.js'
+			),
+		} );
+		await page.evaluate( () => {
+			window.wp = {
+				element: {
+					...window.React,
+					createRoot: window.ReactDOM.createRoot,
+				},
+			};
+		} );
+		await page.addScriptTag( {
+			path: path.join( root, 'build/venue-booking-inquiry/view.js' ),
+		} );
+		await page.waitForSelector( '.ec-booking-inquiry__form' );
+
+		assert.equal( await page.getByText( 'Booking inquiries' ).count(), 1 );
+		assert.equal( await page.getByText( 'Now booking' ).count(), 1 );
+		assert.equal( await page.getByText( 'Signed-in inquiry' ).count(), 1 );
+		assert.ok( await page.getByLabel( 'Artist or project name' ).count() );
+		assert.ok( await page.getByLabel( 'Artist website' ).count() );
+		assert.ok( await page.getByLabel( /I agree that this venue/ ).count() );
+		assert.equal(
+			await page
+				.locator( '.ec-booking-inquiry__turnstile .cf-turnstile' )
+				.count(),
+			1
+		);
+
+		const desktop = await measure( page );
+		assert.equal( desktop.scrollWidth, desktop.viewportWidth );
+		assert.ok( desktop.inlineGutter > 0 );
+		assert.equal( desktop.controlsInsideViewport, true );
+		assert.ok(
+			Number.parseFloat(
+				await page
+					.locator( '.ec-booking-inquiry__panel' )
+					.evaluate(
+						( panel ) => getComputedStyle( panel ).borderLeftWidth
+					)
+			) > 0
+		);
+		await page.screenshot( {
+			path: path.join( artifacts, 'booking-inquiry-desktop.png' ),
+			fullPage: true,
+		} );
+
+		await page.setViewportSize( { width: 390, height: 844 } );
+		const mobile = await measure( page );
+		assert.equal( mobile.scrollWidth, mobile.viewportWidth );
+		assert.ok( mobile.inlineGutter > 0 );
+		assert.ok( mobile.form.right < mobile.viewportWidth );
+		assert.equal( mobile.controlsInsideViewport, true );
+
+		await page.getByLabel( 'Artist or project name' ).fill( 'Proof Band' );
+		await page.getByLabel( 'Contact name' ).fill( 'Booking Agent' );
+		await page.getByLabel( 'Contact email' ).fill( 'agent@example.com' );
+		await page.getByLabel( 'Requested start' ).fill( '2030-08-01T20:00' );
+		await page
+			.getByLabel( 'Performance format' )
+			.selectOption( 'Full band' );
+		await page
+			.getByLabel( 'Performance details' )
+			.fill( 'Routing through Charleston.' );
+		await page.getByLabel( /I agree that this venue/ ).check();
+		await page
+			.getByRole( 'button', { name: 'Send booking inquiry' } )
+			.click();
+		assert.equal(
+			await page
+				.getByText( 'Complete the security check before sending.' )
+				.count(),
+			1
+		);
+		await page.screenshot( {
+			path: path.join( artifacts, 'booking-inquiry-mobile.png' ),
+			fullPage: true,
+		} );
+
+		const evidence = {
+			status: 'passed',
+			viewports: [ '1280x900', '390x844' ],
+			desktop,
+			mobile,
+			artifacts: [
+				path.join( artifacts, 'booking-inquiry-desktop.png' ),
+				path.join( artifacts, 'booking-inquiry-mobile.png' ),
+			],
+		};
+		fs.writeFileSync(
+			path.join( artifacts, 'measurements.json' ),
+			`${ JSON.stringify( evidence, null, 2 ) }\n`
+		);
+		// eslint-disable-next-line no-console -- Emits deterministic evidence for CI and PR logs.
+		console.log( JSON.stringify( evidence ) );
+	} finally {
+		await browser.close();
+	}
+} )().catch( ( error ) => {
+	console.error( error );
+	process.exitCode = 1;
+} );


### PR DESCRIPTION
## Summary
- compose the booking inquiry `BlockShellInner` with canonical `.ec-panel` chrome so desktop reads as one intentional application surface and the shared mobile panel rule restores its inline padding
- contain the inquiry form and its shared `Grid` so the two-column `maxColumns` intrinsic width can shrink to one column without horizontal overflow
- add deterministic Playwright evidence against the production-built React surface at desktop and mobile widths

## Post-#511 Finding
PR #511 fixed the inner component vocabulary: the inquiry now uses shared `PanelHeader`, `Grid`, `Badge`, `FieldGroup`, `ActionRow`, and canonical semantic/focus/spacing tokens. It did not fix outer containment. At 390px, the generic shell's intentional edge-to-edge mobile margin still placed `BlockShellInner` at `x=0`, while the `Grid` with `minColumnWidth=16rem` and `maxColumns=2` retained a 528px intrinsic width. The pre-change post-#511 proof measured `scrollWidth=528` for a 390px viewport.

## Composition
Reused shared components/tokens: `BlockShellInner`, canonical `.ec-panel` chrome, the shared mobile full-width panel rule, `Grid`, `PanelHeader`, `Badge`, `FieldGroup`, `ActionRow`, `--spacing-*`, border, surface, focus, and semantic status tokens.

The only booking-local layout retained is `min-width: 0; width: 100%` on the inquiry form and its direct shared grid. This is unique to the form's bounded two-column `maxColumns` composition and avoids weakening `.ec-block-shell`, `.ec-panel`, or `.ec-card-grid` globally. No color, breakpoint, primitive, nonce, Turnstile, admission, cache, accessibility, or submission behavior changed.

## Browser Evidence
Deterministic command: `BOOKING_INQUIRY_ARTIFACT_DIR=/mnt/extrachill-workspace/tmp/opencode/booking-475-browser-evidence npm run test:browser:booking-inquiry`

- Desktop `1280x900`: viewport/scroll width `1280/1280`, panel `x=96..1184`, form `x=113..1167`, inline gutter `17px`, all controls inside viewport
- Mobile `390x844`: viewport/scroll width `390/390`, shell/panel `x=0..390`, form/grid/Turnstile/action row `x=16..374`, inline gutter `16px`, all controls inside viewport
- The browser proof mounts the production-built React view and checks headings, labels, controls, configured fields, consent, moved Turnstile region, shared panel border, validation status, gutter, and overflow
- Screenshots: `/mnt/extrachill-workspace/tmp/opencode/booking-475-browser-evidence/booking-inquiry-desktop.png` and `/mnt/extrachill-workspace/tmp/opencode/booking-475-browser-evidence/booking-inquiry-mobile.png`
- Measurements: `/mnt/extrachill-workspace/tmp/opencode/booking-475-browser-evidence/measurements.json`

## Verification
- `npx wp-scripts test-unit-js blocks/venue-booking-inquiry/src/style.test.js blocks/venue-booking-inquiry/src/submission.test.js --runInBand` passed: 2 suites, 8 tests
- changed-file `wp-scripts lint-js` passed
- changed-file `wp-scripts lint-style blocks/venue-booking-inquiry/src/style.scss` passed
- `npm run build:venue-booking-inquiry && npm run copy:venue-booking-inquiry` passed; generated `build/` assets remain ignored by repository convention
- deterministic Playwright proof passed at `1280x900` and `390x844`
- `git diff --check` passed

## Baseline
`vendor/bin/phpunit -c phpunit.xml.dist tests/Unit/VenueBookingInquiryRenderTest.php` remains blocked before test execution because the repository's plain bootstrap does not provide `WP_UnitTestCase`. This is the documented upstream WordPress test-framework bootstrap limitation in `tests/bootstrap.php`; all changed-file, focused JS, build, and rendered-browser gates pass.

Closes #475