### PR TITLE
fix: clarify available booking submission dates

### DIFF
--- a/blocks/venue-booking-inquiry/src/view.js
+++ b/blocks/venue-booking-inquiry/src/view.js
@@ -202,7 +202,7 @@ function BookingInquiry( { config, wrapper } ) {
 			setStatus( {
 				tone: 'success',
 				message:
-					'That time is open for inquiries. Complete the booking details below.',
+					'That time is available for submissions. Complete the booking details below.',
 			} );
 		} catch {
 			setStatus( {

--- a/tests/browser/booking-inquiry.evidence.js
+++ b/tests/browser/booking-inquiry.evidence.js
@@ -255,6 +255,9 @@ const measure = ( page ) =>
 		await page
 			.getByRole( 'button', { name: 'Check availability' } )
 			.click();
+		await page
+			.getByText( /That time is available for submissions/ )
+			.waitFor();
 		await page.getByLabel( 'Artist or project name' ).waitFor();
 		assert.ok( await page.getByLabel( 'Artist website' ).count() );
 		assert.ok( await page.getByLabel( /I agree that this venue/ ).count() );


### PR DESCRIPTION
## Summary
- tell applicants immediately that an open date/time is available for submissions
- retain generic unavailable wording so holds, confirmed bookings, events, and pending inquiry state are never disclosed
- preserve the separate rule that submission does not create a hold or confirmation

## Verification
- booking inquiry block build passed
- desktop/mobile booking browser evidence passed
- focused JavaScript lint passed

Fixes #537