### PR TITLE
feat: support 14-day booking holds

### DIFF
--- a/blocks/venue-settings/src/booking-tab.js
+++ b/blocks/venue-settings/src/booking-tab.js
@@ -14,7 +14,12 @@ import {
  * Internal dependencies
  */
 import { Status } from './status';
-import { normalizeKey, sameDocument, validateConfig } from './state';
+import {
+	HOLD_TTL_MAX_MINUTES,
+	normalizeKey,
+	sameDocument,
+	validateConfig,
+} from './state';
 
 function SpacesEditor( { spaces, onChange } ) {
 	const update = ( index, patch ) =>
@@ -160,13 +165,13 @@ export function BookingTab( {
 				<FieldGroup
 					label="Default hold duration (minutes)"
 					htmlFor="venue-hold-ttl"
-					help="Between 5 minutes and 7 days."
+					help="Between 5 minutes and 14 days."
 				>
 					<input
 						id="venue-hold-ttl"
 						type="number"
 						min="5"
-						max="10080"
+						max={ HOLD_TTL_MAX_MINUTES }
 						value={ config.hold_ttl_minutes }
 						onChange={ ( event ) =>
 							setConfig( {

--- a/blocks/venue-settings/src/state.js
+++ b/blocks/venue-settings/src/state.js
@@ -1,3 +1,5 @@
+export const HOLD_TTL_MAX_MINUTES = 20160;
+
 export const editableConfig = ( config ) => {
 	const editable = { ...config };
 	delete editable.revision;
@@ -64,8 +66,11 @@ export const validateConfig = ( config ) => {
 			errors.push( 'Select fields need at least one option.' );
 		}
 	} );
-	if ( config.hold_ttl_minutes < 5 || config.hold_ttl_minutes > 10080 ) {
-		errors.push( 'Hold duration must be between 5 minutes and 7 days.' );
+	if (
+		config.hold_ttl_minutes < 5 ||
+		config.hold_ttl_minutes > HOLD_TTL_MAX_MINUTES
+	) {
+		errors.push( 'Hold duration must be between 5 minutes and 14 days.' );
 	}
 	if ( ! Number.isFinite( config.hold_ttl_minutes ) ) {
 		errors.push( 'Hold duration must be a number.' );

--- a/blocks/venue-settings/src/state.test.js
+++ b/blocks/venue-settings/src/state.test.js
@@ -83,8 +83,19 @@ describe( 'venue settings state', () => {
 				'Space keys must be unique.',
 				'Choose one default space.',
 				'Select fields need at least one option.',
-				'Hold duration must be between 5 minutes and 7 days.',
+				'Hold duration must be between 5 minutes and 14 days.',
 			] )
+		);
+	} );
+
+	it( 'accepts a fourteen-day hold and rejects values above it', () => {
+		const config = validConfig();
+		config.hold_ttl_minutes = 20160;
+		expect( validateConfig( config ) ).toEqual( [] );
+
+		config.hold_ttl_minutes = 20161;
+		expect( validateConfig( config ) ).toContain(
+			'Hold duration must be between 5 minutes and 14 days.'
 		);
 	} );
 } );

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -32,8 +32,14 @@ jest.mock( '@extrachill/components', () => {
 		BlockShellHeader: ( { title } ) =>
 			React.createElement( 'h1', null, title ),
 		BlockShellInner: Wrapper,
-		FieldGroup: ( { label, children } ) =>
-			React.createElement( 'label', null, label, children ),
+		FieldGroup: ( { label, help, children } ) =>
+			React.createElement(
+				'label',
+				null,
+				label,
+				children,
+				help && React.createElement( 'span', null, help )
+			),
 		Grid: Wrapper,
 		InlineStatus: Wrapper,
 		Panel: Wrapper,
@@ -447,6 +453,19 @@ describe( 'venue settings authorization-facing states', () => {
 		await act( async () => buttonByText( container, 'Profile' ).click() );
 		expect( container.textContent ).toContain( 'Profile unavailable.' );
 		expect( container.textContent ).toContain( 'Retry profile' );
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'shows the fourteen-day hold limit in booking settings', async () => {
+		const { container, root } = await renderApp( context() );
+		await act( async () => buttonByText( container, 'Booking' ).click() );
+
+		expect( container.querySelector( '#venue-hold-ttl' ).max ).toBe(
+			'20160'
+		);
+		expect( container.textContent ).toContain(
+			'Between 5 minutes and 14 days.'
+		);
 		await act( async () => root.unmount() );
 	} );
 

--- a/inc/Abilities/VenueBookingConfigAbilities.php
+++ b/inc/Abilities/VenueBookingConfigAbilities.php
@@ -338,7 +338,7 @@ class VenueBookingConfigAbilities {
 			'hold_ttl_minutes'          => array(
 				'type'    => 'integer',
 				'minimum' => 5,
-				'maximum' => 10080,
+				'maximum' => VenueBookingConfig::HOLD_TTL_MAX_MINUTES,
 			),
 			'correspondence'            => $this->correspondence_schema(),
 		);

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -25,6 +25,7 @@ class VenueBookingConfig {
 	public const CORRESPONDENCE_TEMPLATES    = array( 'operator_message', 'follow_up', 'hold_expiring' );
 	public const CORRESPONDENCE_VARIABLES    = array( 'artist_name', 'booking_id', 'contact_name', 'venue_name' );
 	public const CONSENT_VERSION             = 1;
+	public const HOLD_TTL_MAX_MINUTES        = 20160;
 	public const SOCIAL_MARKETING_ACTION     = 'datamachine-socials/cross-post';
 	public const NEWSLETTER_MARKETING_ACTION = 'extrachill-newsletter/canonical-post-campaign';
 
@@ -309,8 +310,8 @@ class VenueBookingConfig {
 			return $correspondence;
 		}
 		$hold_ttl = isset( $config['hold_ttl_minutes'] ) ? (int) $config['hold_ttl_minutes'] : 1440;
-		if ( $hold_ttl < 5 || $hold_ttl > 10080 ) {
-			return new \WP_Error( 'invalid_booking_hold_ttl', __( 'Hold TTL must be between 5 minutes and 7 days.', 'extrachill-events' ) );
+		if ( $hold_ttl < 5 || $hold_ttl > self::HOLD_TTL_MAX_MINUTES ) {
+			return new \WP_Error( 'invalid_booking_hold_ttl', __( 'Hold TTL must be between 5 minutes and 14 days.', 'extrachill-events' ) );
 		}
 
 		$revision = $config['revision'] ?? 0;

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -607,6 +607,15 @@ final class BookingFoundationTest extends BookingTestCase {
 		$this->assertSame( 'booking_config_version_unsupported', $service->get( 55 )->get_error_code() );
 	}
 
+	public function test_config_accepts_fourteen_day_holds_and_rejects_longer_values(): void {
+		$service = new VenueBookingConfig();
+
+		$accepted = $service->normalize( array( 'hold_ttl_minutes' => 20160 ) );
+		$this->assertSame( 20160, $accepted['hold_ttl_minutes'] );
+		$this->assertSame( 'invalid_booking_hold_ttl', $service->normalize( array( 'hold_ttl_minutes' => 20161 ) )->get_error_code() );
+		$this->assertSame( 1440, $service->defaults()['hold_ttl_minutes'] );
+	}
+
 	public function test_config_detects_truncated_collisions_and_validates_channels_currency(): void {
 		$service = new VenueBookingConfig();
 		$prefix  = str_repeat( 'a', 64 );

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -1862,6 +1862,8 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertContains( 'public_requirements', $config_output['required'] );
 		$this->assertContains( 'consent', $config_output['required'] );
 		$this->assertContains( 'marketing_triggers', $config_output['required'] );
+		$this->assertSame( 20160, $config_input['oneOf'][2]['properties']['hold_ttl_minutes']['maximum'] );
+		$this->assertSame( 20160, $config_output['properties']['hold_ttl_minutes']['maximum'] );
 
 		$legacy = ( new VenueBookingConfig() )->defaults();
 		$legacy['version'] = 1;


### PR DESCRIPTION
## Summary
- raise the generic venue booking hold ceiling from 7 days to 14 days across PHP validation, public Ability schemas, and Venue Settings
- keep the existing 1-day default unchanged and preserve absolute hold-expiration/concurrency behavior
- add boundary coverage for 20,160 minutes accepted and 20,161 rejected, plus schema and rendered UI assertions

## Verification
- `vendor/bin/phpunit tests/BookingFoundationTest.php` (42 tests, 406 assertions)
- `vendor/bin/phpunit --configuration phpunit-venue-unit.xml.dist` (50 tests, 347 assertions)
- `npm run test:js -- --runInBand` (82 tests)
- `npm run lint:js`
- `npm run build`
- `homeboy review audit --changed-since=origin/main --summary --placement local` (passed, zero introduced findings)
- `homeboy --placement local review build --changed-since=origin/main extrachill-events` (passed)

Homeboy's changed-file lint and test wrappers exposed existing runner defects while their canonical underlying commands passed: WordPress PHPStan stubs are tracked in Extra-Chill/homeboy-extensions#2512, and Jest/JSX files being invoked with raw Node are tracked in Extra-Chill/homeboy-extensions#2513.

## Operator Follow-up
After this change is released and deployed, set Lo-Fi Brewing venue term `1524` to `20,160` minutes through the canonical venue configuration operation. This PR intentionally does not change live venue configuration.

Closes #523