### PR TITLE
feat: add venue booking guide

### DIFF
--- a/blocks/venue-booking-inquiry/render.php
+++ b/blocks/venue-booking-inquiry/render.php
@@ -35,7 +35,7 @@ $canonical = ( static function () use ( $events_blog_id, $venue_id ) {
 		}
 
 		$booking_config = ( new VenueBookingConfig() )->get_public_projection( $venue_id );
-		if ( is_wp_error( $booking_config ) || empty( $booking_config['enabled'] ) ) {
+		if ( is_wp_error( $booking_config ) || ( empty( $booking_config['enabled'] ) && empty( $booking_config['booking_guide']['entries'] ) ) ) {
 			return null;
 		}
 
@@ -80,12 +80,16 @@ if ( ! is_array( $canonical ) ) {
 $booking_config = $canonical['booking_config'];
 $instance       = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'ec-booking-' ) : 'ec-booking-' . $venue_id;
 $logged_in      = is_user_logged_in();
+$form_enabled   = ! empty( $booking_config['enabled'] );
+$guide_entries  = $booking_config['booking_guide']['entries'];
 if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 	define( 'DONOTCACHEPAGE', true );
 }
 nocache_headers();
-if ( function_exists( 'ec_enqueue_turnstile_script' ) ) {
-	ec_enqueue_turnstile_script();
+if ( $form_enabled ) {
+	if ( function_exists( 'ec_enqueue_turnstile_script' ) ) {
+		ec_enqueue_turnstile_script();
+	}
 }
 
 $public_config = array(
@@ -103,21 +107,41 @@ $public_config = array(
 	'consent'       => $booking_config['consent'],
 );
 
-$json = wp_json_encode( $public_config, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
-if ( false === $json ) {
+$json             = $form_enabled ? wp_json_encode( $public_config, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ) : '';
+$guide_heading_id = $instance . '-guide-title';
+if ( $form_enabled && false === $json ) {
 	return;
 }
 ?>
 <section <?php echo get_block_wrapper_attributes( array( 'class' => 'ec-venue-booking-inquiry' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Core escapes block wrapper attributes. ?>>
-	<div data-booking-app></div>
-	<script type="application/json"><?php echo $json; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON_HEX flags make the script payload inert. ?></script>
-	<div data-booking-turnstile>
-		<?php
-		if ( function_exists( 'ec_render_turnstile_widget' ) ) {
-			echo wp_kses_post( ec_render_turnstile_widget( array( 'data-appearance' => 'always' ) ) );
-		} else {
-			esc_html_e( 'Security challenge unavailable. Please contact the venue directly.', 'extrachill-events' );
-		}
-		?>
-	</div>
+	<?php if ( ! empty( $guide_entries ) ) : ?>
+		<div class="ec-booking-guide" aria-labelledby="<?php echo esc_attr( $guide_heading_id ); ?>">
+			<h2 id="<?php echo esc_attr( $guide_heading_id ); ?>"><?php esc_html_e( 'Booking guide', 'extrachill-events' ); ?></h2>
+			<p><?php esc_html_e( 'Venue-provided information to review before sending a booking inquiry.', 'extrachill-events' ); ?></p>
+			<div class="ec-booking-guide__entries">
+				<?php foreach ( $guide_entries as $entry ) : ?>
+					<article class="ec-booking-guide__entry" data-guide-key="<?php echo esc_attr( $entry['key'] ); ?>">
+						<h3><?php echo esc_html( $entry['title'] ); ?></h3>
+						<?php echo wp_kses_post( wpautop( esc_html( $entry['body'] ) ) ); ?>
+					</article>
+				<?php endforeach; ?>
+			</div>
+			<?php if ( $form_enabled ) : ?>
+				<p class="ec-booking-guide__communication"><?php esc_html_e( 'For details not covered here, send an inquiry below so communication stays with the booking request.', 'extrachill-events' ); ?></p>
+			<?php endif; ?>
+		</div>
+	<?php endif; ?>
+	<?php if ( $form_enabled ) : ?>
+		<div data-booking-app></div>
+		<script type="application/json"><?php echo $json; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON_HEX flags make the script payload inert. ?></script>
+		<div data-booking-turnstile>
+			<?php
+			if ( function_exists( 'ec_render_turnstile_widget' ) ) {
+				echo wp_kses_post( ec_render_turnstile_widget( array( 'data-appearance' => 'always' ) ) );
+			} else {
+				esc_html_e( 'Security challenge unavailable. Please contact the venue directly.', 'extrachill-events' );
+			}
+			?>
+		</div>
+	<?php endif; ?>
 </section>

--- a/blocks/venue-booking-inquiry/src/style.scss
+++ b/blocks/venue-booking-inquiry/src/style.scss
@@ -24,6 +24,45 @@
 	margin-bottom: 0;
 }
 
+.ec-booking-guide {
+	margin-block-end: var(--spacing-xl);
+}
+
+.ec-booking-guide > h2 {
+	margin-block-end: var(--spacing-xs);
+}
+
+.ec-booking-guide__entries {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+	gap: var(--spacing-md);
+	margin-block-start: var(--spacing-lg);
+}
+
+.ec-booking-guide__entry {
+	min-width: 0;
+	padding: var(--spacing-lg);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	background: var(--card-background);
+	overflow-wrap: anywhere;
+}
+
+.ec-booking-guide__entry h3,
+.ec-booking-guide__entry p:first-of-type {
+	margin-block-start: 0;
+}
+
+.ec-booking-guide__entry p:last-child {
+	margin-block-end: 0;
+}
+
+.ec-booking-guide__communication {
+	color: var(--muted-text);
+	font-size: 0.9rem;
+	margin-block-start: var(--spacing-lg);
+}
+
 .ec-booking-inquiry__form {
 	display: grid;
 	gap: 1.25rem;

--- a/blocks/venue-settings/src/guide-tab.js
+++ b/blocks/venue-settings/src/guide-tab.js
@@ -1,0 +1,222 @@
+/**
+ * External dependencies
+ */
+import {
+	ActionRow,
+	FieldGroup,
+	Grid,
+	InlineStatus,
+	Panel,
+	PanelHeader,
+} from '@extrachill/components';
+
+/**
+ * Internal dependencies
+ */
+import { Status } from './status';
+import { normalizeKey, sameDocument, validateConfig } from './state';
+
+export function GuideTab( {
+	config,
+	baseline,
+	setConfig,
+	onSave,
+	saving,
+	status,
+} ) {
+	const entries = config.booking_guide.entries;
+	const errors = validateConfig( config );
+	const dirty = ! sameDocument( config, baseline );
+	const setEntries = ( next ) =>
+		setConfig( {
+			...config,
+			booking_guide: { ...config.booking_guide, entries: next },
+		} );
+	const update = ( index, patch ) =>
+		setEntries(
+			entries.map( ( entry, current ) =>
+				current === index ? { ...entry, ...patch } : entry
+			)
+		);
+	const move = ( index, offset ) => {
+		const next = [ ...entries ];
+		[ next[ index ], next[ index + offset ] ] = [
+			next[ index + offset ],
+			next[ index ],
+		];
+		setEntries( next );
+	};
+
+	return (
+		<Grid minColumnWidth="100%">
+			<Panel>
+				<PanelHeader
+					title="Booking guide"
+					description="Venue-owned answers shown before inquiry and used for grounded operator assistance. Keep personal coordinator details in managed booking communication, not guide entries."
+				/>
+				{ entries.length === 0 && (
+					<p>
+						No guide entries yet. Unknown questions will remain
+						unanswered.
+					</p>
+				) }
+				{ entries.map( ( entry, index ) => (
+					<fieldset
+						className="ec-venue-settings__repeater"
+						key={ `${ entry.key }-${ index }` }
+					>
+						<legend>Guide entry { index + 1 }</legend>
+						<Grid minColumnWidth="16rem" maxColumns={ 2 }>
+							<FieldGroup
+								label="Question or title"
+								htmlFor={ `guide-title-${ index }` }
+								required
+							>
+								<input
+									id={ `guide-title-${ index }` }
+									value={ entry.title }
+									onChange={ ( event ) =>
+										update( index, {
+											title: event.target.value,
+											key:
+												entry.key ||
+												normalizeKey(
+													event.target.value
+												),
+										} )
+									}
+								/>
+							</FieldGroup>
+							<FieldGroup
+								label="Stable key"
+								htmlFor={ `guide-key-${ index }` }
+								help="Used by grounded consumers when citing this answer."
+								required
+							>
+								<input
+									id={ `guide-key-${ index }` }
+									value={ entry.key }
+									onChange={ ( event ) =>
+										update( index, {
+											key: normalizeKey(
+												event.target.value
+											),
+										} )
+									}
+								/>
+							</FieldGroup>
+						</Grid>
+						<FieldGroup
+							label="Answer"
+							htmlFor={ `guide-body-${ index }` }
+							help="State only venue-confirmed facts. Direct artists to the booking inquiry or thread when details vary."
+							required
+						>
+							<textarea
+								id={ `guide-body-${ index }` }
+								maxLength="5000"
+								value={ entry.body }
+								onChange={ ( event ) =>
+									update( index, {
+										body: event.target.value,
+									} )
+								}
+							/>
+						</FieldGroup>
+						<FieldGroup
+							label="Visibility"
+							htmlFor={ `guide-visibility-${ index }` }
+						>
+							<select
+								id={ `guide-visibility-${ index }` }
+								value={ entry.visibility }
+								onChange={ ( event ) =>
+									update( index, {
+										visibility: event.target.value,
+									} )
+								}
+							>
+								<option value="public">Public</option>
+								<option value="operator">Operators only</option>
+							</select>
+						</FieldGroup>
+						<ActionRow>
+							<button
+								type="button"
+								className="button-2"
+								disabled={ index === 0 }
+								onClick={ () => move( index, -1 ) }
+							>
+								Move up
+							</button>
+							<button
+								type="button"
+								className="button-2"
+								disabled={ index === entries.length - 1 }
+								onClick={ () => move( index, 1 ) }
+							>
+								Move down
+							</button>
+							<button
+								type="button"
+								className="button-link-delete"
+								onClick={ () =>
+									setEntries(
+										entries.filter(
+											( _, current ) => current !== index
+										)
+									)
+								}
+							>
+								Remove entry
+							</button>
+						</ActionRow>
+					</fieldset>
+				) ) }
+				<button
+					type="button"
+					className="button-2"
+					onClick={ () =>
+						setEntries( [
+							...entries,
+							{
+								key: '',
+								title: '',
+								body: '',
+								visibility: 'public',
+							},
+						] )
+					}
+				>
+					Add guide entry
+				</button>
+			</Panel>
+			{ errors.length > 0 && (
+				<InlineStatus tone="error">
+					<strong>Resolve before saving:</strong>
+					<ul>
+						{ errors.map( ( error ) => (
+							<li key={ error }>{ error }</li>
+						) ) }
+					</ul>
+				</InlineStatus>
+			) }
+			<Status state={ status } />
+			<ActionRow>
+				<button
+					type="button"
+					className="button-1"
+					disabled={ ! dirty || saving || errors.length > 0 }
+					onClick={ onSave }
+				>
+					{ saving ? 'Saving...' : 'Save booking guide' }
+				</button>
+				{ dirty && (
+					<span className="ec-venue-settings__dirty">
+						Unsaved guide changes
+					</span>
+				) }
+			</ActionRow>
+		</Grid>
+	);
+}

--- a/blocks/venue-settings/src/state.js
+++ b/blocks/venue-settings/src/state.js
@@ -33,6 +33,22 @@ export const validateConfig = ( config ) => {
 	if ( ! config.consent.label.trim() || config.consent.version < 1 ) {
 		errors.push( 'Consent needs public wording and a positive version.' );
 	}
+	if ( config.booking_guide.entries.length > 50 ) {
+		errors.push( 'Use no more than 50 booking guide entries.' );
+	}
+	const guideKeys = new Set();
+	config.booking_guide.entries.forEach( ( entry ) => {
+		if ( ! entry.key || ! entry.title.trim() || ! entry.body.trim() ) {
+			errors.push( 'Each guide entry needs a key, title, and answer.' );
+		}
+		if ( guideKeys.has( entry.key ) ) {
+			errors.push( 'Guide entry keys must be unique.' );
+		}
+		guideKeys.add( entry.key );
+		if ( ! [ 'public', 'operator' ].includes( entry.visibility ) ) {
+			errors.push( 'Guide visibility must be public or operators only.' );
+		}
+	} );
 	const spaceKeys = new Set();
 	let defaultSpaces = 0;
 	config.spaces.forEach( ( space ) => {

--- a/blocks/venue-settings/src/state.test.js
+++ b/blocks/venue-settings/src/state.test.js
@@ -11,7 +11,7 @@ import {
 } from './state';
 
 const validConfig = () => ( {
-	version: 3,
+	version: 4,
 	enabled: true,
 	intake: { version: 1, fields: [] },
 	public_requirements: [],
@@ -21,6 +21,7 @@ const validConfig = () => ( {
 		label: 'I agree.',
 		required: true,
 	},
+	booking_guide: { version: 1, entries: [] },
 	spaces: [ { key: 'main_room', name: 'Main Room', is_default: true } ],
 	default_deal: {
 		version: 1,
@@ -76,6 +77,15 @@ describe( 'venue settings state', () => {
 			required: false,
 			options: [],
 		} );
+		config.booking_guide.entries.push(
+			{ key: 'load_in', title: '', body: '', visibility: 'public' },
+			{
+				key: 'load_in',
+				title: 'Private notes',
+				body: 'Details',
+				visibility: 'private',
+			}
+		);
 		config.hold_ttl_minutes = 1;
 		expect( validateConfig( config ) ).toEqual(
 			expect.arrayContaining( [
@@ -83,6 +93,9 @@ describe( 'venue settings state', () => {
 				'Space keys must be unique.',
 				'Choose one default space.',
 				'Select fields need at least one option.',
+				'Each guide entry needs a key, title, and answer.',
+				'Guide entry keys must be unique.',
+				'Guide visibility must be public or operators only.',
 				'Hold duration must be between 5 minutes and 7 days.',
 			] )
 		);

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -21,6 +21,7 @@ import { errorDetails, runAbility } from './api';
 import { BookingConsole } from './booking-console';
 import { BookingTab } from './booking-tab';
 import { ClaimPanel, ClaimsTab } from './claims-tab';
+import { GuideTab } from './guide-tab';
 import { IntakeTab } from './intake-tab';
 import { LocalSupportTab } from './local-support-tab';
 import { ProfileTab } from './profile-tab';
@@ -257,7 +258,7 @@ export function VenueSettingsApp( { context } ) {
 			setConfigBaseline( editable );
 			setConfigStatus( {
 				tone: 'success',
-				message: 'Booking defaults saved.',
+				message: 'Booking settings saved.',
 			} );
 		} catch ( error ) {
 			const details = errorDetails( error );
@@ -279,6 +280,7 @@ export function VenueSettingsApp( { context } ) {
 		{ id: 'local-support', label: 'Local Support' },
 		{ id: 'profile', label: 'Profile' },
 		{ id: 'booking', label: 'Booking' },
+		{ id: 'guide', label: 'Guide' },
 		{ id: 'intake', label: 'Intake' },
 		...( context.can_manage ? [ { id: 'team', label: 'Team' } ] : [] ),
 		...( context.user.is_admin
@@ -365,6 +367,20 @@ export function VenueSettingsApp( { context } ) {
 				<IntakeTab config={ config } setConfig={ setConfig } />
 			) : (
 				<LoadingPanel label="Loading intake settings..." />
+			);
+		}
+		if ( tab === 'guide' ) {
+			return config ? (
+				<GuideTab
+					config={ config }
+					baseline={ configBaseline }
+					setConfig={ setConfig }
+					onSave={ saveConfig }
+					saving={ savingConfig }
+					status={ configStatus }
+				/>
+			) : (
+				<LoadingPanel label="Loading booking guide..." />
 			);
 		}
 		if ( tab === 'team' ) {

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -82,7 +82,7 @@ const profile = ( id ) => ( {
 	revision: String( id ).padStart( 64, '0' ),
 } );
 const config = ( id ) => ( {
-	version: 3,
+	version: 4,
 	revision: id,
 	updated_by_user_id: null,
 	updated_at: null,
@@ -95,6 +95,7 @@ const config = ( id ) => ( {
 		label: 'I agree.',
 		required: true,
 	},
+	booking_guide: { version: 1, entries: [] },
 	spaces: [],
 	default_deal: {
 		version: 1,
@@ -1070,6 +1071,59 @@ describe( 'venue settings authorization-facing states', () => {
 		} );
 		expect( detailIds[ detailIds.length - 1 ] ).toBe( 32 );
 		expect( container.textContent ).toContain( 'Booking #32' );
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'saves ordered guide entries through the revisioned venue config', async () => {
+		installApi();
+		apiFetch.mockImplementation( ( request ) => {
+			const input = request.data?.input || requestInput( request.path );
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'update-venue-booking-config' ) ) {
+				return Promise.resolve( {
+					...input.config,
+					revision: input.expected_revision + 1,
+					updated_by_user_id: 7,
+					updated_at: '2026-08-02 20:00:00',
+				} );
+			}
+			return Promise.resolve( [] );
+		} );
+		const { container, root } = await renderApp( context() );
+		await act( async () => buttonByText( container, 'Guide' ).click() );
+		await act( async () =>
+			buttonByText( container, 'Add guide entry' ).click()
+		);
+		await setInput(
+			container.querySelector( '#guide-title-0' ),
+			'When is load-in?'
+		);
+		await setControl(
+			container.querySelector( '#guide-body-0' ),
+			'Confirm timing in the managed booking thread.'
+		);
+		await act( async () =>
+			buttonByText( container, 'Save booking guide' ).click()
+		);
+
+		const request = apiFetch.mock.calls.find( ( [ call ] ) =>
+			call.path.includes( 'update-venue-booking-config' )
+		)[ 0 ];
+		expect( request.data.input.expected_revision ).toBe( 44 );
+		expect( request.data.input.config.booking_guide.entries ).toEqual( [
+			{
+				key: 'when_is_load_in',
+				title: 'When is load-in?',
+				body: 'Confirm timing in the managed booking thread.',
+				visibility: 'public',
+			},
+		] );
+		expect( container.textContent ).toContain( 'Booking settings saved.' );
 		await act( async () => root.unmount() );
 	} );
 } );

--- a/inc/Abilities/VenueBookingConfigAbilities.php
+++ b/inc/Abilities/VenueBookingConfigAbilities.php
@@ -102,6 +102,32 @@ class VenueBookingConfigAbilities {
 		);
 
 		wp_register_ability(
+			'extrachill/get-venue-booking-guide',
+			array(
+				'label'               => __( 'Get Venue Booking Guide', 'extrachill-events' ),
+				'description'         => __( 'Read current public and operator booking-guide entries for an authorized venue. Answers must use only returned entries; missing information is unavailable.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array( 'venue_term_id' => $venue_property ),
+					'required'             => array( 'venue_term_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => $this->guide_context_schema(),
+				'execute_callback'    => array( $this, 'get_guide' ),
+				'permission_callback' => array( $this, 'can_access_venue' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => true,
+						'idempotent'  => true,
+						'destructive' => false,
+					),
+				),
+			)
+		);
+
+		wp_register_ability(
 			'extrachill/preview-booking-correspondence-template',
 			array(
 				'label'               => __( 'Preview Booking Correspondence Template', 'extrachill-events' ),
@@ -160,6 +186,16 @@ class VenueBookingConfigAbilities {
 
 	public function get_config( array $input ) {
 		return $this->config->get( absint( $input['venue_term_id'] ?? 0 ) );
+	}
+
+	/**
+	 * Read the narrow booking-guide grounding contract.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public function get_guide( array $input ) {
+		return $this->config->get_guide_context( absint( $input['venue_term_id'] ?? 0 ) );
 	}
 
 	public function update_config( array $input ) {
@@ -266,6 +302,7 @@ class VenueBookingConfigAbilities {
 				'required'             => array( 'id', 'version', 'label', 'required' ),
 				'additionalProperties' => false,
 			),
+			'booking_guide'             => $this->booking_guide_schema(),
 			'spaces'                    => array(
 				'type'     => 'array',
 				'maxItems' => 50,
@@ -342,7 +379,7 @@ class VenueBookingConfigAbilities {
 			),
 			'correspondence'            => $this->correspondence_schema(),
 		);
-		$required     = array( 'version', 'enabled', 'intake', 'public_requirements', 'consent', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
+		$required     = array( 'version', 'enabled', 'intake', 'public_requirements', 'consent', 'booking_guide', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
 		if ( $include_metadata ) {
 			$properties['revision']           = array(
 				'type'    => 'integer',
@@ -367,7 +404,11 @@ class VenueBookingConfigAbilities {
 		if ( ! $accept_legacy ) {
 			return $schema;
 		}
-		$previous                                  = $schema;
+		$public_intake                                  = $schema;
+		$public_intake['properties']['version']['enum'] = array( VenueBookingConfig::PUBLIC_INTAKE_VERSION );
+		$public_intake['required']                      = array_values( array_diff( $public_intake['required'], array( 'booking_guide' ) ) );
+		unset( $public_intake['properties']['booking_guide'] );
+		$previous                                  = $public_intake;
 		$previous['properties']['version']['enum'] = array( VenueBookingConfig::PREVIOUS_VERSION );
 		$previous['required']                      = array_values( array_diff( $previous['required'], array( 'public_requirements', 'consent', 'marketing_triggers' ) ) );
 		unset( $previous['properties']['public_requirements'], $previous['properties']['consent'], $previous['properties']['marketing_triggers'] );
@@ -375,7 +416,86 @@ class VenueBookingConfigAbilities {
 		$legacy['properties']['version']['enum'] = array( VenueBookingConfig::LEGACY_VERSION );
 		$legacy['required']                      = array_values( array_diff( $legacy['required'], array( 'correspondence' ) ) );
 		unset( $legacy['properties']['correspondence'] );
-		return array( 'oneOf' => array( $legacy, $previous, $schema ) );
+		return array( 'oneOf' => array( $legacy, $previous, $public_intake, $schema ) );
+	}
+
+	/** Return the versioned ordered booking-guide schema. */
+	private function booking_guide_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'version' => array(
+					'type' => 'integer',
+					'enum' => array( VenueBookingConfig::BOOKING_GUIDE_VERSION ),
+				),
+				'entries' => array(
+					'type'     => 'array',
+					'maxItems' => 50,
+					'items'    => $this->guide_entry_schema(),
+				),
+			),
+			'required'             => array( 'version', 'entries' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	/** Return one strict guide entry schema. */
+	private function guide_entry_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'key'        => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 64,
+				),
+				'title'      => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 191,
+				),
+				'body'       => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 5000,
+				),
+				'visibility' => array(
+					'type' => 'string',
+					'enum' => array( 'public', 'operator' ),
+				),
+			),
+			'required'             => array( 'key', 'title', 'body', 'visibility' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	/** Return the narrow Roadie grounding contract. */
+	private function guide_context_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'venue_term_id'   => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'venue_name'      => array( 'type' => 'string' ),
+				'config_revision' => array(
+					'type'    => 'integer',
+					'minimum' => 0,
+				),
+				'guide_version'   => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'entries'         => array(
+					'type'     => 'array',
+					'maxItems' => 50,
+					'items'    => $this->guide_entry_schema(),
+				),
+			),
+			'required'             => array( 'venue_term_id', 'venue_name', 'config_revision', 'guide_version', 'entries' ),
+			'additionalProperties' => false,
+		);
 	}
 
 	/** Return the strict correspondence configuration schema. */

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -16,9 +16,11 @@ class VenueBookingConfig {
 
 	public const META_KEY                    = '_extrachill_booking_config';
 	public const HISTORY_META_KEY            = '_extrachill_booking_config_history';
-	public const VERSION                     = 3;
+	public const VERSION                     = 4;
+	public const PUBLIC_INTAKE_VERSION       = 3;
 	public const PREVIOUS_VERSION            = 2;
 	public const LEGACY_VERSION              = 1;
+	public const BOOKING_GUIDE_VERSION       = 1;
 	public const CORRESPONDENCE_VERSION      = 1;
 	public const TEMPLATE_VERSION            = 1;
 	public const REMINDER_POLICY_VERSION     = 1;
@@ -64,32 +66,62 @@ class VenueBookingConfig {
 		}
 
 		$stored = get_term_meta( $venue_term_id, self::META_KEY, true );
-		if ( ! is_array( $stored ) || self::VERSION !== ( $stored['version'] ?? null ) ) {
+		if ( ! is_array( $stored ) || ! in_array( $stored['version'] ?? null, array( self::PUBLIC_INTAKE_VERSION, self::VERSION ), true ) ) {
 			return new \WP_Error( 'invalid_booking_public_config', __( 'The public venue booking configuration is unavailable.', 'extrachill-events' ) );
 		}
 
-		$revision = $stored['revision'] ?? null;
-		if ( ! is_int( $revision ) || $revision < 0 || ! is_array( $stored['intake'] ?? null ) || 1 !== ( $stored['intake']['version'] ?? null ) ) {
+		$normalized = $this->normalize( $stored );
+		if ( is_wp_error( $normalized ) ) {
 			return new \WP_Error( 'invalid_booking_public_config', __( 'The public venue booking configuration is unavailable.', 'extrachill-events' ) );
 		}
-
-		$fields       = $this->normalize_intake_fields( $stored['intake']['fields'] ?? null );
-		$requirements = $this->normalize_public_requirements( $stored['public_requirements'] ?? null );
-		$consent      = $this->normalize_consent( $stored['consent'] ?? null );
-		$spaces       = $this->normalize_spaces( $stored['spaces'] ?? null );
-		foreach ( array( $fields, $requirements, $consent, $spaces ) as $section ) {
-			if ( is_wp_error( $section ) ) {
-				return $section;
-			}
+		$revision = $normalized['revision'];
+		if ( ! is_array( $stored['intake'] ?? null ) || 1 !== ( $stored['intake']['version'] ?? null ) ) {
+			return new \WP_Error( 'invalid_booking_public_config', __( 'The public venue booking configuration is unavailable.', 'extrachill-events' ) );
 		}
 
 		return array(
-			'enabled'             => ! empty( $stored['enabled'] ),
+			'enabled'             => $normalized['enabled'],
 			'revision'            => $revision,
-			'fields'              => $fields,
-			'public_requirements' => $requirements,
-			'consent'             => $consent,
-			'spaces'              => $spaces,
+			'fields'              => $normalized['intake']['fields'],
+			'public_requirements' => $normalized['public_requirements'],
+			'consent'             => $normalized['consent'],
+			'spaces'              => $normalized['spaces'],
+			'booking_guide'       => array(
+				'version' => self::BOOKING_GUIDE_VERSION,
+				'entries' => array_values(
+					array_filter(
+						$normalized['booking_guide']['entries'],
+						static function ( array $entry ): bool {
+							return 'public' === $entry['visibility'];
+						}
+					)
+				),
+			),
+		);
+	}
+
+	/**
+	 * Return only guide data and venue context for an authorized operator.
+	 *
+	 * @param int $venue_term_id Canonical venue term ID.
+	 * @return array|\WP_Error
+	 */
+	public function get_guide_context( int $venue_term_id ) {
+		$venue = $this->venue( $venue_term_id );
+		if ( is_wp_error( $venue ) ) {
+			return $venue;
+		}
+		$config = $this->get( $venue_term_id );
+		if ( is_wp_error( $config ) ) {
+			return $config;
+		}
+
+		return array(
+			'venue_term_id'   => $venue_term_id,
+			'venue_name'      => $venue->name,
+			'config_revision' => $config['revision'],
+			'guide_version'   => $config['booking_guide']['version'],
+			'entries'         => $config['booking_guide']['entries'],
 		);
 	}
 
@@ -241,15 +273,21 @@ class VenueBookingConfig {
 	/** Normalize and validate the complete versioned contract. */
 	public function normalize( array $config ) {
 		$version = $config['version'] ?? self::LEGACY_VERSION;
-		if ( ! is_int( $version ) || ! in_array( $version, array( self::LEGACY_VERSION, self::PREVIOUS_VERSION, self::VERSION ), true ) ) {
+		if ( ! is_int( $version ) || ! in_array( $version, array( self::LEGACY_VERSION, self::PREVIOUS_VERSION, self::PUBLIC_INTAKE_VERSION, self::VERSION ), true ) ) {
 			return new \WP_Error( 'booking_config_version_unsupported', __( 'The venue booking configuration version is unsupported.', 'extrachill-events' ), array( 'version' => $version ) );
 		}
 		$version_three_fields = array( 'public_requirements', 'consent', 'marketing_triggers' );
-		if ( self::VERSION !== $version && array_intersect( $version_three_fields, array_keys( $config ) ) ) {
+		if ( $version < self::PUBLIC_INTAKE_VERSION && array_intersect( $version_three_fields, array_keys( $config ) ) ) {
 			return new \WP_Error( 'booking_config_version_field_invalid', __( 'Public intake and marketing settings require venue booking configuration version 3.', 'extrachill-events' ), array( 'version' => $version ) );
 		}
-		if ( self::VERSION === $version && ! array_key_exists( 'marketing_triggers', $config ) ) {
+		if ( $version >= self::PUBLIC_INTAKE_VERSION && ! array_key_exists( 'marketing_triggers', $config ) ) {
 			return new \WP_Error( 'booking_config_version_field_invalid', __( 'Venue booking configuration version 3 requires marketing triggers.', 'extrachill-events' ), array( 'version' => $version ) );
+		}
+		if ( $version < self::VERSION && array_key_exists( 'booking_guide', $config ) ) {
+			return new \WP_Error( 'booking_config_version_field_invalid', __( 'Booking guide settings require venue booking configuration version 4.', 'extrachill-events' ), array( 'version' => $version ) );
+		}
+		if ( self::VERSION === $version && ! array_key_exists( 'booking_guide', $config ) ) {
+			return new \WP_Error( 'booking_config_version_field_invalid', __( 'Venue booking configuration version 4 requires a booking guide.', 'extrachill-events' ), array( 'version' => $version ) );
 		}
 		$intake_version         = $config['intake']['version'] ?? 1;
 		$deal_version           = $config['default_deal']['version'] ?? 1;
@@ -296,11 +334,15 @@ class VenueBookingConfig {
 		if ( is_wp_error( $consent ) ) {
 			return $consent;
 		}
+		$booking_guide = $this->normalize_booking_guide( $config['booking_guide'] ?? array() );
+		if ( is_wp_error( $booking_guide ) ) {
+			return $booking_guide;
+		}
 		$channels = $this->normalize_channels( $config['marketing_channels'] ?? array() );
 		if ( is_wp_error( $channels ) ) {
 			return $channels;
 		}
-		$triggers = $this->normalize_marketing_triggers( self::VERSION === $version ? $config['marketing_triggers'] : array(), $channels );
+		$triggers = $this->normalize_marketing_triggers( $version >= self::PUBLIC_INTAKE_VERSION ? $config['marketing_triggers'] : array(), $channels );
 		if ( is_wp_error( $triggers ) ) {
 			return $triggers;
 		}
@@ -338,6 +380,7 @@ class VenueBookingConfig {
 			),
 			'public_requirements'       => $requirements,
 			'consent'                   => $consent,
+			'booking_guide'             => $booking_guide,
 			'spaces'                    => $spaces,
 			'default_deal'              => array(
 				'version'                    => 1,
@@ -373,6 +416,10 @@ class VenueBookingConfig {
 				'version'  => self::CONSENT_VERSION,
 				'label'    => __( 'I agree that this venue may use these details to review and respond to my booking inquiry.', 'extrachill-events' ),
 				'required' => true,
+			),
+			'booking_guide'             => array(
+				'version' => self::BOOKING_GUIDE_VERSION,
+				'entries' => array(),
 			),
 			'spaces'                    => array(),
 			'default_deal'              => array(
@@ -565,6 +612,43 @@ class VenueBookingConfig {
 			$normalized[] = $value;
 		}
 		return $normalized;
+	}
+
+	/**
+	 * Normalize ordered public and operator booking-guide entries.
+	 *
+	 * @param mixed $guide Proposed booking guide.
+	 * @return array|\WP_Error
+	 */
+	private function normalize_booking_guide( $guide ) {
+		if ( empty( $guide ) ) {
+			return array(
+				'version' => self::BOOKING_GUIDE_VERSION,
+				'entries' => array(),
+			);
+		}
+		if ( ! is_array( $guide ) || self::BOOKING_GUIDE_VERSION !== ( $guide['version'] ?? null ) || ! is_array( $guide['entries'] ?? null ) || count( $guide['entries'] ) > 50 ) {
+			return new \WP_Error( 'invalid_booking_guide', __( 'The booking guide must use a supported version and contain at most 50 entries.', 'extrachill-events' ) );
+		}
+
+		$entries = array();
+		$seen    = array();
+		foreach ( $guide['entries'] as $entry ) {
+			$key        = mb_substr( sanitize_key( (string) ( $entry['key'] ?? '' ) ), 0, 64 );
+			$title      = mb_substr( sanitize_text_field( (string) ( $entry['title'] ?? '' ) ), 0, 191 );
+			$body       = mb_substr( sanitize_textarea_field( (string) ( $entry['body'] ?? '' ) ), 0, 5000 );
+			$visibility = sanitize_key( (string) ( $entry['visibility'] ?? '' ) );
+			if ( '' === $key || '' === $title || '' === $body || isset( $seen[ $key ] ) || ! in_array( $visibility, array( 'public', 'operator' ), true ) ) {
+				return new \WP_Error( 'invalid_booking_guide_entry', __( 'Each booking guide entry needs a unique key, title, answer, and supported visibility.', 'extrachill-events' ) );
+			}
+			$seen[ $key ] = true;
+			$entries[]    = compact( 'key', 'title', 'body', 'visibility' );
+		}
+
+		return array(
+			'version' => self::BOOKING_GUIDE_VERSION,
+			'entries' => $entries,
+		);
 	}
 
 	/** Normalize the versioned public consent descriptor. */
@@ -856,7 +940,7 @@ class VenueBookingConfig {
 
 	/** Return top-level settings changed by the replacement document. */
 	private function changed_fields( array $current, array $next ): array {
-		$fields  = array( 'enabled', 'intake', 'public_requirements', 'consent', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
+		$fields  = array( 'enabled', 'intake', 'public_requirements', 'consent', 'booking_guide', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
 		$changed = array();
 		foreach ( $fields as $field ) {
 			if ( $current[ $field ] !== $next[ $field ] ) {

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -599,7 +599,7 @@ final class BookingFoundationTest extends BookingTestCase {
 		$migrated = $service->normalize( array( 'version' => 1, 'enabled' => true ) );
 		$this->assertSame( VenueBookingConfig::VERSION, $migrated['version'] );
 		$this->assertArrayHasKey( 'correspondence', $migrated );
-		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => 4 ) )->get_error_code() );
+		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => 5 ) )->get_error_code() );
 		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => '1junk' ) )->get_error_code() );
 		$this->assertSame( 'booking_config_section_version_unsupported', $service->normalize( array( 'intake' => array( 'version' => 2 ) ) )->get_error_code() );
 		$this->assertSame( 'booking_config_section_version_unsupported', $service->normalize( array( 'correspondence' => array( 'version' => 2 ) ) )->get_error_code() );

--- a/tests/BookingMarketingTest.php
+++ b/tests/BookingMarketingTest.php
@@ -388,6 +388,7 @@ final class BookingMarketingTest extends BookingTestCase {
 			'version'            => VenueBookingConfig::VERSION,
 			'revision'           => $revision,
 			'enabled'            => true,
+			'booking_guide'      => array( 'version' => VenueBookingConfig::BOOKING_GUIDE_VERSION, 'entries' => array() ),
 			'marketing_channels' => array_column( $channels, 'key' ),
 			'marketing_triggers' => array(
 				array(
@@ -1191,6 +1192,7 @@ final class BookingMarketingTest extends BookingTestCase {
 		$result               = $config->normalize(
 			array(
 				'version'            => VenueBookingConfig::VERSION,
+				'booking_guide'      => array( 'version' => VenueBookingConfig::BOOKING_GUIDE_VERSION, 'entries' => array() ),
 				'marketing_channels' => array( 'social' ),
 				'marketing_triggers' => array(
 					array(
@@ -1208,6 +1210,7 @@ final class BookingMarketingTest extends BookingTestCase {
 		$result            = $config->normalize(
 			array(
 				'version'            => VenueBookingConfig::VERSION,
+				'booking_guide'      => array( 'version' => VenueBookingConfig::BOOKING_GUIDE_VERSION, 'entries' => array() ),
 				'marketing_channels' => array( 'social' ),
 				'marketing_triggers' => array(
 					array(
@@ -1225,6 +1228,7 @@ final class BookingMarketingTest extends BookingTestCase {
 		$result                = $config->normalize(
 			array(
 				'version'            => VenueBookingConfig::VERSION,
+				'booking_guide'      => array( 'version' => VenueBookingConfig::BOOKING_GUIDE_VERSION, 'entries' => array() ),
 				'marketing_channels' => array( 'social' ),
 				'marketing_triggers' => array(
 					array(
@@ -1274,6 +1278,7 @@ final class BookingMarketingTest extends BookingTestCase {
 		$result  = ( new VenueBookingConfig() )->normalize(
 			array(
 				'version'            => VenueBookingConfig::VERSION,
+				'booking_guide'      => array( 'version' => VenueBookingConfig::BOOKING_GUIDE_VERSION, 'entries' => array() ),
 				'marketing_channels' => array( 'social' ),
 				'marketing_triggers' => array(
 					array(
@@ -1295,7 +1300,7 @@ final class BookingMarketingTest extends BookingTestCase {
 	public function test_version_two_configs_migrate_without_implicit_marketing_triggers(): void {
 		$config            = ( new VenueBookingConfig() )->defaults();
 		$config['version'] = VenueBookingConfig::PREVIOUS_VERSION;
-		unset( $config['public_requirements'], $config['consent'], $config['marketing_triggers'] );
+		unset( $config['public_requirements'], $config['consent'], $config['marketing_triggers'], $config['booking_guide'] );
 		$normalized = ( new VenueBookingConfig() )->normalize( $config );
 		$this->assertSame( VenueBookingConfig::VERSION, $normalized['version'] );
 		$this->assertSame( array(), $normalized['marketing_triggers'] );

--- a/tests/NetworkBookingBlockColdTest.php
+++ b/tests/NetworkBookingBlockColdTest.php
@@ -42,6 +42,8 @@ final class NetworkBookingBlockColdTest extends TestCase {
 
 		$this->assertStringContainsString( 'Cold Room', $output );
 		$this->assertStringContainsString( 'https:\/\/extrachill.com\/wp-json\/extrachill\/v1\/venues\/1524\/booking-inquiries', $output );
+		$this->assertStringContainsString( '"artist_name_label":"Artist or project name"', $output );
+		$this->assertStringNotContainsString( 'Booking guide', $output );
 		$this->assertTrue( $GLOBALS['ec_network_block_test']['turnstile_enqueued'] );
 		$this->assertTrue( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE );
 		$this->assertSame( 1, $GLOBALS['ec_network_block_test']['nocache_headers'] );

--- a/tests/Unit/VenueBookingInquiryRenderTest.php
+++ b/tests/Unit/VenueBookingInquiryRenderTest.php
@@ -37,6 +37,20 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 		$config['enabled']                           = true;
 		$config['revision']                          = 4;
 		$config['public_requirements']               = array( 'Include recent draw and routing.' );
+		$config['booking_guide']['entries']          = array(
+			array(
+				'key'        => 'load_in',
+				'title'      => 'When is load-in?',
+				'body'       => "Load-in timing is confirmed in the booking thread.\nBring your stage plot.",
+				'visibility' => 'public',
+			),
+			array(
+				'key'        => 'settlement',
+				'title'      => 'Settlement notes',
+				'body'       => 'Private operator instructions.',
+				'visibility' => 'operator',
+			),
+		);
 		$config['spaces']                            = array(
 			array(
 				'key'        => 'main-room',
@@ -71,6 +85,10 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Test Room', $output );
 		$this->assertStringContainsString( '42 Test Street, Charleston, SC, 29403', $output );
 		$this->assertStringContainsString( 'Include recent draw and routing.', $output );
+		$this->assertStringContainsString( 'When is load-in?', $output );
+		$this->assertStringContainsString( 'Bring your stage plot.', $output );
+		$this->assertStringNotContainsString( 'Private operator instructions.', $output );
+		$this->assertStringNotContainsString( 'Settlement notes', $output );
 		$this->assertStringContainsString( '"revision":4', $output );
 		$this->assertStringNotContainsString( 'private-provider-account', $output );
 		$this->assertStringNotContainsString( 'private-booking@example.com', $output );
@@ -82,11 +100,26 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 	public function test_disabled_config_fails_closed_without_form_markup(): void {
 		switch_to_blog( self::EVENTS_BLOG_ID );
 		$config            = get_term_meta( $this->venue_id, VenueBookingConfig::META_KEY, true );
-		$config['enabled'] = false;
+		$config['enabled']                          = false;
+		$config['booking_guide']['entries']         = array();
 		update_term_meta( $this->venue_id, VenueBookingConfig::META_KEY, $config );
 		restore_current_blog();
 
 		$this->assertSame( '', $this->render_on( self::MAIN_BLOG_ID, array( 'venueId' => $this->venue_id ) ) );
+	}
+
+	/** A public guide remains useful when inquiry intake is temporarily closed. */
+	public function test_public_guide_renders_without_disabled_inquiry_app(): void {
+		switch_to_blog( self::EVENTS_BLOG_ID );
+		$config            = get_term_meta( $this->venue_id, VenueBookingConfig::META_KEY, true );
+		$config['enabled'] = false;
+		update_term_meta( $this->venue_id, VenueBookingConfig::META_KEY, $config );
+		restore_current_blog();
+
+		$output = $this->render_on( self::MAIN_BLOG_ID, array( 'venueId' => $this->venue_id ) );
+		$this->assertStringContainsString( 'When is load-in?', $output );
+		$this->assertStringNotContainsString( 'data-booking-app', $output );
+		$this->assertStringNotContainsString( 'private-booking@example.com', $output );
 	}
 
 	/** Render the same canonical venue through Events, main, and Studio. */

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -1833,7 +1833,7 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$abilities->register();
 
 		$this->assertSame(
-			array( 'extrachill/get-venue-booking-config', 'extrachill/update-venue-booking-config', 'extrachill/preview-booking-correspondence-template' ),
+			array( 'extrachill/get-venue-booking-config', 'extrachill/update-venue-booking-config', 'extrachill/get-venue-booking-guide', 'extrachill/preview-booking-correspondence-template' ),
 			array_keys( $GLOBALS['venue_membership_test']['abilities'] )
 		);
 		$get    = $GLOBALS['venue_membership_test']['abilities']['extrachill/get-venue-booking-config'];
@@ -1842,7 +1842,7 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertSame( 'venue_action_forbidden', call_user_func( $get['permission_callback'], array( 'venue_term_id' => 56 ) )->get_error_code() );
 		$config_input  = $update['input_schema']['properties']['config'];
 		$config_output = $get['output_schema'];
-		$this->assertCount( 3, $config_input['oneOf'] );
+		$this->assertCount( 4, $config_input['oneOf'] );
 		$this->assertSame( array( 1 ), $config_input['oneOf'][0]['properties']['version']['enum'] );
 		$this->assertNotContains( 'correspondence', $config_input['oneOf'][0]['required'] );
 		$this->assertNotContains( 'public_requirements', $config_input['oneOf'][0]['required'] );
@@ -1857,21 +1857,26 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertContains( 'public_requirements', $config_input['oneOf'][2]['required'] );
 		$this->assertContains( 'consent', $config_input['oneOf'][2]['required'] );
 		$this->assertContains( 'marketing_triggers', $config_input['oneOf'][2]['required'] );
-		$this->assertSame( array( 3 ), $config_output['properties']['version']['enum'] );
+		$this->assertNotContains( 'booking_guide', $config_input['oneOf'][2]['required'] );
+		$this->assertSame( array( 4 ), $config_input['oneOf'][3]['properties']['version']['enum'] );
+		$this->assertContains( 'booking_guide', $config_input['oneOf'][3]['required'] );
+		$this->assertSame( array( 4 ), $config_output['properties']['version']['enum'] );
 		$this->assertContains( 'correspondence', $config_output['required'] );
 		$this->assertContains( 'public_requirements', $config_output['required'] );
 		$this->assertContains( 'consent', $config_output['required'] );
 		$this->assertContains( 'marketing_triggers', $config_output['required'] );
+		$this->assertContains( 'booking_guide', $config_output['required'] );
 
 		$legacy = ( new VenueBookingConfig() )->defaults();
 		$legacy['version'] = 1;
-		unset( $legacy['correspondence'], $legacy['public_requirements'], $legacy['consent'], $legacy['marketing_triggers'] );
+		unset( $legacy['correspondence'], $legacy['public_requirements'], $legacy['consent'], $legacy['marketing_triggers'], $legacy['booking_guide'] );
 		unset( $legacy['revision'], $legacy['updated_by_user_id'], $legacy['updated_at'] );
 		$GLOBALS['venue_membership_test']['term_meta'][55][ VenueBookingConfig::META_KEY ] = $legacy;
 		$current = call_user_func( $get['execute_callback'], array( 'venue_term_id' => 55 ) );
-		$this->assertSame( 3, $current['version'] );
+		$this->assertSame( 4, $current['version'] );
 		$this->assertArrayHasKey( 'correspondence', $current );
 		$this->assertSame( array(), $current['marketing_triggers'] );
+		$this->assertSame( array(), $current['booking_guide']['entries'] );
 		$this->assertSame( 0, $current['revision'] );
 		$this->assertNull( $current['updated_by_user_id'] );
 		$settings = $current;
@@ -1880,6 +1885,20 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$settings['correspondence']['booking_address'] = 'booking@example.com';
 		$settings['correspondence']['templates']['operator_message']['version'] = 2;
 		$settings['correspondence']['templates']['operator_message']['subject'] = 'Booking update for {{artist_name}} at {{venue_name}}';
+		$settings['booking_guide']['entries'] = array(
+			array(
+				'key'        => 'load_in',
+				'title'      => 'When is load-in?',
+				'body'       => 'Confirm timing in the managed booking thread.',
+				'visibility' => 'public',
+			),
+			array(
+				'key'        => 'door_notes',
+				'title'      => 'Door notes',
+				'body'       => 'Operator-only settlement guidance.',
+				'visibility' => 'operator',
+			),
+		);
 		$saved               = call_user_func(
 			$update['execute_callback'],
 			array(
@@ -1893,9 +1912,20 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertTrue( $saved['enabled'] );
 		$history = $GLOBALS['venue_membership_test']['term_history'][55][ VenueBookingConfig::HISTORY_META_KEY ];
 		$this->assertCount( 1, $history );
-		$this->assertSame( array( 'enabled', 'correspondence' ), $history[0]['changed_fields'] );
+		$this->assertSame( array( 'enabled', 'booking_guide', 'correspondence' ), $history[0]['changed_fields'] );
 		$this->assertCount( 1, $GLOBALS['venue_membership_test']['fired_actions']['extrachill_events_venue_booking_config_updated'] );
 		$this->assertNotEmpty( $GLOBALS['venue_membership_test']['cache_deletes'] );
+		$public = ( new VenueBookingConfig() )->get_public_projection( 55 );
+		$this->assertSame( array( 'load_in' ), array_column( $public['booking_guide']['entries'], 'key' ) );
+		$this->assertStringNotContainsString( 'Operator-only', wp_json_encode( $public ) );
+		$guide = $GLOBALS['venue_membership_test']['abilities']['extrachill/get-venue-booking-guide'];
+		$this->assertTrue( call_user_func( $guide['permission_callback'], array( 'venue_term_id' => 55 ) ) );
+		$this->assertSame( 'venue_action_forbidden', call_user_func( $guide['permission_callback'], array( 'venue_term_id' => 56 ) )->get_error_code() );
+		$grounding = call_user_func( $guide['execute_callback'], array( 'venue_term_id' => 55 ) );
+		$this->assertSame( 'The Royal American', $grounding['venue_name'] );
+		$this->assertSame( 1, $grounding['config_revision'] );
+		$this->assertSame( array( 'load_in', 'door_notes' ), array_column( $grounding['entries'], 'key' ) );
+		$this->assertArrayNotHasKey( 'correspondence', $grounding );
 
 		$stale = call_user_func(
 			$update['execute_callback'],

--- a/tests/browser/booking-inquiry.evidence.js
+++ b/tests/browser/booking-inquiry.evidence.js
@@ -60,6 +60,21 @@ const fixture = `<!doctype html>
 	<body>
 		<main>
 			<section class="wp-block-extrachill-venue-booking-inquiry ec-venue-booking-inquiry">
+				<div class="ec-booking-guide" aria-labelledby="booking-guide-title">
+					<h2 id="booking-guide-title">Booking guide</h2>
+					<p>Venue-provided information to review before sending a booking inquiry.</p>
+					<div class="ec-booking-guide__entries">
+						<article class="ec-booking-guide__entry" data-guide-key="load_in">
+							<h3>When is load-in?</h3>
+							<p>Load-in timing is confirmed in the booking thread.</p>
+						</article>
+						<article class="ec-booking-guide__entry" data-guide-key="equipment">
+							<h3>What equipment is available?</h3>
+							<p>The current production package is shared after inquiry review.</p>
+						</article>
+					</div>
+					<p class="ec-booking-guide__communication">For details not covered here, send an inquiry below so communication stays with the booking request.</p>
+				</div>
 				<div data-booking-app></div>
 				<script type="application/json">${ JSON.stringify( config ) }</script>
 				<div data-booking-turnstile><div class="cf-turnstile">Security check</div></div>
@@ -102,6 +117,8 @@ const measure = ( page ) =>
 			scrollWidth: document.documentElement.scrollWidth,
 			shell,
 			panel: bounds( '.ec-booking-inquiry__panel' ),
+			guide: bounds( '.ec-booking-guide' ),
+			guideEntries: bounds( '.ec-booking-guide__entries' ),
 			form,
 			grid: bounds( '.ec-booking-inquiry__form > .ec-card-grid' ),
 			turnstile: bounds( '.ec-booking-inquiry__turnstile' ),
@@ -156,6 +173,13 @@ const measure = ( page ) =>
 		await page.waitForSelector( '.ec-booking-inquiry__form' );
 
 		assert.equal( await page.getByText( 'Booking inquiries' ).count(), 1 );
+		assert.equal(
+			await page
+				.getByRole( 'heading', { name: 'Booking guide' } )
+				.count(),
+			1
+		);
+		assert.equal( await page.getByText( 'When is load-in?' ).count(), 1 );
 		assert.equal( await page.getByText( 'Now booking' ).count(), 1 );
 		assert.equal( await page.getByText( 'Signed-in inquiry' ).count(), 1 );
 		assert.ok( await page.getByLabel( 'Artist or project name' ).count() );
@@ -172,6 +196,7 @@ const measure = ( page ) =>
 		assert.equal( desktop.scrollWidth, desktop.viewportWidth );
 		assert.ok( desktop.inlineGutter > 0 );
 		assert.equal( desktop.controlsInsideViewport, true );
+		assert.ok( desktop.guideEntries.width <= desktop.guide.width );
 		assert.ok(
 			Number.parseFloat(
 				await page
@@ -192,6 +217,7 @@ const measure = ( page ) =>
 		assert.ok( mobile.inlineGutter > 0 );
 		assert.ok( mobile.form.right < mobile.viewportWidth );
 		assert.equal( mobile.controlsInsideViewport, true );
+		assert.ok( mobile.guideEntries.right <= mobile.viewportWidth );
 
 		await page.getByLabel( 'Artist or project name' ).fill( 'Proof Band' );
 		await page.getByLabel( 'Contact name' ).fill( 'Booking Agent' );


### PR DESCRIPTION
## Summary

- Add a versioned, ordered venue-owned booking guide to the existing canonical booking config, editable by authorized venue members in Venue Settings.
- Render public entries beside the canonical venue inquiry while filtering operator entries from page markup and the public projection.
- Expose a narrow, exact-venue-authorized `extrachill/get-venue-booking-guide` ability with venue identity, current config revision, guide version, and guide entries for grounded Roadie consumption.

## Ownership and schema

Events remains the sole owner. Config version 4 adds `booking_guide` version 1 with ordered `entries`; each entry has a stable `key`, `title`, `body`, and `visibility` (`public` or `operator`). No CPT, duplicate profile, generic knowledge substrate, or venue-specific source literals were added.

Version 1-3 persisted configs normalize forward with an empty guide. Existing version 3 public inquiry configs continue rendering before their next revisioned save. Updates retain the existing optimistic revision, atomic audit, metadata cache deletion, and update-hook behavior.

## Public and private rules

Only `public` guide entries enter `get_public_projection()` and canonical venue archive markup. Operator entries remain available only through the exact active-venue membership ability. The grounding response deliberately excludes correspondence addresses, deal defaults, ticket provider references, and all unrelated operational config. Public rendering directs unknown questions into the managed inquiry flow rather than exposing coordinator details.

## Roadie contract and follow-up

Roadie should call `extrachill/get-venue-booking-guide` as the bound user for the pinned venue, answer only from returned entries, identify missing information as unavailable, and cite the returned venue/config revision context. Consumer wiring is outside this repository and is tracked in a focused Roadie follow-up tracked in Extra-Chill/extrachill-roadie#103.

## Verification

Passed:

- `npm run test:js -- --runInBand` (81 tests)
- `vendor/bin/phpunit --no-configuration --bootstrap tests/bootstrap.php tests/VenueMembershipAuthorizationTest.php` (50 tests, 358 assertions)
- `vendor/bin/phpunit --no-configuration --bootstrap tests/bootstrap.php tests/BookingFoundationTest.php` (41 tests, 403 assertions)
- `vendor/bin/phpunit --no-configuration --bootstrap tests/bootstrap.php tests/BookingMarketingTest.php` (36 tests, 163 assertions)
- `npm run lint:js`
- `npm run build`
- `npm run test:browser:booking-inquiry` (1280x900 and 390x844, no overflow)
- `homeboy --placement local review build extrachill-events --path <worktree> --changed-since origin/main`
- PHP syntax checks and `git diff --check`

Homeboy's generic test collector was also run, but it incorrectly invoked Jest/JSX files directly with Node; repository-native Jest passed above. Homeboy changed-only lint's PHPCS and ESLint producers passed; its PHPStan producer reported existing WordPress test-stub signature findings across whole modified legacy files. Homeboy audit timed out and left a stale observation run. The repository test-collection bug is tracked in #532./

Refs #526