### PR TITLE
fix: close public intake for active venue holds

### DIFF
--- a/inc/Core/BookingHoldRepository.php
+++ b/inc/Core/BookingHoldRepository.php
@@ -1040,7 +1040,7 @@ class BookingHoldRepository {
 			$venue_id,
 			$space_key,
 			function () use ( $booking, $available_callback ) {
-				$conflict = $this->find_conflict( $booking, 0, false );
+				$conflict = $this->find_conflict( $booking, 0, true );
 				if ( is_wp_error( $conflict ) ) {
 					return $conflict;
 				}

--- a/tests/BookingHoldTest.php
+++ b/tests/BookingHoldTest.php
@@ -176,15 +176,21 @@ final class BookingHoldTest extends BookingTestCase {
 		$this->assertSame( 'active', $retry['hold']['status'], 'An exactly elapsed hold must not block even before cleanup.' );
 	}
 
-	/** Public availability ignores inquiry/hold state and exposes only filled state. */
-	public function test_public_interval_availability_is_private_interval_based_and_hold_tolerant(): void {
+	/** Public availability ignores private inquiries but closes for venue-created holds. */
+	public function test_public_interval_availability_keeps_inquiries_private_and_blocks_active_holds(): void {
 		$holds = $this->holds();
 		$this->booking( '2030-08-02 00:00:00', '2030-08-02 03:00:00', 'main-room', array( 'status' => 'submitted' ) );
-		$held = $this->booking( '2030-08-02 00:00:00', '2030-08-02 03:00:00', 'main-room' );
-		$holds->create( $held['id'], 1, 12 );
-
 		$this->assertSame(
 			array( 'available' => true ),
+			$holds->public_interval_availability( 55, 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00' ),
+			'Pending inquiries must remain private and accept competition.'
+		);
+
+		$held = $this->booking( '2030-08-02 00:00:00', '2030-08-02 03:00:00', 'main-room' );
+		$hold = $holds->create( $held['id'], 1, 12 );
+
+		$this->assertSame(
+			array( 'available' => false ),
 			$holds->public_interval_availability( 55, 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00' )
 		);
 		$this->assertSame(
@@ -193,6 +199,13 @@ final class BookingHoldTest extends BookingTestCase {
 			'An adjacent same-day interval must remain open.'
 		);
 		$this->assertSame( array( 'available' ), array_keys( $holds->public_interval_availability( 55, 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00' ) ) );
+
+		$holds->release( $hold['hold']['id'], 1, 12, 'Venue reopened the interval.' );
+		$this->assertSame(
+			array( 'available' => true ),
+			$holds->public_interval_availability( 55, 'main-room', '2030-08-01 20:00:00', '2030-08-01 23:00:00' ),
+			'Releasing the venue hold must reopen competition.'
+		);
 	}
 
 	/** Confirmed bookings and canonical events close only overlapping intervals. */
@@ -231,6 +244,16 @@ final class BookingHoldTest extends BookingTestCase {
 			return 'accepted';
 		} ) );
 
+		$held = $this->booking( '2030-08-02 00:00:00', '2030-08-02 03:00:00', 'main-room' );
+		$holds->create( $held['id'], 1, 12 );
+		$reserved = $holds->admit_public_interval( $input, static function () use ( &$called ) {
+			++$called;
+			return 'should-not-run';
+		} );
+		$this->assertSame( 'booking_inquiry_interval_unavailable', $reserved->get_error_code() );
+		$this->assertSame( 1, $called );
+
+		$GLOBALS['wpdb']->rows[ BookingSchema::holds_table() ] = array();
 		$this->booking( '2030-08-02 00:00:00', '2030-08-02 03:00:00', 'main-room', array( 'status' => 'confirmed' ) );
 		$filled = $holds->admit_public_interval( $input, static function () use ( &$called ) {
 			++$called;


### PR DESCRIPTION
## Summary
- keep pending booking requests private and non-blocking so venues can compare competing submissions
- close only overlapping venue-space intervals once an authorized venue operator creates an active hold, or a booking/event is confirmed
- preserve the privacy-safe `{ available: boolean }` response and locked final-admission recheck

## Gardner policy
Chris Gardner clarified that multiple requests should remain possible until the venue places a hold or confirms/books the show. Pending requests must never be shown outside the venue.

## Verification
- `vendor/bin/phpunit tests/BookingHoldTest.php` (45 tests, 215 assertions)
- pending inquiry remains available without exposing request state
- active hold returns only `available: false`
- adjacent same-day interval remains available
- released hold reopens the interval
- hold race prevents final admission callback
- confirmed bookings and canonical events retain existing blocking behavior

Full unconfigured `vendor/bin/phpunit` still requires the repository's WordPress integration bootstrap; direct invocation reaches `WP_UnitTestCase` without that environment. Direct full-file PHPCS reports the repository's existing baseline filename/docblock violations; focused behavior tests pass.

Fixes #535