### PR TITLE
feat: add coordinator-controlled vendor requests

### DIFF
--- a/assets/css/vendor-request.css
+++ b/assets/css/vendor-request.css
@@ -1,0 +1,19 @@
+.ec-vendor-request-page { padding-block: var(--wp--preset--spacing--40, 2rem); }
+.ec-vendor-request { --vendor-accent: #9c4f20; display: grid; gap: 1.25rem; max-width: 72rem; margin-inline: auto; padding: clamp(1rem, 3vw, 2rem); }
+.ec-vendor-request__hero { padding: clamp(1.25rem, 4vw, 2.5rem); border-left: 6px solid var(--vendor-accent); background: linear-gradient(135deg, color-mix(in srgb, var(--vendor-accent) 13%, white), #fff 72%); }
+.ec-vendor-request__eyebrow { margin: 0; font-size: .78rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+.ec-vendor-request__status { display: inline-flex; padding: .25rem .55rem; border: 1px solid currentcolor; border-radius: 999px; font-size: .78rem; font-weight: 750; text-transform: uppercase; }
+.ec-vendor-request__section, .ec-vendor-request__card { padding: 1.25rem; border: 1px solid var(--wp--preset--color--contrast-3, #d3dad7); border-radius: .65rem; background: #fff; }
+.ec-vendor-request__cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(19rem, 1fr)); gap: 1rem; }
+.ec-vendor-request__card { display: grid; gap: .8rem; align-content: start; }
+.ec-vendor-request__card dl { display: grid; grid-template-columns: minmax(6rem, auto) 1fr; gap: .35rem .75rem; margin: 0; }
+.ec-vendor-request__card dt { font-weight: 750; }
+.ec-vendor-request__form { display: grid; gap: .9rem; max-width: 42rem; }
+.ec-vendor-request__form label { display: grid; gap: .35rem; font-weight: 700; }
+.ec-vendor-request__form input:not([type="checkbox"]), .ec-vendor-request__form select, .ec-vendor-request__form textarea { box-sizing: border-box; width: 100%; padding: .65rem; }
+.ec-vendor-request__consent { grid-template-columns: auto 1fr; align-items: start; }
+.ec-vendor-request__privacy { color: var(--wp--preset--color--contrast-2, #64706c); font-size: .9rem; }
+.ec-vendor-request__notice { padding: .85rem 1rem; border-left: 4px solid #315f88; background: #e9f2fa; }
+.ec-vendor-request__notice--success { border-color: #17633f; background: #e1f4e9; }
+.ec-vendor-request__notice--error { border-color: #9f2d25; background: #fbe8e6; }
+@media (max-width: 600px) { .ec-vendor-request-page { padding-block: 0; } .ec-vendor-request { padding-inline: .75rem; } .ec-vendor-request__cards { grid-template-columns: 1fr; } .ec-vendor-request__form button { width: 100%; min-height: 44px; } }

--- a/assets/js/vendor-application.js
+++ b/assets/js/vendor-application.js
@@ -1,0 +1,40 @@
+( () => {
+	const root = document.querySelector( '[data-vendor-application]' );
+	const form = root?.querySelector( '[data-vendor-application-form]' );
+	const status = root?.querySelector( '[data-vendor-application-status]' );
+	if ( ! root || ! form || ! status ) {
+		return;
+	}
+	form.addEventListener( 'submit', async ( event ) => {
+		event.preventDefault();
+		const button = form.querySelector( 'button[type="submit"]' );
+		const data = Object.fromEntries( new FormData( form ).entries() );
+		data.contact_consent = data.contact_consent === '1';
+		data.event_id = Number( data.event_id );
+		data.turnstile_response = data[ 'cf-turnstile-response' ] || '';
+		delete data[ 'cf-turnstile-response' ];
+		button.disabled = true;
+		status.hidden = false;
+		status.textContent = 'Submitting your application…';
+		try {
+			const response = await fetch( root.dataset.endpoint, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify( data ),
+			} );
+			const payload = await response.json();
+			if ( ! response.ok ) {
+				throw new Error(
+					payload.message || 'The application could not be submitted.'
+				);
+			}
+			form.hidden = true;
+			status.textContent = `Application received. Save this private withdrawal receipt: ${
+				payload.public_id || ''
+			}:${ payload.access_token || '' }`;
+		} catch ( error ) {
+			status.textContent = error.message;
+			button.disabled = false;
+		}
+	} );
+} )();

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -30,7 +30,7 @@ define( 'EXTRACHILL_EVENTS_PLUGIN_FILE', __FILE__ );
 define( 'EXTRACHILL_EVENTS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 // WP-CLI commands.
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCommand.php' ) ) {
+if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCommand.php' ) ) { // @phpstan-ignore booleanAnd.rightAlwaysTrue
 	require_once __DIR__ . '/inc/Core/EventSourceRampEvaluator.php';
 	require_once __DIR__ . '/inc/Cli/EventSourceRampCommand.php';
 	\WP_CLI::add_command( 'extrachill events ramp', \ExtraChillEvents\Cli\EventSourceRampCommand::class );
@@ -190,8 +190,11 @@ add_filter(
  */
 class ExtraChillEvents {
 
+	/** @var self|null */
 	private static $instance = null;
-	private $integrations    = array();
+
+	/** @var array */
+	private $integrations = array();
 
 	/**
 	 * Get singleton instance
@@ -269,9 +272,11 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ArtistUrlSubmissionsTable.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingSchema.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportSchema.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestSchema.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueAuthorization.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportAuthorization.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestAuthorization.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueInvitationToken.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueOnboardingRepository.php';
@@ -282,6 +287,9 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportWorkspace.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestNotificationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingNotificationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportNotificationAdapter.php';
@@ -315,6 +323,7 @@ class ExtraChillEvents {
 		\ExtraChillEvents\Core\BookingCorrespondenceAutomationService::register();
 		\ExtraChillEvents\Core\BookingNotificationService::register();
 		\ExtraChillEvents\Core\LocalSupportNotificationService::register();
+		\ExtraChillEvents\Core\VendorRequestNotificationService::register();
 		new \ExtraChillEvents\Core\CanonicalEventPublicationGuard();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/ArtistUrlImport.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/ArtistUrlImportRoutes.php';
@@ -343,6 +352,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/discovery-pages.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/router-pages.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/local-support-workspace.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/vendor-request-workspace.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/booking-console.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-normalizer.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/calendar-stats.php';
@@ -460,6 +470,11 @@ class ExtraChillEvents {
 			new \ExtraChillEvents\Abilities\LocalSupportAbilities();
 		}
 
+		if ( \ExtraChillEvents\Core\VendorRequestSchema::is_ready() ) {
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/VendorRequestAbilities.php';
+			new \ExtraChillEvents\Abilities\VendorRequestAbilities();
+		}
+
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/PriorityVenueAbilities.php';
 		new \ExtraChillEvents\Abilities\PriorityVenueAbilities();
 
@@ -529,6 +544,8 @@ class ExtraChillEvents {
 
 		// Private, site-scoped venue booking tables.
 		\ExtraChillEvents\Core\BookingSchema::install();
+		\ExtraChillEvents\Core\LocalSupportSchema::install();
+		\ExtraChillEvents\Core\VendorRequestSchema::install();
 
 		flush_rewrite_rules();
 	}
@@ -561,6 +578,10 @@ class ExtraChillEvents {
 
 		if ( class_exists( '\\ExtraChillEvents\\Core\\LocalSupportSchema' ) ) {
 			\ExtraChillEvents\Core\LocalSupportSchema::maybe_install();
+		}
+
+		if ( class_exists( '\\ExtraChillEvents\\Core\\VendorRequestSchema' ) ) {
+			\ExtraChillEvents\Core\VendorRequestSchema::maybe_install();
 		}
 	}
 

--- a/inc/Abilities/VendorRequestAbilities.php
+++ b/inc/Abilities/VendorRequestAbilities.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Hidden event vendor request abilities.
+ *
+ * @package ExtraChillEvents\Abilities
+ */
+
+namespace ExtraChillEvents\Abilities;
+
+use ExtraChillEvents\Core\VendorRequestService;
+use function add_action;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Registers public-admission and private-management domain contracts. */
+class VendorRequestAbilities {
+
+	/** @var VendorRequestService */
+	private $service;
+
+	public function __construct( ?VendorRequestService $service = null ) {
+		$this->service = $service ? $service : new VendorRequestService();
+		add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+	}
+
+	public function register(): void {
+		$this->register_ability( 'open-vendor-request', __( 'Open Vendor Request', 'extrachill-events' ), $this->open_schema(), array( $this, 'open_request' ), true );
+		$this->register_ability( 'set-vendor-request-open', __( 'Set Vendor Request Open', 'extrachill-events' ), $this->request_status_schema(), array( $this, 'set_request_open' ), true );
+		$this->register_ability( 'get-public-vendor-request', __( 'Get Public Vendor Request', 'extrachill-events' ), $this->object_schema( array( 'event_id' => $this->integer() ), array( 'event_id' ) ), array( $this, 'get_public_request' ), false, true );
+		$this->register_ability( 'apply-to-vendor-request', __( 'Apply to Vendor Request', 'extrachill-events' ), $this->application_schema(), array( $this, 'apply' ), false );
+		$this->register_ability( 'list-vendor-applications', __( 'List Vendor Applications', 'extrachill-events' ), $this->object_schema( array( 'request_id' => $this->integer() ), array( 'request_id' ) ), array( $this, 'list_applications' ), true );
+		$this->register_ability( 'review-vendor-application', __( 'Review Vendor Application', 'extrachill-events' ), $this->review_schema(), array( $this, 'review_application' ), true );
+		$this->register_ability( 'contact-vendor-applicant', __( 'Contact Vendor Applicant', 'extrachill-events' ), $this->contact_schema(), array( $this, 'contact_applicant' ), true );
+		$this->register_ability( 'withdraw-vendor-application', __( 'Withdraw Vendor Application', 'extrachill-events' ), $this->withdraw_schema(), array( $this, 'withdraw' ), false );
+	}
+
+	public function open_request( array $input ) {
+		return $this->service->open_request( (int) $input['event_id'], (array) ( $input['policy'] ?? array() ), (string) $input['idempotency_key'], get_current_user_id() );
+	}
+
+	public function set_request_open( array $input ) {
+		return $this->service->set_request_open( (int) $input['request_id'], (bool) $input['open'], (int) $input['expected_version'], (string) $input['idempotency_key'], get_current_user_id() );
+	}
+
+	public function get_public_request( array $input ) {
+		return $this->service->public_request_for_event( (int) $input['event_id'] );
+	}
+
+	public function apply( array $input ) {
+		return $this->service->apply( $input, get_current_user_id() );
+	}
+
+	public function list_applications( array $input ) {
+		return $this->service->list_applications( (int) $input['request_id'], get_current_user_id() );
+	}
+
+	public function review_application( array $input ) {
+		return $this->service->review_application( (int) $input['application_id'], (string) $input['status'], (string) ( $input['notes'] ?? '' ), (int) $input['expected_version'], (string) $input['idempotency_key'], get_current_user_id() );
+	}
+
+	public function contact_applicant( array $input ) {
+		return $this->service->contact_applicant( (int) $input['application_id'], (string) $input['subject'], (string) $input['message'], (string) $input['idempotency_key'], get_current_user_id() );
+	}
+
+	public function withdraw( array $input ) {
+		return $this->service->withdraw( (string) $input['public_id'], (string) $input['access_token'], (int) $input['expected_version'], (string) $input['idempotency_key'] );
+	}
+
+	public function authenticated(): bool {
+		return get_current_user_id() > 0;
+	}
+
+	private function register_ability( string $slug, string $label, array $input, callable $callback, bool $authenticated, bool $read_only = false ): void {
+		wp_register_ability(
+			'extrachill-events/' . $slug,
+			array(
+				'label'               => $label,
+				'description'         => __( 'Event-scoped vendor request operation.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => $input,
+				'output_schema'       => array(
+					'type'                 => array( 'object', 'null' ),
+					'additionalProperties' => true,
+				),
+				'execute_callback'    => $callback,
+				'permission_callback' => $authenticated ? array( $this, 'authenticated' ) : '__return_true',
+				'meta'                => array(
+					'show_in_rest' => false,
+					'annotations'  => array(
+						'readonly'    => $read_only,
+						'idempotent'  => true,
+						'destructive' => ! $read_only,
+					),
+				),
+			)
+		);
+	}
+
+	private function open_schema(): array {
+		return $this->object_schema(
+			array(
+				'event_id'        => $this->integer(),
+				'policy'          => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
+				'idempotency_key' => $this->key_schema(),
+			),
+			array( 'event_id', 'idempotency_key' )
+		);
+	}
+
+	private function request_status_schema(): array {
+		return $this->object_schema(
+			array(
+				'request_id'       => $this->integer(),
+				'open'             => array( 'type' => 'boolean' ),
+				'expected_version' => $this->integer(),
+				'idempotency_key'  => $this->key_schema(),
+			),
+			array( 'request_id', 'open', 'expected_version', 'idempotency_key' )
+		);
+	}
+
+	private function application_schema(): array {
+		$nullable = array(
+			'type'      => array( 'string', 'null' ),
+			'maxLength' => 2000,
+		);
+		return $this->object_schema(
+			array(
+				'event_id'        => $this->integer(),
+				'idempotency_key' => $this->key_schema(),
+				'business_name'   => array(
+					'type'      => 'string',
+					'maxLength' => 255,
+				),
+				'contact_name'    => array(
+					'type'      => 'string',
+					'maxLength' => 255,
+				),
+				'contact_email'   => array(
+					'type'      => 'string',
+					'format'    => 'email',
+					'maxLength' => 255,
+				),
+				'contact_phone'   => array(
+					'type'      => array( 'string', 'null' ),
+					'maxLength' => 64,
+				),
+				'category'        => array(
+					'type'      => 'string',
+					'maxLength' => 191,
+				),
+				'website_url'     => array(
+					'type'      => array( 'string', 'null' ),
+					'format'    => 'uri',
+					'maxLength' => 2000,
+				),
+				'footprint'       => array(
+					'type'      => 'string',
+					'maxLength' => 255,
+				),
+				'power_needs'     => $nullable,
+				'insurance_notes' => $nullable,
+				'message'         => array(
+					'type'      => 'string',
+					'maxLength' => 5000,
+				),
+				'contact_consent' => array( 'type' => 'boolean' ),
+			),
+			array( 'event_id', 'idempotency_key', 'business_name', 'contact_name', 'contact_email', 'category', 'footprint', 'message', 'contact_consent' )
+		);
+	}
+
+	private function review_schema(): array {
+		return $this->object_schema(
+			array(
+				'application_id'   => $this->integer(),
+				'status'           => array(
+					'type' => 'string',
+					'enum' => VendorRequestService::APPLICATION_STATUSES,
+				),
+				'notes'            => array(
+					'type'      => 'string',
+					'maxLength' => 5000,
+				),
+				'expected_version' => $this->integer(),
+				'idempotency_key'  => $this->key_schema(),
+			),
+			array( 'application_id', 'status', 'expected_version', 'idempotency_key' )
+		);
+	}
+
+	private function contact_schema(): array {
+		return $this->object_schema(
+			array(
+				'application_id'  => $this->integer(),
+				'subject'         => array(
+					'type'      => 'string',
+					'maxLength' => 255,
+				),
+				'message'         => array(
+					'type'      => 'string',
+					'maxLength' => 10000,
+				),
+				'idempotency_key' => $this->key_schema(),
+			),
+			array( 'application_id', 'subject', 'message', 'idempotency_key' )
+		);
+	}
+
+	private function withdraw_schema(): array {
+		return $this->object_schema(
+			array(
+				'public_id'        => array(
+					'type'   => 'string',
+					'format' => 'uuid',
+				),
+				'access_token'     => array(
+					'type'      => 'string',
+					'minLength' => 64,
+					'maxLength' => 64,
+				),
+				'expected_version' => $this->integer(),
+				'idempotency_key'  => $this->key_schema(),
+			),
+			array( 'public_id', 'access_token', 'expected_version', 'idempotency_key' )
+		);
+	}
+
+	private function object_schema( array $properties, array $required ): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => $properties,
+			'required'             => $required,
+			'additionalProperties' => false,
+		);
+	}
+
+	private function integer(): array {
+		return array(
+			'type'    => 'integer',
+			'minimum' => 1,
+		);
+	}
+
+	private function key_schema(): array {
+		return array(
+			'type'      => 'string',
+			'minLength' => 1,
+			'maxLength' => 191,
+		);
+	}
+}

--- a/inc/Core/VendorRequestAuthorization.php
+++ b/inc/Core/VendorRequestAuthorization.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Event vendor request authorization.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+use function is_wp_error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Revalidates canonical event, exact venue, and coordinator authority. */
+class VendorRequestAuthorization {
+
+	/** @var VenueAuthorization */
+	private $venues;
+
+	public function __construct( ?VenueAuthorization $venues = null ) {
+		$this->venues = $venues ? $venues : new VenueAuthorization();
+	}
+
+	/** Resolve one canonical event bound to exactly one venue. */
+	public function event_context( int $event_id ) {
+		$post = get_post( $event_id );
+		if ( ! $post || 'data_machine_events' !== $post->post_type || 'trash' === $post->post_status ) {
+			return new \WP_Error( 'invalid_vendor_request_event', __( 'A valid canonical event is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$venues = wp_get_object_terms( $event_id, 'venue', array( 'fields' => 'ids' ) );
+		if ( is_wp_error( $venues ) || 1 !== count( (array) $venues ) ) {
+			return new \WP_Error( 'invalid_vendor_request_venue', __( 'The event must have one canonical venue.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return array(
+			'event_id'      => $event_id,
+			'venue_term_id' => (int) reset( $venues ),
+		);
+	}
+
+	/** Require current exact-venue organizer authority. */
+	public function authorize_organizer( array $request, int $user_id ) {
+		$context = $this->event_context( (int) $request['event_id'] );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+		if ( (int) $request['venue_term_id'] !== $context['venue_term_id'] ) {
+			return $this->denied();
+		}
+		$allowed = $this->venues->authorize( $user_id, $context['venue_term_id'], VenueAuthorization::ACTION_ACCESS_VENUE );
+		return true === $allowed ? true : $this->denied();
+	}
+
+	/** Require the persisted coordinator and current venue authority. */
+	public function authorize_coordinator( array $request, int $user_id ) {
+		if ( $user_id < 1 || (int) $request['coordinator_user_id'] !== $user_id ) {
+			return $this->denied();
+		}
+		return $this->authorize_organizer( $request, $user_id );
+	}
+
+	private function denied(): \WP_Error {
+		return new \WP_Error( 'vendor_request_forbidden', __( 'This private vendor request is unavailable.', 'extrachill-events' ), array( 'status' => 403 ) );
+	}
+}

--- a/inc/Core/VendorRequestNotificationService.php
+++ b/inc/Core/VendorRequestNotificationService.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Vendor application notification receipts.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+use function add_action;
+use function is_wp_error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Delivers privacy-safe coordinator notifications with Users receipts. */
+class VendorRequestNotificationService {
+
+	public const PRODUCER = 'extrachill-events-vendor-requests';
+	/** @var VendorRequestRepository */
+	private $repository;
+	/** @var VendorRequestAuthorization */
+	private $authorization;
+	/** @var callable|null */
+	private $delivery;
+	/** @var callable|null */
+	private $actor;
+
+	public function __construct( ?VendorRequestRepository $repository = null, ?VendorRequestAuthorization $authorization = null, $delivery = null, $actor = null ) {
+		$this->repository    = $repository ? $repository : new VendorRequestRepository();
+		$this->authorization = $authorization ? $authorization : new VendorRequestAuthorization();
+		$this->delivery      = is_callable( $delivery ) ? $delivery : null;
+		$this->actor         = is_callable( $actor ) ? $actor : null;
+	}
+
+	public static function register(): void {
+		add_action( 'extrachill_events_vendor_request_changed', array( self::class, 'handle_change' ) );
+	}
+
+	public static function handle_change( array $change ): void {
+		( new self() )->notify_change( $change );
+	}
+
+	/** Deliver and persist one privacy-safe application receipt. */
+	public function notify_change( array $change ) {
+		if ( 'application_submitted' !== ( $change['kind'] ?? '' ) ) {
+			return null;
+		}
+		$request = $this->repository->get_request( absint( $change['request_id'] ?? 0 ) );
+		if ( ! is_array( $request ) ) {
+			return is_wp_error( $request ) ? $request : new \WP_Error( 'vendor_notification_request_missing' );
+		}
+		$recipient = (int) $request['coordinator_user_id'];
+		$allowed   = $this->authorization->authorize_coordinator( $request, $recipient );
+		if ( true !== $allowed ) {
+			return $allowed;
+		}
+		$actor_id = $this->actor ? absint( call_user_func( $this->actor ) ) : ( function_exists( 'ec_get_network_bot_user_id' ) ? absint( ec_get_network_bot_user_id() ) : $recipient );
+		$payload  = array(
+			'actor_id'        => $actor_id,
+			'type'            => 'vendor_application_submitted',
+			'title'           => __( 'A vendor applied to your event', 'extrachill-events' ),
+			'link'            => get_home_url( function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'events' ) ) : null, '/vendor-requests/' . $request['id'] . '/' ),
+			'item_id'         => (int) $request['event_id'],
+			'producer'        => self::PRODUCER,
+			'idempotency_key' => sprintf( 'vendor-application:%d:%d', absint( $change['application_id'] ?? 0 ), absint( $change['version'] ?? 0 ) ),
+		);
+		$receipt  = $this->delivery
+			? call_user_func( $this->delivery, array( $recipient ), $payload )
+			: ( function_exists( 'ec_users_notify_with_receipts' ) ? ec_users_notify_with_receipts( array( $recipient ), $payload ) : new \WP_Error( 'vendor_notification_receipts_unavailable' ) );
+		$status   = is_wp_error( $receipt ) ? 'failed' : ( $receipt['recipients'][ $recipient ]['status'] ?? 'failed' );
+		return $this->repository->append_activity(
+			array(
+				'request_id'      => $request['id'],
+				'application_id'  => absint( $change['application_id'] ?? 0 ),
+				'kind'            => 'notification_receipt',
+				'actor_user_id'   => $payload['actor_id'],
+				'idempotency_key' => 'vendor-notification-receipt:' . $payload['idempotency_key'],
+				'request_hash'    => hash( 'sha256', $payload['idempotency_key'] ),
+				'result_version'  => absint( $change['version'] ?? 0 ),
+				'payload'         => array( 'status' => sanitize_key( $status ) ),
+			)
+		);
+	}
+}

--- a/inc/Core/VendorRequestRepository.php
+++ b/inc/Core/VendorRequestRepository.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Private vendor request persistence.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Provides bounded persistence for vendor requests and applications. */
+class VendorRequestRepository {
+
+	public function create_request( array $data ) {
+		global $wpdb;
+		$now = gmdate( 'Y-m-d H:i:s' );
+		$row = array(
+			'public_id'           => wp_generate_uuid4(),
+			'event_id'            => (int) $data['event_id'],
+			'venue_term_id'       => (int) $data['venue_term_id'],
+			'coordinator_user_id' => (int) $data['coordinator_user_id'],
+			'status'              => 'open',
+			'policy'              => wp_json_encode( $data['policy'] ),
+			'version'             => 1,
+			'created_at'          => $now,
+			'updated_at'          => $now,
+		);
+		if ( false === $row['policy'] || false === $wpdb->insert( VendorRequestSchema::requests_table(), $row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private operational write.
+			return new \WP_Error( 'vendor_request_create_failed', __( 'The vendor request could not be created.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return $this->get_request( (int) $wpdb->insert_id );
+	}
+
+	public function get_request( int $id, bool $for_update = false ) {
+		global $wpdb;
+		$table = VendorRequestSchema::requests_table();
+		$lock  = $for_update ? ' FOR UPDATE' : '';
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1{$lock}", $id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted table and fixed lock clause.
+		return $this->row_result( $row, 'vendor_request_read_failed', array( $this, 'hydrate_request' ) );
+	}
+
+	public function get_request_by_event( int $event_id ) {
+		global $wpdb;
+		$table = VendorRequestSchema::requests_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE event_id = %d LIMIT 1", $event_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact indexed read.
+		return $this->row_result( $row, 'vendor_request_read_failed', array( $this, 'hydrate_request' ) );
+	}
+
+	public function get_request_by_public_id( string $public_id ) {
+		global $wpdb;
+		$table = VendorRequestSchema::requests_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE public_id = %s LIMIT 1", $public_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact opaque identifier read.
+		return $this->row_result( $row, 'vendor_request_read_failed', array( $this, 'hydrate_request' ) );
+	}
+
+	public function create_application( array $data ) {
+		global $wpdb;
+		$now = gmdate( 'Y-m-d H:i:s' );
+		$row = array(
+			'public_id'         => wp_generate_uuid4(),
+			'request_id'        => (int) $data['request_id'],
+			'status'            => 'submitted',
+			'version'           => 1,
+			'business_name'     => $data['business_name'],
+			'category'          => $data['category'],
+			'website_url'       => $data['website_url'],
+			'footprint'         => $data['footprint'],
+			'power_needs'       => $data['power_needs'],
+			'insurance_notes'   => $data['insurance_notes'],
+			'message'           => $data['message'],
+			'contact_payload'   => wp_json_encode( $data['contact'] ),
+			'consent_version'   => 1,
+			'consented_at'      => $now,
+			'revoked_at'        => null,
+			'private_notes'     => null,
+			'access_token_hash' => $data['access_token_hash'],
+			'idempotency_key'   => $data['idempotency_key'],
+			'request_hash'      => $data['request_hash'],
+			'submitter_user_id' => $data['submitter_user_id'],
+			'created_at'        => $now,
+			'updated_at'        => $now,
+		);
+		if ( false === $row['contact_payload'] || false === $wpdb->insert( VendorRequestSchema::applications_table(), $row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Private operational write.
+			return new \WP_Error( 'vendor_application_create_failed', __( 'The vendor application could not be recorded.', 'extrachill-events' ), array( 'database_error' => $wpdb->last_error ) );
+		}
+		return $this->get_application( (int) $wpdb->insert_id );
+	}
+
+	public function get_application( int $id, bool $for_update = false ) {
+		global $wpdb;
+		$table = VendorRequestSchema::applications_table();
+		$lock  = $for_update ? ' FOR UPDATE' : '';
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d LIMIT 1{$lock}", $id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted table and fixed lock clause.
+		return $this->row_result( $row, 'vendor_application_read_failed', array( $this, 'hydrate_application' ) );
+	}
+
+	public function find_application_retry( int $request_id, string $key ) {
+		global $wpdb;
+		$table = VendorRequestSchema::applications_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE request_id = %d AND idempotency_key = %s LIMIT 1", $request_id, $key ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact retry read.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'vendor_application_read_failed', __( 'The private vendor record could not be read.', 'extrachill-events' ) );
+		}
+		if ( ! is_array( $row ) ) {
+			return null;
+		}
+		$hash                        = (string) $row['request_hash'];
+		$application                 = $this->hydrate_application( $row );
+		$application['_replay_hash'] = $hash;
+		return $application;
+	}
+
+	public function list_applications( int $request_id, int $limit = 100 ) {
+		global $wpdb;
+		$table = VendorRequestSchema::applications_table();
+		$limit = max( 1, min( 100, $limit ) );
+		$rows  = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE request_id = %d ORDER BY created_at ASC, id ASC LIMIT %d", $request_id, $limit ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded private read.
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( 'vendor_application_list_failed', __( 'Vendor applications could not be read.', 'extrachill-events' ) ) : array_map( array( $this, 'hydrate_application' ), (array) $rows );
+	}
+
+	public function get_application_by_public_id( string $public_id, bool $for_update = false ) {
+		global $wpdb;
+		$table = VendorRequestSchema::applications_table();
+		$lock  = $for_update ? ' FOR UPDATE' : '';
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE public_id = %s LIMIT 1{$lock}", $public_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact opaque identifier read.
+		return $this->row_result( $row, 'vendor_application_read_failed', array( $this, 'hydrate_application' ) );
+	}
+
+	public function verify_application_token( string $public_id, string $token ): bool {
+		global $wpdb;
+		$table = VendorRequestSchema::applications_table();
+		$hash  = $wpdb->get_var( $wpdb->prepare( "SELECT access_token_hash FROM {$table} WHERE public_id = %s LIMIT 1", $public_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact opaque-token authorization read.
+		$sent  = hash_hmac( 'sha256', trim( $token ), wp_salt( 'auth' ) );
+		return is_string( $hash ) && hash_equals( $hash, $sent );
+	}
+
+	public function update_request( int $id, int $expected_version, array $changes ) {
+		return $this->conditional_update( VendorRequestSchema::requests_table(), $id, $expected_version, $changes, true );
+	}
+
+	public function update_application( int $id, int $expected_version, array $changes ) {
+		return $this->conditional_update( VendorRequestSchema::applications_table(), $id, $expected_version, $changes, false );
+	}
+
+	public function append_activity( array $data ) {
+		global $wpdb;
+		$payload = wp_json_encode(
+			array(
+				'version' => 1,
+				'data'    => $data['payload'] ?? array(),
+			)
+		);
+		$row     = array(
+			'request_id'      => (int) $data['request_id'],
+			'application_id'  => empty( $data['application_id'] ) ? null : (int) $data['application_id'],
+			'kind'            => sanitize_key( $data['kind'] ),
+			'actor_user_id'   => empty( $data['actor_user_id'] ) ? null : (int) $data['actor_user_id'],
+			'idempotency_key' => $data['idempotency_key'],
+			'request_hash'    => $data['request_hash'],
+			'result_version'  => (int) $data['result_version'],
+			'payload'         => $payload,
+			'created_at'      => gmdate( 'Y-m-d H:i:s' ),
+		);
+		if ( false === $payload || false === $wpdb->insert( VendorRequestSchema::activity_table(), $row ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Append-only private audit write.
+			return new \WP_Error( 'vendor_request_activity_write_failed', __( 'Vendor request activity could not be recorded.', 'extrachill-events' ) );
+		}
+		$row['id'] = (int) $wpdb->insert_id;
+		return $row;
+	}
+
+	public function find_activity( int $request_id, string $key ) {
+		global $wpdb;
+		$table = VendorRequestSchema::activity_table();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE request_id = %d AND idempotency_key = %s LIMIT 1", $request_id, $key ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact receipt read.
+		if ( '' !== (string) $wpdb->last_error ) {
+			return new \WP_Error( 'vendor_request_activity_read_failed', __( 'Vendor request activity could not be read.', 'extrachill-events' ) );
+		}
+		if ( ! is_array( $row ) ) {
+			return null;
+		}
+		$payload        = json_decode( (string) $row['payload'], true );
+		$row['payload'] = (array) ( $payload['data'] ?? array() );
+		return $row;
+	}
+
+	public function hydrate_request( array $row ): array {
+		foreach ( array( 'id', 'event_id', 'venue_term_id', 'coordinator_user_id', 'version' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		$row['policy'] = (array) json_decode( (string) $row['policy'], true );
+		return $row;
+	}
+
+	public function hydrate_application( array $row ): array {
+		foreach ( array( 'id', 'request_id', 'version', 'consent_version' ) as $field ) {
+			$row[ $field ] = (int) $row[ $field ];
+		}
+		$row['submitter_user_id'] = null === $row['submitter_user_id'] ? null : (int) $row['submitter_user_id'];
+		$row['contact']           = null === $row['revoked_at'] ? (array) json_decode( (string) $row['contact_payload'], true ) : null;
+		unset( $row['contact_payload'], $row['access_token_hash'], $row['idempotency_key'], $row['request_hash'] );
+		return $row;
+	}
+
+	private function conditional_update( string $table, int $id, int $expected_version, array $changes, bool $request ) {
+		global $wpdb;
+		$changes['version']    = $expected_version + 1;
+		$changes['updated_at'] = gmdate( 'Y-m-d H:i:s' );
+		$updated               = $wpdb->update(
+			$table,
+			$changes,
+			array(
+				'id'      => $id,
+				'version' => $expected_version,
+			)
+		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Optimistic private write.
+		if ( 1 !== $updated ) {
+			return new \WP_Error( 'vendor_request_version_conflict', __( 'The vendor request changed since it was read.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return $request ? $this->get_request( $id ) : $this->get_application( $id );
+	}
+
+	private function row_result( $row, string $code, callable $hydrate ) {
+		global $wpdb;
+		return '' !== (string) $wpdb->last_error ? new \WP_Error( $code, __( 'The private vendor record could not be read.', 'extrachill-events' ) ) : ( is_array( $row ) ? call_user_func( $hydrate, $row ) : null );
+	}
+}

--- a/inc/Core/VendorRequestSchema.php
+++ b/inc/Core/VendorRequestSchema.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Private event vendor request storage.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Owns the site-scoped vendor request schema. */
+class VendorRequestSchema {
+
+	public const SCHEMA_VERSION = '1';
+	public const VERSION_OPTION = 'extrachill_events_vendor_request_schema_version';
+
+	public static function requests_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_vendor_requests';
+	}
+
+	public static function applications_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_vendor_applications';
+	}
+
+	public static function activity_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'ec_vendor_request_activity';
+	}
+
+	/** Install transactional private storage. */
+	public static function install() {
+		global $wpdb;
+		$requests     = self::requests_table();
+		$applications = self::applications_table();
+		$activity     = self::activity_table();
+		$charset      = $wpdb->get_charset_collate();
+
+		$requests_sql = "CREATE TABLE {$requests} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			public_id CHAR(36) NOT NULL,
+			event_id BIGINT UNSIGNED NOT NULL,
+			venue_term_id BIGINT UNSIGNED NOT NULL,
+			coordinator_user_id BIGINT UNSIGNED NOT NULL,
+			status VARCHAR(16) NOT NULL DEFAULT 'open',
+			policy LONGTEXT NOT NULL,
+			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY public_id (public_id),
+			UNIQUE KEY event_id (event_id),
+			KEY coordinator_status (coordinator_user_id, status),
+			KEY venue_status (venue_term_id, status)
+		) ENGINE=InnoDB {$charset};";
+
+		$applications_sql = "CREATE TABLE {$applications} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			public_id CHAR(36) NOT NULL,
+			request_id BIGINT UNSIGNED NOT NULL,
+			status VARCHAR(16) NOT NULL DEFAULT 'submitted',
+			version BIGINT UNSIGNED NOT NULL DEFAULT '1',
+			business_name VARCHAR(255) NOT NULL,
+			category VARCHAR(191) NOT NULL,
+			website_url TEXT NULL,
+			footprint VARCHAR(255) NOT NULL,
+			power_needs TEXT NULL,
+			insurance_notes TEXT NULL,
+			message TEXT NOT NULL,
+			contact_payload LONGTEXT NOT NULL,
+			consent_version BIGINT UNSIGNED NOT NULL DEFAULT '1',
+			consented_at DATETIME NOT NULL,
+			revoked_at DATETIME NULL,
+			private_notes LONGTEXT NULL,
+			access_token_hash CHAR(64) NOT NULL,
+			idempotency_key VARCHAR(191) NOT NULL,
+			request_hash CHAR(64) NOT NULL,
+			submitter_user_id BIGINT UNSIGNED NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY public_id (public_id),
+			UNIQUE KEY access_token_hash (access_token_hash),
+			UNIQUE KEY request_idempotency (request_id, idempotency_key),
+			KEY request_status_created (request_id, status, created_at)
+		) ENGINE=InnoDB {$charset};";
+
+		$activity_sql = "CREATE TABLE {$activity} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			request_id BIGINT UNSIGNED NOT NULL,
+			application_id BIGINT UNSIGNED NULL,
+			kind VARCHAR(64) NOT NULL,
+			actor_user_id BIGINT UNSIGNED NULL,
+			idempotency_key VARCHAR(191) NOT NULL,
+			request_hash CHAR(64) NOT NULL,
+			result_version BIGINT UNSIGNED NOT NULL,
+			payload LONGTEXT NOT NULL,
+			created_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY request_idempotency (request_id, idempotency_key),
+			KEY application_created (application_id, created_at, id),
+			KEY kind_created (kind, created_at)
+		) ENGINE=InnoDB {$charset};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $requests_sql );
+		$requests_error = (string) $wpdb->last_error;
+		dbDelta( $applications_sql );
+		$applications_error = (string) $wpdb->last_error;
+		dbDelta( $activity_sql );
+		$activity_error = (string) $wpdb->last_error;
+		if ( '' !== $requests_error || '' !== $applications_error || '' !== $activity_error ) {
+			return new \WP_Error( 'vendor_request_schema_install_failed', __( 'Vendor request storage could not be installed.', 'extrachill-events' ) );
+		}
+		update_option( self::VERSION_OPTION, self::SCHEMA_VERSION, false );
+		return true;
+	}
+
+	public static function maybe_install() {
+		return self::is_ready() ? true : self::install();
+	}
+
+	public static function is_ready(): bool {
+		return self::SCHEMA_VERSION === (string) get_option( self::VERSION_OPTION, '' );
+	}
+}

--- a/inc/Core/VendorRequestService.php
+++ b/inc/Core/VendorRequestService.php
@@ -1,0 +1,520 @@
+<?php
+/**
+ * Event-scoped vendor request domain service.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+use function do_action;
+use function is_wp_error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Owns vendor request lifecycle, application privacy, and idempotency. */
+class VendorRequestService {
+
+	public const APPLICATION_STATUSES = array( 'submitted', 'reviewing', 'accepted', 'declined', 'withdrawn' );
+
+	/** @var VendorRequestRepository */
+	private $repository;
+	/** @var VendorRequestAuthorization */
+	private $authorization;
+
+	public function __construct( ?VendorRequestRepository $repository = null, ?VendorRequestAuthorization $authorization = null ) {
+		$this->repository    = $repository ? $repository : new VendorRequestRepository();
+		$this->authorization = $authorization ? $authorization : new VendorRequestAuthorization();
+	}
+
+	/** Open one event request and bind the opener as its exact coordinator. */
+	public function open_request( int $event_id, array $policy, string $idempotency_key, int $actor_id ) {
+		$key = $this->key( $idempotency_key );
+		if ( is_wp_error( $key ) ) {
+			return $key;
+		}
+		$context = $this->authorization->event_context( $event_id );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+		$request = array(
+			'event_id'            => $event_id,
+			'venue_term_id'       => $context['venue_term_id'],
+			'coordinator_user_id' => $actor_id,
+		);
+		$allowed = $this->authorization->authorize_coordinator( $request, $actor_id );
+		if ( true !== $allowed ) {
+			return $allowed;
+		}
+		$policy = $this->normalize_policy( $policy );
+		if ( is_wp_error( $policy ) ) {
+			return $policy;
+		}
+		$hash     = $this->hash(
+			'open',
+			array(
+				'event_id' => $event_id,
+				'policy'   => $policy,
+			),
+			$actor_id
+		);
+		$existing = $this->repository->get_request_by_event( $event_id );
+		if ( is_array( $existing ) ) {
+			return (int) $existing['coordinator_user_id'] === $actor_id && $existing['policy'] === $policy ? $existing : $this->idempotency_conflict();
+		}
+		if ( is_wp_error( $existing ) ) {
+			return $existing;
+		}
+		$started = $this->begin();
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$allowed = $this->authorization->authorize_coordinator( $request, $actor_id );
+		if ( true !== $allowed ) {
+			return $this->rollback( $allowed );
+		}
+		$created = $this->repository->create_request( array_merge( $request, array( 'policy' => $policy ) ) );
+		if ( is_wp_error( $created ) ) {
+			return $this->rollback( $created );
+		}
+		$activity = $this->record( $created['id'], null, 'request_opened', $actor_id, $key, $hash, 1, array( 'status' => 'open' ) );
+		if ( is_wp_error( $activity ) ) {
+			return $this->rollback( $activity );
+		}
+		$committed = $this->commit();
+		if ( is_wp_error( $committed ) ) {
+			return $committed;
+		}
+		$this->emit( 'request_opened', $created['id'], null, 1 );
+		return $created;
+	}
+
+	/** Open or close only as the exact persisted coordinator. */
+	public function set_request_open( int $request_id, bool $open, int $expected_version, string $idempotency_key, int $actor_id ) {
+		$request = $this->repository->get_request( $request_id );
+		if ( ! is_array( $request ) ) {
+			return is_wp_error( $request ) ? $request : $this->not_found();
+		}
+		$allowed = $this->authorization->authorize_coordinator( $request, $actor_id );
+		if ( true !== $allowed ) {
+			return $allowed;
+		}
+		$status = $open ? 'open' : 'closed';
+		if ( $request['status'] === $status ) {
+			return $request;
+		}
+		$key = $this->key( $idempotency_key );
+		if ( is_wp_error( $key ) ) {
+			return $key;
+		}
+		if ( (int) $request['version'] !== $expected_version ) {
+			return $this->version_conflict();
+		}
+		$hash    = $this->hash( 'request_status_changed', array( 'status' => $status ), $actor_id );
+		$started = $this->begin();
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$locked = $this->repository->get_request( $request_id, true );
+		if ( ! is_array( $locked ) || (int) $locked['version'] !== $expected_version ) {
+			return $this->rollback( $this->version_conflict() );
+		}
+		$allowed = $this->authorization->authorize_coordinator( $locked, $actor_id );
+		if ( true !== $allowed ) {
+			return $this->rollback( $allowed );
+		}
+		$updated  = $this->repository->update_request( $request_id, $expected_version, array( 'status' => $status ) );
+		$activity = is_wp_error( $updated ) ? $updated : $this->record( $request_id, null, 'request_status_changed', $actor_id, $key, $hash, $updated['version'], array( 'status' => $status ) );
+		if ( is_wp_error( $activity ) ) {
+			return $this->rollback( $activity );
+		}
+		$committed = $this->commit();
+		if ( is_wp_error( $committed ) ) {
+			return $committed;
+		}
+		$this->emit( 'request_status_changed', $request_id, null, $updated['version'] );
+		return $updated;
+	}
+
+	/** Return a deliberately contact-free public projection only while open. */
+	public function public_request_for_event( int $event_id ) {
+		$request = $this->repository->get_request_by_event( $event_id );
+		if ( ! is_array( $request ) || 'open' !== $request['status'] ) {
+			return is_wp_error( $request ) ? $request : null;
+		}
+		return array(
+			'public_id' => $request['public_id'],
+			'event_id'  => $request['event_id'],
+			'policy'    => $request['policy'],
+			'status'    => 'open',
+		);
+	}
+
+	/** Admit one private application under a request-row close-race lock. */
+	public function apply( array $input, int $actor_id = 0 ) {
+		$key = $this->key( $input['idempotency_key'] ?? '' );
+		if ( is_wp_error( $key ) ) {
+			return $key;
+		}
+		$request = $this->repository->get_request_by_event( absint( $input['event_id'] ?? 0 ) );
+		if ( ! is_array( $request ) || 'open' !== $request['status'] ) {
+			return is_wp_error( $request ) ? $request : new \WP_Error( 'vendor_request_not_open', __( 'This event is not accepting vendor applications.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$application = $this->normalize_application( $input, $request['policy'] );
+		if ( is_wp_error( $application ) ) {
+			return $application;
+		}
+		$hash   = $this->hash( 'apply', $application, $actor_id );
+		$replay = $this->repository->find_application_retry( $request['id'], $key );
+		if ( is_array( $replay ) ) {
+			if ( ! hash_equals( (string) $replay['_replay_hash'], $hash ) ) {
+				return $this->idempotency_conflict();
+			}
+			unset( $replay['_replay_hash'] );
+			return array_merge( $this->public_receipt( $replay ), array( 'access_token' => $this->application_token( $request, $key, $hash ) ) );
+		}
+		if ( is_wp_error( $replay ) ) {
+			return $replay;
+		}
+		$token   = $this->application_token( $request, $key, $hash );
+		$started = $this->begin();
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$locked = $this->repository->get_request( $request['id'], true );
+		if ( ! is_array( $locked ) || 'open' !== $locked['status'] ) {
+			return $this->rollback( new \WP_Error( 'vendor_request_not_open', __( 'This event is not accepting vendor applications.', 'extrachill-events' ), array( 'status' => 409 ) ) );
+		}
+		$created = $this->repository->create_application(
+			array_merge(
+				$application,
+				array(
+					'request_id'        => $request['id'],
+					'idempotency_key'   => $key,
+					'request_hash'      => $hash,
+					'access_token_hash' => hash_hmac( 'sha256', $token, wp_salt( 'auth' ) ),
+					'submitter_user_id' => $actor_id > 0 ? $actor_id : null,
+				)
+			)
+		);
+		if ( is_wp_error( $created ) ) {
+			return $this->rollback( $created );
+		}
+		$activity = $this->record( $request['id'], $created['id'], 'application_submitted', $actor_id, $key, $hash, 1, array( 'status' => 'submitted' ) );
+		if ( is_wp_error( $activity ) ) {
+			return $this->rollback( $activity );
+		}
+		$committed = $this->commit();
+		if ( is_wp_error( $committed ) ) {
+			return $committed;
+		}
+		$this->emit( 'application_submitted', $request['id'], $created['id'], 1 );
+		return array_merge( $this->public_receipt( $created ), array( 'access_token' => $token ) );
+	}
+
+	/** List private applications after current event organizer authorization. */
+	public function list_applications( int $request_id, int $actor_id ) {
+		$request = $this->repository->get_request( $request_id );
+		if ( ! is_array( $request ) ) {
+			return is_wp_error( $request ) ? $request : $this->not_found();
+		}
+		$allowed = $this->authorization->authorize_organizer( $request, $actor_id );
+		return true === $allowed ? $this->repository->list_applications( $request_id ) : $allowed;
+	}
+
+	/** Update organizer-owned review status and notes without changing contact consent. */
+	public function review_application( int $application_id, string $status, string $notes, int $expected_version, string $idempotency_key, int $actor_id ) {
+		$application = $this->repository->get_application( $application_id );
+		$request     = is_array( $application ) ? $this->repository->get_request( $application['request_id'] ) : null;
+		if ( ! is_array( $application ) || ! is_array( $request ) ) {
+			return is_wp_error( $application ) ? $application : $this->not_found();
+		}
+		$allowed = $this->authorization->authorize_organizer( $request, $actor_id );
+		if ( true !== $allowed ) {
+			return $allowed;
+		}
+		$status = sanitize_key( $status );
+		if ( ! in_array( $status, array( 'submitted', 'reviewing', 'accepted', 'declined' ), true ) || 'withdrawn' === $application['status'] ) {
+			return new \WP_Error( 'vendor_application_transition_forbidden', __( 'That application review status is not available.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		if ( (int) $application['version'] !== $expected_version ) {
+			return $this->version_conflict();
+		}
+		$key     = $this->key( $idempotency_key );
+		$notes   = mb_substr( sanitize_textarea_field( $notes ), 0, 5000 );
+		$changes = array(
+			'status'        => $status,
+			'private_notes' => '' === $notes ? null : $notes,
+		);
+		if ( is_wp_error( $key ) ) {
+			return $key;
+		}
+		$hash    = $this->hash( 'application_reviewed', $changes, $actor_id );
+		$started = $this->begin();
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$locked = $this->repository->get_application( $application_id, true );
+		if ( ! is_array( $locked ) || (int) $locked['version'] !== $expected_version ) {
+			return $this->rollback( $this->version_conflict() );
+		}
+		$allowed = $this->authorization->authorize_organizer( $request, $actor_id );
+		if ( true !== $allowed ) {
+			return $this->rollback( $allowed );
+		}
+		$updated  = $this->repository->update_application( $application_id, $expected_version, $changes );
+		$activity = is_wp_error( $updated ) ? $updated : $this->record( $request['id'], $application_id, 'application_reviewed', $actor_id, $key, $hash, $updated['version'], array( 'status' => $status ) );
+		if ( is_wp_error( $activity ) ) {
+			return $this->rollback( $activity );
+		}
+		$committed = $this->commit();
+		if ( is_wp_error( $committed ) ) {
+			return $committed;
+		}
+		$this->emit( 'application_reviewed', $request['id'], $application_id, $updated['version'] );
+		return $updated;
+	}
+
+	/** Queue coordinator-initiated contact through the managed Extra Chill mail layer. */
+	public function contact_applicant( int $application_id, string $subject, string $message, string $idempotency_key, int $actor_id, $queue = null ) {
+		$application = $this->repository->get_application( $application_id );
+		$request     = is_array( $application ) ? $this->repository->get_request( $application['request_id'] ) : null;
+		if ( ! is_array( $application ) || ! is_array( $request ) ) {
+			return $this->not_found();
+		}
+		$allowed = $this->authorization->authorize_organizer( $request, $actor_id );
+		if ( true !== $allowed ) {
+			return $allowed;
+		}
+		if ( ! is_array( $application['contact'] ) || empty( $application['contact']['email'] ) || 'withdrawn' === $application['status'] ) {
+			return new \WP_Error( 'vendor_application_contact_unavailable', __( 'The applicant has not authorized managed contact.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$key     = $this->key( $idempotency_key );
+		$subject = mb_substr( sanitize_text_field( $subject ), 0, 255 );
+		$message = mb_substr( sanitize_textarea_field( $message ), 0, 10000 );
+		if ( is_wp_error( $key ) || '' === $subject || '' === $message ) {
+			return is_wp_error( $key ) ? $key : new \WP_Error( 'invalid_vendor_correspondence', __( 'A subject and message are required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$hash     = $this->hash( 'applicant_contacted', compact( 'application_id', 'subject', 'message' ), $actor_id );
+		$existing = $this->repository->find_activity( $request['id'], $key );
+		if ( is_array( $existing ) ) {
+			return hash_equals( (string) $existing['request_hash'], $hash ) ? $existing['payload'] : $this->idempotency_conflict();
+		}
+		$body   = wpautop( esc_html( $message ) );
+		$body  .= '<p><strong>Extra Chill Bot sending on Chris Huber\'s behalf.</strong> Reply through the managed vendor application workflow; applicant and coordinator directories are not shared.</p>';
+		$input  = array(
+			'to'           => $application['contact']['email'],
+			'cc'           => 'chubes@extrachill.com',
+			'subject'      => $subject,
+			'body'         => $body,
+			'content_type' => 'text/html',
+			'from_name'    => 'Extra Chill Bot',
+		);
+		$result = is_callable( $queue ) ? call_user_func( $queue, $input ) : ( function_exists( 'ec_send_email_queued' ) ? ec_send_email_queued( $input ) : new \WP_Error( 'vendor_correspondence_unavailable' ) );
+		if ( is_wp_error( $result ) || ! is_array( $result ) || empty( $result['success'] ) || absint( $result['action_id'] ?? 0 ) < 1 ) {
+			return new \WP_Error( 'vendor_correspondence_uncertain', __( 'The managed message queue outcome is uncertain.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+		$receipt = array(
+			'status'    => 'queued',
+			'action_id' => absint( $result['action_id'] ),
+		);
+		$record  = $this->record( $request['id'], $application_id, 'applicant_contact_queued', $actor_id, $key, $hash, $application['version'], $receipt );
+		return is_wp_error( $record ) ? $record : $receipt;
+	}
+
+	/** Applicant-owned withdrawal atomically revokes all contact disclosure. */
+	public function withdraw( string $public_id, string $access_token, int $expected_version, string $idempotency_key ) {
+		$application = $this->repository->get_application_by_public_id( sanitize_text_field( $public_id ) );
+		if ( ! is_array( $application ) ) {
+			return $this->not_found();
+		}
+		$key = $this->key( $idempotency_key );
+		if ( is_wp_error( $key ) ) {
+			return $key;
+		}
+		$hash    = $this->hash( 'application_withdrawn', array( 'public_id' => $public_id ), 0 );
+		$started = $this->begin();
+		if ( is_wp_error( $started ) ) {
+			return $started;
+		}
+		$locked = $this->repository->get_application( $application['id'], true );
+		if ( ! is_array( $locked ) || (int) $locked['version'] !== $expected_version || ! $this->repository->verify_application_token( $public_id, $access_token ) ) {
+			return $this->rollback( new \WP_Error( 'vendor_application_forbidden', __( 'This vendor application is unavailable.', 'extrachill-events' ), array( 'status' => 403 ) ) );
+		}
+		$changes = array(
+			'status'          => 'withdrawn',
+			'contact_payload' => wp_json_encode( array() ),
+			'consent_version' => $locked['consent_version'] + 1,
+			'revoked_at'      => gmdate( 'Y-m-d H:i:s' ),
+		);
+		$updated = $this->repository->update_application( $application['id'], $expected_version, $changes );
+		if ( is_wp_error( $updated ) ) {
+			return $this->rollback( $updated );
+		}
+		$activity = $this->record( $application['request_id'], $application['id'], 'application_withdrawn', 0, $key, $hash, $updated['version'], array( 'contact_revoked' => true ) );
+		if ( is_wp_error( $activity ) ) {
+			return $this->rollback( $activity );
+		}
+		$committed = $this->commit();
+		if ( is_wp_error( $committed ) ) {
+			return $committed;
+		}
+		$this->emit( 'application_withdrawn', $application['request_id'], $application['id'], $updated['version'] );
+		return array(
+			'public_id' => $updated['public_id'],
+			'status'    => 'withdrawn',
+		);
+	}
+
+	/** Recreate the opaque applicant token for exact idempotent retries. */
+	private function application_token( array $request, string $key, string $hash ): string {
+		return hash_hmac( 'sha256', $request['public_id'] . "\0" . $key . "\0" . $hash, wp_salt( 'secure_auth' ) );
+	}
+
+	private function normalize_policy( array $policy ) {
+		$categories = array_values( array_unique( array_filter( array_map( 'sanitize_text_field', (array) ( $policy['categories'] ?? array() ) ) ) ) );
+		if ( count( $categories ) > 30 ) {
+			return new \WP_Error( 'invalid_vendor_request_policy', __( 'Vendor category policy is invalid.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return array(
+			'categories'         => array_map(
+				static function ( $value ) {
+					return mb_substr( $value, 0, 100 ); },
+				$categories
+			),
+			'power_required'     => ! empty( $policy['power_required'] ),
+			'insurance_required' => ! empty( $policy['insurance_required'] ),
+			'instructions'       => mb_substr( sanitize_textarea_field( (string) ( $policy['instructions'] ?? '' ) ), 0, 2000 ),
+		);
+	}
+
+	private function normalize_application( array $input, array $policy ) {
+		if ( empty( $input['contact_consent'] ) ) {
+			return new \WP_Error( 'vendor_application_consent_required', __( 'Contact-sharing consent is required for this event application.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$data = array(
+			'business_name'   => mb_substr( sanitize_text_field( (string) ( $input['business_name'] ?? '' ) ), 0, 255 ),
+			'category'        => mb_substr( sanitize_text_field( (string) ( $input['category'] ?? '' ) ), 0, 191 ),
+			'website_url'     => esc_url_raw( (string) ( $input['website_url'] ?? '' ) ),
+			'footprint'       => mb_substr( sanitize_text_field( (string) ( $input['footprint'] ?? '' ) ), 0, 255 ),
+			'power_needs'     => mb_substr( sanitize_textarea_field( (string) ( $input['power_needs'] ?? '' ) ), 0, 2000 ),
+			'insurance_notes' => mb_substr( sanitize_textarea_field( (string) ( $input['insurance_notes'] ?? '' ) ), 0, 2000 ),
+			'message'         => mb_substr( sanitize_textarea_field( (string) ( $input['message'] ?? '' ) ), 0, 5000 ),
+			'contact'         => array(
+				'name'  => mb_substr( sanitize_text_field( (string) ( $input['contact_name'] ?? '' ) ), 0, 255 ),
+				'email' => sanitize_email( (string) ( $input['contact_email'] ?? '' ) ),
+				'phone' => mb_substr( sanitize_text_field( (string) ( $input['contact_phone'] ?? '' ) ), 0, 64 ),
+			),
+		);
+		if ( '' === $data['business_name'] || '' === $data['category'] || '' === $data['footprint'] || '' === $data['message'] || '' === $data['contact']['name'] || ! is_email( $data['contact']['email'] ) ) {
+			return new \WP_Error( 'invalid_vendor_application', __( 'Complete all required vendor application fields.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		if ( ! empty( $policy['categories'] ) && ! in_array( $data['category'], $policy['categories'], true ) ) {
+			return new \WP_Error( 'invalid_vendor_application_category', __( 'Select an available vendor category.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		if ( ! empty( $policy['power_required'] ) && '' === $data['power_needs'] ) {
+			return new \WP_Error( 'invalid_vendor_application', __( 'Describe the vendor power needs.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		if ( ! empty( $policy['insurance_required'] ) && '' === $data['insurance_notes'] ) {
+			return new \WP_Error( 'invalid_vendor_application', __( 'Describe insurance or permit readiness.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return $data;
+	}
+
+	private function public_receipt( array $application ): array {
+		return array(
+			'public_id'    => $application['public_id'],
+			'status'       => $application['status'],
+			'submitted_at' => $application['created_at'],
+			'version'      => $application['version'],
+		);
+	}
+
+	private function record( int $request_id, ?int $application_id, string $kind, int $actor_id, string $key, string $hash, int $version, array $payload ) {
+		return $this->repository->append_activity(
+			array(
+				'request_id'      => $request_id,
+				'application_id'  => $application_id,
+				'kind'            => $kind,
+				'actor_user_id'   => 0 < $actor_id ? $actor_id : null,
+				'idempotency_key' => $key,
+				'request_hash'    => $hash,
+				'result_version'  => $version,
+				'payload'         => $payload,
+			)
+		);
+	}
+
+	private function emit( string $kind, int $request_id, ?int $application_id, int $version ): void {
+		do_action(
+			'extrachill_events_vendor_request_changed',
+			array(
+				'kind'           => $kind,
+				'request_id'     => $request_id,
+				'application_id' => $application_id,
+				'version'        => $version,
+			)
+		);
+	}
+
+	private function key( $key ) {
+		$key = trim( sanitize_text_field( (string) $key ) );
+		if ( '' === $key || strlen( $key ) > 191 ) {
+			return new \WP_Error( 'vendor_request_idempotency_key_required', __( 'A bounded idempotency key is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return $key;
+	}
+
+	private function hash( string $operation, array $data, int $actor_id ): string {
+		$this->canonicalize( $data );
+		$encoded = wp_json_encode(
+			array(
+				'operation' => $operation,
+				'actor_id'  => $actor_id,
+				'data'      => $data,
+			)
+		);
+		return hash_hmac( 'sha256', is_string( $encoded ) ? $encoded : '', wp_salt( 'auth' ) );
+	}
+
+	private function canonicalize( array &$value ): void {
+		if ( array() !== $value && array_keys( $value ) !== range( 0, count( $value ) - 1 ) ) {
+			ksort( $value, SORT_STRING );
+		}
+		foreach ( $value as &$item ) {
+			if ( is_array( $item ) ) {
+				$this->canonicalize( $item );
+			}
+		}
+	}
+
+	private function begin() {
+		global $wpdb;
+		return false === $wpdb->query( 'START TRANSACTION' ) ? new \WP_Error( 'vendor_request_transaction_start_failed', __( 'The vendor request transaction could not start.', 'extrachill-events' ) ) : true; // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate transaction boundary.
+	}
+
+	private function commit() {
+		global $wpdb;
+		return false === $wpdb->query( 'COMMIT' ) ? new \WP_Error( 'vendor_request_transaction_commit_uncertain', __( 'The vendor request transaction outcome is uncertain.', 'extrachill-events' ) ) : true; // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate transaction boundary.
+	}
+
+	private function rollback( \WP_Error $error ): \WP_Error {
+		global $wpdb;
+		$wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate transaction boundary.
+		return $error;
+	}
+
+	private function not_found(): \WP_Error {
+		return new \WP_Error( 'vendor_request_not_found', __( 'The vendor request was not found.', 'extrachill-events' ), array( 'status' => 404 ) );
+	}
+
+	private function version_conflict(): \WP_Error {
+		return new \WP_Error( 'vendor_request_version_conflict', __( 'The vendor request changed since it was read.', 'extrachill-events' ), array( 'status' => 409 ) );
+	}
+
+	private function idempotency_conflict(): \WP_Error {
+		return new \WP_Error( 'vendor_request_idempotency_conflict', __( 'The idempotency key was already used for different details.', 'extrachill-events' ), array( 'status' => 409 ) );
+	}
+}

--- a/inc/core/router-pages.php
+++ b/inc/core/router-pages.php
@@ -13,6 +13,8 @@
  *                slug rather than an invented route.
  *   /venue-settings/ — authenticated venue onboarding and settings app.
  *   /local-support/<request-id>/ — private event-scoped support workspace.
+ *   /vendor-requests/<request-id>/ — private event vendor workspace.
+ *   /vendor-apply/<public-id>/ — public contact-safe vendor application.
  *
  * Implemented with rewrite rules + the extrachill_template_archive override,
  * mirroring the discovery-pages pattern. No physical WP pages required.
@@ -35,13 +37,18 @@ function extrachill_events_router_rewrite_rules() {
 		return;
 	}
 
-	add_rewrite_tag( '%ec_events_router%', '(all|venue-settings|local-support)' );
+	add_rewrite_tag( '%ec_events_router%', '(all|venue-settings|local-support|vendor-requests|vendor-apply)' );
 	add_rewrite_tag( '%ec_local_support_request%', '([0-9]+)' );
+	add_rewrite_tag( '%ec_vendor_request%', '([0-9]+)' );
+	add_rewrite_tag( '%ec_vendor_apply%', '([a-f0-9-]{36})' );
 	add_rewrite_rule( '^all/?$', 'index.php?ec_events_router=all', 'top' );
 	add_rewrite_rule( '^all/page/([0-9]{1,})/?$', 'index.php?ec_events_router=all&paged=$matches[1]', 'top' );
 	add_rewrite_rule( '^venue-settings/?$', 'index.php?ec_events_router=venue-settings', 'top' );
 	add_rewrite_rule( '^local-support/?$', 'index.php?ec_events_router=local-support', 'top' );
 	add_rewrite_rule( '^local-support/([0-9]+)/?$', 'index.php?ec_events_router=local-support&ec_local_support_request=$matches[1]', 'top' );
+	add_rewrite_rule( '^vendor-requests/?$', 'index.php?ec_events_router=vendor-requests', 'top' );
+	add_rewrite_rule( '^vendor-requests/([0-9]+)/?$', 'index.php?ec_events_router=vendor-requests&ec_vendor_request=$matches[1]', 'top' );
+	add_rewrite_rule( '^vendor-apply/([a-f0-9-]{36})/?$', 'index.php?ec_events_router=vendor-apply&ec_vendor_apply=$matches[1]', 'top' );
 
 	if ( extrachill_events_location_directory_enabled() ) {
 		add_rewrite_tag( '%ec_events_location_index%', '(1)' );
@@ -69,6 +76,14 @@ function extrachill_events_is_local_support_page(): bool {
 	return ec_is_events_site() && 'local-support' === get_query_var( 'ec_events_router', '' );
 }
 
+function extrachill_events_is_vendor_request_page(): bool {
+	return ec_is_events_site() && 'vendor-requests' === get_query_var( 'ec_events_router', '' );
+}
+
+function extrachill_events_is_vendor_application_page(): bool {
+	return ec_is_events_site() && 'vendor-apply' === get_query_var( 'ec_events_router', '' );
+}
+
 /**
  * Whether the /location directory page is enabled.
  *
@@ -83,7 +98,7 @@ function extrachill_events_location_directory_enabled(): bool {
  * Flush rewrites once when the public location directory route is introduced.
  */
 function extrachill_events_maybe_flush_router_rewrites(): void {
-	$rewrite_version = '5';
+	$rewrite_version = '6';
 	if ( get_option( 'extrachill_events_router_rewrite_version' ) === $rewrite_version ) {
 		return;
 	}
@@ -156,7 +171,7 @@ function extrachill_events_is_location_index(): bool {
  * @return bool
  */
 function extrachill_events_is_router_page(): bool {
-	return extrachill_events_is_all_events_page() || extrachill_events_is_location_index() || extrachill_events_is_venue_settings_page() || extrachill_events_is_local_support_page();
+	return extrachill_events_is_all_events_page() || extrachill_events_is_location_index() || extrachill_events_is_venue_settings_page() || extrachill_events_is_local_support_page() || extrachill_events_is_vendor_request_page() || extrachill_events_is_vendor_application_page();
 }
 
 /**
@@ -170,7 +185,7 @@ function extrachill_events_query_is_router_page( $query ): bool {
 		return false;
 	}
 
-	if ( in_array( $query->get( 'ec_events_router', '' ), array( 'all', 'venue-settings', 'local-support' ), true ) ) {
+	if ( in_array( $query->get( 'ec_events_router', '' ), array( 'all', 'venue-settings', 'local-support', 'vendor-requests', 'vendor-apply' ), true ) ) {
 		return true;
 	}
 
@@ -203,6 +218,10 @@ function extrachill_events_router_template( string $template ): string {
 
 	if ( extrachill_events_is_local_support_page() ) {
 		return EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/templates/local-support.php';
+	}
+
+	if ( extrachill_events_is_vendor_request_page() || extrachill_events_is_vendor_application_page() ) {
+		return EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/templates/vendor-request.php';
 	}
 
 	return $template;
@@ -266,6 +285,10 @@ function extrachill_events_router_title( array $parts ): array {
 		$parts['title'] = __( 'Venue Settings', 'extrachill-events' );
 	} elseif ( extrachill_events_is_local_support_page() ) {
 		$parts['title'] = __( 'Local Support Workspace', 'extrachill-events' );
+	} elseif ( extrachill_events_is_vendor_request_page() ) {
+		$parts['title'] = __( 'Vendor Request Workspace', 'extrachill-events' );
+	} elseif ( extrachill_events_is_vendor_application_page() ) {
+		$parts['title'] = __( 'Vendor Application', 'extrachill-events' );
 	}
 
 	return $parts;

--- a/inc/core/vendor-request-workspace.php
+++ b/inc/core/vendor-request-workspace.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Vendor request public application and private coordinator workspace.
+ *
+ * @package ExtraChillEvents
+ */
+
+use ExtraChillEvents\Core\VendorRequestAuthorization;
+use ExtraChillEvents\Core\VendorRequestRepository;
+use ExtraChillEvents\Core\VendorRequestService;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Render the event action without exposing either party's identity. */
+function extrachill_events_vendor_request_event_action( $post_id ): void {
+	$event_id   = absint( $post_id );
+	$repository = new VendorRequestRepository();
+	$stored     = $repository->get_request_by_event( $event_id );
+	$public     = ( new VendorRequestService( $repository ) )->public_request_for_event( $event_id );
+	if ( is_array( $public ) ) {
+		$url = get_home_url( function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'events' ) ) : null, '/vendor-apply/' . rawurlencode( $public['public_id'] ) . '/' );
+		printf( '<a class="button-1 ec-vendor-request-cta" href="%s">%s</a>', esc_url( $url ), esc_html__( 'Apply as a vendor', 'extrachill-events' ) );
+	}
+	if ( ! is_user_logged_in() ) {
+		return;
+	}
+	$authorization = new VendorRequestAuthorization();
+	if ( is_array( $stored ) ) {
+		$allowed = $authorization->authorize_organizer( $stored, get_current_user_id() );
+		$url     = home_url( '/vendor-requests/' . $stored['id'] . '/' );
+		$label   = __( 'Manage vendor applications', 'extrachill-events' );
+	} else {
+		$context = $authorization->event_context( $event_id );
+		$draft   = is_array( $context ) ? array(
+			'event_id'            => $event_id,
+			'venue_term_id'       => $context['venue_term_id'],
+			'coordinator_user_id' => get_current_user_id(),
+		) : array();
+		$allowed = is_array( $context ) ? $authorization->authorize_coordinator( $draft, get_current_user_id() ) : false;
+		$url     = add_query_arg( 'event_id', $event_id, home_url( '/vendor-requests/' ) );
+		$label   = __( 'Request vendors', 'extrachill-events' );
+	}
+	if ( true === $allowed ) {
+		printf( '<a class="button-2 ec-vendor-request-manage" href="%s">%s</a>', esc_url( $url ), esc_html( $label ) );
+	}
+}
+
+/** Handle nonce-protected private workspace mutations. */
+function extrachill_events_handle_vendor_request_action(): void {
+	$method = sanitize_key( wp_unslash( (string) ( $_SERVER['REQUEST_METHOD'] ?? '' ) ) );
+	if ( ! extrachill_events_is_vendor_request_page() || 'post' !== $method ) {
+		return;
+	}
+	$input = wp_unslash( $_POST );
+	if ( ! wp_verify_nonce( sanitize_text_field( (string) ( $input['_wpnonce'] ?? '' ) ), 'extrachill_events_vendor_request' ) ) {
+		wp_die( esc_html__( 'The vendor request form expired.', 'extrachill-events' ), '', array( 'response' => 403 ) );
+	}
+	$result = extrachill_events_process_vendor_request_action( $input, get_current_user_id() );
+	$id     = absint( $input['request_id'] ?? ( is_array( $result ) ? ( $result['id'] ?? 0 ) : 0 ) );
+	$url    = $id ? home_url( '/vendor-requests/' . $id . '/' ) : home_url( '/vendor-requests/' );
+	wp_safe_redirect( add_query_arg( 'notice', is_wp_error( $result ) ? 'error' : 'updated', $url ) );
+	exit;
+}
+add_action( 'template_redirect', 'extrachill_events_handle_vendor_request_action', 1 );
+
+/** Execute one private form action through the domain service. */
+function extrachill_events_process_vendor_request_action( array $input, int $user_id, ?VendorRequestService $service = null ) {
+	$service = $service ? $service : new VendorRequestService();
+	$action  = sanitize_key( (string) ( $input['vendor_request_action'] ?? '' ) );
+	$key     = sanitize_text_field( (string) ( $input['idempotency_key'] ?? '' ) );
+	if ( 'open' === $action ) {
+		$categories = array_values( array_filter( array_map( 'trim', explode( ',', sanitize_text_field( (string) ( $input['categories'] ?? '' ) ) ) ) ) );
+		return $service->open_request(
+			absint( $input['event_id'] ?? 0 ),
+			array(
+				'categories'         => $categories,
+				'power_required'     => ! empty( $input['power_required'] ),
+				'insurance_required' => ! empty( $input['insurance_required'] ),
+				'instructions'       => sanitize_textarea_field( (string) ( $input['instructions'] ?? '' ) ),
+			),
+			$key,
+			$user_id
+		);
+	}
+	if ( 'status' === $action ) {
+		return $service->set_request_open( absint( $input['request_id'] ?? 0 ), ! empty( $input['open'] ), absint( $input['expected_version'] ?? 0 ), $key, $user_id );
+	}
+	if ( 'review' === $action ) {
+		return $service->review_application( absint( $input['application_id'] ?? 0 ), sanitize_key( (string) ( $input['status'] ?? '' ) ), sanitize_textarea_field( (string) ( $input['notes'] ?? '' ) ), absint( $input['expected_version'] ?? 0 ), $key, $user_id );
+	}
+	if ( 'contact' === $action ) {
+		return $service->contact_applicant( absint( $input['application_id'] ?? 0 ), sanitize_text_field( (string) ( $input['subject'] ?? '' ) ), sanitize_textarea_field( (string) ( $input['message'] ?? '' ) ), $key, $user_id );
+	}
+	return new WP_Error( 'vendor_request_action_invalid', __( 'That vendor request action is unavailable.', 'extrachill-events' ), array( 'status' => 400 ) );
+}
+
+/** Render either a coordinator index or one authorized private workspace. */
+function extrachill_events_render_vendor_request_workspace(): void {
+	if ( ! is_user_logged_in() ) {
+		auth_redirect();
+		return;
+	}
+	$repository    = new VendorRequestRepository();
+	$authorization = new VendorRequestAuthorization();
+	$service       = new VendorRequestService( $repository, $authorization );
+	$request_id    = absint( get_query_var( 'ec_vendor_request', 0 ) );
+	$request       = $request_id ? $repository->get_request( $request_id ) : null;
+	if ( ! is_array( $request ) ) {
+		$event_id  = absint( $_GET['event_id'] ?? 0 ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only canonical event selector.
+		$context   = $event_id ? $authorization->event_context( $event_id ) : null;
+		$candidate = is_array( $context ) ? array(
+			'event_id'            => $event_id,
+			'venue_term_id'       => $context['venue_term_id'],
+			'coordinator_user_id' => get_current_user_id(),
+		) : array();
+		if ( ! is_array( $context ) || true !== $authorization->authorize_coordinator( $candidate, get_current_user_id() ) ) {
+			extrachill_events_render_vendor_request_unavailable();
+			return;
+		}
+		$existing = $repository->get_request_by_event( $event_id );
+		if ( is_array( $existing ) ) {
+			wp_safe_redirect( home_url( '/vendor-requests/' . $existing['id'] . '/' ) );
+			return;
+		}
+		extrachill_events_render_vendor_request_open_form( $event_id );
+		return;
+	}
+	if ( true !== $authorization->authorize_organizer( $request, get_current_user_id() ) ) {
+		extrachill_events_render_vendor_request_unavailable();
+		return;
+	}
+	$applications = $service->list_applications( $request_id, get_current_user_id() );
+	if ( is_wp_error( $applications ) ) {
+		extrachill_events_render_vendor_request_unavailable();
+		return;
+	}
+	$post = get_post( $request['event_id'] );
+	?>
+	<section class="ec-vendor-request" data-vendor-request-workspace>
+		<header class="ec-vendor-request__hero">
+			<p class="ec-vendor-request__eyebrow"><?php esc_html_e( 'Private coordinator workspace', 'extrachill-events' ); ?></p>
+			<h1><?php echo esc_html( $post ? $post->post_title : __( 'Vendor applications', 'extrachill-events' ) ); ?></h1>
+			<span class="ec-vendor-request__status"><?php echo esc_html( $request['status'] ); ?></span>
+		</header>
+		<?php extrachill_events_vendor_request_notice(); ?>
+		<?php if ( get_current_user_id() === (int) $request['coordinator_user_id'] ) : ?>
+			<section class="ec-vendor-request__section"><h2><?php esc_html_e( 'Application window', 'extrachill-events' ); ?></h2>
+				<form method="post" class="ec-vendor-request__inline-form"><?php wp_nonce_field( 'extrachill_events_vendor_request' ); ?><input type="hidden" name="vendor_request_action" value="status"><input type="hidden" name="request_id" value="<?php echo esc_attr( (string) $request['id'] ); ?>"><input type="hidden" name="expected_version" value="<?php echo esc_attr( (string) $request['version'] ); ?>"><input type="hidden" name="idempotency_key" value="<?php echo esc_attr( wp_generate_uuid4() ); ?>"><input type="hidden" name="open" value="<?php echo 'open' === $request['status'] ? '0' : '1'; ?>"><button class="button-1" type="submit"><?php echo esc_html( 'open' === $request['status'] ? __( 'Close applications', 'extrachill-events' ) : __( 'Reopen applications', 'extrachill-events' ) ); ?></button></form>
+			</section>
+		<?php endif; ?>
+		<section class="ec-vendor-request__section"><h2><?php esc_html_e( 'Applicants', 'extrachill-events' ); ?></h2>
+			<?php
+			if ( empty( $applications ) ) :
+				?>
+				<p><?php esc_html_e( 'No vendor applications yet.', 'extrachill-events' ); ?></p><?php endif; ?>
+			<div class="ec-vendor-request__cards">
+			<?php
+			foreach ( $applications as $application ) :
+				extrachill_events_render_vendor_application_card( $application );
+endforeach;
+			?>
+			</div>
+		</section>
+	</section>
+	<?php
+}
+
+/** Render one private application card. */
+function extrachill_events_render_vendor_application_card( array $application ): void {
+	$power     = $application['power_needs'] ? $application['power_needs'] : __( 'None stated', 'extrachill-events' );
+	$insurance = $application['insurance_notes'] ? $application['insurance_notes'] : __( 'None stated', 'extrachill-events' );
+	?>
+	<article class="ec-vendor-request__card">
+		<h3><?php echo esc_html( $application['business_name'] ); ?></h3><p><strong><?php echo esc_html( $application['category'] ); ?></strong> · <?php echo esc_html( $application['status'] ); ?></p>
+		<dl><dt><?php esc_html_e( 'Footprint', 'extrachill-events' ); ?></dt><dd><?php echo esc_html( $application['footprint'] ); ?></dd><dt><?php esc_html_e( 'Power', 'extrachill-events' ); ?></dt><dd><?php echo esc_html( $power ); ?></dd><dt><?php esc_html_e( 'Insurance / permits', 'extrachill-events' ); ?></dt><dd><?php echo esc_html( $insurance ); ?></dd></dl>
+		<p><?php echo nl2br( esc_html( $application['message'] ) ); ?></p>
+		<?php
+		if ( is_array( $application['contact'] ) ) :
+			?>
+			<dl class="ec-vendor-request__contact"><dt><?php esc_html_e( 'Contact', 'extrachill-events' ); ?></dt><dd><?php echo esc_html( $application['contact']['name'] ); ?> · <?php echo esc_html( $application['contact']['email'] ); ?>
+			<?php
+			if ( ! empty( $application['contact']['phone'] ) ) :
+				?>
+			· <?php echo esc_html( $application['contact']['phone'] ); ?><?php endif; ?></dd></dl>
+			<?php
+else :
+	?>
+	<p class="ec-vendor-request__privacy"><?php esc_html_e( 'The applicant withdrew contact consent.', 'extrachill-events' ); ?></p><?php endif; ?>
+		<form method="post" class="ec-vendor-request__form"><?php wp_nonce_field( 'extrachill_events_vendor_request' ); ?><input type="hidden" name="vendor_request_action" value="review"><input type="hidden" name="request_id" value="<?php echo esc_attr( (string) $application['request_id'] ); ?>"><input type="hidden" name="application_id" value="<?php echo esc_attr( (string) $application['id'] ); ?>"><input type="hidden" name="expected_version" value="<?php echo esc_attr( (string) $application['version'] ); ?>"><input type="hidden" name="idempotency_key" value="<?php echo esc_attr( wp_generate_uuid4() ); ?>"><label><?php esc_html_e( 'Review status', 'extrachill-events' ); ?><select name="status">
+		<?php
+		foreach ( array( 'submitted', 'reviewing', 'accepted', 'declined' ) as $status ) :
+			?>
+			<option value="<?php echo esc_attr( $status ); ?>" <?php selected( $application['status'], $status ); ?>><?php echo esc_html( ucfirst( $status ) ); ?></option><?php endforeach; ?></select></label><label><?php esc_html_e( 'Private notes', 'extrachill-events' ); ?><textarea name="notes" rows="3"><?php echo esc_textarea( (string) $application['private_notes'] ); ?></textarea></label><button class="button-2" type="submit"><?php esc_html_e( 'Save review', 'extrachill-events' ); ?></button></form>
+		<?php
+		if ( is_array( $application['contact'] ) && 'withdrawn' !== $application['status'] ) :
+			?>
+			<form method="post" class="ec-vendor-request__form"><?php wp_nonce_field( 'extrachill_events_vendor_request' ); ?><input type="hidden" name="vendor_request_action" value="contact"><input type="hidden" name="request_id" value="<?php echo esc_attr( (string) $application['request_id'] ); ?>"><input type="hidden" name="application_id" value="<?php echo esc_attr( (string) $application['id'] ); ?>"><input type="hidden" name="idempotency_key" value="<?php echo esc_attr( wp_generate_uuid4() ); ?>"><label><?php esc_html_e( 'Subject', 'extrachill-events' ); ?><input name="subject" required maxlength="255"></label><label><?php esc_html_e( 'Managed message', 'extrachill-events' ); ?><textarea name="message" required rows="4"></textarea></label><p class="ec-vendor-request__privacy"><?php esc_html_e( 'Sent by Extra Chill Bot on Chris Huber’s behalf, with Chris copied. Your private email address is not disclosed.', 'extrachill-events' ); ?></p><button class="button-2" type="submit"><?php esc_html_e( 'Queue message', 'extrachill-events' ); ?></button></form><?php endif; ?>
+	</article>
+	<?php
+}
+
+/** Render the exact coordinator's request configuration form. */
+function extrachill_events_render_vendor_request_open_form( int $event_id ): void {
+	?>
+	<section class="ec-vendor-request"><header class="ec-vendor-request__hero"><p class="ec-vendor-request__eyebrow"><?php esc_html_e( 'Event coordinator', 'extrachill-events' ); ?></p><h1><?php esc_html_e( 'Request vendors', 'extrachill-events' ); ?></h1></header><section class="ec-vendor-request__section"><form method="post" class="ec-vendor-request__form"><?php wp_nonce_field( 'extrachill_events_vendor_request' ); ?><input type="hidden" name="vendor_request_action" value="open"><input type="hidden" name="event_id" value="<?php echo esc_attr( (string) $event_id ); ?>"><input type="hidden" name="idempotency_key" value="<?php echo esc_attr( wp_generate_uuid4() ); ?>"><label><?php esc_html_e( 'Vendor categories', 'extrachill-events' ); ?><input name="categories" placeholder="Food, Art, Merchandise" aria-describedby="vendor-category-help"></label><p id="vendor-category-help" class="ec-vendor-request__privacy"><?php esc_html_e( 'Comma-separated. Leave blank to accept any category.', 'extrachill-events' ); ?></p><label><?php esc_html_e( 'Applicant instructions', 'extrachill-events' ); ?><textarea name="instructions" rows="4"></textarea></label><label><input type="checkbox" name="power_required" value="1"> <?php esc_html_e( 'Require power details', 'extrachill-events' ); ?></label><label><input type="checkbox" name="insurance_required" value="1"> <?php esc_html_e( 'Require insurance / permit notes', 'extrachill-events' ); ?></label><button class="button-1" type="submit"><?php esc_html_e( 'Open vendor applications', 'extrachill-events' ); ?></button></form></section></section>
+	<?php
+}
+
+/** Render the public application without coordinator identity or contact. */
+function extrachill_events_render_vendor_application(): void {
+	$public_id  = sanitize_text_field( (string) get_query_var( 'ec_vendor_apply', '' ) );
+	$repository = new VendorRequestRepository();
+	$request    = $repository->get_request_by_public_id( $public_id );
+	if ( ! is_array( $request ) || 'open' !== $request['status'] ) {
+		extrachill_events_render_vendor_request_unavailable( __( 'Vendor applications are closed', 'extrachill-events' ) );
+		return;
+	}
+	$post       = get_post( $request['event_id'] );
+	$categories = (array) ( $request['policy']['categories'] ?? array() );
+	$endpoint   = rest_url( 'extrachill/v1/events/' . $request['event_id'] . '/vendor-applications' );
+	if ( function_exists( 'ec_enqueue_turnstile_script' ) ) {
+		ec_enqueue_turnstile_script();
+	}
+	wp_enqueue_script( 'extrachill-events-vendor-application', EXTRACHILL_EVENTS_PLUGIN_URL . 'assets/js/vendor-application.js', array(), (string) filemtime( EXTRACHILL_EVENTS_PLUGIN_DIR . 'assets/js/vendor-application.js' ), true );
+	?>
+	<section class="ec-vendor-request" data-vendor-application data-endpoint="<?php echo esc_url( $endpoint ); ?>">
+		<header class="ec-vendor-request__hero"><p class="ec-vendor-request__eyebrow"><?php esc_html_e( 'Vendor application', 'extrachill-events' ); ?></p><h1><?php echo esc_html( $post ? $post->post_title : __( 'Event vendor application', 'extrachill-events' ) ); ?></h1>
+		<?php
+		if ( ! empty( $request['policy']['instructions'] ) ) :
+			?>
+			<p><?php echo nl2br( esc_html( $request['policy']['instructions'] ) ); ?></p><?php endif; ?></header>
+		<div class="ec-vendor-request__notice" role="status" aria-live="polite" hidden data-vendor-application-status></div>
+		<section class="ec-vendor-request__section"><form class="ec-vendor-request__form" data-vendor-application-form><input type="hidden" name="event_id" value="<?php echo esc_attr( (string) $request['event_id'] ); ?>"><input type="hidden" name="idempotency_key" value="<?php echo esc_attr( wp_generate_uuid4() ); ?>"><label><?php esc_html_e( 'Business name', 'extrachill-events' ); ?><input name="business_name" required maxlength="255" autocomplete="organization"></label><label><?php esc_html_e( 'Point-of-contact name', 'extrachill-events' ); ?><input name="contact_name" required maxlength="255" autocomplete="name"></label><label><?php esc_html_e( 'Point-of-contact email', 'extrachill-events' ); ?><input type="email" name="contact_email" required maxlength="255" autocomplete="email"></label><label><?php esc_html_e( 'Phone (optional, private)', 'extrachill-events' ); ?><input type="tel" name="contact_phone" maxlength="64" autocomplete="tel"></label><label><?php esc_html_e( 'Vendor category', 'extrachill-events' ); ?>
+		<?php
+		if ( $categories ) :
+			?>
+			<select name="category" required><option value=""><?php esc_html_e( 'Select a category', 'extrachill-events' ); ?></option>
+			<?php
+			foreach ( $categories as $category ) :
+				?>
+			<option value="<?php echo esc_attr( $category ); ?>"><?php echo esc_html( $category ); ?></option><?php endforeach; ?></select>
+			<?php
+else :
+	?>
+	<input name="category" required maxlength="191"><?php endif; ?></label><label><?php esc_html_e( 'Website or social link (optional)', 'extrachill-events' ); ?><input type="url" name="website_url" maxlength="2000"></label><label><?php esc_html_e( 'Booth footprint', 'extrachill-events' ); ?><input name="footprint" required maxlength="255" placeholder="10 × 10 feet"></label><label><?php esc_html_e( 'Power needs', 'extrachill-events' ); ?><textarea name="power_needs" rows="3" <?php echo ! empty( $request['policy']['power_required'] ) ? 'required' : ''; ?>></textarea></label><label><?php esc_html_e( 'Insurance / permit notes', 'extrachill-events' ); ?><textarea name="insurance_notes" rows="3" <?php echo ! empty( $request['policy']['insurance_required'] ) ? 'required' : ''; ?>></textarea></label><label><?php esc_html_e( 'Message', 'extrachill-events' ); ?><textarea name="message" required rows="5" maxlength="5000"></textarea></label><label class="ec-vendor-request__consent"><input type="checkbox" name="contact_consent" value="1" required> <?php esc_html_e( 'I consent to share the contact fields above only with the authorized coordinator and event organizers for this event. I can withdraw this application and revoke contact access.', 'extrachill-events' ); ?></label><div data-vendor-turnstile>
+	<?php
+	if ( function_exists( 'ec_render_turnstile_widget' ) ) {
+		echo wp_kses_post( ec_render_turnstile_widget( array( 'data-appearance' => 'always' ) ) ); }
+	?>
+</div><button class="button-1" type="submit"><?php esc_html_e( 'Submit vendor application', 'extrachill-events' ); ?></button></form></section>
+	</section>
+	<?php
+}
+
+function extrachill_events_vendor_request_notice(): void {
+	$notice = sanitize_key( (string) ( $_GET['notice'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Display-only status.
+	if ( $notice ) {
+		printf( '<div class="ec-vendor-request__notice ec-vendor-request__notice--%1$s" role="status">%2$s</div>', esc_attr( 'error' === $notice ? 'error' : 'success' ), esc_html( 'error' === $notice ? __( 'The action could not be completed.', 'extrachill-events' ) : __( 'Vendor request updated.', 'extrachill-events' ) ) );
+	}
+}
+
+function extrachill_events_render_vendor_request_unavailable( string $title = '' ): void {
+	$heading = '' !== $title ? $title : __( 'Workspace unavailable', 'extrachill-events' );
+	printf( '<section class="ec-vendor-request"><div class="ec-vendor-request__notice ec-vendor-request__notice--error" role="alert"><h1>%s</h1><p>%s</p></div></section>', esc_html( $heading ), esc_html__( 'This vendor request is closed, missing, or not authorized for your account.', 'extrachill-events' ) );
+}
+
+/** Load vendor UI only on its public/private surfaces. */
+function extrachill_events_enqueue_vendor_request_assets(): void {
+	if ( extrachill_events_is_vendor_request_page() || extrachill_events_is_vendor_application_page() || is_singular( 'data_machine_events' ) ) {
+		wp_enqueue_style( 'extrachill-events-vendor-request', EXTRACHILL_EVENTS_PLUGIN_URL . 'assets/css/vendor-request.css', array(), (string) filemtime( EXTRACHILL_EVENTS_PLUGIN_DIR . 'assets/css/vendor-request.css' ) );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_events_enqueue_vendor_request_assets' );
+add_action( 'data_machine_events_action_buttons', 'extrachill_events_vendor_request_event_action', 20, 1 );

--- a/inc/templates/vendor-request.php
+++ b/inc/templates/vendor-request.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Vendor request router template.
+ *
+ * @package ExtraChillEvents
+ */
+
+defined( 'ABSPATH' ) || exit;
+get_header();
+if ( function_exists( 'extrachill_breadcrumbs' ) ) {
+	extrachill_breadcrumbs();
+}
+?>
+<main class="page-content ec-vendor-request-page">
+	<?php extrachill_events_is_vendor_application_page() ? extrachill_events_render_vendor_application() : extrachill_events_render_vendor_request_workspace(); ?>
+</main>
+<?php get_footer(); ?>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"start:concert-stats": "wp-scripts start blocks/concert-stats/src/index.js blocks/concert-stats/src/view.js --output-path=build/concert-stats",
 		"test:js": "wp-scripts test-unit-js",
 		"test:browser": "node tests/browser/local-support.evidence.js",
+		"test:browser:vendor-request": "node tests/browser/vendor-request.evidence.js",
 		"test:browser:booking-inquiry": "node tests/browser/booking-inquiry.evidence.js",
 		"lint:js": "wp-scripts lint-js",
 		"lint:js:fix": "wp-scripts lint-js --fix"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,6 +36,7 @@
 		</testsuite>
 		<testsuite name="venue-membership-authorization">
 			<file>tests/VenueMembershipAuthorizationTest.php</file>
+			<file>tests/VendorRequestDomainTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/VendorRequestDomainTest.php
+++ b/tests/VendorRequestDomainTest.php
@@ -1,0 +1,441 @@
+<?php
+/**
+ * Event vendor request domain tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Abilities\VendorRequestAbilities;
+use ExtraChillEvents\Core\VendorRequestAuthorization;
+use ExtraChillEvents\Core\VendorRequestNotificationService;
+use ExtraChillEvents\Core\VendorRequestRepository;
+use ExtraChillEvents\Core\VendorRequestService;
+
+require_once __DIR__ . '/Support/BookingTestHarness.php';
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $value ) {
+		return filter_var( (string) $value, FILTER_VALIDATE_URL ) ? (string) $value : '';
+	}
+}
+if ( ! function_exists( 'is_email' ) ) {
+	function is_email( $value ) {
+		return false !== filter_var( (string) $value, FILTER_VALIDATE_EMAIL );
+	}
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+if ( ! function_exists( 'wpautop' ) ) {
+	function wpautop( $value ) {
+		return '<p>' . $value . '</p>';
+	}
+}
+if ( ! function_exists( 'get_home_url' ) ) {
+	function get_home_url( $blog_id = null, $path = '' ) {
+		unset( $blog_id );
+		return 'https://events.example' . $path;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/VendorRequestSchema.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VendorRequestAuthorization.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VendorRequestRepository.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VendorRequestService.php';
+require_once dirname( __DIR__ ) . '/inc/Core/VendorRequestNotificationService.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/VendorRequestAbilities.php';
+
+/** Proves vendor policy remains event-scoped and private. */
+final class VendorRequestDomainTest extends BookingTestCase {
+
+	/** @var VendorRequestMemoryRepository */
+	private $repository;
+	/** @var VendorRequestTestAuthorization */
+	private $authorization;
+	/** @var VendorRequestService */
+	private $service;
+
+	protected function setUp(): void {
+		$GLOBALS['ec_artist_test'] = array(
+			'blog_id'       => 7,
+			'uuid'          => 0,
+			'options'       => array(),
+			'abilities'     => array(),
+			'actions'       => array(),
+			'fired_actions' => array(),
+		);
+		$GLOBALS['wpdb']           = new BookingWpdb();
+		$this->repository          = new VendorRequestMemoryRepository();
+		$this->authorization       = new VendorRequestTestAuthorization();
+		$this->service             = new VendorRequestService( $this->repository, $this->authorization );
+	}
+
+	public function test_exact_coordinator_controls_window_while_current_organizer_may_review(): void {
+		$request = $this->open_request();
+		$this->assertSame( 12, $request['coordinator_user_id'] );
+		$this->assertSame( 'vendor_request_forbidden', $this->service->set_request_open( $request['id'], false, 1, 'close-other', 13 )->get_error_code() );
+		$this->assertSame( 'closed', $this->service->set_request_open( $request['id'], false, 1, 'close-coordinator', 12 )['status'] );
+		$this->assertSame( 'open', $this->service->set_request_open( $request['id'], true, 2, 'reopen-coordinator', 12 )['status'] );
+
+		$application = $this->apply();
+		$rows        = $this->service->list_applications( $request['id'], 13 );
+		$this->assertSame( $application['public_id'], $rows[0]['public_id'] );
+		$this->authorization->organizer_venues[13] = array( 56 );
+		$this->assertSame( 'vendor_request_forbidden', $this->service->list_applications( $request['id'], 13 )->get_error_code() );
+	}
+
+	public function test_public_projection_and_event_type_relationship_do_not_leak_contacts(): void {
+		$request = $this->open_request();
+		$public  = $this->service->public_request_for_event( 900 );
+		$this->assertSame( array( 'public_id', 'event_id', 'policy', 'status' ), array_keys( $public ) );
+		$this->assertStringNotContainsString( 'coordinator', wp_json_encode( $public ) );
+		$this->assertStringNotContainsString( 'email', wp_json_encode( $public ) );
+
+		$this->service->set_request_open( $request['id'], false, 1, 'close-public', 12 );
+		$this->assertNull( $this->service->public_request_for_event( 900 ) );
+		$this->assertStringContainsString( "'eventType'", file_get_contents( dirname( __DIR__ ) . '/inc/Core/BookingEventConversionService.php' ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source contract fixture.
+		$this->assertFileDoesNotExist( dirname( __DIR__ ) . '/inc/Core/VendorTaxonomy.php' );
+	}
+
+	public function test_application_is_private_consent_bound_and_idempotent(): void {
+		$this->open_request();
+		$input = $this->application_input();
+		$first = $this->service->apply( $input );
+		$retry = $this->service->apply( $input );
+		$this->assertSame( $first['public_id'], $retry['public_id'] );
+		$this->assertSame( $first['access_token'], $retry['access_token'] );
+		$this->assertCount( 1, $this->repository->applications );
+		$this->assertArrayHasKey( 'access_token', $first );
+
+		$private = $this->service->list_applications( 1, 12 )[0];
+		$this->assertSame( 'vendor@example.com', $private['contact']['email'] );
+		$this->assertSame( '555-0100', $private['contact']['phone'] );
+		$this->assertArrayNotHasKey( 'contact', $first );
+		$this->assertStringNotContainsString( 'vendor@example.com', wp_json_encode( $this->repository->activity ) );
+
+		$changed                  = $input;
+		$changed['business_name'] = 'Different Vendor';
+		$this->assertSame( 'vendor_request_idempotency_conflict', $this->service->apply( $changed )->get_error_code() );
+		$input['idempotency_key'] = 'missing-consent';
+		$input['contact_consent'] = false;
+		$this->assertSame( 'vendor_application_consent_required', $this->service->apply( $input )->get_error_code() );
+	}
+
+	public function test_close_race_rechecks_locked_request_and_preserves_zero_new_rows(): void {
+		$this->open_request();
+		$this->repository->close_on_lock = true;
+		$result                          = $this->service->apply( $this->application_input() );
+		$this->assertSame( 'vendor_request_not_open', $result->get_error_code() );
+		$this->assertCount( 0, $this->repository->applications );
+	}
+
+	public function test_opaque_withdrawal_revokes_contact_and_blocks_correspondence(): void {
+		$this->open_request();
+		$receipt = $this->apply();
+		$result  = $this->service->withdraw( $receipt['public_id'], $receipt['access_token'], 1, 'withdraw-1' );
+		$this->assertSame( 'withdrawn', $result['status'] );
+		$private = $this->service->list_applications( 1, 12 )[0];
+		$this->assertNull( $private['contact'] );
+		$this->assertSame( 2, $private['consent_version'] );
+		$this->assertNotNull( $private['revoked_at'] );
+		$this->assertSame( 'vendor_application_contact_unavailable', $this->service->contact_applicant( 1, 'Hello', 'Message', 'contact-withdrawn', 12, '__return_true' )->get_error_code() );
+	}
+
+	public function test_managed_correspondence_has_required_identity_cc_and_receipt(): void {
+		$this->open_request();
+		$this->apply();
+		$queued = array();
+		$result = $this->service->contact_applicant(
+			1,
+			'Market details',
+			'Please confirm your arrival time.',
+			'contact-1',
+			12,
+			static function ( array $input ) use ( &$queued ): array {
+				$queued = $input;
+				return array(
+					'success'   => true,
+					'action_id' => 77,
+				);
+			}
+		);
+		$this->assertSame(
+			array(
+				'status'    => 'queued',
+				'action_id' => 77,
+			),
+			$result
+		);
+		$this->assertSame( 'chubes@extrachill.com', $queued['cc'] );
+		$this->assertSame( 'Extra Chill Bot', $queued['from_name'] );
+		$this->assertStringContainsString( 'Extra Chill Bot sending on Chris Huber', $queued['body'] );
+		$this->assertSame( 'vendor@example.com', $queued['to'] );
+		$this->assertSame(
+			$result,
+			$this->service->contact_applicant(
+				1,
+				'Market details',
+				'Please confirm your arrival time.',
+				'contact-1',
+				12,
+				static function (): void {
+					throw new RuntimeException( 'Must not queue twice.' );
+				}
+			)
+		);
+	}
+
+	/** Coordinator notification uses a deterministic, contact-free Users receipt. */
+	public function test_application_notification_receipt_contains_no_applicant_contact(): void {
+		$this->open_request();
+		$captured = array();
+		$service  = new VendorRequestNotificationService(
+			$this->repository,
+			$this->authorization,
+			static function ( array $recipients, array $payload ) use ( &$captured ): array {
+				$captured = compact( 'recipients', 'payload' );
+				return array( 'recipients' => array( 12 => array( 'status' => 'inserted' ) ) );
+			},
+			static function (): int {
+				return 99;
+			}
+		);
+		$receipt = $service->notify_change( array( 'kind' => 'application_submitted', 'request_id' => 1, 'application_id' => 4, 'version' => 1 ) );
+		$this->assertSame( array( 12 ), $captured['recipients'] );
+		$this->assertSame( VendorRequestNotificationService::PRODUCER, $captured['payload']['producer'] );
+		$this->assertStringNotContainsString( 'email', wp_json_encode( $captured ) );
+		$this->assertSame( 'inserted', $receipt['payload']['status'] );
+	}
+
+	public function test_abilities_are_hidden_and_ui_is_accessible_and_mobile_bounded(): void {
+		$abilities = new VendorRequestAbilities( $this->service );
+		$abilities->register();
+		$this->assertArrayHasKey( 'extrachill-events/apply-to-vendor-request', $GLOBALS['ec_artist_test']['abilities'] );
+		foreach ( $GLOBALS['ec_artist_test']['abilities'] as $name => $definition ) {
+			if ( false !== strpos( $name, 'vendor' ) ) {
+				$this->assertFalse( $definition['meta']['show_in_rest'], $name );
+			}
+		}
+		$ui  = file_get_contents( dirname( __DIR__ ) . '/inc/core/vendor-request-workspace.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source contract fixture.
+		$css = file_get_contents( dirname( __DIR__ ) . '/assets/css/vendor-request.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source contract fixture.
+		$this->assertStringContainsString( 'Apply as a vendor', $ui );
+		$this->assertStringContainsString( 'aria-live="polite"', $ui );
+		$this->assertStringContainsString( 'role="alert"', $ui );
+		$this->assertStringContainsString( '@media (max-width: 600px)', $css );
+		$this->assertStringContainsString( 'min-height: 44px', $css );
+	}
+
+	private function open_request(): array {
+		return $this->service->open_request(
+			900,
+			array(
+				'categories'     => array( 'Food', 'Art' ),
+				'power_required' => true,
+			),
+			'open-900',
+			12
+		);
+	}
+
+	private function apply(): array {
+		return $this->service->apply( $this->application_input() );
+	}
+
+	private function application_input(): array {
+		return array(
+			'event_id'        => 900,
+			'idempotency_key' => 'apply-1',
+			'business_name'   => 'Lowcountry Goods',
+			'contact_name'    => 'Vendor Person',
+			'contact_email'   => 'vendor@example.com',
+			'contact_phone'   => '555-0100',
+			'category'        => 'Art',
+			'website_url'     => 'https://vendor.example',
+			'footprint'       => '10 x 10 feet',
+			'power_needs'     => 'One 20 amp circuit',
+			'insurance_notes' => 'Certificate available',
+			'message'         => 'We sell handmade goods.',
+			'contact_consent' => true,
+		);
+	}
+}
+
+/** In-memory persistence double preserving private fields and receipts. */
+final class VendorRequestMemoryRepository extends VendorRequestRepository {
+	public $requests      = array();
+	public $applications  = array();
+	public $activity      = array();
+	public $close_on_lock = false;
+
+	public function create_request( array $data ) {
+		$id                    = count( $this->requests ) + 1;
+		$this->requests[ $id ] = array_merge(
+			$data,
+			array(
+				'id'         => $id,
+				'public_id'  => '123e4567-e89b-42d3-a456-000000000001',
+				'status'     => 'open',
+				'version'    => 1,
+				'created_at' => '2026-08-02 20:00:00',
+				'updated_at' => '2026-08-02 20:00:00',
+			)
+		);
+		return $this->requests[ $id ];
+	}
+
+	public function get_request( int $id, bool $for_update = false ) {
+		if ( $for_update && $this->close_on_lock && isset( $this->requests[ $id ] ) ) {
+			$this->requests[ $id ]['status'] = 'closed';
+		}
+		return $this->requests[ $id ] ?? null;
+	}
+
+	public function get_request_by_event( int $event_id ) {
+		foreach ( $this->requests as $request ) {
+			if ( $request['event_id'] === $event_id ) {
+				return $request;
+			}
+		}
+		return null;
+	}
+
+	public function get_request_by_public_id( string $public_id ) {
+		foreach ( $this->requests as $request ) {
+			if ( $request['public_id'] === $public_id ) {
+				return $request;
+			}
+		}
+		return null;
+	}
+
+	public function update_request( int $id, int $expected_version, array $changes ) {
+		if ( ! isset( $this->requests[ $id ] ) || $this->requests[ $id ]['version'] !== $expected_version ) {
+			return new WP_Error( 'vendor_request_version_conflict' );
+		}
+		$this->requests[ $id ] = array_merge( $this->requests[ $id ], $changes, array( 'version' => $expected_version + 1 ) );
+		return $this->requests[ $id ];
+	}
+
+	public function create_application( array $data ) {
+		$id                        = count( $this->applications ) + 1;
+		$this->applications[ $id ] = array_merge(
+			$data,
+			array(
+				'id'              => $id,
+				'public_id'       => '223e4567-e89b-42d3-a456-' . str_pad( (string) $id, 12, '0', STR_PAD_LEFT ),
+				'status'          => 'submitted',
+				'version'         => 1,
+				'consent_version' => 1,
+				'consented_at'    => '2026-08-02 20:00:00',
+				'revoked_at'      => null,
+				'private_notes'   => null,
+				'created_at'      => '2026-08-02 20:00:00',
+				'updated_at'      => '2026-08-02 20:00:00',
+			)
+		);
+		return $this->public_application( $this->applications[ $id ] );
+	}
+
+	public function get_application( int $id, bool $for_update = false ) {
+		unset( $for_update );
+		return isset( $this->applications[ $id ] ) ? $this->public_application( $this->applications[ $id ] ) : null;
+	}
+
+	public function get_application_by_public_id( string $public_id, bool $for_update = false ) {
+		unset( $for_update );
+		foreach ( $this->applications as $application ) {
+			if ( $application['public_id'] === $public_id ) {
+				return $this->public_application( $application );
+			}
+		}
+		return null;
+	}
+
+	public function find_application_retry( int $request_id, string $key ) {
+		foreach ( $this->applications as $application ) {
+			if ( $application['request_id'] === $request_id && $application['idempotency_key'] === $key ) {
+				$row                 = $this->public_application( $application );
+				$row['_replay_hash'] = $application['request_hash'];
+				return $row;
+			}
+		}
+		return null;
+	}
+
+	public function list_applications( int $request_id, int $limit = 100 ) {
+		$rows = array_filter(
+			$this->applications,
+			static function ( $application ) use ( $request_id ): bool {
+				return $application['request_id'] === $request_id;
+			}
+		);
+		return array_map( array( $this, 'public_application' ), array_slice( array_values( $rows ), 0, $limit ) );
+	}
+
+	public function update_application( int $id, int $expected_version, array $changes ) {
+		if ( ! isset( $this->applications[ $id ] ) || $this->applications[ $id ]['version'] !== $expected_version ) {
+			return new WP_Error( 'vendor_request_version_conflict' );
+		}
+		if ( isset( $changes['contact_payload'] ) ) {
+			$changes['contact'] = json_decode( $changes['contact_payload'], true );
+			unset( $changes['contact_payload'] );
+		}
+		$this->applications[ $id ] = array_merge( $this->applications[ $id ], $changes, array( 'version' => $expected_version + 1 ) );
+		return $this->public_application( $this->applications[ $id ] );
+	}
+
+	public function append_activity( array $data ) {
+		$data['id']       = count( $this->activity ) + 1;
+		$this->activity[] = $data;
+		return $data;
+	}
+
+	public function find_activity( int $request_id, string $key ) {
+		foreach ( $this->activity as $activity ) {
+			if ( $activity['request_id'] === $request_id && $activity['idempotency_key'] === $key ) {
+				return $activity;
+			}
+		}
+		return null;
+	}
+
+	public function verify_application_token( string $public_id, string $token ): bool {
+		foreach ( $this->applications as $application ) {
+			if ( $application['public_id'] === $public_id ) {
+				return hash_equals( $application['access_token_hash'], hash_hmac( 'sha256', $token, wp_salt( 'auth' ) ) );
+			}
+		}
+		return false;
+	}
+
+	public function public_application( array $application ): array {
+		$application['contact'] = null === $application['revoked_at'] ? $application['contact'] : null;
+		unset( $application['access_token_hash'], $application['idempotency_key'], $application['request_hash'] );
+		return $application;
+	}
+}
+
+/** Authorization double with exact event and venue membership policy. */
+final class VendorRequestTestAuthorization extends VendorRequestAuthorization {
+	public $organizer_venues = array(
+		12 => array( 55 ),
+		13 => array( 55 ),
+	);
+
+	public function event_context( int $event_id ) {
+		return 900 === $event_id ? array(
+			'event_id'      => 900,
+			'venue_term_id' => 55,
+		) : new WP_Error( 'invalid_vendor_request_event' );
+	}
+
+	public function authorize_organizer( array $request, int $user_id ) {
+		return 900 === $request['event_id'] && 55 === $request['venue_term_id'] && in_array( 55, $this->organizer_venues[ $user_id ] ?? array(), true ) ? true : new WP_Error( 'vendor_request_forbidden' );
+	}
+
+	public function authorize_coordinator( array $request, int $user_id ) {
+		return (int) $request['coordinator_user_id'] === $user_id ? $this->authorize_organizer( $request, $user_id ) : new WP_Error( 'vendor_request_forbidden' );
+	}
+}

--- a/tests/browser/vendor-request-fixture.php
+++ b/tests/browser/vendor-request-fixture.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Deterministic vendor request browser fixture.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+$workspace = 'workspace' === ( $_GET['scenario'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Deterministic fixture selector.
+?><!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><link rel="stylesheet" href="/assets/css/vendor-request.css"><title>Vendor Request Evidence</title></head><body><main>
+<?php if ( $workspace ) : ?>
+	<section class="ec-vendor-request"><header class="ec-vendor-request__hero"><p class="ec-vendor-request__eyebrow">Private coordinator workspace</p><h1>Night Market</h1></header><section class="ec-vendor-request__section"><h2>Applicants</h2><div class="ec-vendor-request__cards"><?php foreach ( array( 'Lowcountry Goods', 'Mobile Vinyl', 'Sweetgrass Studio' ) as $name ) : ?><article class="ec-vendor-request__card"><h3><?php echo htmlspecialchars( $name, ENT_QUOTES, 'UTF-8' ); ?></h3><p>Private application</p><form class="ec-vendor-request__form"><label>Review status<select><option>Submitted</option></select></label><button type="button">Save review</button></form></article><?php endforeach; ?></div></section></section>
+<?php else : ?>
+	<section class="ec-vendor-request" data-vendor-application data-endpoint="/api/vendor-applications"><header class="ec-vendor-request__hero"><p class="ec-vendor-request__eyebrow">Vendor application</p><h1>Night Market</h1></header><div class="ec-vendor-request__notice" role="status" aria-live="polite" hidden data-vendor-application-status></div><section class="ec-vendor-request__section"><form class="ec-vendor-request__form" data-vendor-application-form><input type="hidden" name="event_id" value="900"><input type="hidden" name="idempotency_key" value="browser-key"><label>Business name<input name="business_name" required></label><label>Point-of-contact name<input name="contact_name" required></label><label>Point-of-contact email<input type="email" name="contact_email" required></label><label>Phone (optional, private)<input type="tel" name="contact_phone"></label><label>Vendor category<select name="category" required><option value="Art">Art</option></select></label><label>Website or social link (optional)<input type="url" name="website_url"></label><label>Booth footprint<input name="footprint" required></label><label>Power needs<textarea name="power_needs" required></textarea></label><label>Insurance / permit notes<textarea name="insurance_notes"></textarea></label><label>Message<textarea name="message" required></textarea></label><label class="ec-vendor-request__consent"><input type="checkbox" name="contact_consent" value="1" required> I consent to event-scoped contact sharing.</label><input type="hidden" name="cf-turnstile-response" value="fixture-token"><button type="submit">Submit vendor application</button></form></section></section><script src="/assets/js/vendor-application.js"></script>
+<?php endif; ?>
+</main></body></html>

--- a/tests/browser/vendor-request.evidence.js
+++ b/tests/browser/vendor-request.evidence.js
@@ -1,0 +1,132 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+const assert = require( 'node:assert/strict' );
+const { spawn } = require( 'node:child_process' );
+const net = require( 'node:net' );
+const path = require( 'node:path' );
+const { chromium } = require( 'playwright' );
+
+const root = path.resolve( __dirname, '../..' );
+const availablePort = () =>
+	new Promise( ( resolve, reject ) => {
+		const server = net.createServer();
+		server.once( 'error', reject );
+		server.listen( 0, '127.0.0.1', () => {
+			const { port } = server.address();
+			server.close( () => resolve( port ) );
+		} );
+	} );
+const waitForServer = async ( url ) => {
+	for ( let attempt = 0; attempt < 50; attempt++ ) {
+		try {
+			if ( ( await fetch( url ) ).ok ) {
+				return;
+			}
+		} catch {}
+		await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
+	}
+	throw new Error( 'Vendor fixture server did not start.' );
+};
+
+( async () => {
+	const port = await availablePort();
+	const origin = `http://127.0.0.1:${ port }`;
+	const server = spawn( 'php', [ '-S', `127.0.0.1:${ port }`, '-t', root ], {
+		stdio: 'ignore',
+	} );
+	let browser;
+	try {
+		const publicUrl = `${ origin }/tests/browser/vendor-request-fixture.php`;
+		await waitForServer( publicUrl );
+		browser = await chromium.launch( { headless: true } );
+		const page = await browser.newPage( {
+			viewport: { width: 1280, height: 900 },
+		} );
+		await page.route( '**/api/vendor-applications', async ( route ) => {
+			const input = route.request().postDataJSON();
+			assert.equal( input.turnstile_response, 'fixture-token' );
+			assert.equal( input.contact_consent, true );
+			await route.fulfill( {
+				status: 201,
+				contentType: 'application/json',
+				body: JSON.stringify( {
+					public_id: '223e4567-e89b-42d3-a456-000000000001',
+					access_token: 'a'.repeat( 64 ),
+				} ),
+			} );
+		} );
+		await page.goto( publicUrl );
+		assert.equal( await page.locator( 'label' ).count(), 11 );
+		await page.fill( '[name="business_name"]', 'Lowcountry Goods' );
+		await page.fill( '[name="contact_name"]', 'Vendor Person' );
+		await page.fill( '[name="contact_email"]', 'vendor@example.com' );
+		await page.fill( '[name="footprint"]', '10 x 10 feet' );
+		await page.fill( '[name="power_needs"]', 'One circuit' );
+		await page.fill( '[name="message"]', 'Handmade goods' );
+		await page.check( '[name="contact_consent"]' );
+		await page.click( 'button[type="submit"]' );
+		await page.waitForFunction( () =>
+			document
+				.querySelector( '[role="status"]' )
+				.textContent.includes( 'Save this private withdrawal receipt' )
+		);
+		assert.match(
+			await page.textContent( '[role="status"]' ),
+			/223e4567.*:{1}a{64}/
+		);
+
+		await page.goto( `${ publicUrl }?scenario=workspace` );
+		assert.ok(
+			( await page.locator( '.ec-vendor-request__card' ).count() ) === 3
+		);
+		assert.ok(
+			( await page.$eval(
+				'.ec-vendor-request__cards',
+				( node ) =>
+					getComputedStyle( node ).gridTemplateColumns.split( ' ' )
+						.length
+			) ) > 1
+		);
+		await page.setViewportSize( { width: 390, height: 844 } );
+		await page.reload();
+		assert.equal(
+			await page.$eval(
+				'.ec-vendor-request__cards',
+				( node ) =>
+					getComputedStyle( node ).gridTemplateColumns.split( ' ' )
+						.length
+			),
+			1
+		);
+		assert.ok(
+			await page.$eval(
+				'button',
+				( button ) => button.getBoundingClientRect().height >= 44
+			)
+		);
+		assert.ok(
+			await page.$eval(
+				'html',
+				( html ) => html.scrollWidth <= html.clientWidth
+			)
+		);
+
+		// eslint-disable-next-line no-console -- Deterministic CI evidence.
+		console.log(
+			JSON.stringify( {
+				status: 'passed',
+				viewports: [ '1280x900', '390x844' ],
+				privacy: 'no-public-directory',
+				receipt: 'opaque-withdrawal-token',
+			} )
+		);
+	} finally {
+		if ( browser ) {
+			await browser.close();
+		}
+		server.kill();
+	}
+} )().catch( ( error ) => {
+	console.error( error );
+	process.exitCode = 1;
+} );


### PR DESCRIPTION
## Summary
- add an Events-owned, event-scoped vendor request aggregate with private transactional storage, statuses, notes, activity receipts, idempotent retries, consent revocation, and managed correspondence
- add public `Apply as a vendor` and private coordinator workspace UI, with hidden abilities and no applicant/coordinator directory exposure
- add focused domain, privacy, notification, correspondence, mobile, and accessibility coverage

## Authorization
- the exact current venue-authorized user who opens a request is persisted as its coordinator
- only that coordinator, while still currently authorized for the event's exact venue, can close or reopen applications
- other currently authorized organizers for that exact event venue may list/review applicants and initiate managed contact
- cross-event, cross-venue, unrelated-user, global-team, artist-membership, promoter-taxonomy, and email-domain authority are not inferred
- promoter organization delegation remains separate under #391

## Privacy
- applications, contact payloads, phone, notes, activity, and correspondence receipts live only in private Events tables
- the public projection contains only opaque request identity, event ID, event-specific policy, and open status
- public event markup exposes only the apply CTA while open; no coordinator or applicant contact/directory is added to REST, schema, search, calendar, or event payloads
- application withdrawal uses an opaque token, atomically revokes contact, and blocks later correspondence
- exact retries reproduce the same receipt and opaque withdrawal token without duplicating applications

## Public Transport Dependency
- Events exposes hidden `extrachill-events/apply-to-vendor-request` and `extrachill-events/withdraw-vendor-application` abilities; neither is generic-REST visible
- Extra Chill API must own the Turnstile, rate-limit, route-affinity, canonical identity, and stable public-error facade
- dependency: Extra-Chill/extrachill-api#145
- no Events-owned workaround REST route was added, so this PR uses `Refs #527` rather than closing it

## Local Support Boundary
- reuses Local Support's low-level patterns: exact event/venue reauthorization, transactional row locks, optimistic versions, private payloads, immutable activity receipts, hidden abilities, and Users notification receipts
- keeps vendor schema, lifecycle, policy, UI, and correspondence event-specific; Local Support was not generalized or rewritten

## eventType
- Data Machine Events already owns canonical Schema.org `eventType`; this feature adds no taxonomy or duplicate type field
- current main includes the #524 conversion mapping: `Concert` becomes `MusicEvent`, while `Market`/`Other` use canonical `Event`
- vendor requests remain a coordinator action after the canonical event exists

## Email and Notifications
- new applications use Extra Chill Users idempotent notification receipts for the exact coordinator
- coordinator messages use the queued Data Machine email primitive
- every outgoing vendor email CCs `chubes@extrachill.com` and states that Extra Chill Bot is sending on Chris Huber's behalf

## Verification
- `vendor/bin/phpunit -c phpunit.xml.dist --testsuite venue-membership-authorization` (58 tests, 408 assertions)
- `npm run test:browser:vendor-request` (Chromium, 1280x900 and 390x844)
- `npm run lint:js`
- `npm run build`
- Homeboy run `de2dd7a8-96d5-4cb9-b0e1-119591caeac1`: audit passed with zero findings; lint passed with zero findings
- Homeboy managed tests could not start because the controller lacks `WP_CODEBOX_DB_HOST`; this was a pre-test environment failure, not a test failure

Refs #527