### PR TITLE
feat: make venue booking inquiries date-first

### DIFF
--- a/blocks/venue-booking-inquiry/render.php
+++ b/blocks/venue-booking-inquiry/render.php
@@ -39,7 +39,7 @@ $canonical = ( static function () use ( $events_blog_id, $venue_id ) {
 			return null;
 		}
 
-		$supported_types = array( 'text', 'textarea', 'email', 'phone', 'number', 'select', 'checkbox', 'url' );
+		$supported_types = array( 'text', 'textarea', 'email', 'phone', 'number', 'select', 'checkbox', 'url', 'url_list' );
 		foreach ( $booking_config['fields'] as $field ) {
 			if ( ! in_array( $field['type'], $supported_types, true ) ) {
 				return null;
@@ -77,9 +77,15 @@ if ( ! is_array( $canonical ) ) {
 	return;
 }
 
-$booking_config = $canonical['booking_config'];
-$instance       = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'ec-booking-' ) : 'ec-booking-' . $venue_id;
-$logged_in      = is_user_logged_in();
+$booking_config       = $canonical['booking_config'];
+$instance             = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'ec-booking-' ) : 'ec-booking-' . $venue_id;
+$logged_in            = is_user_logged_in();
+$manage_link_page_url = function_exists( 'ec_get_site_url' ) ? trailingslashit( ec_get_site_url( 'artist' ) ) . 'manage-link-page/' : '';
+$link_page_count      = $logged_in && function_exists( 'ec_get_link_page_count_for_user' ) ? ec_get_link_page_count_for_user( get_current_user_id() ) : 0;
+$link_page_url        = $manage_link_page_url;
+if ( ! $logged_in && '' !== $manage_link_page_url && function_exists( 'ec_users_login_url_with_redirect' ) && function_exists( 'ec_get_site_url' ) ) {
+	$link_page_url = ec_users_login_url_with_redirect( trailingslashit( ec_get_site_url( 'community' ) ) . 'login/', $manage_link_page_url );
+}
 if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 	define( 'DONOTCACHEPAGE', true );
 }
@@ -89,18 +95,25 @@ if ( function_exists( 'ec_enqueue_turnstile_script' ) ) {
 }
 
 $public_config = array(
-	'instanceId'    => $instance,
-	'endpoint'      => rest_url( 'extrachill/v1/venues/' . $venue_id . '/booking-inquiries' ),
-	'restNonce'     => $logged_in ? wp_create_nonce( 'wp_rest' ) : '',
-	'authenticated' => $logged_in,
-	'heading'       => sanitize_text_field( (string) ( $attributes['heading'] ?? __( 'Booking inquiries', 'extrachill-events' ) ) ),
-	'buttonLabel'   => sanitize_text_field( (string) ( $attributes['buttonLabel'] ?? __( 'Send booking inquiry', 'extrachill-events' ) ) ),
-	'revision'      => (int) $booking_config['revision'],
-	'venue'         => $canonical['venue'],
-	'requirements'  => array_values( $booking_config['public_requirements'] ),
-	'spaces'        => array_values( $booking_config['spaces'] ),
-	'fields'        => array_values( $booking_config['fields'] ),
-	'consent'       => $booking_config['consent'],
+	'instanceId'           => $instance,
+	'endpoint'             => rest_url( 'extrachill/v1/venues/' . $venue_id . '/booking-inquiries' ),
+	'availabilityEndpoint' => rest_url( 'extrachill/v1/venues/' . $venue_id . '/booking-availability' ),
+	'restNonce'            => $logged_in ? wp_create_nonce( 'wp_rest' ) : '',
+	'authenticated'        => $logged_in,
+	'heading'              => sanitize_text_field( (string) ( $attributes['heading'] ?? __( 'Booking inquiries', 'extrachill-events' ) ) ),
+	'buttonLabel'          => sanitize_text_field( (string) ( $attributes['buttonLabel'] ?? __( 'Send booking inquiry', 'extrachill-events' ) ) ),
+	'revision'             => (int) $booking_config['revision'],
+	'venue'                => $canonical['venue'],
+	'requirements'         => array_values( $booking_config['public_requirements'] ),
+	'spaces'               => array_values( $booking_config['spaces'] ),
+	'fields'               => array_values( $booking_config['fields'] ),
+	'presentation'         => $booking_config['presentation'],
+	'consent'              => $booking_config['consent'],
+	'linkPage'             => array(
+		'url'           => (string) $link_page_url,
+		'hasPage'       => $link_page_count > 0,
+		'authenticated' => $logged_in,
+	),
 );
 
 $json = wp_json_encode( $public_config, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );

--- a/blocks/venue-booking-inquiry/src/style.scss
+++ b/blocks/venue-booking-inquiry/src/style.scss
@@ -37,6 +37,34 @@
 	width: 100%;
 }
 
+.ec-booking-inquiry__step {
+	border: 0;
+	display: grid;
+	gap: 1rem;
+	margin: 0;
+	max-width: 100%;
+	min-width: 0;
+	padding: 0;
+	width: 100%;
+}
+
+.ec-booking-inquiry__step > * {
+	max-width: 100%;
+	min-width: 0;
+}
+
+.ec-booking-inquiry__step > legend {
+	font-size: 1.25rem;
+	font-weight: 700;
+	margin-bottom: 0.25rem;
+}
+
+.ec-booking-inquiry__step > p {
+	color: var(--muted-text);
+	margin: 0;
+	max-width: 70ch;
+}
+
 .ec-booking-inquiry__checkbox,
 .ec-booking-inquiry__consent {
 	align-items: start;

--- a/blocks/venue-booking-inquiry/src/submission.js
+++ b/blocks/venue-booking-inquiry/src/submission.js
@@ -39,6 +39,32 @@ export const buildPayload = ( config, values, idempotencyKey, token ) => ( {
 	turnstile_response: token,
 } );
 
+export const buildAvailabilityPayload = ( config, values ) => ( {
+	venue: config.venue.id,
+	requested_space_key: values.spaceKey,
+	requested_start_at: apiDate( values.startAt ),
+	requested_end_at: apiDate( values.endAt ),
+} );
+
+export const availabilityErrorState = ( response, payload ) => {
+	if (
+		response.status === 429 ||
+		payload?.code === 'public_read_rate_limited'
+	) {
+		return {
+			tone: 'warning',
+			message:
+				'Too many availability checks were made. Wait a moment and try again.',
+		};
+	}
+	return {
+		tone: response.status >= 500 ? 'error' : 'warning',
+		message:
+			payload?.message ||
+			'Availability could not be checked. Review the time and try again.',
+	};
+};
+
 export const errorState = ( response, payload ) => {
 	const code = payload?.code || '';
 	if ( response.status === 429 || code === 'public_write_rate_limited' ) {
@@ -55,6 +81,17 @@ export const errorState = ( response, payload ) => {
 			retryable: false,
 			message:
 				'This venue updated its booking form. Refresh the page before sending.',
+		};
+	}
+	if ( code === 'booking_inquiry_interval_unavailable' ) {
+		return {
+			tone: 'warning',
+			retryable: true,
+			rotateKey: true,
+			resetAvailability: true,
+			message:
+				payload?.message ||
+				'That time filled while you completed the form. Choose another time and try again.',
 		};
 	}
 	if ( code === 'booking_idempotency_conflict' ) {

--- a/blocks/venue-booking-inquiry/src/submission.test.js
+++ b/blocks/venue-booking-inquiry/src/submission.test.js
@@ -3,7 +3,13 @@
 /**
  * Internal dependencies
  */
-import { apiDate, buildPayload, errorState } from './submission';
+import {
+	apiDate,
+	availabilityErrorState,
+	buildAvailabilityPayload,
+	buildPayload,
+	errorState,
+} from './submission';
 
 const config = {
 	venue: { id: 42 },
@@ -17,7 +23,7 @@ const values = {
 	contactPhone: '',
 	spaceKey: 'main-room',
 	startAt: '2026-08-12T20:00',
-	endAt: '',
+	endAt: '2026-08-12T23:00',
 	message: 'Routing through Charleston.',
 	fields: { draw: '150' },
 	consent: true,
@@ -45,7 +51,7 @@ describe( 'booking inquiry transport helpers', () => {
 			contact_phone: null,
 			requested_space_key: 'main-room',
 			requested_start_at: '2026-08-12 20:00:00',
-			requested_end_at: null,
+			requested_end_at: '2026-08-12 23:00:00',
 			intake: {
 				config_revision: 7,
 				message: 'Routing through Charleston.',
@@ -56,6 +62,15 @@ describe( 'booking inquiry transport helpers', () => {
 		} );
 		expect( payload ).not.toHaveProperty( 'user_id' );
 		expect( payload ).not.toHaveProperty( 'attachments' );
+	} );
+
+	test( 'builds a privacy-safe exact interval availability request', () => {
+		expect( buildAvailabilityPayload( config, values ) ).toEqual( {
+			venue: 42,
+			requested_space_key: 'main-room',
+			requested_start_at: '2026-08-12 20:00:00',
+			requested_end_at: '2026-08-12 23:00:00',
+		} );
 	} );
 
 	test( 'distinguishes safe retry, stale config, and reconciliation states', () => {
@@ -78,5 +93,17 @@ describe( 'booking inquiry transport helpers', () => {
 				{ code: 'booking_inquiry_reconciliation_required' }
 			).message
 		).toContain( 'Do not resend' );
+		expect(
+			errorState(
+				{ status: 409, headers },
+				{ code: 'booking_inquiry_interval_unavailable' }
+			).resetAvailability
+		).toBe( true );
+		expect(
+			availabilityErrorState(
+				{ status: 409 },
+				{ message: 'That exact time is unavailable.' }
+			).message
+		).toBe( 'That exact time is unavailable.' );
 	} );
 } );

--- a/blocks/venue-booking-inquiry/src/view.js
+++ b/blocks/venue-booking-inquiry/src/view.js
@@ -22,7 +22,13 @@ import {
 /**
  * Internal dependencies
  */
-import { buildPayload, errorState, newIdempotencyKey } from './submission';
+import {
+	availabilityErrorState,
+	buildAvailabilityPayload,
+	buildPayload,
+	errorState,
+	newIdempotencyKey,
+} from './submission';
 
 const initialValues = ( config ) => ( {
 	artistName: '',
@@ -82,6 +88,17 @@ const Field = ( { field, value, onChange, prefix } ) => {
 				onChange={ ( event ) => onChange( event.target.value ) }
 			/>
 		);
+	} else if ( field.type === 'url_list' ) {
+		control = (
+			<textarea
+				id={ id }
+				rows="4"
+				value={ value }
+				required={ field.required }
+				placeholder="One https:// link per line"
+				onChange={ ( event ) => onChange( event.target.value ) }
+			/>
+		);
 	} else if ( field.type === 'select' ) {
 		control = (
 			<select
@@ -114,6 +131,8 @@ function BookingInquiry( { config, wrapper } ) {
 	const [ values, setValues ] = useState( () => initialValues( config ) );
 	const [ status, setStatus ] = useState( null );
 	const [ submitting, setSubmitting ] = useState( false );
+	const [ checking, setChecking ] = useState( false );
+	const [ intervalOpen, setIntervalOpen ] = useState( false );
 	const [ receipt, setReceipt ] = useState( null );
 	const key = useRef( newIdempotencyKey() );
 	const turnstileTarget = useRef();
@@ -125,17 +144,20 @@ function BookingInquiry( { config, wrapper } ) {
 		if ( source && turnstileTarget.current ) {
 			turnstileTarget.current.appendChild( source );
 		}
-	}, [ wrapper ] );
+	}, [ wrapper, intervalOpen ] );
 	useEffect( () => {
 		if ( status || receipt ) {
 			resultRef.current?.focus();
 		}
 	}, [ status, receipt ] );
 
-	const update = ( patch ) => {
+	const update = ( patch, resetInterval = false ) => {
 		key.current = newIdempotencyKey();
 		setValues( ( current ) => ( { ...current, ...patch } ) );
 		setStatus( null );
+		if ( resetInterval ) {
+			setIntervalOpen( false );
+		}
 	};
 	const updateField = ( fieldKey, value ) =>
 		update( { fields: { ...values.fields, [ fieldKey ]: value } } );
@@ -147,9 +169,57 @@ function BookingInquiry( { config, wrapper } ) {
 			window.ecTurnstileBoot?.();
 		}
 	};
+	const checkAvailability = async () => {
+		setChecking( true );
+		setStatus( { tone: 'info', message: 'Checking that exact time...' } );
+		try {
+			const headers = { 'Content-Type': 'application/json' };
+			if ( config.restNonce ) {
+				headers[ 'X-WP-Nonce' ] = config.restNonce;
+			}
+			const response = await fetch( config.availabilityEndpoint, {
+				method: 'POST',
+				credentials: 'same-origin',
+				headers,
+				body: JSON.stringify(
+					buildAvailabilityPayload( config, values )
+				),
+			} );
+			const payload = await response.json().catch( () => ( {} ) );
+			if ( ! response.ok ) {
+				setStatus( availabilityErrorState( response, payload ) );
+				return;
+			}
+			if ( payload.available !== true ) {
+				setStatus( {
+					tone: 'warning',
+					message:
+						'That exact time is unavailable. Choose another time to continue.',
+				} );
+				return;
+			}
+			setIntervalOpen( true );
+			setStatus( {
+				tone: 'success',
+				message:
+					'That time is open for inquiries. Complete the booking details below.',
+			} );
+		} catch {
+			setStatus( {
+				tone: 'error',
+				message: 'The availability check was interrupted. Try again.',
+			} );
+		} finally {
+			setChecking( false );
+		}
+	};
 	const submit = async ( event ) => {
 		event.preventDefault();
 		if ( submitting || ! event.currentTarget.reportValidity() ) {
+			return;
+		}
+		if ( ! intervalOpen ) {
+			await checkAvailability();
 			return;
 		}
 		const token =
@@ -184,6 +254,9 @@ function BookingInquiry( { config, wrapper } ) {
 				const next = errorState( response, payload );
 				if ( next.rotateKey ) {
 					key.current = newIdempotencyKey();
+				}
+				if ( next.resetAvailability ) {
+					setIntervalOpen( false );
 				}
 				setStatus( next );
 				return;
@@ -230,6 +303,24 @@ function BookingInquiry( { config, wrapper } ) {
 			</BlockShell>
 		);
 	}
+	const visibleFields = config.fields.filter( ( field ) => {
+		if ( ! field.visible_when ) {
+			return true;
+		}
+		return (
+			String( values.fields[ field.visible_when.field ] ?? '' ) ===
+			field.visible_when.value
+		);
+	} );
+	const hasLinkFields = visibleFields.some( ( field ) =>
+		[ 'url', 'url_list' ].includes( field.type )
+	);
+	let submitLabel = 'Check availability';
+	if ( checking ) {
+		submitLabel = 'Checking...';
+	} else if ( intervalOpen ) {
+		submitLabel = submitting ? 'Sending...' : config.buttonLabel;
+	}
 
 	return (
 		<BlockShell>
@@ -273,185 +364,264 @@ function BookingInquiry( { config, wrapper } ) {
 					onSubmit={ submit }
 					noValidate={ false }
 				>
-					<Grid minColumnWidth="16rem" maxColumns={ 2 }>
-						<FieldGroup
-							label="Artist or project name"
-							htmlFor={ `${ prefix }-artist` }
-							required
-						>
-							<input
-								id={ `${ prefix }-artist` }
-								value={ values.artistName }
-								maxLength="255"
-								required
-								autoComplete="organization"
-								onChange={ ( event ) =>
-									update( { artistName: event.target.value } )
-								}
-							/>
-						</FieldGroup>
-						<FieldGroup
-							label="Contact name"
-							htmlFor={ `${ prefix }-contact` }
-							required
-						>
-							<input
-								id={ `${ prefix }-contact` }
-								value={ values.contactName }
-								maxLength="255"
-								required
-								autoComplete="name"
-								onChange={ ( event ) =>
-									update( {
-										contactName: event.target.value,
-									} )
-								}
-							/>
-						</FieldGroup>
-						<FieldGroup
-							label="Contact email"
-							htmlFor={ `${ prefix }-email` }
-							required
-						>
-							<input
-								id={ `${ prefix }-email` }
-								type="email"
-								value={ values.contactEmail }
-								maxLength="255"
-								required
-								autoComplete="email"
-								onChange={ ( event ) =>
-									update( {
-										contactEmail: event.target.value,
-									} )
-								}
-							/>
-						</FieldGroup>
-						<FieldGroup
-							label="Contact phone"
-							htmlFor={ `${ prefix }-phone` }
-						>
-							<input
-								id={ `${ prefix }-phone` }
-								type="tel"
-								value={ values.contactPhone }
-								maxLength="64"
-								autoComplete="tel"
-								onChange={ ( event ) =>
-									update( {
-										contactPhone: event.target.value,
-									} )
-								}
-							/>
-						</FieldGroup>
-						{ config.spaces.length > 0 && (
+					<fieldset className="ec-booking-inquiry__step">
+						<legend>1. Check your requested time</legend>
+						<p>
+							Availability uses the exact start and end time.
+							Other non-overlapping events on the same date do not
+							block an inquiry.
+						</p>
+						<Grid minColumnWidth="16rem" maxColumns={ 2 }>
+							{ config.spaces.length > 0 && (
+								<FieldGroup
+									label="Requested space"
+									htmlFor={ `${ prefix }-space` }
+									required
+								>
+									<select
+										id={ `${ prefix }-space` }
+										value={ values.spaceKey }
+										required
+										onChange={ ( event ) =>
+											update(
+												{
+													spaceKey:
+														event.target.value,
+												},
+												true
+											)
+										}
+									>
+										{ config.spaces.map( ( space ) => (
+											<option
+												key={ space.key }
+												value={ space.key }
+											>
+												{ space.name }
+											</option>
+										) ) }
+									</select>
+								</FieldGroup>
+							) }
 							<FieldGroup
-								label="Requested space"
-								htmlFor={ `${ prefix }-space` }
+								label="Requested start"
+								htmlFor={ `${ prefix }-start` }
+								required
 							>
-								<select
-									id={ `${ prefix }-space` }
-									value={ values.spaceKey }
+								<input
+									id={ `${ prefix }-start` }
+									type="datetime-local"
+									value={ values.startAt }
+									required
+									onChange={ ( event ) =>
+										update(
+											{ startAt: event.target.value },
+											true
+										)
+									}
+								/>
+							</FieldGroup>
+							<FieldGroup
+								label="Requested end"
+								htmlFor={ `${ prefix }-end` }
+								help="An exact end time is required for interval availability."
+								required
+							>
+								<input
+									id={ `${ prefix }-end` }
+									type="datetime-local"
+									value={ values.endAt }
+									min={ values.startAt }
+									required
+									onChange={ ( event ) =>
+										update(
+											{ endAt: event.target.value },
+											true
+										)
+									}
+								/>
+							</FieldGroup>
+						</Grid>
+					</fieldset>
+					{ intervalOpen && (
+						<>
+							<fieldset className="ec-booking-inquiry__step">
+								<legend>
+									2. Complete your booking inquiry
+								</legend>
+								<p>
+									Provide the full decision-making details
+									requested by this venue.
+								</p>
+								<Grid minColumnWidth="16rem" maxColumns={ 2 }>
+									<FieldGroup
+										label={
+											config.presentation
+												.artist_name_label
+										}
+										htmlFor={ `${ prefix }-artist` }
+										required
+									>
+										<input
+											id={ `${ prefix }-artist` }
+											value={ values.artistName }
+											maxLength="255"
+											required
+											autoComplete="organization"
+											onChange={ ( event ) =>
+												update( {
+													artistName:
+														event.target.value,
+												} )
+											}
+										/>
+									</FieldGroup>
+									<FieldGroup
+										label={
+											config.presentation
+												.contact_name_label
+										}
+										htmlFor={ `${ prefix }-contact` }
+										required
+									>
+										<input
+											id={ `${ prefix }-contact` }
+											value={ values.contactName }
+											maxLength="255"
+											required
+											autoComplete="name"
+											onChange={ ( event ) =>
+												update( {
+													contactName:
+														event.target.value,
+												} )
+											}
+										/>
+									</FieldGroup>
+									<FieldGroup
+										label={
+											config.presentation
+												.contact_email_label
+										}
+										htmlFor={ `${ prefix }-email` }
+										required
+									>
+										<input
+											id={ `${ prefix }-email` }
+											type="email"
+											value={ values.contactEmail }
+											maxLength="255"
+											required
+											autoComplete="email"
+											onChange={ ( event ) =>
+												update( {
+													contactEmail:
+														event.target.value,
+												} )
+											}
+										/>
+									</FieldGroup>
+									<FieldGroup
+										label={
+											config.presentation
+												.contact_phone_label
+										}
+										htmlFor={ `${ prefix }-phone` }
+									>
+										<input
+											id={ `${ prefix }-phone` }
+											type="tel"
+											value={ values.contactPhone }
+											maxLength="64"
+											autoComplete="tel"
+											onChange={ ( event ) =>
+												update( {
+													contactPhone:
+														event.target.value,
+												} )
+											}
+										/>
+									</FieldGroup>
+									{ visibleFields.map( ( field ) => (
+										<Field
+											key={ field.key }
+											field={ field }
+											value={ values.fields[ field.key ] }
+											prefix={ prefix }
+											onChange={ ( value ) =>
+												updateField( field.key, value )
+											}
+										/>
+									) ) }
+								</Grid>
+							</fieldset>
+							{ hasLinkFields && config.linkPage.url && (
+								<Panel>
+									<h4>Share one Link Page instead</h4>
+									<p>
+										This is optional. Paste direct links
+										above, or use a free Extra Chill Link
+										Page for music, socials, videos, and
+										press. It does not affect booking
+										priority.
+									</p>
+									<a
+										href={ config.linkPage.url }
+										className="button-2"
+									>
+										{ config.linkPage.hasPage
+											? 'Use or manage your Link Page'
+											: 'Create a free Link Page' }
+									</a>
+								</Panel>
+							) }
+							<FieldGroup
+								label={ config.presentation.message_label }
+								htmlFor={ `${ prefix }-message` }
+								help={ config.presentation.message_help }
+								required
+							>
+								<textarea
+									id={ `${ prefix }-message` }
+									rows="6"
+									maxLength="10000"
+									value={ values.message }
+									required
 									onChange={ ( event ) =>
 										update( {
-											spaceKey: event.target.value,
+											message: event.target.value,
 										} )
 									}
-								>
-									{ config.spaces.map( ( space ) => (
-										<option
-											key={ space.key }
-											value={ space.key }
-										>
-											{ space.name }
-										</option>
-									) ) }
-								</select>
+								/>
 							</FieldGroup>
-						) }
-						<FieldGroup
-							label="Requested start"
-							htmlFor={ `${ prefix }-start` }
-							required
-						>
-							<input
-								id={ `${ prefix }-start` }
-								type="datetime-local"
-								value={ values.startAt }
-								required
-								onChange={ ( event ) =>
-									update( { startAt: event.target.value } )
-								}
+							<label
+								className="ec-booking-inquiry__consent"
+								htmlFor={ `${ prefix }-consent` }
+							>
+								<input
+									id={ `${ prefix }-consent` }
+									type="checkbox"
+									required={ config.consent.required }
+									checked={ values.consent }
+									onChange={ ( event ) =>
+										update( {
+											consent: event.target.checked,
+										} )
+									}
+								/>{ ' ' }
+								<span>
+									{ config.consent.label }
+									{ config.consent.required && (
+										<span aria-hidden="true"> *</span>
+									) }
+								</span>
+							</label>
+							<div
+								className="ec-booking-inquiry__turnstile"
+								ref={ turnstileTarget }
 							/>
-						</FieldGroup>
-						<FieldGroup
-							label="Requested end"
-							htmlFor={ `${ prefix }-end` }
-							help="Optional if timing is flexible."
-						>
-							<input
-								id={ `${ prefix }-end` }
-								type="datetime-local"
-								value={ values.endAt }
-								min={ values.startAt }
-								onChange={ ( event ) =>
-									update( { endAt: event.target.value } )
-								}
-							/>
-						</FieldGroup>
-						{ config.fields.map( ( field ) => (
-							<Field
-								key={ field.key }
-								field={ field }
-								value={ values.fields[ field.key ] }
-								prefix={ prefix }
-								onChange={ ( value ) =>
-									updateField( field.key, value )
-								}
-							/>
-						) ) }
-					</Grid>
-					<FieldGroup
-						label="Performance details"
-						htmlFor={ `${ prefix }-message` }
-						help="Share lineup, draw, routing, links, and anything the venue should know."
-						required
-					>
-						<textarea
-							id={ `${ prefix }-message` }
-							rows="6"
-							maxLength="10000"
-							value={ values.message }
-							required
-							onChange={ ( event ) =>
-								update( { message: event.target.value } )
-							}
-						/>
-					</FieldGroup>
-					<label
-						className="ec-booking-inquiry__consent"
-						htmlFor={ `${ prefix }-consent` }
-					>
-						<input
-							id={ `${ prefix }-consent` }
-							type="checkbox"
-							required={ config.consent.required }
-							checked={ values.consent }
-							onChange={ ( event ) =>
-								update( { consent: event.target.checked } )
-							}
-						/>{ ' ' }
-						<span>
-							{ config.consent.label }
-							{ config.consent.required && (
-								<span aria-hidden="true"> *</span>
-							) }
-						</span>
-					</label>
-					<div
-						className="ec-booking-inquiry__turnstile"
-						ref={ turnstileTarget }
-					/>
+						</>
+					) }
 					<div ref={ resultRef } tabIndex="-1" aria-live="polite">
 						{ status && (
 							<InlineStatus tone={ status.tone }>
@@ -463,9 +633,9 @@ function BookingInquiry( { config, wrapper } ) {
 						<button
 							className="button-1 button-large"
 							type="submit"
-							disabled={ submitting }
+							disabled={ submitting || checking }
 						>
-							{ submitting ? 'Sending...' : config.buttonLabel }
+							{ submitLabel }
 						</button>
 						<span className="ec-booking-inquiry__privacy">
 							Your inquiry is sent privately and never added to

--- a/blocks/venue-settings/src/intake-public.js
+++ b/blocks/venue-settings/src/intake-public.js
@@ -4,6 +4,15 @@
 import { FieldGroup, Panel, PanelHeader } from '@extrachill/components';
 
 export default function PublicBookingDetails( { config, setConfig } ) {
+	const presentation = config.intake.presentation;
+	const labels = [
+		[ 'artist_name_label', 'Artist name label' ],
+		[ 'contact_name_label', 'Contact name label' ],
+		[ 'contact_email_label', 'Contact email label' ],
+		[ 'contact_phone_label', 'Contact phone label' ],
+		[ 'message_label', 'Additional details label' ],
+		[ 'message_help', 'Additional details help' ],
+	];
 	return (
 		<Panel>
 			<PanelHeader
@@ -29,6 +38,38 @@ export default function PublicBookingDetails( { config, setConfig } ) {
 						} )
 					}
 				/>
+			</FieldGroup>
+			<FieldGroup
+				label="Built-in field presentation"
+				htmlFor="venue-booking-presentation"
+				help="Venue-specific wording for stable contact and details fields."
+			>
+				<div id="venue-booking-presentation">
+					{ labels.map( ( [ key, label ] ) => (
+						<FieldGroup
+							key={ key }
+							label={ label }
+							htmlFor={ `venue-${ key }` }
+						>
+							<input
+								id={ `venue-${ key }` }
+								value={ presentation[ key ] }
+								onChange={ ( event ) =>
+									setConfig( {
+										...config,
+										intake: {
+											...config.intake,
+											presentation: {
+												...presentation,
+												[ key ]: event.target.value,
+											},
+										},
+									} )
+								}
+							/>
+						</FieldGroup>
+					) ) }
+				</div>
 			</FieldGroup>
 			<FieldGroup
 				label="Consent label"

--- a/blocks/venue-settings/src/intake-tab.js
+++ b/blocks/venue-settings/src/intake-tab.js
@@ -18,6 +18,7 @@ const INTAKE_TYPES = [
 	'select',
 	'checkbox',
 	'url',
+	'url_list',
 ];
 
 export function IntakeTab( { config, setConfig } ) {
@@ -128,6 +129,61 @@ export function IntakeTab( { config, setConfig } ) {
 								/>
 							</FieldGroup>
 						) }
+						<FieldGroup
+							label="Show only when"
+							htmlFor={ `intake-condition-field-${ index }` }
+							help="Optional. Conditional fields may depend on an earlier field."
+						>
+							<select
+								id={ `intake-condition-field-${ index }` }
+								value={ field.visible_when?.field || '' }
+								onChange={ ( event ) =>
+									update( index, {
+										visible_when: event.target.value
+											? {
+													field: event.target.value,
+													value:
+														field.visible_when
+															?.value || '',
+											  }
+											: null,
+									} )
+								}
+							>
+								<option value="">Always show</option>
+								{ fields
+									.slice( 0, index )
+									.map( ( controller ) => (
+										<option
+											key={ controller.key }
+											value={ controller.key }
+										>
+											{ controller.label ||
+												controller.key }
+										</option>
+									) ) }
+							</select>
+						</FieldGroup>
+						{ field.visible_when && (
+							<FieldGroup
+								label="Matching value"
+								htmlFor={ `intake-condition-value-${ index }` }
+								required
+							>
+								<input
+									id={ `intake-condition-value-${ index }` }
+									value={ field.visible_when.value }
+									onChange={ ( event ) =>
+										update( index, {
+											visible_when: {
+												...field.visible_when,
+												value: event.target.value,
+											},
+										} )
+									}
+								/>
+							</FieldGroup>
+						) }
 						<label htmlFor={ `intake-required-${ index }` }>
 							<input
 								id={ `intake-required-${ index }` }
@@ -168,6 +224,7 @@ export function IntakeTab( { config, setConfig } ) {
 								type: 'text',
 								required: false,
 								options: [],
+								visible_when: null,
 							},
 						] )
 					}

--- a/blocks/venue-settings/src/state.js
+++ b/blocks/venue-settings/src/state.js
@@ -52,7 +52,7 @@ export const validateConfig = ( config ) => {
 	}
 
 	const fieldKeys = new Set();
-	config.intake.fields.forEach( ( field ) => {
+	config.intake.fields.forEach( ( field, index ) => {
 		if ( ! field.key || ! field.label ) {
 			errors.push( 'Each intake field needs a label and key.' );
 		}
@@ -62,6 +62,20 @@ export const validateConfig = ( config ) => {
 		fieldKeys.add( field.key );
 		if ( field.type === 'select' && ! field.options.length ) {
 			errors.push( 'Select fields need at least one option.' );
+		}
+		if (
+			field.visible_when &&
+			( ! field.visible_when.value ||
+				! config.intake.fields
+					.slice( 0, index )
+					.some(
+						( candidate ) =>
+							candidate.key === field.visible_when.field
+					) )
+		) {
+			errors.push(
+				'Conditional fields need an earlier field and matching value.'
+			);
 		}
 	} );
 	if ( config.hold_ttl_minutes < 5 || config.hold_ttl_minutes > 10080 ) {

--- a/inc/Abilities/VenueBookingAbilities.php
+++ b/inc/Abilities/VenueBookingAbilities.php
@@ -125,6 +125,32 @@ class VenueBookingAbilities {
 		);
 
 		wp_register_ability(
+			'extrachill/check-booking-availability',
+			array(
+				'label'               => __( 'Check Booking Availability', 'extrachill-events' ),
+				'description'         => __( 'Return only whether a requested venue-space interval is filled by a confirmed booking or canonical published event.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => $this->availability_schema(),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array( 'available' => array( 'type' => 'boolean' ) ),
+					'required'             => array( 'available' ),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => array( $this, 'check_availability' ),
+				'permission_callback' => '__return_true',
+				'meta'                => array(
+					'show_in_rest' => false,
+					'annotations'  => array(
+						'readonly'    => true,
+						'idempotent'  => true,
+						'destructive' => false,
+					),
+				),
+			)
+		);
+
+		wp_register_ability(
 			'extrachill/list-venue-bookings',
 			array(
 				'label'               => __( 'List Venue Bookings', 'extrachill-events' ),
@@ -336,6 +362,20 @@ class VenueBookingAbilities {
 	public function create_inquiry( array $input ) {
 		$user_id = get_current_user_id();
 		return $this->inquiry_admission->admit( $input, $user_id > 0 ? $user_id : null );
+	}
+
+	/**
+	 * Return the privacy-safe public interval projection.
+	 *
+	 * @param array $input Exact venue interval input.
+	 */
+	public function check_availability( array $input ) {
+		return $this->holds->public_interval_availability(
+			(int) $input['venue_term_id'],
+			(string) $input['requested_space_key'],
+			(string) $input['requested_start_at'],
+			(string) $input['requested_end_at']
+		);
 	}
 
 	/**
@@ -566,6 +606,32 @@ class VenueBookingAbilities {
 				),
 			),
 			'required'             => array( 'idempotency_key', 'venue_term_id', 'intake' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	/** Return the exact local venue interval accepted by the public facade. */
+	private function availability_schema(): array {
+		$datetime = array(
+			'type'    => 'string',
+			'pattern' => '^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$',
+		);
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'venue_term_id'       => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'requested_space_key' => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 64,
+				),
+				'requested_start_at'  => $datetime,
+				'requested_end_at'    => $datetime,
+			),
+			'required'             => array( 'venue_term_id', 'requested_space_key', 'requested_start_at', 'requested_end_at' ),
 			'additionalProperties' => false,
 		);
 	}

--- a/inc/Abilities/VenueBookingConfigAbilities.php
+++ b/inc/Abilities/VenueBookingConfigAbilities.php
@@ -183,25 +183,25 @@ class VenueBookingConfigAbilities {
 
 	/** Return the complete settings schema, optionally with read metadata. */
 	private function config_schema( bool $include_metadata, bool $accept_legacy = false ): array {
-		$field_schema = array(
+		$field_schema        = array(
 			'type'                 => 'object',
 			'properties'           => array(
-				'key'      => array(
+				'key'          => array(
 					'type'      => 'string',
 					'minLength' => 1,
 					'maxLength' => 64,
 				),
-				'label'    => array(
+				'label'        => array(
 					'type'      => 'string',
 					'minLength' => 1,
 					'maxLength' => 191,
 				),
-				'type'     => array(
+				'type'         => array(
 					'type' => 'string',
-					'enum' => array( 'text', 'textarea', 'email', 'phone', 'number', 'select', 'checkbox', 'url' ),
+					'enum' => array( 'text', 'textarea', 'email', 'phone', 'number', 'select', 'checkbox', 'url', 'url_list' ),
 				),
-				'required' => array( 'type' => 'boolean' ),
-				'options'  => array(
+				'required'     => array( 'type' => 'boolean' ),
+				'options'      => array(
 					'type'     => 'array',
 					'maxItems' => 100,
 					'items'    => array(
@@ -209,11 +209,41 @@ class VenueBookingConfigAbilities {
 						'maxLength' => 191,
 					),
 				),
+				'visible_when' => array(
+					'type'                 => array( 'object', 'null' ),
+					'properties'           => array(
+						'field' => array(
+							'type'      => 'string',
+							'minLength' => 1,
+							'maxLength' => 64,
+						),
+						'value' => array(
+							'type'      => 'string',
+							'minLength' => 1,
+							'maxLength' => 191,
+						),
+					),
+					'required'             => array( 'field', 'value' ),
+					'additionalProperties' => false,
+				),
 			),
 			'required'             => array( 'key', 'label', 'type', 'required', 'options' ),
 			'additionalProperties' => false,
 		);
-		$properties   = array(
+		$presentation_schema = array(
+			'type'                 => 'object',
+			'properties'           => array_fill_keys(
+				array( 'artist_name_label', 'contact_name_label', 'contact_email_label', 'contact_phone_label', 'message_label', 'message_help' ),
+				array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 500,
+				)
+			),
+			'required'             => array( 'artist_name_label', 'contact_name_label', 'contact_email_label', 'contact_phone_label', 'message_label', 'message_help' ),
+			'additionalProperties' => false,
+		);
+		$properties          = array(
 			'version'                   => array(
 				'type' => 'integer',
 				'enum' => array( VenueBookingConfig::VERSION ),
@@ -222,17 +252,18 @@ class VenueBookingConfigAbilities {
 			'intake'                    => array(
 				'type'                 => 'object',
 				'properties'           => array(
-					'version' => array(
+					'version'      => array(
 						'type' => 'integer',
 						'enum' => array( 1 ),
 					),
-					'fields'  => array(
+					'fields'       => array(
 						'type'     => 'array',
 						'maxItems' => 50,
 						'items'    => $field_schema,
 					),
+					'presentation' => $presentation_schema,
 				),
-				'required'             => array( 'version', 'fields' ),
+				'required'             => array( 'version', 'fields', 'presentation' ),
 				'additionalProperties' => false,
 			),
 			'public_requirements'       => array(
@@ -342,7 +373,7 @@ class VenueBookingConfigAbilities {
 			),
 			'correspondence'            => $this->correspondence_schema(),
 		);
-		$required     = array( 'version', 'enabled', 'intake', 'public_requirements', 'consent', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
+		$required            = array( 'version', 'enabled', 'intake', 'public_requirements', 'consent', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
 		if ( $include_metadata ) {
 			$properties['revision']           = array(
 				'type'    => 'integer',
@@ -367,9 +398,10 @@ class VenueBookingConfigAbilities {
 		if ( ! $accept_legacy ) {
 			return $schema;
 		}
-		$previous                                  = $schema;
-		$previous['properties']['version']['enum'] = array( VenueBookingConfig::PREVIOUS_VERSION );
-		$previous['required']                      = array_values( array_diff( $previous['required'], array( 'public_requirements', 'consent', 'marketing_triggers' ) ) );
+		$previous                                     = $schema;
+		$previous['properties']['version']['enum']    = array( VenueBookingConfig::PREVIOUS_VERSION );
+		$previous['required']                         = array_values( array_diff( $previous['required'], array( 'public_requirements', 'consent', 'marketing_triggers' ) ) );
+		$previous['properties']['intake']['required'] = array_values( array_diff( $previous['properties']['intake']['required'], array( 'presentation' ) ) );
 		unset( $previous['properties']['public_requirements'], $previous['properties']['consent'], $previous['properties']['marketing_triggers'] );
 		$legacy                                  = $previous;
 		$legacy['properties']['version']['enum'] = array( VenueBookingConfig::LEGACY_VERSION );

--- a/inc/Core/BookingEventConversionService.php
+++ b/inc/Core/BookingEventConversionService.php
@@ -392,7 +392,7 @@ class BookingEventConversionService {
 				'performerType' => 'PerformingGroup',
 				'venue'         => $venue->name,
 				'eventStatus'   => 'EventScheduled',
-				'eventType'     => 'MusicEvent',
+				'eventType'     => $this->canonical_event_type( $booking ),
 			),
 			$metadata
 		);
@@ -410,6 +410,16 @@ class BookingEventConversionService {
 			'post_status' => 'publish',
 			'event'       => $event,
 		);
+	}
+
+	/**
+	 * Map the configured booking classification into DME's canonical Schema.org field.
+	 *
+	 * @param array $booking Hydrated confirmed booking.
+	 */
+	private function canonical_event_type( array $booking ): string {
+		$fields = is_array( $booking['intake']['data']['fields'] ?? null ) ? $booking['intake']['data']['fields'] : array();
+		return ! isset( $fields['event_type'] ) || 'Concert' === $fields['event_type'] ? 'MusicEvent' : 'Event';
 	}
 
 	/** Require DME to return the exact canonical identity and venue proof requested. */

--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -947,16 +947,119 @@ class BookingHoldRepository {
 		return is_array( $row ) ? $this->hydrate( $row ) : null;
 	}
 
-	/** Detect hold, confirmed-booking, then canonical published-event conflicts. */
-	private function find_conflict( array $booking, int $excluded_hold_id ) {
-		global $wpdb;
-		$holds = BookingSchema::holds_table();
-		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT id, booking_id, 'hold' AS conflict_type FROM {$holds} WHERE venue_term_id = %d AND space_key = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND start_at < %s AND end_at > %s AND booking_id <> %d AND id <> %d LIMIT 1", $booking['venue_term_id'], $booking['space_key'], $booking['performance_end_at'], $booking['performance_start_at'], $booking['id'], $excluded_hold_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serialized database-time overlap check.
-		if ( '' !== (string) $wpdb->last_error ) {
-			return new \WP_Error( 'booking_conflict_check_failed', __( 'Booking conflicts could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+	/**
+	 * Return the privacy-safe filled state for one requested local venue interval.
+	 *
+	 * @param int    $venue_id Venue term ID.
+	 * @param string $space_key Configured booking space.
+	 * @param string $start_at Venue-local interval start.
+	 * @param string $end_at Venue-local interval end.
+	 */
+	public function public_interval_availability( int $venue_id, string $space_key, string $start_at, string $end_at ) {
+		return $this->with_public_interval( $venue_id, $space_key, $start_at, $end_at );
+	}
+
+	/**
+	 * Execute final public admission while filled-state writers are excluded.
+	 *
+	 * @param array    $input Public inquiry input.
+	 * @param callable $callback Admission callback.
+	 */
+	public function admit_public_interval( array $input, callable $callback ) {
+		$intake = is_array( $input['intake'] ?? null ) ? $input['intake'] : array();
+		if ( ! array_key_exists( 'config_revision', $intake ) ) {
+			return $callback();
 		}
-		if ( is_array( $row ) ) {
-			return $row;
+		return $this->with_public_interval(
+			absint( $input['venue_term_id'] ?? 0 ),
+			(string) ( $input['requested_space_key'] ?? '' ),
+			(string) ( $input['requested_start_at'] ?? '' ),
+			(string) ( $input['requested_end_at'] ?? '' ),
+			$callback
+		);
+	}
+
+	/**
+	 * Check one interval and optionally execute admission before releasing its locks.
+	 *
+	 * @param int           $venue_id Venue term ID.
+	 * @param string        $space_key Configured booking space.
+	 * @param string        $start_at Venue-local interval start.
+	 * @param string        $end_at Venue-local interval end.
+	 * @param callable|null $available_callback Optional admission callback.
+	 */
+	private function with_public_interval( int $venue_id, string $space_key, string $start_at, string $end_at, ?callable $available_callback = null ) {
+		$space_key = mb_substr( sanitize_key( $space_key ), 0, 64 );
+		if ( $venue_id < 1 || '' === $space_key || ! $this->valid_datetime( $start_at ) || ! $this->valid_datetime( $end_at ) || $end_at <= $start_at ) {
+			return new \WP_Error( 'booking_availability_interval_invalid', __( 'Choose a valid space, start time, and end time.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+
+		$config = $this->config->get( $venue_id );
+		if ( is_wp_error( $config ) ) {
+			return $config;
+		}
+		if ( empty( $config['enabled'] ) || ! $this->configured_space( $config, $space_key ) ) {
+			return new \WP_Error( 'booking_availability_unavailable', __( 'Availability cannot be checked for this selection.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+
+		$venue_data = function_exists( 'data_machine_events_get_venue_data' ) ? data_machine_events_get_venue_data( $venue_id ) : null;
+		try {
+			$timezone = new \DateTimeZone( is_array( $venue_data ) ? (string) ( $venue_data['timezone'] ?? '' ) : '' );
+		} catch ( \Exception $exception ) {
+			return new \WP_Error(
+				'booking_availability_unavailable',
+				__( 'Availability cannot be checked for this selection.', 'extrachill-events' ),
+				array(
+					'status'    => 503,
+					'retryable' => true,
+				)
+			);
+		}
+		$local_start = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $start_at, $timezone );
+		$local_end   = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $end_at, $timezone );
+		if ( false === $local_start || false === $local_end || $local_start->format( 'Y-m-d H:i:s' ) !== $start_at || $local_end->format( 'Y-m-d H:i:s' ) !== $end_at || $local_end <= $local_start ) {
+			return new \WP_Error( 'booking_availability_interval_invalid', __( 'Choose a valid space, start time, and end time.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$utc     = new \DateTimeZone( 'UTC' );
+		$booking = array(
+			'id'                   => 0,
+			'event_id'             => 0,
+			'venue_term_id'        => $venue_id,
+			'space_key'            => $space_key,
+			'performance_start_at' => $local_start->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
+			'performance_end_at'   => $local_end->setTimezone( $utc )->format( 'Y-m-d H:i:s' ),
+		);
+
+		return $this->with_booking_locks(
+			$venue_id,
+			$space_key,
+			function () use ( $booking, $available_callback ) {
+				$conflict = $this->find_conflict( $booking, 0, false );
+				if ( is_wp_error( $conflict ) ) {
+					return $conflict;
+				}
+				if ( is_array( $conflict ) ) {
+					return $available_callback
+						? new \WP_Error( 'booking_inquiry_interval_unavailable', __( 'That time was filled while you completed the form. Choose another time and try again.', 'extrachill-events' ), array( 'status' => 409 ) )
+						: array( 'available' => false );
+				}
+				return $available_callback ? $available_callback() : array( 'available' => true );
+			}
+		);
+	}
+
+	/** Detect hold, confirmed-booking, then canonical published-event conflicts. */
+	private function find_conflict( array $booking, int $excluded_hold_id, bool $include_holds = true ) {
+		global $wpdb;
+		if ( $include_holds ) {
+			$holds = BookingSchema::holds_table();
+			$row   = $wpdb->get_row( $wpdb->prepare( "SELECT id, booking_id, 'hold' AS conflict_type FROM {$holds} WHERE venue_term_id = %d AND space_key = %s AND status = 'active' AND expires_at > UTC_TIMESTAMP() AND start_at < %s AND end_at > %s AND booking_id <> %d AND id <> %d LIMIT 1", $booking['venue_term_id'], $booking['space_key'], $booking['performance_end_at'], $booking['performance_start_at'], $booking['id'], $excluded_hold_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serialized database-time overlap check.
+			if ( '' !== (string) $wpdb->last_error ) {
+				return new \WP_Error( 'booking_conflict_check_failed', __( 'Booking conflicts could not be checked.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+			}
+			if ( is_array( $row ) ) {
+				return $row;
+			}
 		}
 		$bookings = BookingSchema::bookings_table();
 		$row      = $wpdb->get_row( $wpdb->prepare( "SELECT id, 'confirmed_booking' AS conflict_type FROM {$bookings} WHERE venue_term_id = %d AND space_key = %s AND status = 'confirmed' AND performance_start_at < %s AND performance_end_at > %s AND id <> %d LIMIT 1", $booking['venue_term_id'], $booking['space_key'], $booking['performance_end_at'], $booking['performance_start_at'], $booking['id'] ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serialized overlap check.

--- a/inc/Core/BookingInquiryAdmissionService.php
+++ b/inc/Core/BookingInquiryAdmissionService.php
@@ -53,6 +53,8 @@ final class BookingInquiryAdmissionService {
 	private $bookings;
 	/** @var BookingActivityRepository */
 	private $activity;
+	/** @var BookingHoldRepository */
+	private $availability;
 
 	/**
 	 * Build the admission coordinator from existing domain services.
@@ -62,12 +64,16 @@ final class BookingInquiryAdmissionService {
 	 * @param BookingAttachmentService|null    $attachment_service Attachment writes.
 	 * @param mixed                            $provider            Private provider.
 	 * @param BookingAttachmentPolicy|null     $policy              File policy.
+	 * @param BookingRepository|null           $bookings            Booking reads.
+	 * @param BookingActivityRepository|null   $activity            Activity writes.
+	 * @param BookingHoldRepository|null       $availability        Filled-interval policy.
 	 */
-	public function __construct( ?BookingLifecycle $lifecycle = null, ?BookingAttachmentRepository $attachments = null, ?BookingAttachmentService $attachment_service = null, $provider = null, ?BookingAttachmentPolicy $policy = null, ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null ) {
+	public function __construct( ?BookingLifecycle $lifecycle = null, ?BookingAttachmentRepository $attachments = null, ?BookingAttachmentService $attachment_service = null, $provider = null, ?BookingAttachmentPolicy $policy = null, ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?BookingHoldRepository $availability = null ) {
 		$this->lifecycle          = $lifecycle ? $lifecycle : new BookingLifecycle();
 		$this->attachments        = $attachments ? $attachments : new BookingAttachmentRepository();
 		$this->bookings           = $bookings ? $bookings : new BookingRepository();
 		$this->activity           = $activity ? $activity : new BookingActivityRepository();
+		$this->availability       = $availability ? $availability : new BookingHoldRepository( $this->bookings, $this->activity );
 		$this->policy             = $policy ? $policy : new BookingAttachmentPolicy();
 		$resolved                 = null !== $provider ? $provider : BookingPrivateFileProviders::resolve();
 		$this->provider           = $resolved instanceof BookingPrivateFileProvider || is_wp_error( $resolved )
@@ -130,7 +136,19 @@ final class BookingInquiryAdmissionService {
 			},
 			$files
 		);
-		$booking     = $this->lifecycle->reserve_inquiry( $input, $actor_id, $manifest ? array( 'attachments' => $manifest ) : array(), $owner_token );
+		$replay      = $this->lifecycle->replay_completed_inquiry( $input, $actor_id, $manifest ? array( 'attachments' => $manifest ) : array() );
+		if ( is_wp_error( $replay ) ) {
+			return $this->public_error( $replay );
+		}
+		if ( is_array( $replay ) ) {
+			return $this->receipt( $replay );
+		}
+		$booking = $this->availability->admit_public_interval(
+			$input,
+			function () use ( $input, $actor_id, $manifest, $owner_token ) {
+				return $this->lifecycle->reserve_inquiry( $input, $actor_id, $manifest ? array( 'attachments' => $manifest ) : array(), $owner_token );
+			}
+		);
 		if ( is_wp_error( $booking ) ) {
 			return $this->public_error( $booking );
 		}

--- a/inc/Core/BookingLifecycle.php
+++ b/inc/Core/BookingLifecycle.php
@@ -209,37 +209,74 @@ class BookingLifecycle {
 		$values     = is_array( $intake['fields'] ?? null ) ? $intake['fields'] : array();
 		$normalized = array();
 		foreach ( $config['intake']['fields'] as $field ) {
+			$condition = $field['visible_when'] ?? null;
+			$visible   = ! is_array( $condition ) || (string) ( $normalized[ $condition['field'] ] ?? '' ) === (string) $condition['value'];
+			if ( ! $visible ) {
+				$normalized[ $field['key'] ] = 'checkbox' === $field['type'] ? false : ( 'url_list' === $field['type'] ? array() : '' );
+				continue;
+			}
 			$value = $values[ $field['key'] ] ?? ( 'checkbox' === $field['type'] ? false : '' );
 			if ( 'checkbox' === $field['type'] ) {
 				$value = true === $value;
 			} elseif ( 'number' === $field['type'] ) {
 				$value = '' === $value ? '' : filter_var( $value, FILTER_VALIDATE_FLOAT );
 				if ( false === $value ) {
-					return new \WP_Error( 'booking_inquiry_field_invalid', __( 'A configured booking field is invalid.', 'extrachill-events' ), array(
-						'status' => 400,
-						'field'  => $field['key'],
-					) );
+					return new \WP_Error(
+						'booking_inquiry_field_invalid',
+						__( 'A configured booking field is invalid.', 'extrachill-events' ),
+						array(
+							'status' => 400,
+							'field'  => $field['key'],
+						)
+					);
 				}
 			} elseif ( 'textarea' === $field['type'] ) {
 				$value = sanitize_textarea_field( (string) $value );
 			} elseif ( 'email' === $field['type'] ) {
 				$value = sanitize_email( (string) $value );
+			} elseif ( 'url_list' === $field['type'] ) {
+				$lines = is_array( $value ) ? $value : preg_split( '/\R/', (string) $value );
+				$value = array_values( array_filter( array_map( 'trim', array_slice( (array) $lines, 0, 20 ) ) ) );
+				foreach ( $value as $index => $url ) {
+					$sanitized = esc_url_raw( $url );
+					$scheme    = wp_parse_url( $sanitized, PHP_URL_SCHEME );
+					$host      = wp_parse_url( $sanitized, PHP_URL_HOST );
+					if ( '' === $sanitized || $sanitized !== $url || ! in_array( $scheme, array( 'http', 'https' ), true ) || ! is_string( $host ) || '' === $host ) {
+						return new \WP_Error(
+							'booking_inquiry_field_invalid',
+							__( 'A configured booking field is invalid.', 'extrachill-events' ),
+							array(
+								'status' => 400,
+								'field'  => $field['key'],
+							)
+						);
+					}
+					$value[ $index ] = $sanitized;
+				}
 			} elseif ( 'url' === $field['type'] ) {
 				$value = esc_url_raw( (string) $value );
 			} else {
 				$value = sanitize_text_field( (string) $value );
 			}
-			if ( $field['required'] && ( false === $value || '' === $value ) ) {
-				return new \WP_Error( 'booking_inquiry_field_required', __( 'A required booking field is missing.', 'extrachill-events' ), array(
-					'status' => 400,
-					'field'  => $field['key'],
-				) );
+			if ( $field['required'] && ( false === $value || '' === $value || array() === $value ) ) {
+				return new \WP_Error(
+					'booking_inquiry_field_required',
+					__( 'A required booking field is missing.', 'extrachill-events' ),
+					array(
+						'status' => 400,
+						'field'  => $field['key'],
+					)
+				);
 			}
 			if ( 'select' === $field['type'] && '' !== $value && ! in_array( $value, $field['options'], true ) ) {
-				return new \WP_Error( 'booking_inquiry_field_invalid', __( 'A configured booking field is invalid.', 'extrachill-events' ), array(
-					'status' => 400,
-					'field'  => $field['key'],
-				) );
+				return new \WP_Error(
+					'booking_inquiry_field_invalid',
+					__( 'A configured booking field is invalid.', 'extrachill-events' ),
+					array(
+						'status' => 400,
+						'field'  => $field['key'],
+					)
+				);
 			}
 			$normalized[ $field['key'] ] = $value;
 		}

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -74,10 +74,11 @@ class VenueBookingConfig {
 		}
 
 		$fields       = $this->normalize_intake_fields( $stored['intake']['fields'] ?? null );
+		$presentation = $this->normalize_intake_presentation( $stored['intake']['presentation'] ?? array() );
 		$requirements = $this->normalize_public_requirements( $stored['public_requirements'] ?? null );
 		$consent      = $this->normalize_consent( $stored['consent'] ?? null );
 		$spaces       = $this->normalize_spaces( $stored['spaces'] ?? null );
-		foreach ( array( $fields, $requirements, $consent, $spaces ) as $section ) {
+		foreach ( array( $fields, $presentation, $requirements, $consent, $spaces ) as $section ) {
 			if ( is_wp_error( $section ) ) {
 				return $section;
 			}
@@ -87,6 +88,7 @@ class VenueBookingConfig {
 			'enabled'             => ! empty( $stored['enabled'] ),
 			'revision'            => $revision,
 			'fields'              => $fields,
+			'presentation'        => $presentation,
 			'public_requirements' => $requirements,
 			'consent'             => $consent,
 			'spaces'              => $spaces,
@@ -333,8 +335,9 @@ class VenueBookingConfig {
 			'updated_at'                => $updated_at,
 			'enabled'                   => ! empty( $config['enabled'] ),
 			'intake'                    => array(
-				'version' => 1,
-				'fields'  => $fields,
+				'version'      => 1,
+				'fields'       => $fields,
+				'presentation' => $this->normalize_intake_presentation( $config['intake']['presentation'] ?? array() ),
 			),
 			'public_requirements'       => $requirements,
 			'consent'                   => $consent,
@@ -364,8 +367,9 @@ class VenueBookingConfig {
 			'updated_at'                => null,
 			'enabled'                   => false,
 			'intake'                    => array(
-				'version' => 1,
-				'fields'  => array(),
+				'version'      => 1,
+				'fields'       => array(),
+				'presentation' => $this->normalize_intake_presentation( array() ),
 			),
 			'public_requirements'       => array(),
 			'consent'                   => array(
@@ -526,7 +530,7 @@ class VenueBookingConfig {
 		}
 		$normalized = array();
 		$seen       = array();
-		$types      = array( 'text', 'textarea', 'email', 'phone', 'number', 'select', 'checkbox', 'url' );
+		$types      = array( 'text', 'textarea', 'email', 'phone', 'number', 'select', 'checkbox', 'url', 'url_list' );
 		foreach ( $fields as $field ) {
 			$key   = mb_substr( sanitize_key( (string) ( $field['key'] ?? '' ) ), 0, 64 );
 			$type  = sanitize_key( (string) ( $field['type'] ?? 'text' ) );
@@ -535,20 +539,56 @@ class VenueBookingConfig {
 				return new \WP_Error( 'invalid_booking_intake_field', __( 'Each intake field needs a unique normalized key and supported type.', 'extrachill-events' ) );
 			}
 			$seen[ $key ] = true;
+			$visible_when = null;
+			if ( null !== ( $field['visible_when'] ?? null ) ) {
+				$condition       = is_array( $field['visible_when'] ) ? $field['visible_when'] : array();
+				$condition_field = mb_substr( sanitize_key( (string) ( $condition['field'] ?? '' ) ), 0, 64 );
+				$condition_value = mb_substr( sanitize_text_field( (string) ( $condition['value'] ?? '' ) ), 0, 191 );
+				if ( '' === $condition_field || '' === $condition_value || ! isset( $seen[ $condition_field ] ) || $condition_field === $key ) {
+					return new \WP_Error( 'invalid_booking_intake_condition', __( 'Conditional intake fields must depend on an earlier configured field and value.', 'extrachill-events' ) );
+				}
+				$visible_when = array(
+					'field' => $condition_field,
+					'value' => $condition_value,
+				);
+			}
 			$normalized[] = array(
-				'key'      => $key,
-				'label'    => $label,
-				'type'     => $type,
-				'required' => ! empty( $field['required'] ),
-				'options'  => array_map(
+				'key'          => $key,
+				'label'        => $label,
+				'type'         => $type,
+				'required'     => ! empty( $field['required'] ),
+				'options'      => array_map(
 					static function ( $option ): string {
 						return mb_substr( sanitize_text_field( $option ), 0, 191 );
 					},
 					array_values( array_slice( (array) ( $field['options'] ?? array() ), 0, 100 ) )
 				),
+				'visible_when' => $visible_when,
 			);
 		}
 		return $normalized;
+	}
+
+	/**
+	 * Normalize configurable labels for the stable built-in inquiry fields.
+	 *
+	 * @param mixed $presentation Proposed presentation values.
+	 */
+	private function normalize_intake_presentation( $presentation ): array {
+		$defaults     = array(
+			'artist_name_label'   => __( 'Artist or project name', 'extrachill-events' ),
+			'contact_name_label'  => __( 'Contact name', 'extrachill-events' ),
+			'contact_email_label' => __( 'Contact email', 'extrachill-events' ),
+			'contact_phone_label' => __( 'Contact phone', 'extrachill-events' ),
+			'message_label'       => __( 'Additional performance details', 'extrachill-events' ),
+			'message_help'        => __( 'Share routing, scheduling, and anything else the venue should know.', 'extrachill-events' ),
+		);
+		$presentation = is_array( $presentation ) ? $presentation : array();
+		foreach ( $defaults as $key => $default ) {
+			$value            = mb_substr( sanitize_text_field( (string) ( $presentation[ $key ] ?? $default ) ), 0, 500 );
+			$defaults[ $key ] = '' === $value ? $default : $value;
+		}
+		return $defaults;
 	}
 
 	/** Normalize public, non-operational requirements shown before inquiry intake. */

--- a/tests/BookingEventConversionTest.php
+++ b/tests/BookingEventConversionTest.php
@@ -342,6 +342,7 @@ final class BookingEventConversionTest extends BookingTestCase {
 		$this->assertSame( 'Test Band at The Canonical Room', $input['event']['title'] );
 		$this->assertSame( 'Test Band', $input['event']['performer'] );
 		$this->assertSame( 'PerformingGroup', $input['event']['performerType'] );
+		$this->assertSame( 'MusicEvent', $input['event']['eventType'] );
 		$this->assertSame( 'The Canonical Room', $input['event']['venue'] );
 		$this->assertSame( '123 King Street', $input['event']['venueAddress'] );
 		$this->assertSame( 'Charleston', $input['event']['venueCity'] );
@@ -370,6 +371,22 @@ final class BookingEventConversionTest extends BookingTestCase {
 		$this->assertSame( 2, $activity[0]['payload']['data']['version'] );
 		$this->assertSame( 'event_conversion_started', $activity[1]['kind'] );
 		$this->assertGreaterThanOrEqual( 2, $GLOBALS['wpdb']->booking_lock_queries );
+	}
+
+	public function test_concert_intake_maps_into_existing_canonical_event_type(): void {
+		$ability = $GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event'];
+		$booking = $this->booking( array( 'intake' => array( 'fields' => array( 'event_type' => 'Concert' ) ) ) );
+
+		$this->assertIsArray( $this->service()->convert( $booking['id'], 1, 12 ) );
+		$this->assertSame( 'MusicEvent', $ability->calls[0]['event']['eventType'] );
+	}
+
+	public function test_market_intake_uses_generic_canonical_event_type(): void {
+		$ability = $GLOBALS['ec_artist_test']['ability_objects']['data-machine-events/upsert-event'];
+		$booking = $this->booking( array( 'intake' => array( 'fields' => array( 'event_type' => 'Market' ) ) ) );
+
+		$this->assertIsArray( $this->service()->convert( $booking['id'], 1, 12 ) );
+		$this->assertSame( 'Event', $ability->calls[0]['event']['eventType'] );
 	}
 
 	public function test_recovers_production_created_event_by_source_identity_without_duplication(): void {

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -971,6 +971,45 @@ final class BookingFoundationTest extends BookingTestCase {
 		$this->assertSame( 'booking_inquiry_field_required', $missing->get_error_code() );
 	}
 
+	public function test_public_intake_supports_conditional_details_and_validated_link_lists(): void {
+		$config                       = ( new VenueBookingConfig() )->defaults();
+		$config['enabled']            = true;
+		$config['revision']           = 4;
+		$config['intake']['fields']   = array(
+			array( 'key' => 'event_type', 'label' => 'Event type', 'type' => 'select', 'required' => true, 'options' => array( 'Concert', 'Market', 'Other' ) ),
+			array( 'key' => 'other_event', 'label' => 'Other event details', 'type' => 'text', 'required' => true, 'options' => array(), 'visible_when' => array( 'field' => 'event_type', 'value' => 'Other' ) ),
+			array( 'key' => 'press_links', 'label' => 'Press links', 'type' => 'url_list', 'required' => false, 'options' => array() ),
+		);
+		$normalized                    = ( new VenueBookingConfig() )->normalize( $config );
+		$this->assertIsArray( $normalized );
+		$GLOBALS['ec_artist_test']['meta'][7][55][ VenueBookingConfig::META_KEY ] = $normalized;
+		$base = array(
+			'venue_term_id' => 55,
+			'artist_name'   => 'Test Band',
+			'intake'        => array(
+				'config_revision' => 4,
+				'message'         => 'A complete proposal.',
+				'fields'          => array(
+					'event_type' => 'Concert',
+					'other_event' => '',
+					'press_links' => "https://example.com/press\nhttps://example.com/review",
+				),
+				'consent'         => array( 'id' => 'booking-privacy', 'version' => 1, 'accepted' => true ),
+			),
+		);
+		$concert = ( new BookingLifecycle() )->create_inquiry( array_merge( $base, array( 'idempotency_key' => 'conditional-concert' ) ) );
+		$this->assertSame( '', $concert['intake']['data']['fields']['other_event'] );
+		$this->assertSame( array( 'https://example.com/press', 'https://example.com/review' ), $concert['intake']['data']['fields']['press_links'] );
+
+		$other = $base;
+		$other['idempotency_key'] = 'conditional-other';
+		$other['intake']['fields']['event_type'] = 'Other';
+		$this->assertSame( 'booking_inquiry_field_required', ( new BookingLifecycle() )->create_inquiry( $other )->get_error_code() );
+		$other['intake']['fields']['other_event'] = 'Listening party';
+		$other['intake']['fields']['press_links'] = 'not-a-url';
+		$this->assertSame( 'booking_inquiry_field_invalid', ( new BookingLifecycle() )->create_inquiry( $other )->get_error_code() );
+	}
+
 	public function test_failed_idempotent_insert_without_winner_preserves_database_error(): void {
 		$lifecycle                     = new BookingLifecycle();
 		$GLOBALS['wpdb']->fail_inserts = true;
@@ -1157,6 +1196,7 @@ final class BookingFoundationTest extends BookingTestCase {
 		$this->assertSame(
 			array(
 				'extrachill/create-booking-inquiry',
+				'extrachill/check-booking-availability',
 				'extrachill/list-venue-bookings',
 				'extrachill/get-venue-booking',
 				'extrachill/get-venue-booking-activity',
@@ -1167,6 +1207,8 @@ final class BookingFoundationTest extends BookingTestCase {
 			array_keys( $registered )
 		);
 		$this->assertFalse( $registered['extrachill/create-booking-inquiry']['meta']['show_in_rest'] );
+		$this->assertFalse( $registered['extrachill/check-booking-availability']['meta']['show_in_rest'] );
+		$this->assertTrue( $registered['extrachill/check-booking-availability']['meta']['annotations']['readonly'] );
 		$this->assertTrue( $registered['extrachill/list-venue-bookings']['meta']['show_in_rest'] );
 		foreach ( array( 'extrachill/list-venue-bookings', 'extrachill/get-venue-booking' ) as $reconciling_ability ) {
 			$this->assertFalse( $registered[ $reconciling_ability ]['meta']['annotations']['readonly'] );
@@ -1180,6 +1222,7 @@ final class BookingFoundationTest extends BookingTestCase {
 		}
 		$this->assertSame( BookingLifecycle::STATUSES, $registered['extrachill/transition-venue-booking']['input_schema']['properties']['to_status']['enum'] );
 		$this->assertSame( array( 'idempotency_key', 'venue_term_id', 'intake' ), $registered['extrachill/create-booking-inquiry']['input_schema']['required'] );
+		$this->assertSame( array( 'venue_term_id', 'requested_space_key', 'requested_start_at', 'requested_end_at' ), $registered['extrachill/check-booking-availability']['input_schema']['required'] );
 		$attachment_schema = $registered['extrachill/create-booking-inquiry']['input_schema']['properties']['attachments'];
 		$this->assertSame( 5, $attachment_schema['maxItems'] );
 		$this->assertSame( array( 'name', 'tmp_name', 'error', 'size', 'purpose' ), $attachment_schema['items']['required'] );

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -176,6 +176,70 @@ final class BookingHoldTest extends BookingTestCase {
 		$this->assertSame( 'active', $retry['hold']['status'], 'An exactly elapsed hold must not block even before cleanup.' );
 	}
 
+	/** Public availability ignores inquiry/hold state and exposes only filled state. */
+	public function test_public_interval_availability_is_private_interval_based_and_hold_tolerant(): void {
+		$holds = $this->holds();
+		$this->booking( '2030-08-02 00:00:00', '2030-08-02 03:00:00', 'main-room', array( 'status' => 'submitted' ) );
+		$held = $this->booking( '2030-08-02 00:00:00', '2030-08-02 03:00:00', 'main-room' );
+		$holds->create( $held['id'], 1, 12 );
+
+		$this->assertSame(
+			array( 'available' => true ),
+			$holds->public_interval_availability( 55, 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00' )
+		);
+		$this->assertSame(
+			array( 'available' => true ),
+			$holds->public_interval_availability( 55, 'main-room', '2030-08-01 17:00:00', '2030-08-01 20:00:00' ),
+			'An adjacent same-day interval must remain open.'
+		);
+		$this->assertSame( array( 'available' ), array_keys( $holds->public_interval_availability( 55, 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00' ) ) );
+	}
+
+	/** Confirmed bookings and canonical events close only overlapping intervals. */
+	public function test_public_interval_availability_blocks_confirmed_and_canonical_overlaps(): void {
+		$holds = $this->holds();
+		$this->booking( '2030-08-02 00:00:00', '2030-08-02 03:00:00', 'main-room', array( 'status' => 'confirmed' ) );
+
+		$this->assertSame( array( 'available' => false ), $holds->public_interval_availability( 55, 'main-room', '2030-08-01 20:30:00', '2030-08-01 22:00:00' ) );
+		$this->assertSame( array( 'available' => true ), $holds->public_interval_availability( 55, 'patio', '2030-08-01 20:30:00', '2030-08-01 22:00:00' ) );
+
+		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ] = array();
+		$GLOBALS['wpdb']->event_dates[] = array(
+			'post_id'        => 901,
+			'venue_term_id' => 55,
+			'start_datetime' => '2030-08-01 21:00:00',
+			'end_datetime'   => '2030-08-01 22:00:00',
+			'post_status'    => 'publish',
+		);
+		$this->assertSame( array( 'available' => false ), $holds->public_interval_availability( 55, 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00' ) );
+		$this->assertSame( array( 'available' => true ), $holds->public_interval_availability( 55, 'main-room', '2030-08-01 18:00:00', '2030-08-01 21:00:00' ) );
+	}
+
+	/** Final admission callback runs under the filled-state lock and loses a race clearly. */
+	public function test_public_interval_final_admission_revalidates_before_callback(): void {
+		$holds = $this->holds();
+		$input = array(
+			'venue_term_id'        => 55,
+			'requested_space_key'  => 'main-room',
+			'requested_start_at'   => '2030-08-01 20:00:00',
+			'requested_end_at'     => '2030-08-01 23:00:00',
+			'intake'               => array( 'config_revision' => 1 ),
+		);
+		$called = 0;
+		$this->assertSame( 'accepted', $holds->admit_public_interval( $input, static function () use ( &$called ) {
+			++$called;
+			return 'accepted';
+		} ) );
+
+		$this->booking( '2030-08-02 00:00:00', '2030-08-02 03:00:00', 'main-room', array( 'status' => 'confirmed' ) );
+		$filled = $holds->admit_public_interval( $input, static function () use ( &$called ) {
+			++$called;
+			return 'should-not-run';
+		} );
+		$this->assertSame( 'booking_inquiry_interval_unavailable', $filled->get_error_code() );
+		$this->assertSame( 1, $called );
+	}
+
 	public function test_duplicate_exact_active_hold_is_rejected_without_booking_mutation(): void {
 		$holds   = $this->holds();
 		$booking = $this->booking();

--- a/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
+++ b/tests/MySQLIntegration/InternalBookingCalendarAlphaTest.php
@@ -295,10 +295,17 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 	/** Configure admission and multiple spaces through the public config ability. */
 	private function configure_venue( int $venue_id, int $operator_id, array $space_keys ): void {
 		$config = $this->ability_data( 'extrachill/get-venue-booking-config', array( 'venue_term_id' => $venue_id ), $operator_id );
+		$this->assertSame( 'Contact phone', $config['intake']['presentation']['contact_phone_label'] );
 		$revision = $config['revision'];
 		unset( $config['revision'], $config['updated_by_user_id'], $config['updated_at'] );
 		$config['enabled'] = true;
 		$config['spaces']  = array();
+		$config['intake']['presentation']['contact_phone_label'] = 'Phone (Emergency use only)';
+		$config['intake']['fields'] = array(
+			array( 'key' => 'event_type', 'label' => 'Event type', 'type' => 'select', 'required' => false, 'options' => array( 'Concert', 'Market', 'Other' ), 'visible_when' => null ),
+			array( 'key' => 'other_event', 'label' => 'Other event details', 'type' => 'text', 'required' => false, 'options' => array(), 'visible_when' => array( 'field' => 'event_type', 'value' => 'Other' ) ),
+			array( 'key' => 'press_links', 'label' => 'Press links', 'type' => 'url_list', 'required' => false, 'options' => array(), 'visible_when' => null ),
+		);
 		$config['correspondence']['reminder_policies']['hold_expiring']['version']          += 1;
 		$config['correspondence']['reminder_policies']['hold_expiring']['enabled']           = true;
 		$config['correspondence']['reminder_policies']['hold_expiring']['delay_minutes']     = 60;
@@ -309,6 +316,9 @@ final class InternalBookingCalendarAlphaTest extends WP_UnitTestCase {
 		$updated = $this->ability_data( 'extrachill/update-venue-booking-config', array( 'venue_term_id' => $venue_id, 'expected_revision' => $revision, 'config' => $config ), $operator_id );
 		$this->assertTrue( $updated['enabled'] );
 		$this->assertCount( count( $space_keys ), $updated['spaces'] );
+		$this->assertSame( 'Phone (Emergency use only)', $updated['intake']['presentation']['contact_phone_label'] );
+		$this->assertSame( 'url_list', $updated['intake']['fields'][2]['type'] );
+		$this->assertSame( array( 'field' => 'event_type', 'value' => 'Other' ), $updated['intake']['fields'][1]['visible_when'] );
 	}
 
 	/** Submit through the protected REST route from the main site. */

--- a/tests/Unit/VenueBookingInquiryRenderTest.php
+++ b/tests/Unit/VenueBookingInquiryRenderTest.php
@@ -52,7 +52,15 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 				'required' => true,
 				'options'  => array(),
 			),
+			array(
+				'key'      => 'press_links',
+				'label'    => 'Press links',
+				'type'     => 'url_list',
+				'required' => false,
+				'options'  => array(),
+			),
 		);
+		$config['intake']['presentation']['contact_phone_label'] = 'Phone (Emergency use only)';
 		$config['ticket_provider_reference']         = 'private-provider-account';
 		$config['correspondence']['booking_address'] = 'private-booking@example.com';
 		update_term_meta( $this->venue_id, VenueBookingConfig::META_KEY, $config );
@@ -72,6 +80,9 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '42 Test Street, Charleston, SC, 29403', $output );
 		$this->assertStringContainsString( 'Include recent draw and routing.', $output );
 		$this->assertStringContainsString( '"revision":4', $output );
+		$this->assertStringContainsString( 'Phone (Emergency use only)', $output );
+		$this->assertStringContainsString( 'manage-link-page', $output );
+		$this->assertStringContainsString( '"hasPage":false', $output );
 		$this->assertStringNotContainsString( 'private-provider-account', $output );
 		$this->assertStringNotContainsString( 'private-booking@example.com', $output );
 		$this->assertStringNotContainsString( 'attachment', strtolower( $output ) );

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -1858,6 +1858,17 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertContains( 'consent', $config_input['oneOf'][2]['required'] );
 		$this->assertContains( 'marketing_triggers', $config_input['oneOf'][2]['required'] );
 		$this->assertSame( array( 3 ), $config_output['properties']['version']['enum'] );
+		$intake_output = $config_output['properties']['intake'];
+		$this->assertContains( 'presentation', $intake_output['required'] );
+		$this->assertSame(
+			array( 'artist_name_label', 'contact_name_label', 'contact_email_label', 'contact_phone_label', 'message_label', 'message_help' ),
+			$intake_output['properties']['presentation']['required']
+		);
+		$this->assertContains( 'url_list', $intake_output['properties']['fields']['items']['properties']['type']['enum'] );
+		$this->assertSame( array( 'object', 'null' ), $intake_output['properties']['fields']['items']['properties']['visible_when']['type'] );
+		$this->assertNotContains( 'presentation', $config_input['oneOf'][0]['properties']['intake']['required'] );
+		$this->assertNotContains( 'presentation', $config_input['oneOf'][1]['properties']['intake']['required'] );
+		$this->assertContains( 'presentation', $config_input['oneOf'][2]['properties']['intake']['required'] );
 		$this->assertContains( 'correspondence', $config_output['required'] );
 		$this->assertContains( 'public_requirements', $config_output['required'] );
 		$this->assertContains( 'consent', $config_output['required'] );
@@ -1870,6 +1881,7 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$GLOBALS['venue_membership_test']['term_meta'][55][ VenueBookingConfig::META_KEY ] = $legacy;
 		$current = call_user_func( $get['execute_callback'], array( 'venue_term_id' => 55 ) );
 		$this->assertSame( 3, $current['version'] );
+		$this->assertSame( 'Contact phone', $current['intake']['presentation']['contact_phone_label'] );
 		$this->assertArrayHasKey( 'correspondence', $current );
 		$this->assertSame( array(), $current['marketing_triggers'] );
 		$this->assertSame( 0, $current['revision'] );

--- a/tests/browser/booking-inquiry.evidence.js
+++ b/tests/browser/booking-inquiry.evidence.js
@@ -14,6 +14,7 @@ const artifacts =
 const config = {
 	instanceId: 'ec-booking-browser-proof',
 	endpoint: '/booking-inquiries',
+	availabilityEndpoint: '/booking-availability',
 	restNonce: 'booking-proof-nonce',
 	authenticated: true,
 	heading: 'Booking inquiries',
@@ -37,13 +38,41 @@ const config = {
 			options: [],
 		},
 		{
-			key: 'format',
-			label: 'Performance format',
+			key: 'event_type',
+			label: 'Event type',
 			type: 'select',
 			required: true,
-			options: [ 'Full band', 'Solo' ],
+			options: [ 'Concert', 'Market', 'Other' ],
+		},
+		{
+			key: 'other_event',
+			label: 'Other event details',
+			type: 'text',
+			required: true,
+			options: [],
+			visible_when: { field: 'event_type', value: 'Other' },
+		},
+		{
+			key: 'press_links',
+			label: 'Press links',
+			type: 'url_list',
+			required: false,
+			options: [],
 		},
 	],
+	presentation: {
+		artist_name_label: 'Artist or project name',
+		contact_name_label: 'Contact name',
+		contact_email_label: 'Contact email',
+		contact_phone_label: 'Phone (Emergency use only)',
+		message_label: 'Additional performance details',
+		message_help: 'Share routing and scheduling notes.',
+	},
+	linkPage: {
+		url: 'https://artist.example/manage-link-page/',
+		hasPage: true,
+		authenticated: true,
+	},
 	consent: {
 		required: true,
 		label: 'I agree that this venue may use these details to review and respond to my booking inquiry.',
@@ -103,7 +132,7 @@ const measure = ( page ) =>
 			shell,
 			panel: bounds( '.ec-booking-inquiry__panel' ),
 			form,
-			grid: bounds( '.ec-booking-inquiry__form > .ec-card-grid' ),
+			grid: bounds( '.ec-booking-inquiry__step .ec-card-grid' ),
 			turnstile: bounds( '.ec-booking-inquiry__turnstile' ),
 			actions: bounds( '.ec-action-row' ),
 			inlineGutter: form.left - shell.left,
@@ -149,6 +178,24 @@ const measure = ( page ) =>
 					createRoot: window.ReactDOM.createRoot,
 				},
 			};
+			window.bookingAvailable = false;
+			window.fetch = async ( url ) => {
+				if ( String( url ).includes( 'booking-availability' ) ) {
+					return new Response(
+						JSON.stringify( {
+							available: window.bookingAvailable,
+						} ),
+						{
+							status: 200,
+							headers: { 'Content-Type': 'application/json' },
+						}
+					);
+				}
+				return new Response( JSON.stringify( { public_id: 'proof' } ), {
+					status: 201,
+					headers: { 'Content-Type': 'application/json' },
+				} );
+			};
 		} );
 		await page.addScriptTag( {
 			path: path.join( root, 'build/venue-booking-inquiry/view.js' ),
@@ -158,9 +205,47 @@ const measure = ( page ) =>
 		assert.equal( await page.getByText( 'Booking inquiries' ).count(), 1 );
 		assert.equal( await page.getByText( 'Now booking' ).count(), 1 );
 		assert.equal( await page.getByText( 'Signed-in inquiry' ).count(), 1 );
-		assert.ok( await page.getByLabel( 'Artist or project name' ).count() );
+		assert.equal(
+			await page.getByLabel( 'Artist or project name' ).count(),
+			0
+		);
+		assert.ok( await page.getByLabel( 'Requested start' ).count() );
+		assert.ok( await page.getByLabel( 'Requested end' ).count() );
+		await page.getByLabel( 'Requested start' ).fill( '2030-08-01T20:00' );
+		await page.getByLabel( 'Requested end' ).fill( '2030-08-01T23:00' );
+		await page
+			.getByRole( 'button', { name: 'Check availability' } )
+			.click();
+		await page.getByText( /That exact time is unavailable/ ).waitFor();
+		assert.equal(
+			await page.getByLabel( 'Artist or project name' ).count(),
+			0
+		);
+		assert.equal(
+			await page.getByLabel( 'Requested start' ).inputValue(),
+			'2030-08-01T20:00'
+		);
+		await page.evaluate( () => {
+			window.bookingAvailable = true;
+		} );
+		await page
+			.getByRole( 'button', { name: 'Check availability' } )
+			.click();
+		await page.getByLabel( 'Artist or project name' ).waitFor();
 		assert.ok( await page.getByLabel( 'Artist website' ).count() );
 		assert.ok( await page.getByLabel( /I agree that this venue/ ).count() );
+		assert.equal(
+			await page.getByLabel( 'Other event details' ).count(),
+			0
+		);
+		await page.getByLabel( 'Event type' ).selectOption( 'Other' );
+		assert.ok( await page.getByLabel( 'Other event details' ).count() );
+		await page.getByLabel( 'Event type' ).selectOption( 'Concert' );
+		assert.ok(
+			await page
+				.getByRole( 'link', { name: 'Use or manage your Link Page' } )
+				.count()
+		);
 		assert.equal(
 			await page
 				.locator( '.ec-booking-inquiry__turnstile .cf-turnstile' )
@@ -196,12 +281,9 @@ const measure = ( page ) =>
 		await page.getByLabel( 'Artist or project name' ).fill( 'Proof Band' );
 		await page.getByLabel( 'Contact name' ).fill( 'Booking Agent' );
 		await page.getByLabel( 'Contact email' ).fill( 'agent@example.com' );
-		await page.getByLabel( 'Requested start' ).fill( '2030-08-01T20:00' );
+		await page.getByLabel( 'Event type' ).selectOption( 'Concert' );
 		await page
-			.getByLabel( 'Performance format' )
-			.selectOption( 'Full band' );
-		await page
-			.getByLabel( 'Performance details' )
+			.getByLabel( 'Additional performance details' )
 			.fill( 'Routing through Charleston.' );
 		await page.getByLabel( /I agree that this venue/ ).check();
 		await page


### PR DESCRIPTION
## Summary

- Add an Events-owned privacy-safe interval availability ability and revalidate final inquiry admission under the same venue/space locks used by confirmation and canonical publication.
- Make the public inquiry progressive and date-first while preserving the complete venue-configured decision intake, Turnstile, idempotency, anonymous/authenticated attribution, config revisions, accessibility, and mobile layout.
- Extend generic intake configuration with conditional fields, validated one-link-per-line URL lists, and venue-specific built-in labels; reuse the canonical Artist Platform Link Page management and Users continuation/ownership helpers.
- Preserve DME ownership of canonical Schema.org `eventType`: configured `Concert` maps to `MusicEvent`, while `Market` and generic `Other` map to `Event`; legacy unclassified bookings remain `MusicEvent`.

## Availability policy

Availability is a half-open exact interval by venue + configured booking space + start/end, converted through the venue timezone. Multiple non-overlapping events may stack on the same calendar date, and private confirmed bookings in another configured space do not close the selected space.

Pending inquiries, review/negotiation state, and active holds remain available for competing submissions. Only overlapping confirmed bookings and canonical published events return unavailable. Canonical events use DME's existing venue interval-overlap contract; because canonical events have no booking-space dimension, their published venue interval remains authoritative venue-wide.

Final public admission performs the same filled-state check while holding the booking venue/space advisory locks. A race returns `booking_inquiry_interval_unavailable` with a choose-another-time retry, while exact completed idempotent replays still return their original receipt.

## Privacy rule

The availability success projection is exactly `{ available: boolean }`. It never exposes inquiry counts, artist/contact identities, hold owners, booking IDs, event IDs, conflict types, internal statuses, DME details, database errors, or lock state.

## Generic intake

Venue configuration can present the complete intake Gardner requested: contact role and contact details, event type and conditional other details, bill status and proposed lineup, independent local/touring and need-local-support fields, genre/style, music/social/video/press links, touring-party size, expected draw, routing notes, and additional details.

This PR adds only two generic schema capabilities:

- `visible_when` for an intake field that depends on an earlier configured field/value.
- `url_list` for up to 20 validated absolute HTTP(S) links, entered one per line.

Built-in artist/contact/additional-details labels are venue-configurable, allowing presentation such as `Emergency use only` without hard-coding Lo-Fi into product code.

## Link Page reuse

The optional CTA links to the existing Artist Platform `/manage-link-page/` surface. Anonymous visitors use the existing Users safe login continuation helper, authenticated Link Page owners get `Use or manage your Link Page`, and no booking storage, rendering, analytics, or authorization is duplicated. Ignoring the CTA does not change submission behavior or booking odds.

## Dependencies and boundaries

Blocked on Extra-Chill/extrachill-api#146, which owns the thin anonymous/authenticated public route-affinity transport for `extrachill/check-booking-availability`. The Events PR intentionally does not add an Events-owned REST workaround. Until that dependency lands, the progressive UI endpoint is not active end to end.

Press-kit upload remains deferred to #336 and #317; this PR does not enable public Media Library or unmanaged temporary uploads.

Related post-admission receipt/reply threading, private calendar status presentation, and competing-request notifications remain in #525. Venue discovery classification remains #91, booking FAQ/equipment/deal guidance remains #526, and coordinator-controlled market vendor requests remain #527.

## Verification

- `vendor/bin/phpunit -c phpunit-booking.xml.dist` (440 tests, 4667 assertions)
- `vendor/bin/phpunit -c phpunit-network-block.xml.dist` (3 tests, 20 assertions)
- `npm run test:js -- --runInBand` (81 tests)
- `npm run lint:js`
- `npm run test:browser:booking-inquiry` (1280x900 and 390x844, no overflow; unavailable/preserved interval, progressive expansion, conditional fields, Link Page CTA, Turnstile state)
- `npm run build`
- `homeboy --placement local review build ...` (passed; production ZIP and PHP syntax/structure validation)

Homeboy's generic changed-test adapter attempted to execute a Jest test directly with bare Node and failed module resolution; the repository-owned `wp-scripts` JS suite above passes. Its generic level-7 PHPStan profile has no component configuration and reported baseline-wide findings; scoped JS lint and WordPress-format fixes for changed code were applied.

Refs #524