### PR TITLE
fix: notify authorized venue booking members

### DIFF
--- a/inc/Core/BookingCommunicationService.php
+++ b/inc/Core/BookingCommunicationService.php
@@ -48,14 +48,14 @@ class BookingCommunicationService {
 	private $transaction_active = false;
 
 	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, $queue = null, $schedule = null, $cancel = null, $find_actions = null, ?VenueBookingConfig $config = null, $venue_recipients = null ) {
-		$this->bookings      = $bookings ? $bookings : new BookingRepository();
-		$this->activity      = $activity ? $activity : new BookingActivityRepository();
-		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
-		$this->config        = $config ? $config : new VenueBookingConfig( $this->authorization );
-		$this->queue         = $queue;
-		$this->schedule      = $schedule;
-		$this->cancel        = $cancel;
-		$this->find_actions  = $find_actions;
+		$this->bookings         = $bookings ? $bookings : new BookingRepository();
+		$this->activity         = $activity ? $activity : new BookingActivityRepository();
+		$this->authorization    = $authorization ? $authorization : new VenueAuthorization();
+		$this->config           = $config ? $config : new VenueBookingConfig( $this->authorization );
+		$this->queue            = $queue;
+		$this->schedule         = $schedule;
+		$this->cancel           = $cancel;
+		$this->find_actions     = $find_actions;
 		$this->venue_recipients = $venue_recipients;
 	}
 
@@ -282,6 +282,7 @@ class BookingCommunicationService {
 	/** Recheck the complete reminder policy while holding the booking row lock. */
 	public function dispatch_reminder( int $activity_id ) {
 		$this->delivery_cc = null;
+
 		$intent = $this->activity->get( $activity_id );
 		if ( ! is_array( $intent ) || 'booking_message_requested' !== $intent['kind'] || empty( $intent['payload']['data']['send_at'] ) ) {
 			return new \WP_Error( 'booking_reminder_invalid', __( 'The booking reminder intent is invalid.', 'extrachill-events' ) );
@@ -343,6 +344,7 @@ class BookingCommunicationService {
 			return is_wp_error( $committed ) ? $committed : $this->state_for_intent( $intent );
 		}
 		$this->delivery_cc = $cc;
+
 		$claim = $this->append_state( $intent, 'booking_message_dispatching', 'dispatching', array() );
 		if ( is_wp_error( $claim ) ) {
 			return $this->rollback( $claim );
@@ -960,7 +962,13 @@ class BookingCommunicationService {
 			$attempts[ $attempt ] = true;
 		}
 		usort( $evidence, static fn( array $left, array $right ): int => (int) $left['action_id'] <=> (int) $right['action_id'] );
-		$priority = array( 'canceled' => 0, 'failed' => 1, 'pending' => 2, 'in-progress' => 3, 'complete' => 4 );
+		$priority = array(
+			'canceled'    => 0,
+			'failed'      => 1,
+			'pending'     => 2,
+			'in-progress' => 3,
+			'complete'    => 4,
+		);
 		$status   = 'canceled';
 		foreach ( $evidence as $item ) {
 			if ( ( $priority[ $item['status'] ] ?? -1 ) > $priority[ $status ] ) {
@@ -1014,6 +1022,7 @@ class BookingCommunicationService {
 	private function claim_side_effect( array $intent, string $stage, array $allowed_statuses ) {
 		global $wpdb;
 		$this->delivery_cc = null;
+
 		$snapshot = $this->bookings->get( (int) $intent['booking_id'] );
 		if ( ! is_array( $snapshot ) ) {
 			return is_wp_error( $snapshot ) ? $snapshot : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
@@ -1022,11 +1031,12 @@ class BookingCommunicationService {
 			return new \WP_Error( 'booking_communication_transaction_start_failed', __( 'The booking communication transaction could not start.', 'extrachill-events' ) );
 		}
 		$this->transaction_active = true;
+
 		$locked = $this->lock_venue_memberships( (int) $snapshot['venue_term_id'] );
 		if ( is_wp_error( $locked ) ) {
 			return $this->rollback( $locked );
 		}
-		$booking                  = $this->bookings->get_for_update( $intent['booking_id'] );
+		$booking = $this->bookings->get_for_update( $intent['booking_id'] );
 		if ( ! is_array( $booking ) ) {
 			return $this->rollback( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
 		}
@@ -1080,6 +1090,7 @@ class BookingCommunicationService {
 			return $this->rollback( $cc );
 		}
 		$this->delivery_cc = $cc;
+
 		$event = $this->append_state( $intent, $claim_kind, $stage, array() );
 		if ( is_wp_error( $event ) ) {
 			return $this->rollback( $event );
@@ -1121,12 +1132,12 @@ class BookingCommunicationService {
 			$request['template'],
 			$request['template_version'],
 			array(
-				'artist_name'   => (string) $booking['artist_name'],
-				'booking_id'    => (string) $booking['public_id'],
-				'contact_name'  => (string) $booking['contact_name'],
+				'artist_name'    => (string) $booking['artist_name'],
+				'booking_id'     => (string) $booking['public_id'],
+				'contact_name'   => (string) $booking['contact_name'],
 				'requested_date' => $this->requested_date_label( (string) ( $booking['requested_start_at'] ?? '' ) ),
-				'venue_name'    => (string) $venue->name,
-				'message'       => $request['message'],
+				'venue_name'     => (string) $venue->name,
+				'message'        => $request['message'],
 			)
 		);
 		if ( is_wp_error( $prepared ) ) {
@@ -1248,6 +1259,7 @@ class BookingCommunicationService {
 			return new \WP_Error( 'booking_communication_transaction_start_failed', __( 'The booking communication transaction could not start.', 'extrachill-events' ) );
 		}
 		$this->transaction_active = true;
+
 		$locked = $this->lock_venue_memberships( $venue_id );
 		if ( is_wp_error( $locked ) ) {
 			return $this->rollback( $locked );

--- a/inc/Core/BookingCommunicationService.php
+++ b/inc/Core/BookingCommunicationService.php
@@ -38,10 +38,16 @@ class BookingCommunicationService {
 	private $cancel;
 	/** @var callable|null */
 	private $find_actions;
+	/** @var callable|null */
+	private $venue_recipients;
+	/** @var array */
+	private $locked_memberships = array();
+	/** @var string|null */
+	private $delivery_cc;
 	/** @var bool */
 	private $transaction_active = false;
 
-	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, $queue = null, $schedule = null, $cancel = null, $find_actions = null, ?VenueBookingConfig $config = null ) {
+	public function __construct( ?BookingRepository $bookings = null, ?BookingActivityRepository $activity = null, ?VenueAuthorization $authorization = null, $queue = null, $schedule = null, $cancel = null, $find_actions = null, ?VenueBookingConfig $config = null, $venue_recipients = null ) {
 		$this->bookings      = $bookings ? $bookings : new BookingRepository();
 		$this->activity      = $activity ? $activity : new BookingActivityRepository();
 		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
@@ -50,6 +56,7 @@ class BookingCommunicationService {
 		$this->schedule      = $schedule;
 		$this->cancel        = $cancel;
 		$this->find_actions  = $find_actions;
+		$this->venue_recipients = $venue_recipients;
 	}
 
 	/** Register the policy preflight that runs before a delayed reminder is queued. */
@@ -274,13 +281,22 @@ class BookingCommunicationService {
 
 	/** Recheck the complete reminder policy while holding the booking row lock. */
 	public function dispatch_reminder( int $activity_id ) {
+		$this->delivery_cc = null;
 		$intent = $this->activity->get( $activity_id );
 		if ( ! is_array( $intent ) || 'booking_message_requested' !== $intent['kind'] || empty( $intent['payload']['data']['send_at'] ) ) {
 			return new \WP_Error( 'booking_reminder_invalid', __( 'The booking reminder intent is invalid.', 'extrachill-events' ) );
 		}
+		$snapshot = $this->bookings->get( (int) $intent['booking_id'] );
+		if ( ! is_array( $snapshot ) ) {
+			return is_wp_error( $snapshot ) ? $snapshot : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
 		$started = $this->begin();
 		if ( is_wp_error( $started ) ) {
 			return $started;
+		}
+		$locked = $this->lock_venue_memberships( (int) $snapshot['venue_term_id'] );
+		if ( is_wp_error( $locked ) ) {
+			return $this->rollback( $locked );
 		}
 		$booking = $this->bookings->get_for_update( $intent['booking_id'] );
 		if ( ! is_array( $booking ) ) {
@@ -317,6 +333,16 @@ class BookingCommunicationService {
 			$committed = $this->commit();
 			return is_wp_error( $committed ) ? $committed : $this->state_for_intent( $intent );
 		}
+		$cc = $this->resolve_venue_cc( (int) $booking['venue_term_id'], (string) $data['recipient'] );
+		if ( is_wp_error( $cc ) ) {
+			$event = $this->append_state( $intent, 'booking_reminder_suppressed', 'suppressed', array( 'reason' => 'venue_recipients_unavailable' ) );
+			if ( is_wp_error( $event ) ) {
+				return $this->rollback( $event );
+			}
+			$committed = $this->commit();
+			return is_wp_error( $committed ) ? $committed : $this->state_for_intent( $intent );
+		}
+		$this->delivery_cc = $cc;
 		$claim = $this->append_state( $intent, 'booking_message_dispatching', 'dispatching', array() );
 		if ( is_wp_error( $claim ) ) {
 			return $this->rollback( $claim );
@@ -335,6 +361,9 @@ class BookingCommunicationService {
 
 	/** Call the non-idempotent queue only after a durable claim. */
 	private function deliver_claimed( array $intent, bool $commit_transaction = false ) {
+		if ( null === $this->delivery_cc ) {
+			return new \WP_Error( 'booking_correspondence_venue_recipients_unavailable', __( 'Authorized venue recipients could not be resolved for this booking message.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
 		$input = $this->queue_input( $intent );
 		try {
 			if ( $this->queue ) {
@@ -831,12 +860,11 @@ class BookingCommunicationService {
 				'args'  => array( $intent['id'] ),
 			);
 		} elseif ( 'dispatching' === $stage ) {
-			$payload             = $this->queue_input( $intent );
-			$payload['_attempt'] = 1;
-			$query               = array(
-				'hook'  => class_exists( '\DataMachine\Abilities\Publish\SendEmailQueuedAbility' ) ? \DataMachine\Abilities\Publish\SendEmailQueuedAbility::WORKER_HOOK : 'datamachine_send_email_worker',
-				'group' => class_exists( '\DataMachine\Abilities\Publish\SendEmailQueuedAbility' ) ? \DataMachine\Abilities\Publish\SendEmailQueuedAbility::GROUP : 'data-machine-email',
-				'args'  => array( $payload ),
+			$query = array(
+				'hook'                  => class_exists( '\DataMachine\Abilities\Publish\SendEmailQueuedAbility' ) ? \DataMachine\Abilities\Publish\SendEmailQueuedAbility::WORKER_HOOK : 'datamachine_send_email_worker',
+				'group'                 => class_exists( '\DataMachine\Abilities\Publish\SendEmailQueuedAbility' ) ? \DataMachine\Abilities\Publish\SendEmailQueuedAbility::GROUP : 'data-machine-email',
+				'args'                  => array( 'booking_communication_intent_ref' => 'intent:' . (int) $intent['id'] ),
+				'partial_args_matching' => 'like',
 			);
 		} else {
 			return new \WP_Error( 'booking_message_reconciliation_unavailable', __( 'The scheduler evidence contract is unavailable.', 'extrachill-events' ), array( 'status' => 503 ) );
@@ -848,7 +876,10 @@ class BookingCommunicationService {
 				unset( $throwable );
 				return new \WP_Error( 'booking_message_reconciliation_query_failed', __( 'Action Scheduler evidence could not be read.', 'extrachill-events' ), array( 'status' => 503 ) );
 			}
-			return is_array( $result ) || is_wp_error( $result ) ? $result : new \WP_Error( 'booking_message_reconciliation_evidence_invalid', __( 'Scheduler evidence for this booking message is invalid.', 'extrachill-events' ) );
+			if ( is_wp_error( $result ) || ! is_array( $result ) ) {
+				return is_wp_error( $result ) ? $result : new \WP_Error( 'booking_message_reconciliation_evidence_invalid', __( 'Scheduler evidence for this booking message is invalid.', 'extrachill-events' ) );
+			}
+			return 'dispatching' === $stage ? $this->collapse_dispatch_evidence( $result ) : $result;
 		}
 		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
 			return new \WP_Error( 'booking_message_reconciliation_unavailable', __( 'Action Scheduler evidence is unavailable.', 'extrachill-events' ), array( 'status' => 503 ) );
@@ -861,7 +892,7 @@ class BookingCommunicationService {
 						$query,
 						array(
 							'status'   => $status,
-							'per_page' => 2,
+							'per_page' => self::MAX_ATTEMPTS + 1,
 						)
 					),
 					'ids'
@@ -877,23 +908,84 @@ class BookingCommunicationService {
 				if ( ! is_numeric( $action_id ) || (int) $action_id < 1 ) {
 					return new \WP_Error( 'booking_message_reconciliation_evidence_invalid', __( 'Scheduler evidence for this booking message is invalid.', 'extrachill-events' ) );
 				}
+				$attempt = null;
+				if ( 'dispatching' === $stage ) {
+					$payload = $this->scheduler_action_payload( (int) $action_id, (int) $intent['id'] );
+					if ( is_wp_error( $payload ) ) {
+						return $payload;
+					}
+					if ( ! is_array( $payload ) ) {
+						continue;
+					}
+					$attempt = $payload['_attempt'] ?? null;
+				}
 				$evidence[ (int) $action_id ] = array(
 					'action_id' => (int) $action_id,
 					'status'    => $status,
+					'attempt'   => $attempt,
 				);
 			}
 		}
-		return array_values( $evidence );
+		$evidence = array_values( $evidence );
+		return 'dispatching' === $stage ? $this->collapse_dispatch_evidence( $evidence ) : $evidence;
+	}
+
+	/** Read one queued payload and verify its exact non-sensitive intent marker. */
+	private function scheduler_action_payload( int $action_id, int $intent_id ) {
+		if ( ! class_exists( 'ActionScheduler_Store' ) ) {
+			return new \WP_Error( 'booking_message_reconciliation_unavailable', __( 'Action Scheduler evidence is unavailable.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+		try {
+			$action = \ActionScheduler_Store::instance()->fetch_action( $action_id );
+			$args   = is_object( $action ) && method_exists( $action, 'get_args' ) ? $action->get_args() : null;
+		} catch ( \Throwable $throwable ) {
+			unset( $throwable );
+			return new \WP_Error( 'booking_message_reconciliation_query_failed', __( 'Action Scheduler evidence could not be read.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+		$payload = is_array( $args ) && is_array( $args[0] ?? null ) ? $args[0] : null;
+		return is_array( $payload ) && ( $payload['context']['booking_communication_intent_ref'] ?? '' ) === 'intent:' . $intent_id ? $payload : false;
+	}
+
+	/** Collapse one legitimate retry chain while preserving duplicate-attempt ambiguity. */
+	private function collapse_dispatch_evidence( array $evidence ) {
+		if ( count( $evidence ) < 2 ) {
+			return $evidence;
+		}
+		$attempts = array();
+		foreach ( $evidence as $item ) {
+			$attempt = $item['attempt'] ?? null;
+			if ( ! is_int( $attempt ) || $attempt < 1 || isset( $attempts[ $attempt ] ) ) {
+				return $evidence;
+			}
+			$attempts[ $attempt ] = true;
+		}
+		usort( $evidence, static fn( array $left, array $right ): int => (int) $left['action_id'] <=> (int) $right['action_id'] );
+		$priority = array( 'canceled' => 0, 'failed' => 1, 'pending' => 2, 'in-progress' => 3, 'complete' => 4 );
+		$status   = 'canceled';
+		foreach ( $evidence as $item ) {
+			if ( ( $priority[ $item['status'] ] ?? -1 ) > $priority[ $status ] ) {
+				$status = $item['status'];
+			}
+		}
+		return array(
+			array(
+				'action_id' => (int) $evidence[0]['action_id'],
+				'status'    => $status,
+			),
+		);
 	}
 
 	private function queue_input( array $intent ): array {
 		$data = $intent['payload']['data'];
 		return array(
 			'to'           => $data['recipient'],
-			'cc'           => $data['cc'],
+			'cc'           => $this->delivery_cc,
 			'subject'      => $data['subject'],
 			'body'         => $data['body'],
-			'context'      => array( 'booking_communication_intent_id' => (int) $intent['id'] ),
+			'context'      => array(
+				'booking_communication_intent_id'  => (int) $intent['id'],
+				'booking_communication_intent_ref' => 'intent:' . (int) $intent['id'],
+			),
 			'content_type' => 'text/plain',
 			'from_name'    => $data['from_name'],
 			'reply_to'     => $data['reply_to'],
@@ -921,10 +1013,19 @@ class BookingCommunicationService {
 	/** Serialize the external side effect and leave a durable retry boundary. */
 	private function claim_side_effect( array $intent, string $stage, array $allowed_statuses ) {
 		global $wpdb;
+		$this->delivery_cc = null;
+		$snapshot = $this->bookings->get( (int) $intent['booking_id'] );
+		if ( ! is_array( $snapshot ) ) {
+			return is_wp_error( $snapshot ) ? $snapshot : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) );
+		}
 		if ( false === $wpdb->query( 'START TRANSACTION' ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Side-effect claim transaction boundary.
 			return new \WP_Error( 'booking_communication_transaction_start_failed', __( 'The booking communication transaction could not start.', 'extrachill-events' ) );
 		}
 		$this->transaction_active = true;
+		$locked = $this->lock_venue_memberships( (int) $snapshot['venue_term_id'] );
+		if ( is_wp_error( $locked ) ) {
+			return $this->rollback( $locked );
+		}
 		$booking                  = $this->bookings->get_for_update( $intent['booking_id'] );
 		if ( ! is_array( $booking ) ) {
 			return $this->rollback( is_wp_error( $booking ) ? $booking : new \WP_Error( 'booking_not_found', __( 'The booking was not found.', 'extrachill-events' ) ) );
@@ -974,6 +1075,11 @@ class BookingCommunicationService {
 			$committed = $this->commit();
 			return is_wp_error( $committed ) ? $committed : $this->state_for_intent( $intent );
 		}
+		$cc = $this->resolve_venue_cc( (int) $booking['venue_term_id'], (string) $data['recipient'] );
+		if ( is_wp_error( $cc ) ) {
+			return $this->rollback( $cc );
+		}
+		$this->delivery_cc = $cc;
 		$event = $this->append_state( $intent, $claim_kind, $stage, array() );
 		if ( is_wp_error( $event ) ) {
 			return $this->rollback( $event );
@@ -1042,7 +1148,6 @@ class BookingCommunicationService {
 				'config_revision'         => (int) $prepared['config_revision'],
 				'subject'                 => $prepared['subject'],
 				'body'                    => $prepared['body'],
-				'cc'                      => $prepared['cc_address'] ? $prepared['cc_address'] : '',
 				'from_name'               => $prepared['from_name'],
 				'reply_to'                => $prepared['booking_address'] ? $prepared['booking_address'] : $request['reply_to'],
 				'send_at'                 => $send_at,
@@ -1143,13 +1248,70 @@ class BookingCommunicationService {
 			return new \WP_Error( 'booking_communication_transaction_start_failed', __( 'The booking communication transaction could not start.', 'extrachill-events' ) );
 		}
 		$this->transaction_active = true;
-		$table                    = BookingSchema::memberships_table();
-		$locked                   = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d ORDER BY id ASC FOR UPDATE", $venue_id ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact venue authority lock.
-		if ( '' !== (string) $wpdb->last_error ) {
-			return $this->rollback( new \WP_Error( 'booking_communication_authorization_lock_failed', __( 'Venue booking authority could not be locked.', 'extrachill-events' ) ) );
+		$locked = $this->lock_venue_memberships( $venue_id );
+		if ( is_wp_error( $locked ) ) {
+			return $this->rollback( $locked );
 		}
-		$allowed = $this->authorization->authorize_locked( $actor_id, $venue_id, VenueAuthorization::ACTION_ACCESS_VENUE, (array) $locked );
+		$allowed = $this->authorization->authorize_locked( $actor_id, $venue_id, VenueAuthorization::ACTION_ACCESS_VENUE, $locked );
 		return true === $allowed ? true : $this->rollback( is_wp_error( $allowed ) ? $allowed : $this->forbidden() );
+	}
+
+	/** Lock the exact venue membership set before recipient and booking reads. */
+	private function lock_venue_memberships( int $venue_id ) {
+		global $wpdb;
+		$table  = BookingSchema::memberships_table();
+		$locked = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE venue_term_id = %d AND status = %s ORDER BY id ASC LIMIT 101 FOR UPDATE", $venue_id, VenueAuthorization::STATUS_ACTIVE ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serializes a bounded active recipient set with membership changes.
+		if ( '' !== (string) $wpdb->last_error || ! is_array( $locked ) ) {
+			return new \WP_Error( 'booking_communication_authorization_lock_failed', __( 'Venue booking authority could not be locked.', 'extrachill-events' ) );
+		}
+		if ( count( $locked ) > 100 ) {
+			return new \WP_Error( 'booking_correspondence_venue_recipients_invalid', __( 'The venue has too many membership records to resolve booking recipients safely.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+		$this->locked_memberships = $locked;
+		return $locked;
+	}
+
+	/** Resolve authorized venue members without persisting their addresses. */
+	private function resolve_venue_cc( int $venue_id, string $primary_recipient ) {
+		$resolved = $this->venue_recipients
+			? call_user_func( $this->venue_recipients, $venue_id, $this->locked_memberships, $primary_recipient )
+			: $this->default_venue_recipients( $venue_id );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
+		}
+		if ( ! is_array( $resolved ) || count( $resolved ) > 100 ) {
+			return new \WP_Error( 'booking_correspondence_venue_recipients_invalid', __( 'Authorized venue recipients are invalid for this booking message.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+		$primary = strtolower( sanitize_email( $primary_recipient ) );
+		$emails  = array();
+		foreach ( $resolved as $email ) {
+			$email = sanitize_email( (string) $email );
+			if ( '' !== $email && strtolower( $email ) !== $primary ) {
+				$emails[ strtolower( $email ) ] = $email;
+			}
+		}
+		ksort( $emails, SORT_STRING );
+		if ( empty( $emails ) ) {
+			return new \WP_Error( 'booking_correspondence_venue_recipients_unavailable', __( 'No authorized venue recipients are available for this booking message.', 'extrachill-events' ), array( 'status' => 503 ) );
+		}
+		return implode( ',', array_values( $emails ) );
+	}
+
+	/** Resolve active members that retain the venue booking feature gate. */
+	private function default_venue_recipients( int $venue_id ): array {
+		$emails = array();
+		foreach ( $this->locked_memberships as $row ) {
+			$user_id = (int) ( $row['user_id'] ?? 0 );
+			if ( (int) ( $row['venue_term_id'] ?? 0 ) !== $venue_id || VenueAuthorization::STATUS_ACTIVE !== ( $row['status'] ?? '' ) || true !== $this->authorization->authorize_locked( $user_id, $venue_id, VenueAuthorization::ACTION_ACCESS_VENUE, $this->locked_memberships ) ) {
+				continue;
+			}
+			$user  = get_userdata( $user_id );
+			$email = $user && isset( $user->user_email ) ? sanitize_email( (string) $user->user_email ) : '';
+			if ( '' !== $email ) {
+				$emails[] = $email;
+			}
+		}
+		return $emails;
 	}
 
 	private function begin() {

--- a/inc/Core/BookingPrivacyService.php
+++ b/inc/Core/BookingPrivacyService.php
@@ -379,7 +379,7 @@ class BookingPrivacyService {
 				continue;
 			}
 			$preserved = array( 'privacy_redacted' => true );
-			foreach ( array( 'template', 'template_version', 'request_hash', 'booking_version', 'source_activity_id', 'cc', 'from_name', 'identity', 'mail_site_id', 'intent_id', 'action_id', 'attempt', 'retryable', 'reason', 'error_code' ) as $key ) {
+			foreach ( array( 'template', 'template_version', 'request_hash', 'booking_version', 'source_activity_id', 'from_name', 'mail_site_id', 'intent_id', 'action_id', 'attempt', 'retryable', 'reason', 'error_code' ) as $key ) {
 				if ( array_key_exists( $key, $data ) ) {
 					$preserved[ $key ] = $data[ $key ];
 				}

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -85,11 +85,11 @@ class VenueBookingConfig {
 			return new \WP_Error( 'invalid_booking_public_config', __( 'The public venue booking configuration is unavailable.', 'extrachill-events' ) );
 		}
 
-		$fields       = $this->normalize_intake_fields( $stored['intake']['fields'] ?? null );
-		$presentation = $this->normalize_intake_presentation( $stored['intake']['presentation'] ?? array() );
-		$requirements = $this->normalize_public_requirements( $stored['public_requirements'] ?? null );
-		$consent      = $this->normalize_consent( $stored['consent'] ?? null );
-		$spaces       = $this->normalize_spaces( $stored['spaces'] ?? null );
+		$fields        = $this->normalize_intake_fields( $stored['intake']['fields'] ?? null );
+		$presentation  = $this->normalize_intake_presentation( $stored['intake']['presentation'] ?? array() );
+		$requirements  = $this->normalize_public_requirements( $stored['public_requirements'] ?? null );
+		$consent       = $this->normalize_consent( $stored['consent'] ?? null );
+		$spaces        = $this->normalize_spaces( $stored['spaces'] ?? null );
 		$booking_guide = $this->normalize_booking_guide( $stored['booking_guide'] ?? array() );
 		foreach ( array( $fields, $presentation, $requirements, $consent, $spaces, $booking_guide ) as $section ) {
 			if ( is_wp_error( $section ) ) {
@@ -873,8 +873,8 @@ class VenueBookingConfig {
 		if ( '' === $from_name || mb_strlen( $from_name ) > 100 || preg_match( '/[\r\n]/', $from_name ) || '' === $footer || mb_strlen( $footer ) > 500 ) {
 			return new \WP_Error( 'invalid_booking_correspondence_identity', __( 'The booking correspondence sender or footer is invalid.', 'extrachill-events' ) );
 		}
-		$templates = array();
-		$provided  = is_array( $correspondence['templates'] ?? null ) ? $correspondence['templates'] : array();
+		$templates       = array();
+		$provided        = is_array( $correspondence['templates'] ?? null ) ? $correspondence['templates'] : array();
 		$legacy_subjects = array(
 			'follow_up'       => 'Following up on booking {{booking_id}}',
 			'inquiry_receipt' => 'Booking inquiry received at {{venue_name}} [{{booking_id}}]',

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -51,7 +51,13 @@ class VenueBookingConfig {
 		if ( ! is_array( $stored ) ) {
 			return new \WP_Error( 'invalid_booking_config_document', __( 'Stored venue booking configuration is malformed.', 'extrachill-events' ) );
 		}
-		return $this->normalize( $stored );
+		$normalized = $this->normalize( $stored );
+		if ( ! is_wp_error( $normalized ) && array_key_exists( 'cc_address', (array) ( $stored['correspondence'] ?? array() ) ) ) {
+			$repaired = $stored;
+			unset( $repaired['correspondence']['cc_address'] );
+			update_term_meta( $venue_term_id, self::META_KEY, $repaired, $stored );
+		}
+		return $normalized;
 	}
 
 	/**
@@ -542,7 +548,6 @@ class VenueBookingConfig {
 			'subject'          => mb_substr( sanitize_text_field( $render( $template['subject'] ) ), 0, 200 ),
 			'body'             => $render( $template['body'] ) . "\n\n" . $config['correspondence']['footer'],
 			'booking_address'  => $config['correspondence']['booking_address'],
-			'cc_address'       => $config['correspondence']['cc_address'],
 			'from_name'        => $config['correspondence']['from_name'],
 			'reminder_policy'  => $config['correspondence']['reminder_policies'][ $template_key ] ?? null,
 		);
@@ -555,7 +560,7 @@ class VenueBookingConfig {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
-		unset( $result['booking_address'], $result['cc_address'], $result['from_name'], $result['reminder_policy'] );
+		unset( $result['booking_address'], $result['from_name'], $result['reminder_policy'] );
 		return $result;
 	}
 
@@ -863,10 +868,6 @@ class VenueBookingConfig {
 		if ( '' !== (string) ( $correspondence['booking_address'] ?? '' ) && '' === $address ) {
 			return new \WP_Error( 'invalid_booking_correspondence_address', __( 'The booking correspondence address is invalid.', 'extrachill-events' ) );
 		}
-		$cc_address = sanitize_email( (string) ( $correspondence['cc_address'] ?? '' ) );
-		if ( '' !== (string) ( $correspondence['cc_address'] ?? '' ) && '' === $cc_address ) {
-			return new \WP_Error( 'invalid_booking_correspondence_cc_address', __( 'The booking correspondence CC address is invalid.', 'extrachill-events' ) );
-		}
 		$from_name = sanitize_text_field( (string) ( $correspondence['from_name'] ?? $defaults['from_name'] ) );
 		$footer    = sanitize_textarea_field( (string) ( $correspondence['footer'] ?? $defaults['footer'] ) );
 		if ( '' === $from_name || mb_strlen( $from_name ) > 100 || preg_match( '/[\r\n]/', $from_name ) || '' === $footer || mb_strlen( $footer ) > 500 ) {
@@ -928,7 +929,7 @@ class VenueBookingConfig {
 		return array(
 			'version'           => self::CORRESPONDENCE_VERSION,
 			'booking_address'   => '' === $address ? null : $address,
-			'cc_address'        => '' === $cc_address ? null : $cc_address,
+			'cc_address'        => null,
 			'from_name'         => $from_name,
 			'footer'            => $footer,
 			'variables'         => $this->variable_schema(),

--- a/tests/BookingCommunicationTest.php
+++ b/tests/BookingCommunicationTest.php
@@ -33,6 +33,9 @@ final class BookingCommunicationTest extends BookingTestCase {
 			'fired_actions' => array(),
 			'scheduled'     => array(),
 			'cache_deletes' => array(),
+			'users'         => array(
+				12 => (object) array( 'ID' => 12, 'user_email' => 'operator@example.com' ),
+			),
 			'terms'         => array(
 				7 => array(
 					55 => (object) array( 'term_id' => 55, 'taxonomy' => 'venue', 'name' => 'The Room' ),
@@ -65,6 +68,14 @@ final class BookingCommunicationTest extends BookingTestCase {
 			'post_meta'     => array(),
 		);
 		$GLOBALS['wpdb'] = new BookingWpdb();
+		$GLOBALS['wpdb']->rows[ BookingSchema::memberships_table() ][1] = array(
+			'id'            => 1,
+			'venue_term_id' => 55,
+			'user_id'       => 12,
+			'is_owner'      => 1,
+			'status'        => 'active',
+			'version'       => 1,
+		);
 	}
 
 	private function booking( string $email = 'artist@example.com', string $status = 'under_review' ): array {
@@ -113,6 +124,11 @@ final class BookingCommunicationTest extends BookingTestCase {
 			},
 			static function ( int $action_id ) use ( &$cancelled ) {
 				$cancelled[] = $action_id;
+			},
+			null,
+			null,
+			static function (): array {
+				return array( 'owner@example.com', 'operator@example.com' );
 			}
 		);
 	}
@@ -133,7 +149,7 @@ final class BookingCommunicationTest extends BookingTestCase {
 
 		$this->assertSame( 'queued', $result['status'] );
 		$this->assertCount( 1, $queued );
-		$this->assertSame( '', $queued[0]['cc'] );
+		$this->assertSame( 'operator@example.com,owner@example.com', $queued[0]['cc'] );
 		$this->assertSame( 'Extra Chill Bookings', $queued[0]['from_name'] );
 		$this->assertSame( 'venue-booking@example.com', $queued[0]['reply_to'] );
 		$this->assertStringContainsString( 'Powered by Extra Chill', $queued[0]['body'] );
@@ -148,6 +164,149 @@ final class BookingCommunicationTest extends BookingTestCase {
 		$this->assertArrayNotHasKey( 'references', $queued[0] );
 	}
 
+	public function test_default_cc_uses_only_current_explicit_venue_access(): void {
+		$booking = $this->booking();
+		$rows    = array(
+			array( 'id' => 2, 'venue_term_id' => 55, 'user_id' => 21, 'status' => 'active' ),
+			array( 'id' => 3, 'venue_term_id' => 55, 'user_id' => 22, 'status' => 'active' ),
+			array( 'id' => 4, 'venue_term_id' => 56, 'user_id' => 23, 'status' => 'active' ),
+			array( 'id' => 5, 'venue_term_id' => 55, 'user_id' => 24, 'status' => 'revoked' ),
+			array( 'id' => 6, 'venue_term_id' => 55, 'user_id' => 25, 'status' => 'active' ),
+			array( 'id' => 7, 'venue_term_id' => 55, 'user_id' => 26, 'status' => 'active' ),
+			array( 'id' => 8, 'venue_term_id' => 55, 'user_id' => 28, 'status' => 'active' ),
+		);
+		foreach ( $rows as $row ) {
+			$GLOBALS['wpdb']->rows[ BookingSchema::memberships_table() ][ $row['id'] ] = $row;
+		}
+		$GLOBALS['ec_artist_test']['users'] += array(
+			21 => (object) array( 'ID' => 21, 'user_email' => 'owner@example.com' ),
+			22 => (object) array( 'ID' => 22, 'user_email' => 'gardner@example.com' ),
+			23 => (object) array( 'ID' => 23, 'user_email' => 'other-venue@example.com' ),
+			24 => (object) array( 'ID' => 24, 'user_email' => 'revoked@example.com' ),
+			25 => (object) array( 'ID' => 25, 'user_email' => 'owner@example.com' ),
+			26 => (object) array( 'ID' => 26 ),
+			27 => (object) array( 'ID' => 27, 'user_email' => 'team-only@example.com' ),
+			28 => (object) array( 'ID' => 28, 'user_email' => 'artist@example.com' ),
+		);
+		$authorization = new BookingTestAuthorization(
+			array(
+				'21:55' => true,
+				'22:55' => true,
+				'23:56' => true,
+				'24:55' => true,
+				'25:55' => true,
+				'26:55' => true,
+				'27:55' => true,
+				'28:55' => true,
+			)
+		);
+		$queued = array();
+		$service = new BookingCommunicationService(
+			null,
+			null,
+			$authorization,
+			static function ( array $input ) use ( &$queued ): array {
+				$queued[] = $input;
+				return array( 'success' => true, 'action_id' => 301 );
+			}
+		);
+
+		$this->assertSame( 'queued', $service->request( $this->input( $booking['id'] ), 12 )['status'] );
+		$this->assertSame( 'gardner@example.com,operator@example.com,owner@example.com', $queued[0]['cc'] );
+		$this->assertStringNotContainsString( 'artist@example.com', $queued[0]['cc'] );
+		$this->assertStringNotContainsString( 'team-only@example.com', $queued[0]['cc'] );
+		$this->assertStringNotContainsString( 'other-venue@example.com', $queued[0]['cc'] );
+		$this->assertStringNotContainsString( 'revoked@example.com', $queued[0]['cc'] );
+	}
+
+	public function test_missing_authorized_venue_recipients_fails_before_queueing(): void {
+		$booking = $this->booking();
+		$queued = $scheduled = $cancelled = array();
+		$service = new BookingCommunicationService(
+			null,
+			null,
+			new BookingTestAuthorization(),
+			static function ( array $input ) use ( &$queued ): array {
+				$queued[] = $input;
+				return array( 'success' => true, 'action_id' => 302 );
+			},
+			null,
+			null,
+			null,
+			null,
+			static function (): array {
+				return array();
+			}
+		);
+
+		$result = $service->request( $this->input( $booking['id'] ), 12 );
+
+		$this->assertSame( 'booking_correspondence_venue_recipients_unavailable', $result->get_error_code() );
+		$this->assertCount( 0, $queued );
+	}
+
+	public function test_delayed_message_re_resolves_membership_at_dispatch(): void {
+		$booking = $this->booking();
+		$GLOBALS['ec_artist_test']['users'][22] = (object) array( 'ID' => 22, 'user_email' => 'gardner@example.com' );
+		$queued = $scheduled = array();
+		$authorization = new BookingTestAuthorization( array( '22:55' => true ) );
+		$service = new BookingCommunicationService(
+			null,
+			null,
+			$authorization,
+			static function ( array $input ) use ( &$queued ): array {
+				$queued[] = $input;
+				return array( 'success' => true, 'action_id' => 303 );
+			},
+			static function ( int $timestamp, string $hook, array $args, string $group ) use ( &$scheduled ): int {
+				$scheduled[] = compact( 'timestamp', 'hook', 'args', 'group' );
+				return 304;
+			}
+		);
+		$state = $service->request( $this->input( $booking['id'], array( 'template' => 'follow_up' ) ), 12 );
+		$GLOBALS['wpdb']->rows[ BookingSchema::memberships_table() ][1]['status'] = 'revoked';
+		$GLOBALS['wpdb']->rows[ BookingSchema::memberships_table() ][2] = array( 'id' => 2, 'venue_term_id' => 55, 'user_id' => 22, 'status' => 'active' );
+
+		$result = $service->dispatch_reminder( $state['intent_id'] );
+
+		$this->assertSame( 'queued', $result['status'] );
+		$this->assertSame( 'gardner@example.com', $queued[0]['cc'] );
+		$this->assertStringNotContainsString( 'operator@example.com', $queued[0]['cc'] );
+	}
+
+	public function test_delayed_message_without_current_venue_recipients_is_durably_suppressed(): void {
+		$booking = $this->booking();
+		$available = true;
+		$queued = $scheduled = array();
+		$service = new BookingCommunicationService(
+			null,
+			null,
+			new BookingTestAuthorization(),
+			static function ( array $input ) use ( &$queued ): array {
+				$queued[] = $input;
+				return array( 'success' => true, 'action_id' => 305 );
+			},
+			static function ( int $timestamp, string $hook, array $args, string $group ) use ( &$scheduled ): int {
+				$scheduled[] = compact( 'timestamp', 'hook', 'args', 'group' );
+				return 306;
+			},
+			null,
+			null,
+			null,
+			static function () use ( &$available ): array {
+				return $available ? array( 'operator@example.com' ) : array();
+			}
+		);
+		$state     = $service->request( $this->input( $booking['id'], array( 'template' => 'follow_up' ) ), 12 );
+		$available = false;
+
+		$result = $service->dispatch_reminder( $state['intent_id'] );
+
+		$this->assertSame( 'suppressed', $result['status'] );
+		$this->assertCount( 0, $queued );
+		$this->assertContains( 'booking_reminder_suppressed', array_column( ( new BookingActivityRepository() )->list_for_booking( $booking['id'] ), 'kind' ) );
+	}
+
 	public function test_preview_and_queued_delivery_share_the_exact_rendering_contract(): void {
 		$booking = $this->booking();
 		$config  = ( new VenueBookingConfig() )->get( 55 );
@@ -156,7 +315,6 @@ final class BookingCommunicationTest extends BookingTestCase {
 			'subject' => '{{artist_name}} at {{venue_name}} [{{booking_id}}]',
 			'body'    => "Hello {{contact_name}},\n\n{{message}}",
 		);
-		$config['correspondence']['cc_address'] = 'audit@example.com';
 		$config['correspondence']['from_name']  = 'The Room Bookings';
 		$config['correspondence']['footer']     = 'Powered by The Room on Extra Chill';
 		$GLOBALS['ec_artist_test']['meta'][7][55][ VenueBookingConfig::META_KEY ] = $config;
@@ -184,7 +342,7 @@ final class BookingCommunicationTest extends BookingTestCase {
 		$this->assertSame( 'queued', $result['status'] );
 		$this->assertSame( $preview['subject'], $queued[0]['subject'] );
 		$this->assertSame( $preview['body'], $queued[0]['body'] );
-		$this->assertSame( 'audit@example.com', $queued[0]['cc'] );
+		$this->assertSame( 'operator@example.com,owner@example.com', $queued[0]['cc'] );
 		$this->assertSame( 'The Room Bookings', $queued[0]['from_name'] );
 		$this->assertStringContainsString( 'Powered by The Room on Extra Chill', $queued[0]['body'] );
 		$this->assertStringNotContainsString( '<b>', $queued[0]['body'] );
@@ -208,6 +366,7 @@ final class BookingCommunicationTest extends BookingTestCase {
 
 		$this->assertSame( 'Booking inquiry received: Test Band at The Room - Aug 1', $preview['subject'] );
 		$this->assertStringNotContainsString( 'long-public-reference', $preview['subject'] );
+		$this->assertArrayNotHasKey( 'cc_address', $GLOBALS['ec_artist_test']['meta'][7][55][ VenueBookingConfig::META_KEY ]['correspondence'] );
 	}
 
 	public function test_configured_policy_owns_schedule_and_stale_template_versions_fail_closed(): void {
@@ -409,7 +568,17 @@ final class BookingCommunicationTest extends BookingTestCase {
 			static function () use ( &$calls ) {
 				++$calls;
 				throw new RuntimeException( 'uncertain queue boundary' );
-			},
+			}
+		);
+
+		$first = $service->request( $this->input( $booking['id'] ), 12 );
+		$this->assertSame( 'booking_message_delivery_uncertain', $first->get_error_code() );
+		$intent = ( new BookingActivityRepository() )->find_by_idempotency( $booking['id'], 'booking-message-request:message-1' );
+		$reconciler = new BookingCommunicationService(
+			null,
+			null,
+			new BookingTestAuthorization(),
+			null,
 			null,
 			null,
 			static function ( array $evidence_query ) use ( &$query ) {
@@ -417,19 +586,15 @@ final class BookingCommunicationTest extends BookingTestCase {
 				return array( array( 'action_id' => 501, 'status' => 'complete' ) );
 			}
 		);
-
-		$first = $service->request( $this->input( $booking['id'] ), 12 );
-		$this->assertSame( 'booking_message_delivery_uncertain', $first->get_error_code() );
-		$intent = ( new BookingActivityRepository() )->find_by_idempotency( $booking['id'], 'booking-message-request:message-1' );
-		$result = $service->reconcile( $intent['id'], 12 );
+		$result = $reconciler->reconcile( $intent['id'], 12 );
 		$this->assertSame( 'queued', $result['status'] );
 		$this->assertSame( 501, $result['action_id'] );
 		$this->assertSame( 'datamachine_send_email_worker', $query['hook'] );
 		$this->assertSame( 'data-machine-email', $query['group'] );
-		$this->assertSame( 1, $query['args'][0]['_attempt'] );
-		$this->assertSame( $intent['id'], $query['args'][0]['context']['booking_communication_intent_id'] );
+		$this->assertSame( 'like', $query['partial_args_matching'] );
+		$this->assertSame( 'intent:' . $intent['id'], $query['args']['booking_communication_intent_ref'] );
 		$this->assertSame( 1, $calls );
-		$this->assertSame( 'booking_message_reconciliation_not_required', $service->reconcile( $intent['id'], 12 )->get_error_code() );
+		$this->assertSame( 'booking_message_reconciliation_not_required', $reconciler->reconcile( $intent['id'], 12 )->get_error_code() );
 	}
 
 	public function test_operator_recovers_only_live_reminder_schedule_evidence(): void {
@@ -453,6 +618,39 @@ final class BookingCommunicationTest extends BookingTestCase {
 		$result = $service->reconcile( $intent['id'], 12 );
 		$this->assertSame( 'scheduled', $result['status'] );
 		$this->assertSame( 601, $result['action_id'] );
+	}
+
+	public function test_dispatch_reconciliation_collapses_unique_retry_attempts(): void {
+		$booking = $this->booking();
+		$service = new BookingCommunicationService(
+			null,
+			null,
+			new BookingTestAuthorization(),
+			static function () {
+				throw new RuntimeException( 'uncertain queue boundary' );
+			}
+		);
+		$this->assertSame( 'booking_message_delivery_uncertain', $service->request( $this->input( $booking['id'] ), 12 )->get_error_code() );
+		$intent = ( new BookingActivityRepository() )->find_by_idempotency( $booking['id'], 'booking-message-request:message-1' );
+		$reconciler = new BookingCommunicationService(
+			null,
+			null,
+			new BookingTestAuthorization(),
+			null,
+			null,
+			null,
+			static function (): array {
+				return array(
+					array( 'action_id' => 501, 'status' => 'failed', 'attempt' => 1 ),
+					array( 'action_id' => 502, 'status' => 'pending', 'attempt' => 2 ),
+				);
+			}
+		);
+
+		$result = $reconciler->reconcile( $intent['id'], 12 );
+
+		$this->assertSame( 'queued', $result['status'] );
+		$this->assertSame( 501, $result['action_id'] );
 	}
 
 	public function test_reconciliation_does_not_infer_replay_from_absent_or_terminal_evidence(): void {

--- a/tests/BookingCorrespondenceAutomationTest.php
+++ b/tests/BookingCorrespondenceAutomationTest.php
@@ -93,6 +93,13 @@ final class BookingCorrespondenceAutomationTest extends BookingTestCase {
 			static function ( array $input ) use ( &$queued, $success ) {
 				$queued[] = $input;
 				return $success ? array( 'success' => true, 'action_id' => 100 + count( $queued ) ) : array( 'success' => false, 'error' => 'temporary' );
+			},
+			null,
+			null,
+			null,
+			null,
+			static function (): array {
+				return array( 'owner@example.com', 'operator@example.com' );
 			}
 		);
 		return new BookingCorrespondenceAutomationService( null, null, $communication );
@@ -108,7 +115,7 @@ final class BookingCorrespondenceAutomationTest extends BookingTestCase {
 		$this->assertSame( array( 'completed' => true ), $service->reconcile_source( $source['id'] ) );
 		$this->assertCount( 1, $queued );
 		$this->assertSame( 'artist@example.com', $queued[0]['to'] );
-		$this->assertSame( '', $queued[0]['cc'] );
+		$this->assertSame( 'operator@example.com,owner@example.com', $queued[0]['cc'] );
 		$this->assertSame( 'Extra Chill Bookings', $queued[0]['from_name'] );
 		$this->assertSame( 'booking@lofi.example', $queued[0]['reply_to'] );
 		$this->assertSame( 'Booking inquiry received: Test Band at Lo-Fi Brewing - Aug 1', $queued[0]['subject'] );
@@ -215,7 +222,10 @@ final class BookingCorrespondenceAutomationTest extends BookingTestCase {
 			return array( 'success' => true, 'action_id' => 200 + count( $calls ) );
 		};
 		$automation = static function () use ( $queue ): BookingCorrespondenceAutomationService {
-			return new BookingCorrespondenceAutomationService( null, null, new BookingCommunicationService( null, null, null, $queue ) );
+			$recipients = static function (): array {
+				return array( 'owner@example.com', 'operator@example.com' );
+			};
+			return new BookingCorrespondenceAutomationService( null, null, new BookingCommunicationService( null, null, null, $queue, null, null, null, null, $recipients ) );
 		};
 
 		$first = $automation()->reconcile_source( $source['id'] );

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -402,6 +402,9 @@ if ( ! function_exists( 'get_userdata' ) ) {
 		if ( isset( $GLOBALS['venue_membership_test'] ) ) {
 			return $GLOBALS['venue_membership_test']['users'][ $user_id ] ?? false;
 		}
+		if ( isset( $GLOBALS['ec_artist_test']['users'][ $user_id ] ) ) {
+			return $GLOBALS['ec_artist_test']['users'][ $user_id ];
+		}
 		return (int) $user_id > 0 ? (object) array( 'ID' => (int) $user_id ) : false; }
 }
 if ( ! function_exists( 'user_can' ) ) {
@@ -1528,7 +1531,14 @@ final class BookingWpdb {
 				}
 				$this->elapse_hold_after_membership_lock = null;
 			}
-			return array_values( $this->rows[ $this->prefix . 'ec_venue_members' ] ?? array() );
+			$rows = array_values( $this->rows[ $this->prefix . 'ec_venue_members' ] ?? array() );
+			if ( isset( $venue[1] ) ) {
+				$rows = array_values( array_filter( $rows, static fn( array $row ): bool => (int) ( $row['venue_term_id'] ?? 0 ) === (int) $venue[1] ) );
+			}
+			if ( false !== strpos( $query, "status = 'active'" ) ) {
+				$rows = array_values( array_filter( $rows, static fn( array $row ): bool => 'active' === ( $row['status'] ?? '' ) ) );
+			}
+			return $rows;
 		}
 		if ( preg_match( '/SHOW INDEX FROM `([^`]+)`/', $query, $match ) ) {
 			++$this->schema_queries;


### PR DESCRIPTION
## Summary
- derive booking email CC recipients from current explicit active venue memberships with booking feature access
- resolve recipients under the venue membership lock at actual dispatch, including delayed reminders
- exclude team-only users, unrelated venues, revoked members, missing emails, duplicates, and the primary recipient
- keep member addresses out of venue config, booking activity, and API projections
- preserve exact crash recovery using a non-sensitive Action Scheduler intent reference and valid retry-chain collapse

## Lo-Fi behavior
Production currently has exactly two active authorized Lo-Fi members: user 1 and user 38. After deployment, booking emails will CC those two users without notifying unrelated Extra Chill team members.

## Safety
- fail closed when no authorized venue recipient exists
- delayed reminders are durably suppressed if venue access disappears
- active recipients are re-resolved after membership changes
- recipient sets are deterministic and bounded to 100 active members
- the deprecated config CC field is lazily removed with compare-and-swap and never drives delivery
- legacy CC/identity fields are discarded during privacy redaction

## Verification
- focused communication: 46 tests / 295 assertions
- full booking suite: 460 tests / 4,823 assertions
- focused concurrency/privacy review: no blocking findings
- PHP syntax and diff whitespace checks pass

Fixes #547