### PR TITLE
fix: clear Events discovery PHPStan findings

### DIFF
--- a/inc/core/account-market.php
+++ b/inc/core/account-market.php
@@ -81,7 +81,7 @@ function extrachill_events_get_account_market(): ?array {
  */
 function extrachill_events_is_exploring_all_markets(): bool {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public read-only discovery preference.
-	$value = isset( $_GET['explore_all'] ) && is_scalar( $_GET['explore_all'] ) ? sanitize_text_field( wp_unslash( $_GET['explore_all'] ) ) : '';
+	$value = isset( $_GET['explore_all'] ) && is_scalar( $_GET['explore_all'] ) ? sanitize_text_field( (string) wp_unslash( $_GET['explore_all'] ) ) : '';
 
 	return '1' === $value;
 }
@@ -388,19 +388,23 @@ function extrachill_events_update_archive_scene( WP_Term $term, string $nonce ):
  */
 function extrachill_events_handle_archive_scene_update(): void {
 	$term           = extrachill_events_get_archive_scene_term();
-	$request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) : '';
+	$request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( (string) wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) : '';
 	if ( null === $term || 'POST' !== $request_method || ! isset( $_POST['extrachill_events_scene_action'] ) || ! isset( $_POST['extrachill_events_scene_nonce'] ) ) {
 		return;
 	}
 
-	$nonce = isset( $_POST['extrachill_events_scene_nonce'] ) && is_scalar( $_POST['extrachill_events_scene_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['extrachill_events_scene_nonce'] ) ) : '';
+	$nonce       = is_scalar( $_POST['extrachill_events_scene_nonce'] ) ? sanitize_text_field( (string) wp_unslash( $_POST['extrachill_events_scene_nonce'] ) ) : '';
+	$archive_url = get_term_link( $term );
+	if ( is_wp_error( $archive_url ) ) {
+		return;
+	}
 	if ( ! wp_verify_nonce( $nonce, 'extrachill_events_save_scene_' . $term->term_id ) ) {
-		wp_safe_redirect( add_query_arg( 'scene_status', 'failed', get_term_link( $term ) ) );
+		wp_safe_redirect( add_query_arg( 'scene_status', 'failed', $archive_url ) );
 		exit;
 	}
 
 	$status = extrachill_events_update_archive_scene( $term, $nonce ) ? 'saved' : 'failed';
-	wp_safe_redirect( add_query_arg( 'scene_status', $status, get_term_link( $term ) ) );
+	wp_safe_redirect( add_query_arg( 'scene_status', $status, $archive_url ) );
 	exit;
 }
 add_action( 'template_redirect', 'extrachill_events_handle_archive_scene_update', 5 );
@@ -414,12 +418,15 @@ function extrachill_events_render_archive_scene_cta(): void {
 		return;
 	}
 
-	$archive_url  = get_term_link( $term );
+	$archive_url = get_term_link( $term );
+	if ( is_wp_error( $archive_url ) ) {
+		return;
+	}
 	$is_logged_in = is_user_logged_in();
 	$current      = extrachill_events_get_account_market();
 	$is_current   = $current && (int) $current['term_id'] === (int) $term->term_id;
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only flash status set by this handler's nonce-protected redirect.
-	$status = isset( $_GET['scene_status'] ) && is_scalar( $_GET['scene_status'] ) ? sanitize_text_field( wp_unslash( $_GET['scene_status'] ) ) : '';
+	$status = isset( $_GET['scene_status'] ) && is_scalar( $_GET['scene_status'] ) ? sanitize_text_field( (string) wp_unslash( $_GET['scene_status'] ) ) : '';
 
 	if ( $is_logged_in ) {
 		if ( ! defined( 'DONOTCACHEPAGE' ) ) {

--- a/inc/core/discovery-pages.php
+++ b/inc/core/discovery-pages.php
@@ -29,8 +29,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Valid scope slugs and their human-readable labels.
- *
- * @var array<string, string>
  */
 define(
 	'EXTRACHILL_EVENTS_DISCOVERY_SCOPES',
@@ -60,7 +58,7 @@ function extrachill_events_prevent_root_scope_permalink_guess( $redirect_url ) {
 		return null;
 	}
 
-	$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+	$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( (string) wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 	$request_path = wp_parse_url( $request_uri, PHP_URL_PATH );
 	$scope        = is_string( $request_path ) ? trim( $request_path, '/' ) : '';
 
@@ -208,7 +206,7 @@ function extrachill_events_discovery_description( string $description ): string 
 	}
 
 	$term = get_queried_object();
-	if ( ! $term || ! isset( $term->term_id ) ) {
+	if ( ! $term instanceof WP_Term ) {
 		return $description;
 	}
 
@@ -236,7 +234,7 @@ function extrachill_events_discovery_canonical( string $canonical ): string {
 	}
 
 	$term = get_queried_object();
-	if ( ! $term ) {
+	if ( ! $term instanceof WP_Term ) {
 		return $canonical;
 	}
 
@@ -277,7 +275,7 @@ function extrachill_events_discovery_og_data( array $og_data ): array {
 	}
 
 	$term = get_queried_object();
-	if ( ! $term ) {
+	if ( ! $term instanceof WP_Term ) {
 		return $og_data;
 	}
 
@@ -356,7 +354,7 @@ function extrachill_events_discovery_breadcrumbs( string $trail ): string {
 	}
 
 	$term = get_queried_object();
-	if ( ! $term ) {
+	if ( ! $term instanceof WP_Term ) {
 		return $trail;
 	}
 
@@ -368,10 +366,14 @@ function extrachill_events_discovery_breadcrumbs( string $trail ): string {
 		$ancestors = array_reverse( $ancestors );
 		foreach ( $ancestors as $ancestor_id ) {
 			$ancestor = get_term( $ancestor_id, 'location' );
-			if ( $ancestor && ! is_wp_error( $ancestor ) ) {
+			if ( $ancestor instanceof WP_Term ) {
+				$ancestor_link = get_term_link( $ancestor );
+				if ( is_wp_error( $ancestor_link ) ) {
+					continue;
+				}
 				$parts[] = sprintf(
 					'<a href="%s">%s</a>',
-					esc_url( get_term_link( $ancestor ) ),
+					esc_url( $ancestor_link ),
 					esc_html( $ancestor->name )
 				);
 			}
@@ -379,9 +381,13 @@ function extrachill_events_discovery_breadcrumbs( string $trail ): string {
 	}
 
 	// City link (back to unscoped location archive).
+	$term_link = get_term_link( $term );
+	if ( is_wp_error( $term_link ) ) {
+		return $trail;
+	}
 	$parts[] = sprintf(
 		'<a href="%s">%s</a>',
-		esc_url( get_term_link( $term ) ),
+		esc_url( $term_link ),
 		esc_html( $term->name )
 	);
 
@@ -519,12 +525,16 @@ function extrachill_events_scope_nav_query_args(): array {
 	}
 
 	if ( ! empty( $request['tax_filter'] ) && is_array( $request['tax_filter'] ) ) {
+		$tax_filter = array();
 		foreach ( $request['tax_filter'] as $taxonomy => $term_ids ) {
 			$taxonomy = sanitize_key( (string) $taxonomy );
 			$term_ids = array_values( array_filter( array_map( 'absint', (array) $term_ids ) ) );
 			if ( $taxonomy && $term_ids ) {
-				$args['tax_filter'][ $taxonomy ] = $term_ids;
+				$tax_filter[ $taxonomy ] = $term_ids;
 			}
+		}
+		if ( $tax_filter ) {
+			$args['tax_filter'] = $tax_filter;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- narrow request scalars and queried taxonomy objects before passing them to WordPress APIs
- handle `WP_Error` from archive and breadcrumb term-link resolution
- build taxonomy filter query arguments through a typed temporary array
- remove the malformed constant `@var` annotation that blocked release PHPStan

## Testing
- `vendor/bin/phpunit tests/Unit/Core/AccountMarketTest.php` (30 tests, 81 assertions)
- `vendor/bin/phpcs --standard=WordPress inc/core/account-market.php inc/core/discovery-pages.php`
- `homeboy review lint extrachill-events --path <worktree> --changed-only --placement local --errors-only`
- `git diff --check`

Fixes #516