### PR TITLE
fix: use venue timezone in booking correspondence

### DIFF
--- a/inc/Core/BookingCommunicationService.php
+++ b/inc/Core/BookingCommunicationService.php
@@ -1074,9 +1074,13 @@ class BookingCommunicationService {
 	/** Compare venue-local requested wall times with canonical UTC performance times. */
 	private function requested_interval_overlaps_confirmed( array $booking, array $confirmed ): bool {
 		$venue_data = function_exists( 'data_machine_events_get_venue_data' ) ? data_machine_events_get_venue_data( (int) $booking['venue_term_id'] ) : null;
+		$name       = is_array( $venue_data ) ? (string) ( $venue_data['timezone'] ?? '' ) : '';
+		if ( '' === $name || ! in_array( $name, timezone_identifiers_list(), true ) ) {
+			return false;
+		}
 		try {
-			$timezone = new \DateTimeZone( is_array( $venue_data ) ? (string) ( $venue_data['timezone'] ?? '' ) : '' );
-		} catch ( \Exception $exception ) {
+			$timezone = new \DateTimeZone( $name );
+		} catch ( \Throwable $exception ) {
 			return false;
 		}
 		$requested_start = $this->strict_local_datetime( (string) ( $booking['requested_start_at'] ?? '' ), $timezone );

--- a/inc/Core/BookingCommunicationService.php
+++ b/inc/Core/BookingCommunicationService.php
@@ -1068,10 +1068,52 @@ class BookingCommunicationService {
 			&& 'confirmed' === $confirmed['status']
 			&& (int) $confirmed['venue_term_id'] === (int) $booking['venue_term_id']
 			&& (string) $confirmed['space_key'] === (string) $booking['requested_space_key']
-			&& ! empty( $booking['requested_start_at'] )
-			&& ! empty( $booking['requested_end_at'] )
-			&& $booking['requested_start_at'] < $confirmed['performance_end_at']
-			&& $booking['requested_end_at'] > $confirmed['performance_start_at'];
+			&& $this->requested_interval_overlaps_confirmed( $booking, $confirmed );
+	}
+
+	/** Compare venue-local requested wall times with canonical UTC performance times. */
+	private function requested_interval_overlaps_confirmed( array $booking, array $confirmed ): bool {
+		$venue_data = function_exists( 'data_machine_events_get_venue_data' ) ? data_machine_events_get_venue_data( (int) $booking['venue_term_id'] ) : null;
+		try {
+			$timezone = new \DateTimeZone( is_array( $venue_data ) ? (string) ( $venue_data['timezone'] ?? '' ) : '' );
+		} catch ( \Exception $exception ) {
+			return false;
+		}
+		$requested_start = $this->strict_local_datetime( (string) ( $booking['requested_start_at'] ?? '' ), $timezone );
+		$requested_end   = $this->strict_local_datetime( (string) ( $booking['requested_end_at'] ?? '' ), $timezone );
+		$confirmed_start = $this->strict_utc_datetime( (string) ( $confirmed['performance_start_at'] ?? '' ) );
+		$confirmed_end   = $this->strict_utc_datetime( (string) ( $confirmed['performance_end_at'] ?? '' ) );
+		return $requested_start && $requested_end && $confirmed_start && $confirmed_end
+			&& $requested_end > $requested_start
+			&& $confirmed_end > $confirmed_start
+			&& $requested_start->getTimestamp() < $confirmed_end->getTimestamp()
+			&& $requested_end->getTimestamp() > $confirmed_start->getTimestamp();
+	}
+
+	/** Resolve exactly one UTC instant for a venue-local wall time. */
+	private function strict_local_datetime( string $value, \DateTimeZone $timezone ) {
+		$wall = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $value, new \DateTimeZone( 'UTC' ) );
+		if ( false === $wall || $wall->format( 'Y-m-d H:i:s' ) !== $value ) {
+			return false;
+		}
+		$transitions = $timezone->getTransitions( $wall->getTimestamp() - DAY_IN_SECONDS, $wall->getTimestamp() + DAY_IN_SECONDS );
+		if ( ! is_array( $transitions ) ) {
+			return false;
+		}
+		$candidates = array();
+		foreach ( array_unique( array_column( $transitions, 'offset' ) ) as $offset ) {
+			$candidate = ( new \DateTimeImmutable( '@' . ( $wall->getTimestamp() - (int) $offset ) ) )->setTimezone( $timezone );
+			if ( $candidate->format( 'Y-m-d H:i:s' ) === $value ) {
+				$candidates[ $candidate->getTimestamp() ] = $candidate;
+			}
+		}
+		return 1 === count( $candidates ) ? reset( $candidates ) : false;
+	}
+
+	/** Parse one canonical UTC performance timestamp exactly. */
+	private function strict_utc_datetime( string $value ) {
+		$date = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $value, new \DateTimeZone( 'UTC' ) );
+		return false !== $date && $date->format( 'Y-m-d H:i:s' ) === $value ? $date : false;
 	}
 
 	private function request_hash( array $request, int $actor_id ): string {

--- a/inc/Core/BookingCorrespondenceAutomationService.php
+++ b/inc/Core/BookingCorrespondenceAutomationService.php
@@ -120,12 +120,15 @@ class BookingCorrespondenceAutomationService {
 		if ( ! $venue || is_wp_error( $venue ) ) {
 			return new \WP_Error( 'booking_correspondence_venue_unavailable', __( 'The booking venue could not be resolved for correspondence.', 'extrachill-events' ) );
 		}
+		$interval = $this->requested_interval( $booking );
+		if ( is_wp_error( $interval ) ) {
+			return $interval;
+		}
 		$message = sprintf(
-			"We received your booking inquiry and it is pending review.\n\nArtist: %s\nVenue: %s\nRequested interval: %s to %s UTC\nRequested space: %s\nReference: %s\n\nSubmitting an inquiry does not place a hold or confirm the booking. Reply to this email to continue this booking thread.",
+			"We received your booking inquiry and it is pending review.\n\nArtist: %s\nVenue: %s\nRequested interval: %s\nRequested space: %s\nReference: %s\n\nSubmitting an inquiry does not place a hold or confirm the booking. Reply to this email to continue this booking thread.",
 			$booking['artist_name'],
 			$venue->name,
-			$booking['requested_start_at'] ? $booking['requested_start_at'] : 'Not specified',
-			$booking['requested_end_at'] ? $booking['requested_end_at'] : 'Not specified',
+			$interval['display'],
 			$this->space_name( $booking, true ),
 			$booking['public_id']
 		);
@@ -142,21 +145,35 @@ class BookingCorrespondenceAutomationService {
 		if ( is_wp_error( $batch ) ) {
 			return $batch;
 		}
+		$bounds = $this->confirmed_local_bounds( $confirmed );
+		if ( is_wp_error( $bounds ) ) {
+			return $bounds;
+		}
 		$after      = is_array( $batch ) ? (int) ( $batch['payload']['data']['after_booking_id'] ?? 0 ) : 0;
-		$candidates = $this->bookings->list_competing_requests( $confirmed, $after, self::BATCH_SIZE );
+		$candidates = $this->bookings->list_competing_requests( $confirmed, $bounds['start_at'], $bounds['end_at'], $after, self::BATCH_SIZE );
 		if ( is_wp_error( $candidates ) ) {
 			return $candidates;
 		}
 		foreach ( $candidates as $candidate ) {
 			$current = $this->bookings->get( (int) $candidate['id'] );
-			if ( ! is_array( $current ) || ! $this->still_competes( $current, $confirmed ) ) {
+			if ( ! is_array( $current ) ) {
 				continue;
 			}
+			$competes = $this->still_competes( $current, $confirmed );
+			if ( is_wp_error( $competes ) ) {
+				return $competes;
+			}
+			if ( ! $competes ) {
+				continue;
+			}
+			$interval = $this->requested_interval( $current );
+			if ( is_wp_error( $interval ) ) {
+				return $interval;
+			}
 			$message = sprintf(
-				'The interval you requested at %s (%s to %s UTC, %s) has been filled. Your inquiry has not been declined: reply to this email with another exact date, start/end time, and space you would like us to review.',
+				'The interval you requested at %s (%s, %s) has been filled. Your inquiry has not been declined: reply to this email with another exact date, start/end time, and space you would like us to review.',
 				$this->venue_name( $confirmed ),
-				$current['requested_start_at'],
-				$current['requested_end_at'],
+				$interval['display'],
 				$this->space_name( $current, true )
 			);
 			$result  = $this->communication->request_automatic( (int) $current['id'], (int) $source['id'], 'date_filled', $message );
@@ -183,15 +200,97 @@ class BookingCorrespondenceAutomationService {
 		return is_wp_error( $marker ) ? $marker : array( 'completed' => false );
 	}
 
-	private function still_competes( array $candidate, array $confirmed ): bool {
+	private function still_competes( array $candidate, array $confirmed ) {
 		$terminal = array( 'confirmed', 'declined', 'withdrawn', 'cancelled', 'completed' );
-		return ! in_array( $candidate['status'], $terminal, true )
-			&& (int) $candidate['venue_term_id'] === (int) $confirmed['venue_term_id']
-			&& (string) $candidate['requested_space_key'] === (string) $confirmed['space_key']
-			&& ! empty( $candidate['requested_start_at'] )
-			&& ! empty( $candidate['requested_end_at'] )
-			&& $candidate['requested_start_at'] < $confirmed['performance_end_at']
-			&& $candidate['requested_end_at'] > $confirmed['performance_start_at'];
+		if ( in_array( $candidate['status'], $terminal, true ) || (int) $candidate['venue_term_id'] !== (int) $confirmed['venue_term_id'] || (string) $candidate['requested_space_key'] !== (string) $confirmed['space_key'] || empty( $candidate['requested_start_at'] ) || empty( $candidate['requested_end_at'] ) ) {
+			return false;
+		}
+		$requested = $this->requested_interval( $candidate );
+		if ( is_wp_error( $requested ) ) {
+			return $requested;
+		}
+		$confirmed_start = $this->utc_datetime( (string) $confirmed['performance_start_at'] );
+		$confirmed_end   = $this->utc_datetime( (string) $confirmed['performance_end_at'] );
+		if ( ! $confirmed_start || ! $confirmed_end || $confirmed_end <= $confirmed_start ) {
+			return new \WP_Error( 'booking_correspondence_interval_invalid', __( 'The confirmed booking interval is invalid for correspondence.', 'extrachill-events' ) );
+		}
+		return $requested['start']->getTimestamp() < $confirmed_end->getTimestamp() && $requested['end']->getTimestamp() > $confirmed_start->getTimestamp();
+	}
+
+	/** Resolve one requested venue-local wall-clock interval for display and comparison. */
+	private function requested_interval( array $booking ) {
+		$timezone = $this->venue_timezone( (int) $booking['venue_term_id'] );
+		if ( is_wp_error( $timezone ) ) {
+			return $timezone;
+		}
+		$start_candidates = $this->local_datetime_candidates( (string) ( $booking['requested_start_at'] ?? '' ), $timezone );
+		$end_candidates   = $this->local_datetime_candidates( (string) ( $booking['requested_end_at'] ?? '' ), $timezone );
+		if ( is_wp_error( $start_candidates ) || is_wp_error( $end_candidates ) || 1 !== count( $start_candidates ) || 1 !== count( $end_candidates ) ) {
+			return new \WP_Error( 'booking_correspondence_interval_invalid', __( 'The requested venue-local interval is invalid or ambiguous for correspondence.', 'extrachill-events' ) );
+		}
+		$start = $start_candidates[0];
+		$end   = $end_candidates[0];
+		if ( $end <= $start ) {
+			return new \WP_Error( 'booking_correspondence_interval_invalid', __( 'The requested venue-local interval is invalid for correspondence.', 'extrachill-events' ) );
+		}
+		$display  = $start->format( 'l, F j, Y, g:i A' ) . ' to ';
+		$display .= $start->format( 'Y-m-d' ) === $end->format( 'Y-m-d' ) ? $end->format( 'g:i A T' ) : $end->format( 'l, F j, Y, g:i A T' );
+		$display .= ' (' . $timezone->getName() . ')';
+		return compact( 'start', 'end', 'display' );
+	}
+
+	/** Project one confirmed UTC interval into the venue-local request storage domain. */
+	private function confirmed_local_bounds( array $booking ) {
+		$timezone = $this->venue_timezone( (int) $booking['venue_term_id'] );
+		$start    = $this->utc_datetime( (string) ( $booking['performance_start_at'] ?? '' ) );
+		$end      = $this->utc_datetime( (string) ( $booking['performance_end_at'] ?? '' ) );
+		if ( is_wp_error( $timezone ) ) {
+			return $timezone;
+		}
+		if ( ! $start || ! $end || $end <= $start ) {
+			return new \WP_Error( 'booking_correspondence_interval_invalid', __( 'The confirmed booking interval is invalid for correspondence.', 'extrachill-events' ) );
+		}
+		return array(
+			'start_at' => $start->setTimezone( $timezone )->format( 'Y-m-d H:i:s' ),
+			'end_at'   => $end->setTimezone( $timezone )->format( 'Y-m-d H:i:s' ),
+		);
+	}
+
+	/** Resolve the canonical timezone owned by the venue data projection. */
+	private function venue_timezone( int $venue_id ) {
+		$venue_data = function_exists( 'data_machine_events_get_venue_data' ) ? data_machine_events_get_venue_data( $venue_id ) : null;
+		try {
+			return new \DateTimeZone( is_array( $venue_data ) ? (string) ( $venue_data['timezone'] ?? '' ) : '' );
+		} catch ( \Exception $exception ) {
+			return new \WP_Error( 'booking_correspondence_timezone_invalid', __( 'The venue timezone is unavailable for correspondence.', 'extrachill-events' ) );
+		}
+	}
+
+	/** Return every UTC instant represented by one strict local wall time. */
+	private function local_datetime_candidates( string $value, \DateTimeZone $timezone ) {
+		$wall = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $value, new \DateTimeZone( 'UTC' ) );
+		if ( false === $wall || $wall->format( 'Y-m-d H:i:s' ) !== $value ) {
+			return new \WP_Error( 'booking_correspondence_interval_invalid', __( 'The requested venue-local interval is invalid for correspondence.', 'extrachill-events' ) );
+		}
+		$transitions = $timezone->getTransitions( $wall->getTimestamp() - DAY_IN_SECONDS, $wall->getTimestamp() + DAY_IN_SECONDS );
+		if ( ! is_array( $transitions ) ) {
+			return new \WP_Error( 'booking_correspondence_timezone_invalid', __( 'The venue timezone cannot be checked safely for correspondence.', 'extrachill-events' ) );
+		}
+		$candidates = array();
+		foreach ( array_unique( array_column( $transitions, 'offset' ) ) as $offset ) {
+			$candidate = ( new \DateTimeImmutable( '@' . ( $wall->getTimestamp() - (int) $offset ) ) )->setTimezone( $timezone );
+			if ( $candidate->format( 'Y-m-d H:i:s' ) === $value ) {
+				$candidates[ $candidate->getTimestamp() ] = $candidate;
+			}
+		}
+		ksort( $candidates, SORT_NUMERIC );
+		return array_values( $candidates );
+	}
+
+	/** Parse one canonical UTC performance timestamp exactly. */
+	private function utc_datetime( string $value ) {
+		$date = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $value, new \DateTimeZone( 'UTC' ) );
+		return false !== $date && $date->format( 'Y-m-d H:i:s' ) === $value ? $date : false;
 	}
 
 	private function complete_source( array $source, array $payload ) {

--- a/inc/Core/BookingCorrespondenceAutomationService.php
+++ b/inc/Core/BookingCorrespondenceAutomationService.php
@@ -259,9 +259,13 @@ class BookingCorrespondenceAutomationService {
 	/** Resolve the canonical timezone owned by the venue data projection. */
 	private function venue_timezone( int $venue_id ) {
 		$venue_data = function_exists( 'data_machine_events_get_venue_data' ) ? data_machine_events_get_venue_data( $venue_id ) : null;
+		$name       = is_array( $venue_data ) ? (string) ( $venue_data['timezone'] ?? '' ) : '';
+		if ( '' === $name || ! in_array( $name, timezone_identifiers_list(), true ) ) {
+			return new \WP_Error( 'booking_correspondence_timezone_invalid', __( 'The venue timezone is unavailable for correspondence.', 'extrachill-events' ) );
+		}
 		try {
-			return new \DateTimeZone( is_array( $venue_data ) ? (string) ( $venue_data['timezone'] ?? '' ) : '' );
-		} catch ( \Exception $exception ) {
+			return new \DateTimeZone( $name );
+		} catch ( \Throwable $exception ) {
 			return new \WP_Error( 'booking_correspondence_timezone_invalid', __( 'The venue timezone is unavailable for correspondence.', 'extrachill-events' ) );
 		}
 	}

--- a/inc/Core/BookingRepository.php
+++ b/inc/Core/BookingRepository.php
@@ -354,17 +354,17 @@ class BookingRepository {
 		return $hydrated;
 	}
 
-	/** List a bounded cursor page of requests competing with one confirmed interval. */
-	public function list_competing_requests( array $confirmed, int $after_id = 0, int $limit = 25 ) {
+	/** List a bounded cursor page using confirmed bounds projected into requested local storage. */
+	public function list_competing_requests( array $confirmed, string $requested_start_at, string $requested_end_at, int $after_id = 0, int $limit = 25 ) {
 		global $wpdb;
-		if ( 'confirmed' !== ( $confirmed['status'] ?? '' ) || empty( $confirmed['space_key'] ) || empty( $confirmed['performance_start_at'] ) || empty( $confirmed['performance_end_at'] ) ) {
+		if ( 'confirmed' !== ( $confirmed['status'] ?? '' ) || empty( $confirmed['space_key'] ) || empty( $confirmed['performance_start_at'] ) || empty( $confirmed['performance_end_at'] ) || is_wp_error( $this->datetime( $requested_start_at, 'requested_start_at' ) ) || is_wp_error( $this->datetime( $requested_end_at, 'requested_end_at' ) ) || $requested_end_at <= $requested_start_at ) {
 			return new \WP_Error( 'booking_competing_interval_invalid', __( 'The confirmed booking interval is invalid.', 'extrachill-events' ) );
 		}
 		$table    = BookingSchema::bookings_table();
 		$limit    = max( 1, min( 50, $limit ) );
 		$terminal = array( 'confirmed', 'declined', 'withdrawn', 'cancelled', 'completed', 'admission_pending' );
 		$sql      = "SELECT * FROM {$table} WHERE venue_term_id = %d AND requested_space_key = %s AND requested_start_at < %s AND requested_end_at > %s AND id <> %d AND id > %d AND status NOT IN ('" . implode( "','", $terminal ) . "') ORDER BY id ASC LIMIT %d"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Fixed status allowlist and trusted table.
-		$rows     = $wpdb->get_results( $wpdb->prepare( $sql, $confirmed['venue_term_id'], $confirmed['space_key'], $confirmed['performance_end_at'], $confirmed['performance_start_at'], $confirmed['id'], max( 0, $after_id ), $limit ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Values are prepared.
+		$rows     = $wpdb->get_results( $wpdb->prepare( $sql, $confirmed['venue_term_id'], $confirmed['space_key'], $requested_end_at, $requested_start_at, $confirmed['id'], max( 0, $after_id ), $limit ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Values are prepared.
 		if ( '' !== (string) $wpdb->last_error || ! is_array( $rows ) ) {
 			return new \WP_Error( 'booking_competing_requests_read_failed', __( 'Competing booking requests could not be read.', 'extrachill-events' ) );
 		}

--- a/phpunit-booking.xml.dist
+++ b/phpunit-booking.xml.dist
@@ -19,6 +19,7 @@
 			<file>tests/BookingMutationTest.php</file>
 			<file>tests/BookingEventConversionTest.php</file>
 			<file>tests/BookingCommunicationTest.php</file>
+			<file>tests/BookingCorrespondenceAutomationTest.php</file>
 			<file>tests/BookingMarketingTest.php</file>
 			<file>tests/BookingMarketingDelegatedSchemaTest.php</file>
 			<file>tests/TicketSettlementTest.php</file>

--- a/tests/BookingCorrespondenceAutomationTest.php
+++ b/tests/BookingCorrespondenceAutomationTest.php
@@ -36,13 +36,17 @@ final class BookingCorrespondenceAutomationTest extends BookingTestCase {
 			'meta'            => array(
 				7 => array(
 					55 => array(
+						'_venue_timezone'             => 'America/New_York',
 						VenueBookingConfig::META_KEY => array(
 							'enabled'        => true,
 							'spaces'         => array( array( 'key' => 'main-room', 'name' => 'Main Room', 'is_default' => true ) ),
 							'correspondence' => array( 'booking_address' => 'booking@lofi.example' ),
 						),
 					),
-					56 => array( VenueBookingConfig::META_KEY => array( 'enabled' => true ) ),
+					56 => array(
+						'_venue_timezone'             => 'America/Chicago',
+						VenueBookingConfig::META_KEY => array( 'enabled' => true ),
+					),
 				),
 			),
 			'posts'           => array(),
@@ -107,6 +111,8 @@ final class BookingCorrespondenceAutomationTest extends BookingTestCase {
 		$this->assertSame( 'chubes@extrachill.com', $queued[0]['cc'] );
 		$this->assertSame( 'booking@lofi.example', $queued[0]['reply_to'] );
 		$this->assertStringContainsString( 'pending review', $queued[0]['body'] );
+		$this->assertStringContainsString( 'Thursday, August 1, 2030, 8:00 PM to 11:00 PM EDT (America/New_York)', $queued[0]['body'] );
+		$this->assertStringNotContainsString( ' UTC', $queued[0]['body'] );
 		$this->assertStringContainsString( 'does not place a hold or confirm', $queued[0]['body'] );
 		$this->assertStringContainsString( $booking['public_id'], $queued[0]['body'] );
 		$this->assertStringContainsString( "Extra Chill Bot sending on Chris's behalf.", $queued[0]['body'] );
@@ -126,14 +132,35 @@ final class BookingCorrespondenceAutomationTest extends BookingTestCase {
 		$this->assertCount( 1, array_filter( $activities, static function ( array $row ): bool { return 'booking_message_requested' === $row['kind']; } ) );
 	}
 
+	public function test_receipt_fails_closed_for_nonexistent_and_ambiguous_venue_times(): void {
+		$queued = array();
+		foreach (
+			array(
+				array( '2030-03-10 02:30:00', '2030-03-10 03:30:00' ),
+				array( '2030-11-03 01:30:00', '2030-11-03 02:30:00' ),
+			) as $interval
+		) {
+			$booking = $this->booking(
+				array(
+					'requested_start_at' => $interval[0],
+					'requested_end_at'   => $interval[1],
+				)
+			);
+			$source = $this->source( $booking, 'inquiry_submitted' );
+			$result = $this->service( $queued )->reconcile_source( $source['id'] );
+			$this->assertSame( 'booking_correspondence_interval_invalid', $result->get_error_code() );
+		}
+		$this->assertCount( 0, $queued );
+	}
+
 	public function test_confirmation_notifies_only_current_half_open_same_space_competitors(): void {
 		$selected = $this->booking(
 			array(
 				'artist_name'          => 'Selected Artist',
 				'contact_email'        => 'selected@example.com',
 				'space_key'            => 'main-room',
-				'performance_start_at' => '2030-08-01 20:00:00',
-				'performance_end_at'   => '2030-08-01 23:00:00',
+				'performance_start_at' => '2030-08-02 00:00:00',
+				'performance_end_at'   => '2030-08-02 03:00:00',
 			)
 		);
 		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $selected['id'] ]['status'] = 'confirmed';
@@ -151,6 +178,8 @@ final class BookingCorrespondenceAutomationTest extends BookingTestCase {
 		$this->assertSame( 'overlap@example.com', $queued[0]['to'] );
 		$this->assertStringContainsString( 'has been filled', $queued[0]['body'] );
 		$this->assertStringContainsString( 'reply to this email with another exact date', $queued[0]['body'] );
+		$this->assertStringContainsString( 'Thursday, August 1, 2030, 10:00 PM to Friday, August 2, 2030, 12:00 AM EDT (America/New_York)', $queued[0]['body'] );
+		$this->assertStringNotContainsString( ' UTC', $queued[0]['body'] );
 		$this->assertStringNotContainsString( 'Selected Artist', $queued[0]['body'] );
 		$this->assertStringNotContainsString( $selected['public_id'], $queued[0]['body'] );
 		$this->assertSame( 'submitted', ( new BookingRepository() )->get( $overlap['id'] )['status'] );
@@ -161,8 +190,8 @@ final class BookingCorrespondenceAutomationTest extends BookingTestCase {
 			array(
 				'contact_email'        => 'selected@example.com',
 				'space_key'            => 'main-room',
-				'performance_start_at' => '2030-08-01 20:00:00',
-				'performance_end_at'   => '2030-08-01 23:00:00',
+				'performance_start_at' => '2030-08-02 00:00:00',
+				'performance_end_at'   => '2030-08-02 03:00:00',
 			)
 		);
 		$GLOBALS['wpdb']->rows[ BookingSchema::bookings_table() ][ $selected['id'] ]['status'] = 'confirmed';


### PR DESCRIPTION
## Summary
- render inquiry receipts and date-filled notices as readable venue-local times with timezone abbreviation and canonical zone
- project confirmed UTC performance bounds into local request storage for candidate queries, then compare canonical instants before queueing
- fail closed on missing/invalid venue timezones and ambiguous or nonexistent DST wall times
- include correspondence automation in the standard booking suite

## Production feedback
Chris Gardner reported that applicants see times labeled UTC even though the form asks for venue-local dates. Applicants should see language such as `Friday, January 15, 2027, 8:00 PM to 11:00 PM EST (America/New_York)`.

## Verification
- `vendor/bin/phpunit -c phpunit-booking.xml.dist`
- 454 tests, 4,786 assertions
- covers EST/EDT rendering, cross-midnight formatting, non-UTC overlap, adjacent half-open intervals, and DST ambiguity/nonexistence
- syntax and whitespace checks pass

Lo-Fi intake is disabled at config revision 8 until this patch is deployed and rehearsed.

Fixes #542