### PR TITLE
fix: use product identity in transactional emails

### DIFF
--- a/inc/Abilities/VenueBookingConfigAbilities.php
+++ b/inc/Abilities/VenueBookingConfigAbilities.php
@@ -589,9 +589,23 @@ class VenueBookingConfigAbilities {
 					'type'   => array( 'string', 'null' ),
 					'format' => 'email',
 				),
+				'cc_address'        => array(
+					'type'   => array( 'string', 'null' ),
+					'format' => 'email',
+				),
+				'from_name'         => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 100,
+				),
+				'footer'            => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 500,
+				),
 				'variables'         => array(
 					'type'     => 'array',
-					'maxItems' => 5,
+					'maxItems' => 6,
 					'items'    => array(
 						'type'                 => 'object',
 						'properties'           => array(
@@ -629,7 +643,7 @@ class VenueBookingConfigAbilities {
 					'additionalProperties' => false,
 				),
 			),
-			'required'             => array( 'version', 'booking_address', 'variables', 'templates', 'reminder_policies' ),
+			'required'             => array( 'version', 'booking_address', 'cc_address', 'from_name', 'footer', 'variables', 'templates', 'reminder_policies' ),
 			'additionalProperties' => false,
 		);
 	}

--- a/inc/Core/BookingCommunicationService.php
+++ b/inc/Core/BookingCommunicationService.php
@@ -139,9 +139,6 @@ class BookingCommunicationService {
 					array(
 						'request_hash'    => $hash,
 						'booking_version' => (int) $booking['version'],
-						'cc'              => 'chubes@extrachill.com',
-						'from_name'       => 'Extra Chill Bot',
-						'identity'        => 'Extra Chill Bot sending on Chris\'s behalf.',
 						'mail_site_id'    => function_exists( 'extrachill_mail_site_id' ) ? extrachill_mail_site_id() : get_current_blog_id(),
 					)
 				),
@@ -218,9 +215,6 @@ class BookingCommunicationService {
 						'request_hash'       => hash( 'sha256', $key . "\0" . $request['subject'] . "\0" . $request['body'] ),
 						'booking_version'    => (int) $booking['version'],
 						'source_activity_id' => $source_activity_id,
-						'cc'                 => 'chubes@extrachill.com',
-						'from_name'          => 'Extra Chill Bot',
-						'identity'           => 'Extra Chill Bot sending on Chris\'s behalf.',
 						'mail_site_id'       => function_exists( 'extrachill_mail_site_id' ) ? extrachill_mail_site_id() : get_current_blog_id(),
 					)
 				),
@@ -1021,11 +1015,12 @@ class BookingCommunicationService {
 			$request['template'],
 			$request['template_version'],
 			array(
-				'artist_name'  => (string) $booking['artist_name'],
-				'booking_id'   => (string) $booking['public_id'],
-				'contact_name' => (string) $booking['contact_name'],
-				'venue_name'   => (string) $venue->name,
-				'message'      => $request['message'],
+				'artist_name'   => (string) $booking['artist_name'],
+				'booking_id'    => (string) $booking['public_id'],
+				'contact_name'  => (string) $booking['contact_name'],
+				'requested_date' => $this->requested_date_label( (string) ( $booking['requested_start_at'] ?? '' ) ),
+				'venue_name'    => (string) $venue->name,
+				'message'       => $request['message'],
 			)
 		);
 		if ( is_wp_error( $prepared ) ) {
@@ -1047,12 +1042,20 @@ class BookingCommunicationService {
 				'config_revision'         => (int) $prepared['config_revision'],
 				'subject'                 => $prepared['subject'],
 				'body'                    => $prepared['body'],
+				'cc'                      => $prepared['cc_address'] ? $prepared['cc_address'] : '',
+				'from_name'               => $prepared['from_name'],
 				'reply_to'                => $prepared['booking_address'] ? $prepared['booking_address'] : $request['reply_to'],
 				'send_at'                 => $send_at,
 				'expected_statuses'       => $expected_statuses,
 				'reminder_policy_version' => $policy_version,
 			)
 		);
+	}
+
+	/** Format the venue-local requested date for concise email subjects. */
+	private function requested_date_label( string $value ): string {
+		$date = \DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $value, new \DateTimeZone( 'UTC' ) );
+		return false !== $date && $date->format( 'Y-m-d H:i:s' ) === $value ? $date->format( 'M j' ) : '';
 	}
 
 	/** Revalidate server-owned automatic correspondence immediately before queueing. */

--- a/inc/Core/VendorRequestService.php
+++ b/inc/Core/VendorRequestService.php
@@ -303,14 +303,14 @@ class VendorRequestService {
 			return hash_equals( (string) $existing['request_hash'], $hash ) ? $existing['payload'] : $this->idempotency_conflict();
 		}
 		$body   = wpautop( esc_html( $message ) );
-		$body  .= '<p><strong>Extra Chill Bot sending on Chris Huber\'s behalf.</strong> Reply through the managed vendor application workflow; applicant and coordinator directories are not shared.</p>';
+		$body  .= '<p><strong>Powered by Extra Chill.</strong> Reply through the managed vendor application workflow; applicant and coordinator directories are not shared.</p>';
 		$input  = array(
 			'to'           => $application['contact']['email'],
-			'cc'           => 'chubes@extrachill.com',
+			'cc'           => '',
 			'subject'      => $subject,
 			'body'         => $body,
 			'content_type' => 'text/html',
-			'from_name'    => 'Extra Chill Bot',
+			'from_name'    => 'Extra Chill Events',
 		);
 		$result = is_callable( $queue ) ? call_user_func( $queue, $input ) : ( function_exists( 'ec_send_email_queued' ) ? ec_send_email_queued( $input ) : new \WP_Error( 'vendor_correspondence_unavailable' ) );
 		if ( is_wp_error( $result ) || ! is_array( $result ) || empty( $result['success'] ) || absint( $result['action_id'] ?? 0 ) < 1 ) {

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -25,7 +25,7 @@ class VenueBookingConfig {
 	public const TEMPLATE_VERSION            = 1;
 	public const REMINDER_POLICY_VERSION     = 1;
 	public const CORRESPONDENCE_TEMPLATES    = array( 'operator_message', 'follow_up', 'hold_expiring', 'inquiry_receipt', 'date_filled' );
-	public const CORRESPONDENCE_VARIABLES    = array( 'artist_name', 'booking_id', 'contact_name', 'venue_name' );
+	public const CORRESPONDENCE_VARIABLES    = array( 'artist_name', 'booking_id', 'contact_name', 'requested_date', 'venue_name' );
 	public const CONSENT_VERSION             = 1;
 	public const HOLD_TTL_MAX_MINUTES        = 20160;
 	public const SOCIAL_MARKETING_ACTION     = 'datamachine-socials/cross-post';
@@ -452,6 +452,9 @@ class VenueBookingConfig {
 			'correspondence'            => array(
 				'version'           => self::CORRESPONDENCE_VERSION,
 				'booking_address'   => null,
+				'cc_address'        => null,
+				'from_name'         => 'Extra Chill Bookings',
+				'footer'            => 'Powered by Extra Chill',
 				'variables'         => $this->variable_schema(),
 				'templates'         => array(
 					'operator_message' => array(
@@ -461,7 +464,7 @@ class VenueBookingConfig {
 					),
 					'follow_up'        => array(
 						'version' => self::TEMPLATE_VERSION,
-						'subject' => 'Following up on booking {{booking_id}}',
+						'subject' => 'Following up: {{artist_name}} at {{venue_name}}',
 						'body'    => "Following up on your booking inquiry for {{venue_name}}:\n\n{{message}}",
 					),
 					'hold_expiring'    => array(
@@ -471,12 +474,12 @@ class VenueBookingConfig {
 					),
 					'inquiry_receipt'  => array(
 						'version' => self::TEMPLATE_VERSION,
-						'subject' => 'Booking inquiry received at {{venue_name}} [{{booking_id}}]',
+						'subject' => 'Booking inquiry received: {{artist_name}} at {{venue_name}} - {{requested_date}}',
 						'body'    => "Hello {{contact_name}},\n\n{{message}}",
 					),
 					'date_filled'      => array(
 						'version' => self::TEMPLATE_VERSION,
-						'subject' => 'Booking date update from {{venue_name}}',
+						'subject' => 'Booking date update: {{artist_name}} at {{venue_name}} - {{requested_date}}',
 						'body'    => "Hello {{contact_name}},\n\n{{message}}",
 					),
 				),
@@ -536,9 +539,11 @@ class VenueBookingConfig {
 			'template'         => $template_key,
 			'template_version' => $template['version'],
 			'config_revision'  => $config['revision'],
-			'subject'          => $render( $template['subject'] ),
-			'body'             => $render( $template['body'] ) . "\n\nExtra Chill Bot sending on Chris's behalf.",
+			'subject'          => mb_substr( sanitize_text_field( $render( $template['subject'] ) ), 0, 200 ),
+			'body'             => $render( $template['body'] ) . "\n\n" . $config['correspondence']['footer'],
 			'booking_address'  => $config['correspondence']['booking_address'],
+			'cc_address'       => $config['correspondence']['cc_address'],
+			'from_name'        => $config['correspondence']['from_name'],
 			'reminder_policy'  => $config['correspondence']['reminder_policies'][ $template_key ] ?? null,
 		);
 		return $result;
@@ -550,7 +555,7 @@ class VenueBookingConfig {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
-		unset( $result['booking_address'], $result['reminder_policy'] );
+		unset( $result['booking_address'], $result['cc_address'], $result['from_name'], $result['reminder_policy'] );
 		return $result;
 	}
 
@@ -858,6 +863,15 @@ class VenueBookingConfig {
 		if ( '' !== (string) ( $correspondence['booking_address'] ?? '' ) && '' === $address ) {
 			return new \WP_Error( 'invalid_booking_correspondence_address', __( 'The booking correspondence address is invalid.', 'extrachill-events' ) );
 		}
+		$cc_address = sanitize_email( (string) ( $correspondence['cc_address'] ?? '' ) );
+		if ( '' !== (string) ( $correspondence['cc_address'] ?? '' ) && '' === $cc_address ) {
+			return new \WP_Error( 'invalid_booking_correspondence_cc_address', __( 'The booking correspondence CC address is invalid.', 'extrachill-events' ) );
+		}
+		$from_name = sanitize_text_field( (string) ( $correspondence['from_name'] ?? $defaults['from_name'] ) );
+		$footer    = sanitize_textarea_field( (string) ( $correspondence['footer'] ?? $defaults['footer'] ) );
+		if ( '' === $from_name || mb_strlen( $from_name ) > 100 || preg_match( '/[\r\n]/', $from_name ) || '' === $footer || mb_strlen( $footer ) > 500 ) {
+			return new \WP_Error( 'invalid_booking_correspondence_identity', __( 'The booking correspondence sender or footer is invalid.', 'extrachill-events' ) );
+		}
 		$templates = array();
 		$provided  = is_array( $correspondence['templates'] ?? null ) ? $correspondence['templates'] : array();
 		foreach ( self::CORRESPONDENCE_TEMPLATES as $key ) {
@@ -906,6 +920,9 @@ class VenueBookingConfig {
 		return array(
 			'version'           => self::CORRESPONDENCE_VERSION,
 			'booking_address'   => '' === $address ? null : $address,
+			'cc_address'        => '' === $cc_address ? null : $cc_address,
+			'from_name'         => $from_name,
+			'footer'            => $footer,
 			'variables'         => $this->variable_schema(),
 			'templates'         => $templates,
 			'reminder_policies' => $policies,
@@ -929,6 +946,11 @@ class VenueBookingConfig {
 				'key'        => 'contact_name',
 				'type'       => 'string',
 				'max_length' => 255,
+			),
+			array(
+				'key'        => 'requested_date',
+				'type'       => 'string',
+				'max_length' => 32,
 			),
 			array(
 				'key'        => 'venue_name',

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -874,11 +874,19 @@ class VenueBookingConfig {
 		}
 		$templates = array();
 		$provided  = is_array( $correspondence['templates'] ?? null ) ? $correspondence['templates'] : array();
+		$legacy_subjects = array(
+			'follow_up'       => 'Following up on booking {{booking_id}}',
+			'inquiry_receipt' => 'Booking inquiry received at {{venue_name}} [{{booking_id}}]',
+			'date_filled'     => 'Booking date update from {{venue_name}}',
+		);
 		foreach ( self::CORRESPONDENCE_TEMPLATES as $key ) {
 			$template = is_array( $provided[ $key ] ?? null ) ? $provided[ $key ] : $defaults['templates'][ $key ];
 			$version  = $template['version'] ?? self::TEMPLATE_VERSION;
 			$subject  = trim( (string) ( $template['subject'] ?? '' ) );
 			$body     = trim( (string) ( $template['body'] ?? '' ) );
+			if ( ( $legacy_subjects[ $key ] ?? null ) === $subject ) {
+				$subject = $defaults['templates'][ $key ]['subject'];
+			}
 			if ( ! is_int( $version ) || $version < 1 || $version > 1000000 || '' === $subject || mb_strlen( $subject ) > 200 || preg_match( '/[\r\n]/', $subject ) || '' === $body || mb_strlen( $body ) > 10000 ) {
 				return new \WP_Error( 'invalid_booking_correspondence_template', __( 'A booking correspondence template is invalid.', 'extrachill-events' ), array( 'template' => $key ) );
 			}

--- a/inc/Core/VenueInvitationDeliveryWorker.php
+++ b/inc/Core/VenueInvitationDeliveryWorker.php
@@ -89,7 +89,7 @@ class VenueInvitationDeliveryWorker {
 			$body .= '<p>' . esc_html__( 'Set your account password first, then return to the invitation link below to accept.', 'extrachill-events' ) . '</p>';
 			$body .= '<p><a href="' . esc_url( $accept_url ) . '">' . esc_html__( 'Accept venue invitation', 'extrachill-events' ) . '</a></p>';
 		}
-		$body .= '<p>' . esc_html__( 'This message was sent by Extra Chill Bot acting on Chris Huber\'s behalf.', 'extrachill-events' ) . '</p>';
+		$body .= '<p>' . esc_html__( 'Powered by Extra Chill.', 'extrachill-events' ) . '</p>';
 
 		if ( ! function_exists( 'ec_send_email' ) ) {
 			$this->repository->finish_delivery( $delivery_id, false );
@@ -98,10 +98,10 @@ class VenueInvitationDeliveryWorker {
 		$result = ec_send_email(
 			array(
 				'to'        => $user->user_email,
-				'cc'        => 'chubes@extrachill.com',
+				'cc'        => '',
 				/* translators: %s: Venue name. */
 				'subject'   => sprintf( __( 'Invitation to manage %s', 'extrachill-events' ), $venue->name ),
-				'from_name' => 'Extra Chill Bot',
+				'from_name' => 'Extra Chill Events',
 				'template'  => 'extrachill/branded',
 				'context'   => array(
 					'recipient_name' => $user->display_name,

--- a/tests/BookingCommunicationTest.php
+++ b/tests/BookingCommunicationTest.php
@@ -191,6 +191,25 @@ final class BookingCommunicationTest extends BookingTestCase {
 		$this->assertStringContainsString( '{{venue_name}}', $queued[0]['body'] );
 	}
 
+	public function test_legacy_default_receipt_subject_upgrades_without_overwriting_custom_templates(): void {
+		$config = ( new VenueBookingConfig() )->get( 55 );
+		$config['correspondence']['templates']['inquiry_receipt']['subject'] = 'Booking inquiry received at {{venue_name}} [{{booking_id}}]';
+		$GLOBALS['ec_artist_test']['meta'][7][55][ VenueBookingConfig::META_KEY ] = $config;
+		$variables = array(
+			'artist_name'   => 'Test Band',
+			'booking_id'    => 'long-public-reference',
+			'contact_name'  => 'Artist Agent',
+			'requested_date' => 'Aug 1',
+			'venue_name'    => 'The Room',
+			'message'       => 'Received.',
+		);
+
+		$preview = ( new VenueBookingConfig() )->preview( 55, 'inquiry_receipt', 1, $variables );
+
+		$this->assertSame( 'Booking inquiry received: Test Band at The Room - Aug 1', $preview['subject'] );
+		$this->assertStringNotContainsString( 'long-public-reference', $preview['subject'] );
+	}
+
 	public function test_configured_policy_owns_schedule_and_stale_template_versions_fail_closed(): void {
 		$booking = $this->booking();
 		$queued = $scheduled = $cancelled = array();

--- a/tests/BookingCommunicationTest.php
+++ b/tests/BookingCommunicationTest.php
@@ -133,10 +133,12 @@ final class BookingCommunicationTest extends BookingTestCase {
 
 		$this->assertSame( 'queued', $result['status'] );
 		$this->assertCount( 1, $queued );
-		$this->assertSame( 'chubes@extrachill.com', $queued[0]['cc'] );
-		$this->assertSame( 'Extra Chill Bot', $queued[0]['from_name'] );
+		$this->assertSame( '', $queued[0]['cc'] );
+		$this->assertSame( 'Extra Chill Bookings', $queued[0]['from_name'] );
 		$this->assertSame( 'venue-booking@example.com', $queued[0]['reply_to'] );
-		$this->assertStringContainsString( "Extra Chill Bot sending on Chris's behalf.", $queued[0]['body'] );
+		$this->assertStringContainsString( 'Powered by Extra Chill', $queued[0]['body'] );
+		$this->assertStringNotContainsString( 'Extra Chill Bot', $queued[0]['body'] );
+		$this->assertStringNotContainsString( 'Chris', $queued[0]['body'] );
 		$this->assertArrayNotHasKey( 'attachments', $queued[0] );
 		$this->assertArrayNotHasKey( 'credentials', $queued[0] );
 		$activity = ( new BookingActivityRepository() )->list_for_booking( $booking['id'] );
@@ -154,6 +156,9 @@ final class BookingCommunicationTest extends BookingTestCase {
 			'subject' => '{{artist_name}} at {{venue_name}} [{{booking_id}}]',
 			'body'    => "Hello {{contact_name}},\n\n{{message}}",
 		);
+		$config['correspondence']['cc_address'] = 'audit@example.com';
+		$config['correspondence']['from_name']  = 'The Room Bookings';
+		$config['correspondence']['footer']     = 'Powered by The Room on Extra Chill';
 		$GLOBALS['ec_artist_test']['meta'][7][55][ VenueBookingConfig::META_KEY ] = $config;
 		$variables = array(
 			'artist_name' => 'Test Band',
@@ -179,6 +184,9 @@ final class BookingCommunicationTest extends BookingTestCase {
 		$this->assertSame( 'queued', $result['status'] );
 		$this->assertSame( $preview['subject'], $queued[0]['subject'] );
 		$this->assertSame( $preview['body'], $queued[0]['body'] );
+		$this->assertSame( 'audit@example.com', $queued[0]['cc'] );
+		$this->assertSame( 'The Room Bookings', $queued[0]['from_name'] );
+		$this->assertStringContainsString( 'Powered by The Room on Extra Chill', $queued[0]['body'] );
 		$this->assertStringNotContainsString( '<b>', $queued[0]['body'] );
 		$this->assertStringContainsString( '{{venue_name}}', $queued[0]['body'] );
 	}

--- a/tests/BookingCorrespondenceAutomationTest.php
+++ b/tests/BookingCorrespondenceAutomationTest.php
@@ -108,14 +108,19 @@ final class BookingCorrespondenceAutomationTest extends BookingTestCase {
 		$this->assertSame( array( 'completed' => true ), $service->reconcile_source( $source['id'] ) );
 		$this->assertCount( 1, $queued );
 		$this->assertSame( 'artist@example.com', $queued[0]['to'] );
-		$this->assertSame( 'chubes@extrachill.com', $queued[0]['cc'] );
+		$this->assertSame( '', $queued[0]['cc'] );
+		$this->assertSame( 'Extra Chill Bookings', $queued[0]['from_name'] );
 		$this->assertSame( 'booking@lofi.example', $queued[0]['reply_to'] );
+		$this->assertSame( 'Booking inquiry received: Test Band at Lo-Fi Brewing - Aug 1', $queued[0]['subject'] );
+		$this->assertStringNotContainsString( $booking['public_id'], $queued[0]['subject'] );
 		$this->assertStringContainsString( 'pending review', $queued[0]['body'] );
 		$this->assertStringContainsString( 'Thursday, August 1, 2030, 8:00 PM to 11:00 PM EDT (America/New_York)', $queued[0]['body'] );
 		$this->assertStringNotContainsString( ' UTC', $queued[0]['body'] );
 		$this->assertStringContainsString( 'does not place a hold or confirm', $queued[0]['body'] );
 		$this->assertStringContainsString( $booking['public_id'], $queued[0]['body'] );
-		$this->assertStringContainsString( "Extra Chill Bot sending on Chris's behalf.", $queued[0]['body'] );
+		$this->assertStringContainsString( 'Powered by Extra Chill', $queued[0]['body'] );
+		$this->assertStringNotContainsString( 'Extra Chill Bot', $queued[0]['body'] );
+		$this->assertStringNotContainsString( 'Chris', $queued[0]['body'] );
 		$this->assertArrayNotHasKey( 'attachments', $queued[0] );
 	}
 
@@ -176,6 +181,7 @@ final class BookingCorrespondenceAutomationTest extends BookingTestCase {
 		$this->assertSame( array( 'completed' => true ), $this->service( $queued )->reconcile_source( $source['id'] ) );
 		$this->assertCount( 1, $queued );
 		$this->assertSame( 'overlap@example.com', $queued[0]['to'] );
+		$this->assertSame( 'Booking date update: Overlap at Lo-Fi Brewing - Aug 1', $queued[0]['subject'] );
 		$this->assertStringContainsString( 'has been filled', $queued[0]['body'] );
 		$this->assertStringContainsString( 'reply to this email with another exact date', $queued[0]['body'] );
 		$this->assertStringContainsString( 'Thursday, August 1, 2030, 10:00 PM to Friday, August 2, 2030, 12:00 AM EDT (America/New_York)', $queued[0]['body'] );

--- a/tests/VendorRequestDomainTest.php
+++ b/tests/VendorRequestDomainTest.php
@@ -143,7 +143,7 @@ final class VendorRequestDomainTest extends BookingTestCase {
 		$this->assertSame( 'vendor_application_contact_unavailable', $this->service->contact_applicant( 1, 'Hello', 'Message', 'contact-withdrawn', 12, '__return_true' )->get_error_code() );
 	}
 
-	public function test_managed_correspondence_has_required_identity_cc_and_receipt(): void {
+	public function test_managed_correspondence_has_product_identity_footer_and_receipt(): void {
 		$this->open_request();
 		$this->apply();
 		$queued = array();
@@ -168,9 +168,11 @@ final class VendorRequestDomainTest extends BookingTestCase {
 			),
 			$result
 		);
-		$this->assertSame( 'chubes@extrachill.com', $queued['cc'] );
-		$this->assertSame( 'Extra Chill Bot', $queued['from_name'] );
-		$this->assertStringContainsString( 'Extra Chill Bot sending on Chris Huber', $queued['body'] );
+		$this->assertSame( 'Extra Chill Events', $queued['from_name'] );
+		$this->assertSame( '', $queued['cc'] );
+		$this->assertStringContainsString( 'Powered by Extra Chill', $queued['body'] );
+		$this->assertStringNotContainsString( 'Extra Chill Bot', $queued['body'] );
+		$this->assertStringNotContainsString( 'Chris', $queued['body'] );
 		$this->assertSame( 'vendor@example.com', $queued['to'] );
 		$this->assertSame(
 			$result,

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -1863,6 +1863,11 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertSame( array( 4 ), $config_input['oneOf'][3]['properties']['version']['enum'] );
 		$this->assertContains( 'booking_guide', $config_input['oneOf'][3]['required'] );
 		$this->assertSame( array( 4 ), $config_output['properties']['version']['enum'] );
+		$correspondence_output = $config_output['properties']['correspondence'];
+		$this->assertSame( 6, $correspondence_output['properties']['variables']['maxItems'] );
+		$this->assertContains( 'cc_address', $correspondence_output['required'] );
+		$this->assertContains( 'from_name', $correspondence_output['required'] );
+		$this->assertContains( 'footer', $correspondence_output['required'] );
 		$intake_output = $config_output['properties']['intake'];
 		$this->assertContains( 'presentation', $intake_output['required'] );
 		$this->assertSame(

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -1613,9 +1613,11 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$GLOBALS['venue_membership_test']['doing_action'] = 'action_scheduler_run_queue';
 		$delivered = ( new VenueInvitationDeliveryWorker() )->deliver( $scheduled['args'][0] );
 		$this->assertFalse( is_wp_error( $delivered ) );
-		$this->assertSame( 'chubes@extrachill.com', $GLOBALS['venue_membership_test']['sent_emails'][0]['cc'] );
-		$this->assertSame( 'Extra Chill Bot', $GLOBALS['venue_membership_test']['sent_emails'][0]['from_name'] );
-		$this->assertStringContainsString( 'acting on Chris Huber', $GLOBALS['venue_membership_test']['sent_emails'][0]['context']['body_html'] );
+		$this->assertSame( '', $GLOBALS['venue_membership_test']['sent_emails'][0]['cc'] );
+		$this->assertSame( 'Extra Chill Events', $GLOBALS['venue_membership_test']['sent_emails'][0]['from_name'] );
+		$this->assertStringContainsString( 'Powered by Extra Chill', $GLOBALS['venue_membership_test']['sent_emails'][0]['context']['body_html'] );
+		$this->assertStringNotContainsString( 'Extra Chill Bot', $GLOBALS['venue_membership_test']['sent_emails'][0]['context']['body_html'] );
+		$this->assertStringNotContainsString( 'Chris', $GLOBALS['venue_membership_test']['sent_emails'][0]['context']['body_html'] );
 		$this->assertSame( array(), $GLOBALS['venue_membership_test']['permission_boundary_failures'] );
 
 		$this->install_account_creator();


### PR DESCRIPTION
## Summary
- replace hardcoded bot, founder, and founder-CC values in automated Events emails with product-owned sender identity and `Powered by Extra Chill` footers
- move booking sender, optional CC, and footer into existing venue correspondence configuration
- replace UUID-heavy booking receipt subjects with artist, venue, and requested local date while retaining the reference in the body
- apply the clarified transactional-email policy consistently to booking, vendor contact, and venue invitation automation

## Default booking email
- From: `Extra Chill Bookings`
- Subject: `Booking inquiry received: Test Band at Lo-Fi Brewing - Aug 1`
- Footer: `Powered by Extra Chill`
- Reply-to remains the configured venue booking address
- Public booking UUID remains in the body for support correlation

## Verification
- `vendor/bin/phpunit -c phpunit-booking.xml.dist`
- 454 tests, 4,799 assertions
- `vendor/bin/phpunit tests/VendorRequestDomainTest.php`
- 8 tests, 55 assertions
- no `Extra Chill Bot`, Chris attribution, or founder email literals remain under `inc/Core`
- PHP syntax and diff whitespace checks pass

Fixes #544
Fixes #545