### PR TITLE
fix: restore Local Scene navigation

### DIFF
--- a/inc/core/account-market.php
+++ b/inc/core/account-market.php
@@ -52,7 +52,7 @@ function extrachill_events_get_account_market(): ?array {
 	$slug        = sanitize_title( $location['slug'] ?? '' );
 	$hierarchy   = is_array( $location['hierarchy'] ?? null ) ? $location['hierarchy'] : array();
 	$label       = sanitize_text_field( $hierarchy['label'] ?? $location['name'] ?? '' );
-	$url         = esc_url_raw( $location['archive_url'] ?? '' );
+	$url         = esc_url_raw( $location['url'] ?? '' );
 
 	if ( $term_id < 1 || '' === $slug ) {
 		return null;
@@ -307,7 +307,13 @@ function extrachill_events_render_home_market_router( array $locations ): void {
 			<article class="events-primary-market">
 				<div>
 					<span class="events-primary-market__eyebrow"><?php esc_html_e( 'Your Local Scene', 'extrachill-events' ); ?></span>
-					<h3><?php echo esc_html( '' !== $market['label'] ? $market['label'] : $market['slug'] ); ?></h3>
+					<h3>
+						<?php if ( '' !== $market['url'] ) : ?>
+							<a href="<?php echo esc_url( $market['url'] ); ?>" class="taxonomy-badge location-badge location-<?php echo esc_attr( $market['slug'] ); ?>"><?php echo esc_html( '' !== $market['label'] ? $market['label'] : $market['slug'] ); ?></a>
+						<?php else : ?>
+							<?php echo esc_html( '' !== $market['label'] ? $market['label'] : $market['slug'] ); ?>
+						<?php endif; ?>
+					</h3>
 					<?php if ( $market_count > 0 ) : ?>
 						<p><?php echo esc_html( sprintf( /* translators: %s: Number of upcoming events. */ _n( '%s upcoming event', '%s upcoming events', $market_count, 'extrachill-events' ), number_format_i18n( $market_count ) ) ); ?></p>
 					<?php endif; ?>
@@ -333,6 +339,7 @@ function extrachill_events_render_home_market_router( array $locations ): void {
 		<?php endif; ?>
 
 		<div class="events-home-router__paths">
+			<a href="<?php echo esc_url( home_url( '/near-me/' ) ); ?>"><?php esc_html_e( 'Shows near me', 'extrachill-events' ); ?> &rarr;</a>
 			<a href="<?php echo esc_url( home_url( '/location/' ) ); ?>"><?php esc_html_e( 'Browse all locations', 'extrachill-events' ); ?> &rarr;</a>
 			<a href="<?php echo esc_url( home_url( '/all/' ) ); ?>"><?php esc_html_e( 'See every event', 'extrachill-events' ); ?> &rarr;</a>
 		</div>

--- a/inc/core/discovery-pages.php
+++ b/inc/core/discovery-pages.php
@@ -42,6 +42,32 @@ define(
 	)
 );
 
+/**
+ * Keep reserved root scope paths from fuzzy-matching unrelated event slugs.
+ *
+ * Discovery scopes are valid only beneath a location archive.
+ *
+ * @param null|string|false $redirect_url Guessed redirect URL, or null to continue guessing.
+ * @return null|string|false
+ */
+function extrachill_events_prevent_root_scope_permalink_guess( $redirect_url ) {
+	if ( null !== $redirect_url ) {
+		return $redirect_url;
+	}
+
+	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : 7;
+	if ( (int) get_current_blog_id() !== $events_blog_id ) {
+		return null;
+	}
+
+	$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+	$request_path = wp_parse_url( $request_uri, PHP_URL_PATH );
+	$scope        = is_string( $request_path ) ? trim( $request_path, '/' ) : '';
+
+	return isset( EXTRACHILL_EVENTS_DISCOVERY_SCOPES[ $scope ] ) ? false : null;
+}
+add_filter( 'pre_redirect_guess_404_permalink', 'extrachill_events_prevent_root_scope_permalink_guess' );
+
 // --- Rewrite Rules ---
 
 /**

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -1187,7 +1187,7 @@ final class AccountMarketTest extends TestCase {
 		$this->assertStringContainsString( 'href="https://events.example/location/charleston/">City calendar</a>', $output );
 		$this->assertStringContainsString( '883 upcoming events', $output );
 		$this->assertStringContainsString( 'Austin, Texas', $output );
-		$this->assertStringContainsString( 'href="https://events.example/near-me/">Shows near me', $output );
+		$this->assertStringContainsString( 'href="' . esc_url( home_url( '/near-me/' ) ) . '">Shows near me', $output );
 		$this->assertStringContainsString( 'Browse all locations', $output );
 		$this->assertStringNotContainsString( 'Showing events for', $output );
 	}

--- a/tests/Unit/Core/AccountMarketTest.php
+++ b/tests/Unit/Core/AccountMarketTest.php
@@ -620,7 +620,7 @@ final class AccountMarketTest extends TestCase {
 							'lon' => -79.9311,
 						),
 						'hierarchy'   => array( 'label' => 'Charleston, South Carolina' ),
-						'archive_url' => 'https://events.example/location/charleston-sc/',
+						'url'         => 'https://events.example/location/charleston-sc/',
 					),
 				);
 			}
@@ -1147,10 +1147,10 @@ final class AccountMarketTest extends TestCase {
 			public function execute(): array {
 				return array(
 					'local_scene' => array(
-						'slug'        => 'charleston',
-						'term_id'     => 1618,
-						'hierarchy'   => array( 'label' => 'Charleston, South Carolina' ),
-						'archive_url' => 'https://events.example/location/charleston/',
+						'slug'      => 'charleston',
+						'term_id'   => 1618,
+						'hierarchy' => array( 'label' => 'Charleston, South Carolina' ),
+						'url'       => 'https://events.example/location/charleston/',
 					),
 				);
 			}
@@ -1181,13 +1181,36 @@ final class AccountMarketTest extends TestCase {
 
 		$this->assertStringContainsString( 'Your Local Scene', $output );
 		$this->assertStringContainsString( 'Charleston, South Carolina', $output );
-		$this->assertStringContainsString( 'https://events.example/location/charleston/', $output );
+		$this->assertStringContainsString( 'class="taxonomy-badge location-badge location-charleston"', $output );
+		$this->assertStringContainsString( 'href="https://events.example/location/charleston/tonight/"', $output );
+		$this->assertStringContainsString( 'href="https://events.example/location/charleston/this-weekend/"', $output );
+		$this->assertStringContainsString( 'href="https://events.example/location/charleston/">City calendar</a>', $output );
 		$this->assertStringContainsString( '883 upcoming events', $output );
-		$this->assertStringContainsString( 'location/charleston/tonight/', $output );
-		$this->assertStringContainsString( 'location/charleston/this-weekend/', $output );
 		$this->assertStringContainsString( 'Austin, Texas', $output );
+		$this->assertStringContainsString( 'href="https://events.example/near-me/">Shows near me', $output );
 		$this->assertStringContainsString( 'Browse all locations', $output );
 		$this->assertStringNotContainsString( 'Showing events for', $output );
+	}
+
+	/**
+	 */
+	public function test_reserved_root_scope_does_not_guess_an_event_permalink(): void {
+		$this->use_events_blog();
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Preserving the test environment verbatim.
+		$original_request_uri   = $_SERVER['REQUEST_URI'] ?? null;
+		$_SERVER['REQUEST_URI'] = '/tonight/';
+
+		try {
+			$this->assertFalse( extrachill_events_prevent_root_scope_permalink_guess( null ) );
+			$_SERVER['REQUEST_URI'] = '/events/tonight-at-the-improv/';
+			$this->assertNull( extrachill_events_prevent_root_scope_permalink_guess( null ) );
+		} finally {
+			if ( null === $original_request_uri ) {
+				unset( $_SERVER['REQUEST_URI'] );
+			} else {
+				$_SERVER['REQUEST_URI'] = $original_request_uri;
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- consume the canonical `local_scene.url` settings field so Charleston calendar, Tonight, and This Weekend links are absolute and city-scoped
- make the saved Local Scene a visible, clickable location badge and expose the existing Shows Near Me flow from the homepage
- prevent reserved root scope paths such as `/tonight/` from fuzzy-redirecting to unrelated event slugs
- update account-market fixtures to match the real provider payload and assert exact navigation URLs

## Testing
- `vendor/bin/phpunit tests/Unit/Core/AccountMarketTest.php` (30 tests, 81 assertions)
- `vendor/bin/phpcs --standard=WordPress inc/core/account-market.php inc/core/discovery-pages.php`
- `git diff --check`

## Test Harness Note
The repository-wide local PHPUnit command still fails during collection because the existing default bootstrap does not provide `WP_UnitTestCase`; managed WordPress tests remain covered by CI.

Fixes #513
Addresses #514