### PR TITLE
feat: automate booking receipt and competing-date follow-up

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -287,6 +287,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportNotificationAdapter.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportNotificationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingCommunicationService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingCorrespondenceAutomationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingHoldRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingMutationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingEventSyncService.php';
@@ -311,6 +312,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/CanonicalEventPublicationGuard.php';
 		\ExtraChillEvents\Core\BookingHoldRepository::register();
 		\ExtraChillEvents\Core\BookingCommunicationService::register();
+		\ExtraChillEvents\Core\BookingCorrespondenceAutomationService::register();
 		\ExtraChillEvents\Core\BookingNotificationService::register();
 		\ExtraChillEvents\Core\LocalSupportNotificationService::register();
 		new \ExtraChillEvents\Core\CanonicalEventPublicationGuard();

--- a/inc/Core/BookingActivityRepository.php
+++ b/inc/Core/BookingActivityRepository.php
@@ -529,6 +529,15 @@ class BookingActivityRepository {
 		return $this->hydrate_rows( $rows, 'booking_notification_source_scan_failed' );
 	}
 
+	/** List lifecycle sources whose automatic correspondence is incomplete. */
+	public function correspondence_sources_without_completion( int $limit ) {
+		global $wpdb;
+		$table = BookingSchema::activity_table();
+		$limit = max( 1, min( 100, $limit ) );
+		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT source.* FROM {$table} source WHERE source.kind IN ('inquiry_submitted', 'deal_confirmed') AND NOT EXISTS (SELECT 1 FROM {$table} done WHERE done.kind = 'booking_correspondence_source_completed' AND done.external_id = CAST(source.id AS CHAR)) ORDER BY source.id ASC LIMIT %d", $limit ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded recovery scan over lifecycle sources.
+		return $this->hydrate_rows( $rows, 'booking_correspondence_source_scan_failed' );
+	}
+
 	/** List pending outbox requests without terminal delivery/suppression records. */
 	public function pending_notification_requests( int $limit ) {
 		global $wpdb;

--- a/inc/Core/BookingCommunicationService.php
+++ b/inc/Core/BookingCommunicationService.php
@@ -19,7 +19,7 @@ class BookingCommunicationService {
 	public const SCHEDULER_GROUP        = 'extrachill-events-booking-reminders';
 	public const SUPPRESSION_BATCH_SIZE = 25;
 	public const MAX_ATTEMPTS           = 3;
-	public const TEMPLATES              = array( 'operator_message', 'follow_up', 'hold_expiring' );
+	public const TEMPLATES              = array( 'operator_message', 'follow_up', 'hold_expiring', 'inquiry_receipt', 'date_filled' );
 	public const TERMINAL_STATUSES      = array( 'declined', 'withdrawn', 'cancelled', 'completed' );
 
 	/** @var BookingRepository */
@@ -153,6 +153,85 @@ class BookingCommunicationService {
 		$initialized = $this->activity->create_communication_state( $intent );
 		if ( is_wp_error( $initialized ) ) {
 			return $this->rollback( $initialized );
+		}
+		$committed = $this->commit();
+		return is_wp_error( $committed ) ? $committed : $this->resume( $intent );
+	}
+
+	/** Persist deterministic lifecycle correspondence without operator impersonation. */
+	public function request_automatic( int $booking_id, int $source_activity_id, string $template, string $message ) {
+		$source  = $this->activity->get( $source_activity_id );
+		$booking = $this->bookings->get( $booking_id );
+		$allowed = array(
+			'inquiry_receipt' => 'inquiry_submitted',
+			'date_filled'     => 'deal_confirmed',
+		);
+		if ( ! is_array( $source ) || ! is_array( $booking ) || ( $allowed[ $template ] ?? null ) !== $source['kind'] || empty( $booking['contact_email'] ) ) {
+			return new \WP_Error( 'booking_automatic_message_invalid', __( 'The automatic booking message is invalid.', 'extrachill-events' ) );
+		}
+		if ( 'inquiry_receipt' === $template && (int) $source['booking_id'] !== $booking_id ) {
+			return new \WP_Error( 'booking_automatic_message_invalid', __( 'The automatic booking message is invalid.', 'extrachill-events' ) );
+		}
+		$key      = sprintf( 'booking-message-request:automatic:%s:%d:%d', $template, $source_activity_id, $booking_id );
+		$existing = $this->activity->find_by_idempotency( $booking_id, $key );
+		if ( is_wp_error( $existing ) ) {
+			return $existing;
+		}
+		if ( is_array( $existing ) ) {
+			return $this->resume( $existing );
+		}
+		$started = $this->begin();
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$booking = $this->bookings->get_for_update( $booking_id );
+		$source  = $this->activity->get( $source_activity_id );
+		if ( ! is_array( $booking ) || ! is_array( $source ) || empty( $booking['contact_email'] ) || ! $this->automatic_message_applicable( $booking, $source, $template ) ) {
+			return $this->rollback( new \WP_Error( 'booking_automatic_message_stale', __( 'The automatic booking message is no longer applicable.', 'extrachill-events' ) ) );
+		}
+		$request = $this->prepare_request(
+			array(
+				'booking_id'       => $booking_id,
+				'idempotency_key'  => sprintf( 'automatic:%s:%d:%d', $template, $source_activity_id, $booking_id ),
+				'template'         => $template,
+				'template_version' => null,
+				'recipient'        => $booking['contact_email'],
+				'message'          => mb_substr( sanitize_textarea_field( $message ), 0, 10000 ),
+				'reply_to'         => $booking['contact_email'],
+			),
+			$booking
+		);
+		if ( is_wp_error( $request ) ) {
+			return $this->rollback( $request );
+		}
+		$intent = $this->activity->append(
+			array(
+				'booking_id'      => $booking_id,
+				'kind'            => 'booking_message_requested',
+				'actor_type'      => 'system',
+				'direction'       => 'outbound',
+				'channel'         => 'email',
+				'idempotency_key' => $key,
+				'payload'         => array_merge(
+					$request,
+					array(
+						'request_hash'       => hash( 'sha256', $key . "\0" . $request['subject'] . "\0" . $request['body'] ),
+						'booking_version'    => (int) $booking['version'],
+						'source_activity_id' => $source_activity_id,
+						'cc'                 => 'chubes@extrachill.com',
+						'from_name'          => 'Extra Chill Bot',
+						'identity'           => 'Extra Chill Bot sending on Chris\'s behalf.',
+						'mail_site_id'       => function_exists( 'extrachill_mail_site_id' ) ? extrachill_mail_site_id() : get_current_blog_id(),
+					)
+				),
+			)
+		);
+		if ( is_wp_error( $intent ) ) {
+			return $this->rollback( $intent );
+		}
+		$state = $this->activity->create_communication_state( $intent );
+		if ( is_wp_error( $state ) ) {
+			return $this->rollback( $state );
 		}
 		$committed = $this->commit();
 		return is_wp_error( $committed ) ? $committed : $this->resume( $intent );
@@ -883,7 +962,12 @@ class BookingCommunicationService {
 		}
 		$data   = $intent['payload']['data'];
 		$reason = null;
-		if ( (int) $booking['version'] !== (int) $data['booking_version'] || in_array( $booking['status'], self::TERMINAL_STATUSES, true ) ) {
+		if ( isset( $data['source_activity_id'] ) ) {
+			$source = $this->activity->get( (int) $data['source_activity_id'] );
+			if ( ! is_array( $source ) || ! $this->automatic_message_applicable( $booking, $source, (string) $data['template'] ) ) {
+				$reason = 'booking_status_changed';
+			}
+		} elseif ( (int) $booking['version'] !== (int) $data['booking_version'] || in_array( $booking['status'], self::TERMINAL_STATUSES, true ) ) {
 			$reason = 'booking_status_changed';
 		} elseif ( strtolower( (string) $booking['contact_email'] ) !== strtolower( $data['recipient'] ) ) {
 			$reason = 'booking_recipient_changed';
@@ -969,6 +1053,25 @@ class BookingCommunicationService {
 				'reminder_policy_version' => $policy_version,
 			)
 		);
+	}
+
+	/** Revalidate server-owned automatic correspondence immediately before queueing. */
+	private function automatic_message_applicable( array $booking, array $source, string $template ): bool {
+		if ( 'inquiry_receipt' === $template ) {
+			return 'inquiry_submitted' === $source['kind'] && (int) $source['booking_id'] === (int) $booking['id'];
+		}
+		if ( 'date_filled' !== $template || 'deal_confirmed' !== $source['kind'] || in_array( $booking['status'], array( 'confirmed', 'declined', 'withdrawn', 'cancelled', 'completed' ), true ) ) {
+			return false;
+		}
+		$confirmed = $this->bookings->get( (int) $source['booking_id'] );
+		return is_array( $confirmed )
+			&& 'confirmed' === $confirmed['status']
+			&& (int) $confirmed['venue_term_id'] === (int) $booking['venue_term_id']
+			&& (string) $confirmed['space_key'] === (string) $booking['requested_space_key']
+			&& ! empty( $booking['requested_start_at'] )
+			&& ! empty( $booking['requested_end_at'] )
+			&& $booking['requested_start_at'] < $confirmed['performance_end_at']
+			&& $booking['requested_end_at'] > $confirmed['performance_start_at'];
 	}
 
 	private function request_hash( array $request, int $actor_id ): string {

--- a/inc/Core/BookingCorrespondenceAutomationService.php
+++ b/inc/Core/BookingCorrespondenceAutomationService.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Post-commit booking receipt and competing-request correspondence.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Recovers lifecycle-backed automatic correspondence through the existing outbox. */
+class BookingCorrespondenceAutomationService {
+
+	public const EMIT_HOOK       = 'extrachill_events_emit_booking_correspondence';
+	public const RECONCILE_HOOK  = 'extrachill_events_reconcile_booking_correspondence';
+	public const SCHEDULER_GROUP = 'extrachill-events-booking-correspondence';
+	public const BATCH_SIZE      = 25;
+
+	/** @var bool */
+	private static $registered = false;
+	/** @var BookingRepository */
+	private $bookings;
+	/** @var BookingActivityRepository */
+	private $activity;
+	/** @var BookingCommunicationService */
+	private $communication;
+	/** @var VenueBookingConfig */
+	private $config;
+
+	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?BookingCommunicationService $communication = null, ?VenueBookingConfig $config = null ) {
+		$this->bookings      = $bookings ? $bookings : new BookingRepository();
+		$this->activity      = $activity ? $activity : new BookingActivityRepository();
+		$this->communication = $communication ? $communication : new BookingCommunicationService( $this->bookings, $this->activity );
+		$this->config        = $config ? $config : new VenueBookingConfig();
+	}
+
+	/** Register immediate and crash-recovery producers. */
+	public static function register(): void {
+		self::$registered = true;
+		add_action( self::EMIT_HOOK, array( self::class, 'emit' ), 10, 1 );
+		add_action( self::RECONCILE_HOOK, array( self::class, 'reconcile_scheduled' ) );
+		add_action( 'init', array( self::class, 'ensure_reconciliation_schedule' ) );
+	}
+
+	/** Ensure a missed post-commit callback is recovered. */
+	public static function ensure_reconciliation_schedule(): void {
+		if ( ! function_exists( 'as_schedule_recurring_action' ) || ! function_exists( 'as_next_scheduled_action' ) || as_next_scheduled_action( self::RECONCILE_HOOK, array(), self::SCHEDULER_GROUP ) ) {
+			return;
+		}
+		as_schedule_recurring_action( time() + MINUTE_IN_SECONDS, 5 * MINUTE_IN_SECONDS, self::RECONCILE_HOOK, array(), self::SCHEDULER_GROUP, true );
+	}
+
+	/** Best-effort immediate processing after the owning transaction commits. */
+	public static function emit( int $source_activity_id ): void {
+		if ( ! self::$registered ) {
+			return;
+		}
+		$service = new self();
+		$service->schedule_reconciliation();
+		$service->reconcile_source( $source_activity_id );
+	}
+
+	/** Scheduler callback. */
+	public static function reconcile_scheduled(): void {
+		$result = ( new self() )->reconcile_pending();
+		if ( is_wp_error( $result ) ) {
+			throw new \RuntimeException( $result->get_error_message() ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Scheduler-only diagnostic.
+		}
+	}
+
+	/** Recover a bounded source page. */
+	public function reconcile_pending( int $limit = 25 ) {
+		$sources = $this->activity->correspondence_sources_without_completion( $limit );
+		if ( is_wp_error( $sources ) ) {
+			return $sources;
+		}
+		$completed = 0;
+		foreach ( $sources as $source ) {
+			$result = $this->process_source( $source );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			$completed += ! empty( $result['completed'] ) ? 1 : 0;
+		}
+		if ( count( $sources ) === max( 1, min( 100, $limit ) ) ) {
+			$this->schedule_reconciliation();
+		}
+		return compact( 'completed' );
+	}
+
+	/** Reconcile one exact lifecycle source. */
+	public function reconcile_source( int $source_activity_id ) {
+		$source = $this->activity->get( $source_activity_id );
+		return is_array( $source ) ? $this->process_source( $source ) : new \WP_Error( 'booking_correspondence_source_invalid', __( 'The booking correspondence source is invalid.', 'extrachill-events' ) );
+	}
+
+	private function process_source( array $source ) {
+		$done = $this->activity->find_by_external_id( (int) $source['booking_id'], 'booking_correspondence_source_completed', (string) $source['id'] );
+		if ( is_wp_error( $done ) || is_array( $done ) ) {
+			return is_wp_error( $done ) ? $done : array( 'completed' => true );
+		}
+		if ( 'inquiry_submitted' === $source['kind'] ) {
+			return $this->process_receipt( $source );
+		}
+		if ( 'deal_confirmed' === $source['kind'] ) {
+			return $this->process_competitors( $source );
+		}
+		return new \WP_Error( 'booking_correspondence_source_invalid', __( 'The booking correspondence source is invalid.', 'extrachill-events' ) );
+	}
+
+	private function process_receipt( array $source ) {
+		$booking = $this->bookings->get( (int) $source['booking_id'] );
+		if ( ! is_array( $booking ) ) {
+			return is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_correspondence_booking_missing', __( 'The booking correspondence record is unavailable.', 'extrachill-events' ) );
+		}
+		$venue = get_term( (int) $booking['venue_term_id'], 'venue' );
+		if ( ! $venue || is_wp_error( $venue ) ) {
+			return new \WP_Error( 'booking_correspondence_venue_unavailable', __( 'The booking venue could not be resolved for correspondence.', 'extrachill-events' ) );
+		}
+		$message = sprintf(
+			"We received your booking inquiry and it is pending review.\n\nArtist: %s\nVenue: %s\nRequested interval: %s to %s UTC\nRequested space: %s\nReference: %s\n\nSubmitting an inquiry does not place a hold or confirm the booking. Reply to this email to continue this booking thread.",
+			$booking['artist_name'],
+			$venue->name,
+			$booking['requested_start_at'] ? $booking['requested_start_at'] : 'Not specified',
+			$booking['requested_end_at'] ? $booking['requested_end_at'] : 'Not specified',
+			$this->space_name( $booking, true ),
+			$booking['public_id']
+		);
+		$result  = $this->communication->request_automatic( (int) $booking['id'], (int) $source['id'], 'inquiry_receipt', $message );
+		return $this->accepted( $result ) ? $this->complete_source( $source, array( 'template' => 'inquiry_receipt' ) ) : $result;
+	}
+
+	private function process_competitors( array $source ) {
+		$confirmed = $this->bookings->get( (int) $source['booking_id'] );
+		if ( ! is_array( $confirmed ) || 'confirmed' !== $confirmed['status'] ) {
+			return is_wp_error( $confirmed ) ? $confirmed : $this->complete_source( $source, array( 'reason' => 'confirmation_no_longer_current' ) );
+		}
+		$batch = $this->activity->find_by_external_id( (int) $confirmed['id'], 'booking_correspondence_batch_completed', (string) $source['id'] );
+		if ( is_wp_error( $batch ) ) {
+			return $batch;
+		}
+		$after      = is_array( $batch ) ? (int) ( $batch['payload']['data']['after_booking_id'] ?? 0 ) : 0;
+		$candidates = $this->bookings->list_competing_requests( $confirmed, $after, self::BATCH_SIZE );
+		if ( is_wp_error( $candidates ) ) {
+			return $candidates;
+		}
+		foreach ( $candidates as $candidate ) {
+			$current = $this->bookings->get( (int) $candidate['id'] );
+			if ( ! is_array( $current ) || ! $this->still_competes( $current, $confirmed ) ) {
+				continue;
+			}
+			$message = sprintf(
+				'The interval you requested at %s (%s to %s UTC, %s) has been filled. Your inquiry has not been declined: reply to this email with another exact date, start/end time, and space you would like us to review.',
+				$this->venue_name( $confirmed ),
+				$current['requested_start_at'],
+				$current['requested_end_at'],
+				$this->space_name( $current, true )
+			);
+			$result  = $this->communication->request_automatic( (int) $current['id'], (int) $source['id'], 'date_filled', $message );
+			if ( ! $this->accepted( $result ) ) {
+				return $result;
+			}
+		}
+		if ( count( $candidates ) < self::BATCH_SIZE ) {
+			return $this->complete_source( $source, array( 'template' => 'date_filled' ) );
+		}
+		$last   = end( $candidates );
+		$cursor = (int) $last['id'];
+		$marker = $this->activity->append(
+			array(
+				'booking_id'      => $confirmed['id'],
+				'kind'            => 'booking_correspondence_batch_completed',
+				'actor_type'      => 'system',
+				'external_id'     => (string) $source['id'],
+				'idempotency_key' => sprintf( 'booking-correspondence-batch:%d:%d', $source['id'], $cursor ),
+				'payload'         => array( 'after_booking_id' => $cursor ),
+			)
+		);
+		$this->schedule_reconciliation();
+		return is_wp_error( $marker ) ? $marker : array( 'completed' => false );
+	}
+
+	private function still_competes( array $candidate, array $confirmed ): bool {
+		$terminal = array( 'confirmed', 'declined', 'withdrawn', 'cancelled', 'completed' );
+		return ! in_array( $candidate['status'], $terminal, true )
+			&& (int) $candidate['venue_term_id'] === (int) $confirmed['venue_term_id']
+			&& (string) $candidate['requested_space_key'] === (string) $confirmed['space_key']
+			&& ! empty( $candidate['requested_start_at'] )
+			&& ! empty( $candidate['requested_end_at'] )
+			&& $candidate['requested_start_at'] < $confirmed['performance_end_at']
+			&& $candidate['requested_end_at'] > $confirmed['performance_start_at'];
+	}
+
+	private function complete_source( array $source, array $payload ) {
+		$record = $this->activity->append(
+			array(
+				'booking_id'      => $source['booking_id'],
+				'kind'            => 'booking_correspondence_source_completed',
+				'actor_type'      => 'system',
+				'external_id'     => (string) $source['id'],
+				'idempotency_key' => 'booking-correspondence-source:' . $source['id'],
+				'payload'         => array_merge( array( 'source_activity_id' => (int) $source['id'] ), $payload ),
+			)
+		);
+		return is_wp_error( $record ) ? $record : array( 'completed' => true );
+	}
+
+	private function accepted( $state ): bool {
+		return is_array( $state ) && 'queued' === ( $state['status'] ?? '' );
+	}
+
+	private function venue_name( array $booking ): string {
+		$venue = get_term( (int) $booking['venue_term_id'], 'venue' );
+		return $venue && ! is_wp_error( $venue ) ? (string) $venue->name : __( 'the venue', 'extrachill-events' );
+	}
+
+	private function space_name( array $booking, bool $requested ): string {
+		$key    = (string) ( $requested ? $booking['requested_space_key'] : $booking['space_key'] );
+		$config = $this->config->get( (int) $booking['venue_term_id'] );
+		if ( is_array( $config ) ) {
+			foreach ( $config['spaces'] as $space ) {
+				if ( $key === $space['key'] ) {
+					return (string) $space['name'];
+				}
+			}
+		}
+		return '' !== $key ? $key : __( 'Not specified', 'extrachill-events' );
+	}
+
+	private function schedule_reconciliation(): void {
+		if ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action( time() + 1, self::RECONCILE_HOOK, array(), self::SCHEDULER_GROUP, true );
+		}
+	}
+}

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -931,7 +931,13 @@ class BookingHoldRepository {
 					)
 				);
 				$committed = $this->commit();
-				return is_wp_error( $committed ) ? $committed : $output;
+				if ( is_wp_error( $committed ) ) {
+					return $committed;
+				}
+				if ( 'confirmed' === $to_status ) {
+					BookingCorrespondenceAutomationService::emit( (int) $event['id'] );
+				}
+				return $output;
 			}
 		);
 	}

--- a/inc/Core/BookingLifecycle.php
+++ b/inc/Core/BookingLifecycle.php
@@ -328,6 +328,7 @@ class BookingLifecycle {
 			return $committed;
 		}
 		BookingNotificationService::emit( BookingNotificationService::TYPE_INQUIRY_SUBMITTED, (int) $event['id'] );
+		BookingCorrespondenceAutomationService::emit( (int) $event['id'] );
 		return $this->bookings->get( $locked['id'] );
 	}
 

--- a/inc/Core/BookingRepository.php
+++ b/inc/Core/BookingRepository.php
@@ -354,6 +354,31 @@ class BookingRepository {
 		return $hydrated;
 	}
 
+	/** List a bounded cursor page of requests competing with one confirmed interval. */
+	public function list_competing_requests( array $confirmed, int $after_id = 0, int $limit = 25 ) {
+		global $wpdb;
+		if ( 'confirmed' !== ( $confirmed['status'] ?? '' ) || empty( $confirmed['space_key'] ) || empty( $confirmed['performance_start_at'] ) || empty( $confirmed['performance_end_at'] ) ) {
+			return new \WP_Error( 'booking_competing_interval_invalid', __( 'The confirmed booking interval is invalid.', 'extrachill-events' ) );
+		}
+		$table    = BookingSchema::bookings_table();
+		$limit    = max( 1, min( 50, $limit ) );
+		$terminal = array( 'confirmed', 'declined', 'withdrawn', 'cancelled', 'completed', 'admission_pending' );
+		$sql      = "SELECT * FROM {$table} WHERE venue_term_id = %d AND requested_space_key = %s AND requested_start_at < %s AND requested_end_at > %s AND id <> %d AND id > %d AND status NOT IN ('" . implode( "','", $terminal ) . "') ORDER BY id ASC LIMIT %d"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Fixed status allowlist and trusted table.
+		$rows     = $wpdb->get_results( $wpdb->prepare( $sql, $confirmed['venue_term_id'], $confirmed['space_key'], $confirmed['performance_end_at'], $confirmed['performance_start_at'], $confirmed['id'], max( 0, $after_id ), $limit ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Values are prepared.
+		if ( '' !== (string) $wpdb->last_error || ! is_array( $rows ) ) {
+			return new \WP_Error( 'booking_competing_requests_read_failed', __( 'Competing booking requests could not be read.', 'extrachill-events' ) );
+		}
+		$items = array();
+		foreach ( $rows as $row ) {
+			$item = $this->hydrate( $row );
+			if ( is_wp_error( $item ) ) {
+				return $item;
+			}
+			$items[] = $item;
+		}
+		return $items;
+	}
+
 	/** Conditionally update mutable booking fields at an expected version. */
 	public function update( int $id, array $changes, int $expected_version ) {
 		global $wpdb;

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -22,7 +22,7 @@ class VenueBookingConfig {
 	public const CORRESPONDENCE_VERSION      = 1;
 	public const TEMPLATE_VERSION            = 1;
 	public const REMINDER_POLICY_VERSION     = 1;
-	public const CORRESPONDENCE_TEMPLATES    = array( 'operator_message', 'follow_up', 'hold_expiring' );
+	public const CORRESPONDENCE_TEMPLATES    = array( 'operator_message', 'follow_up', 'hold_expiring', 'inquiry_receipt', 'date_filled' );
 	public const CORRESPONDENCE_VARIABLES    = array( 'artist_name', 'booking_id', 'contact_name', 'venue_name' );
 	public const CONSENT_VERSION             = 1;
 	public const SOCIAL_MARKETING_ACTION     = 'datamachine-socials/cross-post';
@@ -406,6 +406,16 @@ class VenueBookingConfig {
 						'version' => self::TEMPLATE_VERSION,
 						'subject' => 'Booking hold update for {{artist_name}}',
 						'body'    => "A reminder about your booking hold at {{venue_name}}:\n\n{{message}}",
+					),
+					'inquiry_receipt'  => array(
+						'version' => self::TEMPLATE_VERSION,
+						'subject' => 'Booking inquiry received at {{venue_name}} [{{booking_id}}]',
+						'body'    => "Hello {{contact_name}},\n\n{{message}}",
+					),
+					'date_filled'      => array(
+						'version' => self::TEMPLATE_VERSION,
+						'subject' => 'Booking date update from {{venue_name}}',
+						'body'    => "Hello {{contact_name}},\n\n{{message}}",
 					),
 				),
 				'reminder_policies' => array(

--- a/tests/BookingCorrespondenceAutomationTest.php
+++ b/tests/BookingCorrespondenceAutomationTest.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Booking lifecycle correspondence automation tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Core\BookingActivityRepository;
+use ExtraChillEvents\Core\BookingCommunicationService;
+use ExtraChillEvents\Core\BookingCorrespondenceAutomationService;
+use ExtraChillEvents\Core\BookingRepository;
+use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\VenueBookingConfig;
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
+final class BookingCorrespondenceAutomationTest extends BookingTestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id'         => 7,
+			'stack'           => array(),
+			'uuid'            => 0,
+			'options'         => array(),
+			'abilities'       => array(),
+			'actions'         => array(),
+			'fired_actions'   => array(),
+			'scheduled'       => array(),
+			'cache_deletes'   => array(),
+			'terms'           => array(
+				7 => array(
+					55 => (object) array( 'term_id' => 55, 'taxonomy' => 'venue', 'name' => 'Lo-Fi Brewing' ),
+					56 => (object) array( 'term_id' => 56, 'taxonomy' => 'venue', 'name' => 'Other Room' ),
+				),
+			),
+			'meta'            => array(
+				7 => array(
+					55 => array(
+						VenueBookingConfig::META_KEY => array(
+							'enabled'        => true,
+							'spaces'         => array( array( 'key' => 'main-room', 'name' => 'Main Room', 'is_default' => true ) ),
+							'correspondence' => array( 'booking_address' => 'booking@lofi.example' ),
+						),
+					),
+					56 => array( VenueBookingConfig::META_KEY => array( 'enabled' => true ) ),
+				),
+			),
+			'posts'           => array(),
+			'post_meta'       => array(),
+		);
+		$GLOBALS['wpdb'] = new BookingWpdb();
+	}
+
+	private function booking( array $overrides = array() ): array {
+		return ( new BookingRepository() )->create(
+			array_merge(
+				array(
+					'venue_term_id'       => 55,
+					'artist_name'         => 'Test Band',
+					'contact_name'        => 'Band Manager',
+					'contact_email'       => 'artist@example.com',
+					'requested_space_key' => 'main-room',
+					'requested_start_at'  => '2030-08-01 20:00:00',
+					'requested_end_at'    => '2030-08-01 23:00:00',
+					'intake'              => array(),
+				),
+				$overrides
+			)
+		);
+	}
+
+	private function source( array $booking, string $kind ): array {
+		return ( new BookingActivityRepository() )->append(
+			array(
+				'booking_id'      => $booking['id'],
+				'kind'            => $kind,
+				'actor_type'      => 'system',
+				'idempotency_key' => $kind . ':' . $booking['id'],
+				'payload'         => array( 'status' => $booking['status'] ),
+			)
+		);
+	}
+
+	private function service( array &$queued, bool $success = true ): BookingCorrespondenceAutomationService {
+		$communication = new BookingCommunicationService(
+			null,
+			null,
+			null,
+			static function ( array $input ) use ( &$queued, $success ) {
+				$queued[] = $input;
+				return $success ? array( 'success' => true, 'action_id' => 100 + count( $queued ) ) : array( 'success' => false, 'error' => 'temporary' );
+			}
+		);
+		return new BookingCorrespondenceAutomationService( null, null, $communication );
+	}
+
+	public function test_committed_inquiry_receipt_is_threaded_private_and_replay_safe(): void {
+		$booking = $this->booking();
+		$source  = $this->source( $booking, 'inquiry_submitted' );
+		$queued  = array();
+		$service = $this->service( $queued );
+
+		$this->assertSame( array( 'completed' => true ), $service->reconcile_source( $source['id'] ) );
+		$this->assertSame( array( 'completed' => true ), $service->reconcile_source( $source['id'] ) );
+		$this->assertCount( 1, $queued );
+		$this->assertSame( 'artist@example.com', $queued[0]['to'] );
+		$this->assertSame( 'chubes@extrachill.com', $queued[0]['cc'] );
+		$this->assertSame( 'booking@lofi.example', $queued[0]['reply_to'] );
+		$this->assertStringContainsString( 'pending review', $queued[0]['body'] );
+		$this->assertStringContainsString( 'does not place a hold or confirm', $queued[0]['body'] );
+		$this->assertStringContainsString( $booking['public_id'], $queued[0]['body'] );
+		$this->assertStringContainsString( "Extra Chill Bot sending on Chris's behalf.", $queued[0]['body'] );
+		$this->assertArrayNotHasKey( 'attachments', $queued[0] );
+	}
+
+	public function test_failed_queue_retries_from_durable_intent_without_duplicate_request(): void {
+		$booking = $this->booking();
+		$source  = $this->source( $booking, 'inquiry_submitted' );
+		$queued  = array();
+		$failed  = $this->service( $queued, false )->reconcile_source( $source['id'] );
+		$this->assertSame( 'booking_message_queue_failed', $failed->get_error_code() );
+
+		$recovered = $this->service( $queued, true )->reconcile_source( $source['id'] );
+		$this->assertSame( array( 'completed' => true ), $recovered );
+		$activities = array_values( $GLOBALS['wpdb']->rows[ BookingSchema::activity_table() ] );
+		$this->assertCount( 1, array_filter( $activities, static function ( array $row ): bool { return 'booking_message_requested' === $row['kind']; } ) );
+	}
+
+	public function test_confirmation_notifies_only_current_half_open_same_space_competitors(): void {
+		$selected = $this->booking(
+			array(
+				'artist_name'          => 'Selected Artist',
+				'contact_email'        => 'selected@example.com',
+				'space_key'            => 'main-room',
+				'performance_start_at' => '2030-08-01 20:00:00',
+				'performance_end_at'   => '2030-08-01 23:00:00',
+			)
+		);
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $selected['id'] ]['status'] = 'confirmed';
+		$selected['status'] = 'confirmed';
+		$overlap = $this->booking( array( 'artist_name' => 'Overlap', 'contact_email' => 'overlap@example.com', 'requested_start_at' => '2030-08-01 22:00:00', 'requested_end_at' => '2030-08-02 00:00:00' ) );
+		$this->booking( array( 'artist_name' => 'Adjacent', 'contact_email' => 'adjacent@example.com', 'requested_start_at' => '2030-08-01 23:00:00', 'requested_end_at' => '2030-08-02 01:00:00' ) );
+		$this->booking( array( 'venue_term_id' => 56, 'artist_name' => 'Elsewhere', 'contact_email' => 'elsewhere@example.com', 'requested_space_key' => 'main-room' ) );
+		$terminal = $this->booking( array( 'artist_name' => 'Declined', 'contact_email' => 'declined@example.com' ) );
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $terminal['id'] ]['status'] = 'declined';
+		$source = $this->source( $selected, 'deal_confirmed' );
+		$queued = array();
+
+		$this->assertSame( array( 'completed' => true ), $this->service( $queued )->reconcile_source( $source['id'] ) );
+		$this->assertCount( 1, $queued );
+		$this->assertSame( 'overlap@example.com', $queued[0]['to'] );
+		$this->assertStringContainsString( 'has been filled', $queued[0]['body'] );
+		$this->assertStringContainsString( 'reply to this email with another exact date', $queued[0]['body'] );
+		$this->assertStringNotContainsString( 'Selected Artist', $queued[0]['body'] );
+		$this->assertStringNotContainsString( $selected['public_id'], $queued[0]['body'] );
+		$this->assertSame( 'submitted', ( new BookingRepository() )->get( $overlap['id'] )['status'] );
+	}
+
+	public function test_partial_competing_fanout_retries_only_the_failed_recipient(): void {
+		$selected = $this->booking(
+			array(
+				'contact_email'        => 'selected@example.com',
+				'space_key'            => 'main-room',
+				'performance_start_at' => '2030-08-01 20:00:00',
+				'performance_end_at'   => '2030-08-01 23:00:00',
+			)
+		);
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $selected['id'] ]['status'] = 'confirmed';
+		$selected['status'] = 'confirmed';
+		$this->booking( array( 'contact_email' => 'first@example.com' ) );
+		$this->booking( array( 'contact_email' => 'second@example.com' ) );
+		$source = $this->source( $selected, 'deal_confirmed' );
+		$calls  = array();
+		$fail   = true;
+		$queue  = static function ( array $input ) use ( &$calls, &$fail ) {
+			$calls[] = $input['to'];
+			if ( $fail && 'second@example.com' === $input['to'] ) {
+				return array( 'success' => false, 'error' => 'temporary' );
+			}
+			return array( 'success' => true, 'action_id' => 200 + count( $calls ) );
+		};
+		$automation = static function () use ( $queue ): BookingCorrespondenceAutomationService {
+			return new BookingCorrespondenceAutomationService( null, null, new BookingCommunicationService( null, null, null, $queue ) );
+		};
+
+		$first = $automation()->reconcile_source( $source['id'] );
+		$this->assertSame( 'booking_message_queue_failed', $first->get_error_code() );
+		$fail = false;
+		$this->assertSame( array( 'completed' => true ), $automation()->reconcile_source( $source['id'] ) );
+		$this->assertSame( array( 'completed' => true ), $automation()->reconcile_source( $source['id'] ) );
+		$this->assertSame( array( 'first@example.com', 'second@example.com', 'second@example.com' ), $calls );
+		$activities = array_values( $GLOBALS['wpdb']->rows[ BookingSchema::activity_table() ] );
+		$this->assertCount( 2, array_filter( $activities, static function ( array $row ): bool { return 'booking_message_requested' === $row['kind']; } ) );
+	}
+}

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -8,6 +8,7 @@
 use ExtraChillEvents\Core\BookingActivityRepository;
 use ExtraChillEvents\Core\BookingAttachmentPolicy;
 use ExtraChillEvents\Core\BookingCommunicationService;
+use ExtraChillEvents\Core\BookingCorrespondenceAutomationService;
 use ExtraChillEvents\Core\BookingNotificationService;
 use ExtraChillEvents\Core\BookingPrivateFileProvider;
 use ExtraChillEvents\Core\BookingLifecycle;
@@ -1350,6 +1351,43 @@ final class BookingWpdb {
 		if ( $this->fail_reads ) {
 			$this->last_error = 'simulated result read failure';
 			return null; }
+		if ( false !== strpos( $query, 'SELECT source.* FROM' ) && false !== strpos( $query, "source.kind IN ('inquiry_submitted', 'deal_confirmed')" ) ) {
+			preg_match( '/LIMIT (\d+)/', $query, $limit );
+			$completed = array();
+			foreach ( $this->rows[ $this->prefix . 'ec_booking_activity' ] ?? array() as $row ) {
+				if ( 'booking_correspondence_source_completed' === $row['kind'] ) {
+					$completed[] = (string) $row['external_id'];
+				}
+			}
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $this->prefix . 'ec_booking_activity' ] ?? array(),
+					static function ( $row ) use ( $completed ) {
+						return in_array( $row['kind'], array( 'inquiry_submitted', 'deal_confirmed' ), true ) && ! in_array( (string) $row['id'], $completed, true );
+					}
+				)
+			);
+			usort( $rows, static function ( $left, $right ) { return $left['id'] <=> $right['id']; } );
+			return array_slice( $rows, 0, (int) ( $limit[1] ?? 25 ) );
+		}
+		if ( false !== strpos( $query, 'SELECT * FROM' ) && false !== strpos( $query, 'requested_space_key =' ) && preg_match( "/venue_term_id = (\d+) AND requested_space_key = '([^']+)' AND requested_start_at < '([^']+)' AND requested_end_at > '([^']+)'.*id <> (\d+) AND id > (\d+).*LIMIT (\d+)/", $query, $match ) ) {
+			$rows = array_values(
+				array_filter(
+					$this->rows[ $this->prefix . 'ec_bookings' ] ?? array(),
+					static function ( $row ) use ( $match ) {
+						return (int) $row['venue_term_id'] === (int) $match[1]
+							&& $row['requested_space_key'] === stripslashes( $match[2] )
+							&& $row['requested_start_at'] < $match[3]
+							&& $row['requested_end_at'] > $match[4]
+							&& (int) $row['id'] !== (int) $match[5]
+							&& (int) $row['id'] > (int) $match[6]
+							&& ! in_array( $row['status'], array( 'confirmed', 'declined', 'withdrawn', 'cancelled', 'completed', 'admission_pending' ), true );
+					}
+				)
+			);
+			usort( $rows, static function ( $left, $right ) { return $left['id'] <=> $right['id']; } );
+			return array_slice( $rows, 0, (int) $match[7] );
+		}
 		if ( false !== strpos( $query, 'SELECT source.* FROM' ) && false !== strpos( $query, "source.kind IN ('inquiry_submitted'" ) ) {
 			preg_match( '/LIMIT (\d+)/', $query, $limit );
 			$requests = array();
@@ -2129,6 +2167,7 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingAttachmentDeliveryReposit
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingAttachmentService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingInquiryAdmissionService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueBookingConfig.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingCorrespondenceAutomationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/TicketReconciliationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/TicketSettlementService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/ShowSettlementService.php';


### PR DESCRIPTION
## Summary
- Queue a deterministic, replyable submitter receipt only after `inquiry_submitted` commits, repeating artist, venue, exact requested UTC interval/space, public reference, pending-review state, and the no-hold/no-confirmation disclaimer.
- Recover lifecycle correspondence from the existing activity ledger and route it through `BookingCommunicationService`, preserving configured template/version/revision evidence, durable claims, retry state, Data Machine queue receipts, CC to Chris, bot disclosure, and attachment exclusion.
- After `deal_confirmed` commits, page through same-venue/same-space half-open interval overlaps, revalidate each nonterminal candidate immediately before queueing, and send one privacy-safe alternate-date reply prompt per applicable request.

## Lifecycle And Outbox
- Inquiry and confirmation transactions commit before the automation emitter runs; queue failures cannot roll back either lifecycle mutation.
- A five-minute recurring recovery pass finds landed `inquiry_submitted` and `deal_confirmed` sources without completion markers.
- Email intents use source/template/booking-scoped idempotency keys and the existing communication state machine. Partial fan-out replay resumes failed recipients without requeueing successful ones.
- Competing fan-out uses bounded 25-record cursor batches with durable batch markers and follow-up scheduling.

## Email Policy
- Adds venue-configured `inquiry_receipt` and `date_filled` correspondence templates at version 1.
- Every message uses `Extra Chill Bot`, CCs `chubes@extrachill.com`, and includes `Extra Chill Bot sending on Chris's behalf.`
- The configured booking address remains `Reply-To`, establishing the existing inbound booking thread.
- No private attachments or attachment references are accepted by this path.

## Selection And Privacy
- Competitors must match exact venue and requested space and overlap the confirmed performance interval using half-open boundaries (`request_start < confirmed_end` and `request_end > confirmed_start`).
- Confirmed, declined, withdrawn, cancelled, completed, cross-venue, cross-space, adjacent, and stale requests are excluded.
- Filled-date copy does not reveal the selected artist, deal, booking/reference IDs, request counts, or other applicants, and leaves the competing request in its recoverable lifecycle status.

## Calendar Audit
- No second calendar or event model was added. The existing authorization-gated booking calendar already renders overlapping records independently, includes visible status text, and applies stable pending/review, held/negotiating, confirmed/completed, and terminal tones.
- Pending requests remain private booking records and are not converted to canonical events by this work.

## #524 Dependency
- Main does not yet contain #524's secure date-first alternate-date continuation. Filled-date notices therefore use the existing reply-ingestion thread as the safe initial continuation and do not expose or trust booking IDs in public query parameters.
- A canonical `Choose another date` link can be added after #524 lands with its privacy-safe continuation contract; this PR does not absorb #524's form implementation.

## Verification
- `vendor/bin/phpunit tests/BookingCorrespondenceAutomationTest.php` (4 tests, 27 assertions)
- Affected booking suites: 211 tests, 1,541 assertions passed across automation, communication, admission, holds, foundation, mutation, notification, and conversion
- `npm run test:js -- --runInBand` (15 suites, 80 tests)
- `npm run lint:js`
- `npm run build`
- PHP syntax checks and `git diff --check`
- Homeboy changed-file PHPCS and ESLint passed. Homeboy PHPStan is blocked by its extension-default WordPress bootstrap model (381 repository-context findings, including the existing `is_wp_error()` signature), and the Homeboy WP integration test adapter is blocked before execution because `WP_CODEBOX_DB_HOST` is unavailable. The unscoped PHPUnit config likewise includes `WP_UnitTestCase` tests without that bootstrap.

Closes #525