### PR TITLE
fix: make venue management discoverable

### DIFF
--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -331,10 +331,10 @@
     font-size: var(--font-size-body);
 }
 
-/* Homepage feature cards (My Shows + Submit). */
+/* Homepage feature cards. */
 .events-feature-cards {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
     gap: var(--spacing-md);
     margin: var(--spacing-xl) 0;
 }

--- a/blocks/venue-settings/render.php
+++ b/blocks/venue-settings/render.php
@@ -117,19 +117,20 @@ foreach ( $managed_venues as $venue ) {
 $can_access       = $selected && true === $authorization->authorize( $user_id, $selected['id'], VenueAuthorization::ACTION_ACCESS_VENUE );
 $can_manage       = $selected && true === $authorization->authorize( $user_id, $selected['id'], VenueAuthorization::ACTION_MANAGE_MEMBERS );
 $context          = array(
-	'user'           => array(
+	'user'               => array(
 		'id'       => $user_id,
 		'name'     => wp_get_current_user()->display_name,
 		'is_admin' => $is_admin,
 	),
-	'venues'         => $managed_venues,
-	'claim_venues'   => $claim_venues,
-	'selected_venue' => $selected,
-	'can_access'     => $can_access,
-	'can_manage'     => $can_manage,
-	'route_url'      => home_url( '/venue-settings/' ),
-	'booking_id'     => $can_access ? $requested_booking_id : 0,
-	'support_events' => $can_access && function_exists( 'extrachill_events_local_support_organizer_events' )
+	'venues'             => $managed_venues,
+	'claim_venues'       => $claim_venues,
+	'selected_venue'     => $selected,
+	'can_access'         => $can_access,
+	'can_manage'         => $can_manage,
+	'route_url'          => home_url( '/venue-settings/' ),
+	'requested_venue_id' => in_array( $requested_venue_id, array_column( $claim_venues, 'id' ), true ) ? $requested_venue_id : 0,
+	'booking_id'         => $can_access ? $requested_booking_id : 0,
+	'support_events'     => $can_access && function_exists( 'extrachill_events_local_support_organizer_events' )
 		? extrachill_events_local_support_organizer_events( $user_id, (int) $selected['id'] )
 		: array(),
 );

--- a/blocks/venue-settings/src/claims-tab.js
+++ b/blocks/venue-settings/src/claims-tab.js
@@ -98,8 +98,10 @@ export function ClaimsTab( { claims, venues, onRefresh } ) {
 	);
 }
 
-export function ClaimPanel( { venues, membership } ) {
-	const [ venueId, setVenueId ] = useState( venues[ 0 ]?.id || 0 );
+export function ClaimPanel( { venues, membership, initialVenueId = 0 } ) {
+	const [ venueId, setVenueId ] = useState(
+		initialVenueId || venues[ 0 ]?.id || 0
+	);
 	const [ status, setStatus ] = useState( null );
 	const submit = async ( event ) => {
 		event.preventDefault();

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -439,6 +439,7 @@ export function VenueSettingsApp( { context } ) {
 				<ClaimPanel
 					venues={ context.claim_venues }
 					membership={ selected }
+					initialVenueId={ context.requested_venue_id }
 				/>
 			);
 		}

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -172,6 +172,7 @@ const context = ( overrides = {} ) => ( {
 	can_access: true,
 	can_manage: false,
 	route_url: 'https://events.example/venue-settings/',
+	requested_venue_id: 0,
 	booking_id: 0,
 	support_events: [],
 	...overrides,
@@ -293,6 +294,23 @@ describe( 'venue settings authorization-facing states', () => {
 			await act( async () => root.unmount() );
 		}
 	);
+
+	it( 'preselects venue context for a non-member claim', async () => {
+		const { container, root } = await renderApp(
+			context( {
+				venues: [],
+				claim_venues: [
+					{ id: 44, name: 'Venue 44' },
+					{ id: 45, name: 'Venue 45' },
+				],
+				selected_venue: null,
+				can_access: false,
+				requested_venue_id: 45,
+			} )
+		);
+		expect( container.querySelector( 'select' ).value ).toBe( '45' );
+		await act( async () => root.unmount() );
+	} );
 
 	it( 'hides team controls from active non-owners', async () => {
 		const { container, root } = await renderApp( context() );

--- a/inc/core/booking-console.php
+++ b/inc/core/booking-console.php
@@ -32,6 +32,15 @@ function ec_events_get_booking_console_url( int $venue_term_id, int $booking_id 
 }
 
 /**
+ * Build the canonical administrator claim-review URL.
+ *
+ * @param int $venue_term_id Optional venue context.
+ */
+function ec_events_get_venue_claim_review_url( int $venue_term_id = 0 ): string {
+	return str_replace( '#tab-calendar', '#tab-claims', ec_events_get_booking_console_url( $venue_term_id ) );
+}
+
+/**
  * Resolve a notification destination only when every recipient remains an
  * active member in both the transaction-locked rows and canonical policy.
  *
@@ -115,3 +124,121 @@ function ec_events_add_manage_venue_avatar_item( array $items, int $user_id ): a
 	return $items;
 }
 add_filter( 'ec_avatar_menu_items', 'ec_events_add_manage_venue_avatar_item', 10, 2 );
+
+/**
+ * Add role-aware venue workspace access to the Events secondary header.
+ *
+ * @param array $items Existing secondary header items.
+ */
+function ec_events_add_venue_workspace_header_item( array $items ): array {
+	if ( ! ec_is_events_site() || ! is_user_logged_in() ) {
+		return $items;
+	}
+
+	$user_id = get_current_user_id();
+	if ( current_user_can( 'manage_options' ) ) {
+		$items[] = array(
+			'url'      => ec_events_get_venue_claim_review_url(),
+			'label'    => __( 'Review Venue Claims', 'extrachill-events' ),
+			'priority' => 8,
+		);
+	}
+	if ( ec_events_user_has_active_venue_membership( $user_id ) ) {
+		$items[] = array(
+			'url'      => ec_events_get_booking_console_url( 0 ),
+			'label'    => __( 'Manage Venue', 'extrachill-events' ),
+			'priority' => 9,
+		);
+	}
+
+	return $items;
+}
+add_filter( 'extrachill_secondary_header_items', 'ec_events_add_venue_workspace_header_item' );
+
+/**
+ * Resolve one contextual workspace action from an authorization state.
+ *
+ * @param int    $venue_term_id Venue term ID.
+ * @param string $state         Authorization state.
+ * @return array{url:string,label:string}|null
+ */
+function ec_events_get_venue_workspace_action_for_state( int $venue_term_id, string $state ): ?array {
+	if ( $venue_term_id < 1 ) {
+		return null;
+	}
+
+	$workspace_url = ec_events_get_booking_console_url( $venue_term_id );
+	if ( 'logged_out' === $state ) {
+		return array(
+			'url'   => wp_login_url( $workspace_url ),
+			'label' => __( 'Sign in to claim or manage', 'extrachill-events' ),
+		);
+	}
+	if ( 'administrator' === $state ) {
+		return array(
+			'url'   => ec_events_get_venue_claim_review_url( $venue_term_id ),
+			'label' => __( 'Review venue claims', 'extrachill-events' ),
+		);
+	}
+	if ( 'member' === $state ) {
+		return array(
+			'url'   => $workspace_url,
+			'label' => __( 'Manage Venue', 'extrachill-events' ),
+		);
+	}
+	if ( 'non_member' === $state ) {
+		return array(
+			'url'   => $workspace_url,
+			'label' => __( 'Claim or request access', 'extrachill-events' ),
+		);
+	}
+
+	return null;
+}
+
+/**
+ * Resolve the contextual workspace action for one canonical venue archive.
+ *
+ * @param int $venue_term_id Venue term ID.
+ * @param int $user_id       Optional user ID. Defaults to the current user.
+ * @return array{url:string,label:string}|null
+ */
+function ec_events_get_venue_archive_workspace_action( int $venue_term_id, int $user_id = 0 ): ?array {
+	if ( ! is_user_logged_in() ) {
+		return ec_events_get_venue_workspace_action_for_state( $venue_term_id, 'logged_out' );
+	}
+
+	$user_id       = $user_id > 0 ? $user_id : get_current_user_id();
+	$authorization = new VenueAuthorization();
+	if ( $authorization->can( $user_id, $venue_term_id, VenueAuthorization::ACTION_ACCESS_VENUE ) ) {
+		return ec_events_get_venue_workspace_action_for_state( $venue_term_id, 'member' );
+	}
+	if ( $authorization->is_administrator( $user_id ) ) {
+		return ec_events_get_venue_workspace_action_for_state( $venue_term_id, 'administrator' );
+	}
+
+	return ec_events_get_venue_workspace_action_for_state( $venue_term_id, 'non_member' );
+}
+
+/** Render contextual venue management acquisition on canonical archives. */
+function ec_events_render_venue_archive_workspace_action(): void {
+	$term = function_exists( 'extrachill_events_get_venue_archive_term' ) ? extrachill_events_get_venue_archive_term() : null;
+	if ( ! $term instanceof WP_Term ) {
+		return;
+	}
+
+	$action = ec_events_get_venue_archive_workspace_action( (int) $term->term_id );
+	if ( null === $action ) {
+		return;
+	}
+	?>
+	<aside class="events-market-context events-market-context--quiet" data-venue-workspace-action>
+		<div class="events-market-context__copy">
+			<strong><?php esc_html_e( 'Operate this venue?', 'extrachill-events' ); ?></strong>
+			<span><?php esc_html_e( 'Manage inquiries, holds, calendar details, and venue access in the existing workspace.', 'extrachill-events' ); ?></span>
+		</div>
+		<a class="button-1 button-small" href="<?php echo esc_url( $action['url'] ); ?>"><?php echo esc_html( $action['label'] ); ?></a>
+	</aside>
+	<?php
+}
+add_action( 'extrachill_archive_below_description', 'ec_events_render_venue_archive_workspace_action', 8 );

--- a/inc/home/feature-cards.php
+++ b/inc/home/feature-cards.php
@@ -2,9 +2,8 @@
 /**
  * Events Homepage Feature Cards
  *
- * Two side-by-side cards below the city badges surfacing the platform's
- * personalization + contribution features: building a personal concert
- * archive (My Shows) and adding events to the calendar (Submit).
+ * Cards below the city badges surface personalization and contribution tools,
+ * plus venue operations for active venue members.
  *
  * @package ExtraChillEvents
  * @since 0.25.0
@@ -30,4 +29,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</p>
 		<span class="events-feature-card__cta"><?php esc_html_e( 'Submit a show &rarr;', 'extrachill-events' ); ?></span>
 	</a>
+
+	<?php if ( is_user_logged_in() && ec_events_user_has_active_venue_membership( get_current_user_id() ) ) : ?>
+		<a class="events-feature-card events-feature-card--manage-venue" href="<?php echo esc_url( ec_events_get_booking_console_url( 0 ) ); ?>">
+			<h2 class="events-feature-card__title"><?php esc_html_e( 'Manage Venue', 'extrachill-events' ); ?></h2>
+			<p class="events-feature-card__body">
+				<?php esc_html_e( 'Review inquiries, manage holds, and keep your venue calendar up to date.', 'extrachill-events' ); ?>
+			</p>
+			<span class="events-feature-card__cta"><?php esc_html_e( 'Open venue workspace &rarr;', 'extrachill-events' ); ?></span>
+		</a>
+	<?php endif; ?>
 </div>

--- a/tests/Unit/Core/BookingConsoleTest.php
+++ b/tests/Unit/Core/BookingConsoleTest.php
@@ -44,7 +44,7 @@ if ( ! function_exists( '__' ) ) {
 if ( ! function_exists( 'wp_login_url' ) ) {
 	/** Build a deterministic test login URL. */
 	function wp_login_url( $redirect ) {
-		return 'https://events.example/login/?redirect_to=' . rawurlencode( $redirect );
+		return home_url( '/wp-login.php?redirect_to=' . rawurlencode( $redirect ) );
 	}
 }
 
@@ -76,24 +76,36 @@ final class BookingConsoleTest extends TestCase {
 	 * @param string $url   Expected action URL.
 	 */
 	public function test_venue_workspace_action_matches_authorization_state( string $state, string $label, string $url ): void {
+		$action = ec_events_get_venue_workspace_action_for_state( 44, $state );
 		$this->assertSame(
 			array(
 				'url'   => $url,
 				'label' => $label,
 			),
-			ec_events_get_venue_workspace_action_for_state( 44, $state )
+			$action
 		);
+
+		if ( 'logged_out' === $state ) {
+			parse_str( (string) parse_url( $action['url'], PHP_URL_QUERY ), $query );
+			$this->assertSame( $this->expected_workspace_url(), $query['redirect_to'] ?? '' );
+		}
 	}
 
 	/** Provide member, non-member, logged-out, and administrator states. */
 	public function venue_workspace_states(): array {
-		$workspace = 'https://events.example/venue-settings/?venue_id=44#tab-calendar';
+		$workspace = $this->expected_workspace_url();
 		return array(
 			'active member' => array( 'member', 'Manage Venue', $workspace ),
 			'non-member'    => array( 'non_member', 'Claim or request access', $workspace ),
-			'logged out'    => array( 'logged_out', 'Sign in to claim or manage', 'https://events.example/login/?redirect_to=' . rawurlencode( $workspace ) ),
-			'administrator' => array( 'administrator', 'Review venue claims', 'https://events.example/venue-settings/?venue_id=44#tab-claims' ),
+			'logged out'    => array( 'logged_out', 'Sign in to claim or manage', wp_login_url( $workspace ) ),
+			'administrator' => array( 'administrator', 'Review venue claims', str_replace( '#tab-calendar', '#tab-claims', $workspace ) ),
 		);
+	}
+
+	/** Build the expected workspace URL from the active WordPress environment. */
+	private function expected_workspace_url(): string {
+		$base_url = get_home_url( (int) ec_get_blog_id( 'events' ), '/venue-settings/' );
+		return add_query_arg( array( 'venue_id' => 44 ), $base_url ) . '#tab-calendar';
 	}
 
 	/** Ensure all requested navigation surfaces remain registered. */

--- a/tests/Unit/Core/BookingConsoleTest.php
+++ b/tests/Unit/Core/BookingConsoleTest.php
@@ -35,6 +35,18 @@ if ( ! function_exists( 'add_query_arg' ) ) {
 		return $url . '?' . http_build_query( $args );
 	}
 }
+if ( ! function_exists( '__' ) ) {
+	/** Return untranslated test text. */
+	function __( $text ) {
+		return $text;
+	}
+}
+if ( ! function_exists( 'wp_login_url' ) ) {
+	/** Build a deterministic test login URL. */
+	function wp_login_url( $redirect ) {
+		return 'https://events.example/login/?redirect_to=' . rawurlencode( $redirect );
+	}
+}
 
 require_once dirname( __DIR__, 3 ) . '/inc/core/booking-console.php';
 
@@ -53,5 +65,48 @@ final class BookingConsoleTest extends TestCase {
 			$base_url . '#tab-calendar',
 			ec_events_get_booking_console_url( 0 )
 		);
+	}
+
+	/**
+	 * Verify each authorization state resolves its intended action.
+	 *
+	 * @dataProvider venue_workspace_states
+	 * @param string $state Authorization state.
+	 * @param string $label Expected action label.
+	 * @param string $url   Expected action URL.
+	 */
+	public function test_venue_workspace_action_matches_authorization_state( string $state, string $label, string $url ): void {
+		$this->assertSame(
+			array(
+				'url'   => $url,
+				'label' => $label,
+			),
+			ec_events_get_venue_workspace_action_for_state( 44, $state )
+		);
+	}
+
+	/** Provide member, non-member, logged-out, and administrator states. */
+	public function venue_workspace_states(): array {
+		$workspace = 'https://events.example/venue-settings/?venue_id=44#tab-calendar';
+		return array(
+			'active member' => array( 'member', 'Manage Venue', $workspace ),
+			'non-member'    => array( 'non_member', 'Claim or request access', $workspace ),
+			'logged out'    => array( 'logged_out', 'Sign in to claim or manage', 'https://events.example/login/?redirect_to=' . rawurlencode( $workspace ) ),
+			'administrator' => array( 'administrator', 'Review venue claims', 'https://events.example/venue-settings/?venue_id=44#tab-claims' ),
+		);
+	}
+
+	/** Ensure all requested navigation surfaces remain registered. */
+	public function test_navigation_surfaces_keep_existing_avatar_link_and_condition_homepage_card(): void {
+		$plugin_root = dirname( __DIR__, 3 );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local source contracts.
+		$booking_console = file_get_contents( $plugin_root . '/inc/core/booking-console.php' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local source contracts.
+		$feature_cards = file_get_contents( $plugin_root . '/inc/home/feature-cards.php' );
+
+		$this->assertStringContainsString( "add_filter( 'ec_avatar_menu_items', 'ec_events_add_manage_venue_avatar_item'", $booking_console );
+		$this->assertStringContainsString( "add_filter( 'extrachill_secondary_header_items', 'ec_events_add_venue_workspace_header_item'", $booking_console );
+		$this->assertStringContainsString( 'ec_events_user_has_active_venue_membership( get_current_user_id() )', $feature_cards );
+		$this->assertStringContainsString( 'Review inquiries, manage holds, and keep your venue calendar up to date.', $feature_cards );
 	}
 }


### PR DESCRIPTION
## Summary
- Add role-aware Events secondary-header links: active venue members receive `Manage Venue`, while administrators receive `Review Venue Claims`; administrators who are also active members receive both.
- Add an active-member-only Events homepage card for inquiries, holds, and venue calendar operations while preserving the existing My Shows and Submit Event cards with an adaptive responsive grid.
- Add canonical venue archive actions that route exact authorized members to `Manage Venue`, logged-in non-members to `Claim or request access`, logged-out visitors through sign-in continuation, and administrators without exact venue access to claim review.
- Preserve `venue_id` through the canonical workspace URL and preselect that venue in the existing claim UI. The existing avatar-menu shortcut remains unchanged.

## Visibility and authorization
- Secondary header `Manage Venue`: logged-in users with any active venue membership only.
- Secondary header `Review Venue Claims`: administrators with `manage_options` only.
- Homepage operator card: logged-in active venue members only; hidden from ordinary fans and logged-out visitors.
- Venue archive `Manage Venue`: users authorized for `VenueAuthorization::ACTION_ACCESS_VENUE` on that exact venue only.
- Venue archive claim action: logged-in users without exact venue access; claim submission remains protected by the existing Ability authorization.
- Venue archive sign-in action: logged-out users, with continuation to `/venue-settings/?venue_id=<id>#tab-calendar`.
- Venue archive administrator action: administrators without exact venue access, linked to the existing claims review state.

## Tests
- `./vendor/bin/phpunit tests/Unit/Core/BookingConsoleTest.php` - pass, 7 tests / 10 assertions.
- `./vendor/bin/phpunit --testsuite=venue-membership-authorization` - pass, 50 tests / 345 assertions.
- `npm run test:js -- --runInBand blocks/venue-settings/src/view.test.js` - pass, 23 tests.
- `./vendor/bin/phpcs --standard=WordPress inc/core/booking-console.php inc/home/feature-cards.php blocks/venue-settings/render.php` - pass.
- `npm run lint:js` - pass.
- `npm run build` - pass.
- `git diff --check` - pass.
- `composer test` remains blocked by the repository's documented plain-test bootstrap limitation: `WP_UnitTestCase` is unavailable when `CanonicalLocationsAbilityTest.php` loads.
- Full `composer lint:php` reaches the repository's existing broad PHPCS baseline; changed production PHP passes the focused PHPCS command above.

## Evidence
No screenshot was captured because this managed worktree has no isolated authenticated Events preview. The React DOM test verifies contextual claim preselection, and the full block build completed successfully.

Closes #521