### PR TITLE
feat: add secure venue booking embeds

### DIFF
--- a/blocks/venue-booking-inquiry/render.php
+++ b/blocks/venue-booking-inquiry/render.php
@@ -125,8 +125,13 @@ $guide_heading_id = $instance . '-guide-title';
 if ( $form_enabled && false === $json ) {
 	return;
 }
+$wrapper_extra = array( 'class' => 'ec-venue-booking-inquiry' );
+if ( (int) get_current_blog_id() === $events_blog_id && is_tax( 'venue' ) ) {
+	$wrapper_extra['id'] = 'booking-inquiry';
+}
+$wrapper_attributes = get_block_wrapper_attributes( $wrapper_extra );
 ?>
-<section <?php echo get_block_wrapper_attributes( array( 'class' => 'ec-venue-booking-inquiry' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Core escapes block wrapper attributes. ?>>
+<section <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Core escapes block wrapper attributes. ?>>
 	<?php if ( ! empty( $guide_entries ) ) : ?>
 		<div class="ec-booking-guide" aria-labelledby="<?php echo esc_attr( $guide_heading_id ); ?>">
 			<h2 id="<?php echo esc_attr( $guide_heading_id ); ?>"><?php esc_html_e( 'Booking guide', 'extrachill-events' ); ?></h2>

--- a/blocks/venue-settings/render.php
+++ b/blocks/venue-settings/render.php
@@ -116,6 +116,7 @@ foreach ( $managed_venues as $venue ) {
 
 $can_access       = $selected && true === $authorization->authorize( $user_id, $selected['id'], VenueAuthorization::ACTION_ACCESS_VENUE );
 $can_manage       = $selected && true === $authorization->authorize( $user_id, $selected['id'], VenueAuthorization::ACTION_MANAGE_MEMBERS );
+$selected_term    = $selected ? get_term( (int) $selected['id'], 'venue' ) : null;
 $context          = array(
 	'user'               => array(
 		'id'       => $user_id,
@@ -130,6 +131,7 @@ $context          = array(
 	'route_url'          => home_url( '/venue-settings/' ),
 	'requested_venue_id' => in_array( $requested_venue_id, array_column( $claim_venues, 'id' ), true ) ? $requested_venue_id : 0,
 	'booking_id'         => $can_access ? $requested_booking_id : 0,
+	'booking_url'        => $can_access && $selected_term instanceof WP_Term ? \ExtraChillEvents\Core\VenueBookingEmbed::booking_url( $selected_term ) : '',
 	'support_events'     => $can_access && function_exists( 'extrachill_events_local_support_organizer_events' )
 		? extrachill_events_local_support_organizer_events( $user_id, (int) $selected['id'] )
 		: array(),

--- a/blocks/venue-settings/src/booking-embed.js
+++ b/blocks/venue-settings/src/booking-embed.js
@@ -1,0 +1,59 @@
+export const normalizeBookingOrigin = ( value ) => {
+	if ( value !== value.trim() || value.includes( '*' ) ) {
+		return null;
+	}
+	try {
+		const url = new URL( value );
+		if (
+			url.protocol !== 'https:' ||
+			url.username ||
+			url.password ||
+			url.port ||
+			url.pathname !== '/' ||
+			url.search ||
+			url.hash ||
+			url.hostname === 'localhost' ||
+			! url.hostname.includes( '.' ) ||
+			/^[\d.]+$/.test( url.hostname )
+		) {
+			return null;
+		}
+		return `https://${ url.hostname.toLowerCase() }`;
+	} catch {
+		return null;
+	}
+};
+
+const escapeAttribute = ( value ) =>
+	String( value )
+		.replaceAll( '&', '&amp;' )
+		.replaceAll( '"', '&quot;' )
+		.replaceAll( '<', '&lt;' )
+		.replaceAll( '>', '&gt;' );
+
+export const bookingButtonSnippet = ( bookingUrl, venueName ) =>
+	`<a href="${ escapeAttribute( bookingUrl ) }">Book ${ escapeAttribute(
+		venueName
+	) }</a>`;
+
+export const bookingEmbedSnippet = ( bookingUrl, venueName, parentOrigin ) => {
+	const src = new URL( bookingUrl );
+	src.hash = '';
+	src.searchParams.set( 'booking-embed', '1' );
+	src.searchParams.set( 'parent-origin', parentOrigin );
+	const id = `extrachill-booking-${ parentOrigin.replace(
+		/[^a-z0-9]+/gi,
+		'-'
+	) }`;
+	const eventsOrigin = src.origin;
+	const title = `Book ${ venueName }`;
+	return `<iframe id="${ id }" src="${ escapeAttribute(
+		src.toString()
+	) }" title="${ escapeAttribute(
+		title
+	) }" loading="lazy" referrerpolicy="strict-origin" sandbox="allow-forms allow-scripts allow-same-origin" style="width:100%;min-height:720px;border:0" scrolling="no"><a href="${ escapeAttribute(
+		bookingUrl
+	) }">Open ${ escapeAttribute(
+		title
+	) } on Extra Chill</a></iframe><script>(function(){var f=document.getElementById('${ id }');window.addEventListener('message',function(e){var d=e.data;if(e.source!==f.contentWindow||e.origin!=='${ eventsOrigin }'||!d||d.type!=='extrachill:booking-height'||!Number.isInteger(d.height)||d.height<320||d.height>10000){return;}f.style.height=d.height+'px';});}());</script>`;
+};

--- a/blocks/venue-settings/src/booking-embed.test.js
+++ b/blocks/venue-settings/src/booking-embed.test.js
@@ -1,0 +1,63 @@
+/* global describe, expect, it */
+
+import {
+	bookingButtonSnippet,
+	bookingEmbedSnippet,
+	normalizeBookingOrigin,
+} from './booking-embed';
+
+describe( 'venue booking embed generator', () => {
+	it( 'accepts only exact standard-port HTTPS origins', () => {
+		expect( normalizeBookingOrigin( 'https://Venue.Example' ) ).toBe(
+			'https://venue.example'
+		);
+		[
+			'http://venue.example',
+			'https://venue.example/path',
+			'https://user@venue.example',
+			'https://*.example',
+			'https://localhost',
+			'https://127.0.0.1',
+			'https://venue.example:8443',
+		].forEach( ( origin ) =>
+			expect( normalizeBookingOrigin( origin ) ).toBeNull()
+		);
+	} );
+
+	it( 'builds accessible link and iframe markup without hand-edited IDs', () => {
+		const link =
+			'https://events.extrachill.com/venue/the-room/#booking-inquiry';
+		expect( bookingButtonSnippet( link, 'The Room' ) ).toContain(
+			'Book The Room'
+		);
+		const snippet = bookingEmbedSnippet(
+			link,
+			'The Room',
+			'https://venue.example'
+		);
+		expect( snippet ).toContain( 'title="Book The Room"' );
+		expect( snippet ).toContain( 'loading="lazy"' );
+		expect( snippet ).toContain( 'Open Book The Room on Extra Chill' );
+		expect( snippet ).toContain(
+			'parent-origin=https%3A%2F%2Fvenue.example'
+		);
+	} );
+
+	it( 'uses strict message source, origin, type, and bounded integer checks', () => {
+		const snippet = bookingEmbedSnippet(
+			'https://events.extrachill.com/venue/the-room/',
+			'The Room',
+			'https://venue.example'
+		);
+		expect( snippet ).toContain( 'e.source!==f.contentWindow' );
+		expect( snippet ).toContain(
+			"e.origin!=='https://events.extrachill.com'"
+		);
+		expect( snippet ).toContain( "d.type!=='extrachill:booking-height'" );
+		expect( snippet ).toContain( 'Number.isInteger(d.height)' );
+		expect( snippet ).not.toContain( "postMessage('*'" );
+		expect( snippet ).not.toMatch(
+			/contact|email|token|public_id|reference|intake/
+		);
+	} );
+} );

--- a/blocks/venue-settings/src/booking-tab.js
+++ b/blocks/venue-settings/src/booking-tab.js
@@ -1,3 +1,5 @@
+import { useState } from '@wordpress/element';
+
 /**
  * External dependencies
  */
@@ -14,6 +16,7 @@ import {
  * Internal dependencies
  */
 import { Status } from './status';
+import { bookingButtonSnippet, bookingEmbedSnippet } from './booking-embed';
 import {
 	HOLD_TTL_MAX_MINUTES,
 	normalizeKey,
@@ -132,12 +135,24 @@ export function BookingTab( {
 	onSave,
 	saving,
 	status,
+	bookingUrl,
+	venueName,
 } ) {
+	const [ copied, setCopied ] = useState( '' );
 	const errors = validateConfig( config );
 	const dirty = ! sameDocument( config, baseline );
 	const deal = config.default_deal;
 	const setDeal = ( patch ) =>
 		setConfig( { ...config, default_deal: { ...deal, ...patch } } );
+	const origins = config.embed.allowed_parent_origins;
+	const buttonSnippet = bookingButtonSnippet( bookingUrl, venueName );
+	const embedSnippet = origins.length
+		? bookingEmbedSnippet( bookingUrl, venueName, origins[ 0 ] )
+		: '';
+	const copy = async ( label, value ) => {
+		await navigator.clipboard.writeText( value );
+		setCopied( label );
+	};
 	return (
 		<Grid minColumnWidth="100%">
 			<Panel>
@@ -221,6 +236,85 @@ export function BookingTab( {
 						}
 					/>
 				</FieldGroup>
+			</Panel>
+			<Panel>
+				<PanelHeader
+					title="Booking link and embed"
+					description="Share the canonical booking page or authorize one exact HTTPS website to frame the hosted form."
+				/>
+				<FieldGroup
+					label="Canonical booking link"
+					htmlFor="venue-booking-link"
+				>
+					<input
+						id="venue-booking-link"
+						readOnly
+						value={ bookingUrl }
+					/>
+				</FieldGroup>
+				<ActionRow>
+					<button
+						type="button"
+						className="button-2"
+						onClick={ () => copy( 'link', bookingUrl ) }
+					>
+						Copy link
+					</button>
+					<button
+						type="button"
+						className="button-2"
+						onClick={ () => copy( 'button', buttonSnippet ) }
+					>
+						Copy button HTML
+					</button>
+					{ copied && <span role="status">Copied { copied }.</span> }
+				</ActionRow>
+				<FieldGroup
+					label="Allowed parent origins"
+					htmlFor="venue-booking-origins"
+					help="One exact HTTPS origin per line, such as https://venue.example. Paths, wildcards, ports, credentials, localhost, and IP addresses are rejected. The first origin is used for the generated snippet."
+				>
+					<textarea
+						id="venue-booking-origins"
+						rows="4"
+						value={ origins.join( '\n' ) }
+						onChange={ ( event ) =>
+							setConfig( {
+								...config,
+								embed: {
+									allowed_parent_origins: event.target.value
+										.split( /\r?\n/ )
+										.map( ( origin ) => origin.trim() )
+										.filter( Boolean ),
+								},
+							} )
+						}
+					/>
+				</FieldGroup>
+				{ embedSnippet && (
+					<>
+						<FieldGroup
+							label="Responsive iframe snippet"
+							htmlFor="venue-booking-embed-code"
+						>
+							<textarea
+								id="venue-booking-embed-code"
+								rows="8"
+								readOnly
+								value={ embedSnippet }
+							/>
+						</FieldGroup>
+						<button
+							type="button"
+							className="button-2"
+							onClick={ () =>
+								copy( 'embed snippet', embedSnippet )
+							}
+						>
+							Copy iframe snippet
+						</button>
+					</>
+				) }
 			</Panel>
 			<SpacesEditor
 				spaces={ config.spaces }

--- a/blocks/venue-settings/src/state.js
+++ b/blocks/venue-settings/src/state.js
@@ -1,3 +1,5 @@
+import { normalizeBookingOrigin } from './booking-embed';
+
 export const HOLD_TTL_MAX_MINUTES = 20160;
 
 export const editableConfig = ( config ) => {
@@ -29,6 +31,20 @@ export const normalizeKey = ( value ) =>
 
 export const validateConfig = ( config ) => {
 	const errors = [];
+	if (
+		! config.embed ||
+		! Array.isArray( config.embed.allowed_parent_origins ) ||
+		config.embed.allowed_parent_origins.some(
+			( origin ) => normalizeBookingOrigin( origin ) !== origin
+		)
+	) {
+		errors.push(
+			'Embed parent origins must be exact normalized HTTPS origins.'
+		);
+	}
+	if ( config.embed?.allowed_parent_origins?.length > 20 ) {
+		errors.push( 'Use no more than 20 embed parent origins.' );
+	}
 	if ( config.public_requirements.length > 20 ) {
 		errors.push( 'Use no more than 20 public requirements.' );
 	}

--- a/blocks/venue-settings/src/state.test.js
+++ b/blocks/venue-settings/src/state.test.js
@@ -11,7 +11,7 @@ import {
 } from './state';
 
 const validConfig = () => ( {
-	version: 4,
+	version: 5,
 	enabled: true,
 	intake: { version: 1, fields: [] },
 	public_requirements: [],
@@ -22,6 +22,7 @@ const validConfig = () => ( {
 		required: true,
 	},
 	booking_guide: { version: 1, entries: [] },
+	embed: { allowed_parent_origins: [] },
 	spaces: [ { key: 'main_room', name: 'Main Room', is_default: true } ],
 	default_deal: {
 		version: 1,

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -357,6 +357,8 @@ export function VenueSettingsApp( { context } ) {
 					onSave={ saveConfig }
 					saving={ savingConfig }
 					status={ configStatus }
+					bookingUrl={ context.booking_url }
+					venueName={ selected.name }
 				/>
 			) : (
 				<LoadingPanel label="Loading booking settings..." />

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -88,7 +88,7 @@ const profile = ( id ) => ( {
 	revision: String( id ).padStart( 64, '0' ),
 } );
 const config = ( id ) => ( {
-	version: 4,
+	version: 5,
 	revision: id,
 	updated_by_user_id: null,
 	updated_at: null,
@@ -102,6 +102,7 @@ const config = ( id ) => ( {
 		required: true,
 	},
 	booking_guide: { version: 1, entries: [] },
+	embed: { allowed_parent_origins: [] },
 	spaces: [],
 	default_deal: {
 		version: 1,
@@ -179,6 +180,7 @@ const context = ( overrides = {} ) => ( {
 	can_access: true,
 	can_manage: false,
 	route_url: 'https://events.example/venue-settings/',
+	booking_url: 'https://events.example/venue/venue-44/#booking-inquiry',
 	requested_venue_id: 0,
 	booking_id: 0,
 	support_events: [],

--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -312,6 +312,8 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingAttachmentService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingInquiryAdmissionService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingConfig.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingEmbed.php';
+		\ExtraChillEvents\Core\VenueBookingEmbed::register();
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/TicketReconciliationService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/TicketSettlementService.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ShowSettlementService.php';

--- a/inc/Abilities/VenueBookingConfigAbilities.php
+++ b/inc/Abilities/VenueBookingConfigAbilities.php
@@ -334,6 +334,22 @@ class VenueBookingConfigAbilities {
 				'additionalProperties' => false,
 			),
 			'booking_guide'             => $this->booking_guide_schema(),
+			'embed'                     => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'allowed_parent_origins' => array(
+						'type'        => 'array',
+						'maxItems'    => 20,
+						'uniqueItems' => true,
+						'items'       => array(
+							'type'      => 'string',
+							'maxLength' => 255,
+						),
+					),
+				),
+				'required'             => array( 'allowed_parent_origins' ),
+				'additionalProperties' => false,
+			),
 			'spaces'                    => array(
 				'type'     => 'array',
 				'maxItems' => 50,
@@ -410,7 +426,7 @@ class VenueBookingConfigAbilities {
 			),
 			'correspondence'            => $this->correspondence_schema(),
 		);
-		$required            = array( 'version', 'enabled', 'intake', 'public_requirements', 'consent', 'booking_guide', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
+		$required            = array( 'version', 'enabled', 'intake', 'public_requirements', 'consent', 'booking_guide', 'embed', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
 		if ( $include_metadata ) {
 			$properties['revision']           = array(
 				'type'    => 'integer',
@@ -435,7 +451,11 @@ class VenueBookingConfigAbilities {
 		if ( ! $accept_legacy ) {
 			return $schema;
 		}
-		$public_intake                                  = $schema;
+		$booking_guide                                  = $schema;
+		$booking_guide['properties']['version']['enum'] = array( VenueBookingConfig::BOOKING_GUIDE_CONFIG_VERSION );
+		$booking_guide['required']                      = array_values( array_diff( $booking_guide['required'], array( 'embed' ) ) );
+		unset( $booking_guide['properties']['embed'] );
+		$public_intake                                  = $booking_guide;
 		$public_intake['properties']['version']['enum'] = array( VenueBookingConfig::PUBLIC_INTAKE_VERSION );
 		$public_intake['required']                      = array_values( array_diff( $public_intake['required'], array( 'booking_guide' ) ) );
 		unset( $public_intake['properties']['booking_guide'] );
@@ -448,7 +468,7 @@ class VenueBookingConfigAbilities {
 		$legacy['properties']['version']['enum'] = array( VenueBookingConfig::LEGACY_VERSION );
 		$legacy['required']                      = array_values( array_diff( $legacy['required'], array( 'correspondence' ) ) );
 		unset( $legacy['properties']['correspondence'] );
-		return array( 'oneOf' => array( $legacy, $previous, $public_intake, $schema ) );
+		return array( 'oneOf' => array( $legacy, $previous, $public_intake, $booking_guide, $schema ) );
 	}
 
 	/** Return the versioned ordered booking-guide schema. */

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -16,7 +16,8 @@ class VenueBookingConfig {
 
 	public const META_KEY                    = '_extrachill_booking_config';
 	public const HISTORY_META_KEY            = '_extrachill_booking_config_history';
-	public const VERSION                     = 4;
+	public const VERSION                     = 5;
+	public const BOOKING_GUIDE_CONFIG_VERSION = 4;
 	public const PUBLIC_INTAKE_VERSION       = 3;
 	public const PREVIOUS_VERSION            = 2;
 	public const LEGACY_VERSION              = 1;
@@ -36,6 +37,30 @@ class VenueBookingConfig {
 
 	public function __construct( ?VenueAuthorization $authorization = null ) {
 		$this->authorization = $authorization;
+	}
+
+	/**
+	 * Normalize one exact, standard-port HTTPS web origin.
+	 *
+	 * @param mixed $origin Candidate origin.
+	 * @return string|\WP_Error
+	 */
+	public static function normalize_embed_origin( $origin ) {
+		if ( ! is_string( $origin ) || trim( $origin ) !== $origin || '' === $origin || false !== strpos( $origin, '*' ) ) {
+			return new \WP_Error( 'invalid_booking_embed_origin', __( 'Enter exact HTTPS origins without wildcards.', 'extrachill-events' ) );
+		}
+		$parts = wp_parse_url( $origin );
+		if ( ! is_array( $parts ) || 'https' !== strtolower( (string) ( $parts['scheme'] ?? '' ) ) || empty( $parts['host'] ) ) {
+			return new \WP_Error( 'invalid_booking_embed_origin', __( 'Booking embed origins must use HTTPS.', 'extrachill-events' ) );
+		}
+		if ( isset( $parts['user'] ) || isset( $parts['pass'] ) || isset( $parts['port'] ) || isset( $parts['query'] ) || isset( $parts['fragment'] ) || ( isset( $parts['path'] ) && '' !== $parts['path'] ) ) {
+			return new \WP_Error( 'invalid_booking_embed_origin', __( 'Booking embed origins cannot contain credentials, ports, paths, queries, or fragments.', 'extrachill-events' ) );
+		}
+		$host = strtolower( rtrim( (string) $parts['host'], '.' ) );
+		if ( 'localhost' === $host || filter_var( $host, FILTER_VALIDATE_IP ) || ! preg_match( '/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/', $host ) ) {
+			return new \WP_Error( 'invalid_booking_embed_origin', __( 'Booking embed origins must use a public DNS hostname.', 'extrachill-events' ) );
+		}
+		return 'https://' . $host;
 	}
 
 	/** Return validated config for a canonical venue term. */
@@ -73,7 +98,7 @@ class VenueBookingConfig {
 		}
 
 		$stored = get_term_meta( $venue_term_id, self::META_KEY, true );
-		if ( ! is_array( $stored ) || ! in_array( $stored['version'] ?? null, array( self::PUBLIC_INTAKE_VERSION, self::VERSION ), true ) ) {
+		if ( ! is_array( $stored ) || ! in_array( $stored['version'] ?? null, array( self::PUBLIC_INTAKE_VERSION, self::BOOKING_GUIDE_CONFIG_VERSION, self::VERSION ), true ) ) {
 			return new \WP_Error( 'invalid_booking_public_config', __( 'The public venue booking configuration is unavailable.', 'extrachill-events' ) );
 		}
 
@@ -292,7 +317,7 @@ class VenueBookingConfig {
 	/** Normalize and validate the complete versioned contract. */
 	public function normalize( array $config ) {
 		$version = $config['version'] ?? self::LEGACY_VERSION;
-		if ( ! is_int( $version ) || ! in_array( $version, array( self::LEGACY_VERSION, self::PREVIOUS_VERSION, self::PUBLIC_INTAKE_VERSION, self::VERSION ), true ) ) {
+		if ( ! is_int( $version ) || ! in_array( $version, array( self::LEGACY_VERSION, self::PREVIOUS_VERSION, self::PUBLIC_INTAKE_VERSION, self::BOOKING_GUIDE_CONFIG_VERSION, self::VERSION ), true ) ) {
 			return new \WP_Error( 'booking_config_version_unsupported', __( 'The venue booking configuration version is unsupported.', 'extrachill-events' ), array( 'version' => $version ) );
 		}
 		$version_three_fields = array( 'public_requirements', 'consent', 'marketing_triggers' );
@@ -302,11 +327,14 @@ class VenueBookingConfig {
 		if ( $version >= self::PUBLIC_INTAKE_VERSION && ! array_key_exists( 'marketing_triggers', $config ) ) {
 			return new \WP_Error( 'booking_config_version_field_invalid', __( 'Venue booking configuration version 3 requires marketing triggers.', 'extrachill-events' ), array( 'version' => $version ) );
 		}
-		if ( $version < self::VERSION && array_key_exists( 'booking_guide', $config ) ) {
+		if ( $version < self::BOOKING_GUIDE_CONFIG_VERSION && array_key_exists( 'booking_guide', $config ) ) {
 			return new \WP_Error( 'booking_config_version_field_invalid', __( 'Booking guide settings require venue booking configuration version 4.', 'extrachill-events' ), array( 'version' => $version ) );
 		}
-		if ( self::VERSION === $version && ! array_key_exists( 'booking_guide', $config ) ) {
+		if ( $version >= self::BOOKING_GUIDE_CONFIG_VERSION && ! array_key_exists( 'booking_guide', $config ) ) {
 			return new \WP_Error( 'booking_config_version_field_invalid', __( 'Venue booking configuration version 4 requires a booking guide.', 'extrachill-events' ), array( 'version' => $version ) );
+		}
+		if ( $version < self::VERSION && array_key_exists( 'embed', $config ) ) {
+			return new \WP_Error( 'booking_config_version_field_invalid', __( 'Embed settings require venue booking configuration version 5.', 'extrachill-events' ), array( 'version' => $version ) );
 		}
 		$intake_version         = $config['intake']['version'] ?? 1;
 		$deal_version           = $config['default_deal']['version'] ?? 1;
@@ -357,6 +385,10 @@ class VenueBookingConfig {
 		if ( is_wp_error( $booking_guide ) ) {
 			return $booking_guide;
 		}
+		$embed = $this->normalize_embed( $config['embed'] ?? array() );
+		if ( is_wp_error( $embed ) ) {
+			return $embed;
+		}
 		$channels = $this->normalize_channels( $config['marketing_channels'] ?? array() );
 		if ( is_wp_error( $channels ) ) {
 			return $channels;
@@ -401,6 +433,7 @@ class VenueBookingConfig {
 			'public_requirements'       => $requirements,
 			'consent'                   => $consent,
 			'booking_guide'             => $booking_guide,
+			'embed'                     => $embed,
 			'spaces'                    => $spaces,
 			'default_deal'              => array(
 				'version'                    => 1,
@@ -442,6 +475,7 @@ class VenueBookingConfig {
 				'version' => self::BOOKING_GUIDE_VERSION,
 				'entries' => array(),
 			),
+			'embed'                     => array( 'allowed_parent_origins' => array() ),
 			'spaces'                    => array(),
 			'default_deal'              => array(
 				'version'                    => 1,
@@ -1030,9 +1064,36 @@ class VenueBookingConfig {
 		return '' === $value ? null : mb_substr( $value, 0, $length );
 	}
 
+	/**
+	 * Normalize exact HTTPS origins used by the hosted booking embed.
+	 *
+	 * @param mixed $embed Candidate embed config.
+	 * @return array|\WP_Error
+	 */
+	private function normalize_embed( $embed ) {
+		$allowed_parent_origins = is_array( $embed ) ? ( $embed['allowed_parent_origins'] ?? array() ) : null;
+		if ( ! is_array( $allowed_parent_origins ) ) {
+			return new \WP_Error( 'invalid_booking_embed_config', __( 'Booking embed settings are malformed.', 'extrachill-events' ) );
+		}
+		if ( count( $allowed_parent_origins ) > 20 ) {
+			return new \WP_Error( 'invalid_booking_embed_config', __( 'Configure no more than 20 booking embed origins.', 'extrachill-events' ) );
+		}
+
+		$origins = array();
+		foreach ( $allowed_parent_origins as $origin ) {
+			$normalized = self::normalize_embed_origin( $origin );
+			if ( is_wp_error( $normalized ) ) {
+				return $normalized;
+			}
+			$origins[] = $normalized;
+		}
+
+		return array( 'allowed_parent_origins' => array_values( array_unique( $origins ) ) );
+	}
+
 	/** Return top-level settings changed by the replacement document. */
 	private function changed_fields( array $current, array $next ): array {
-		$fields  = array( 'enabled', 'intake', 'public_requirements', 'consent', 'booking_guide', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
+		$fields  = array( 'enabled', 'intake', 'public_requirements', 'consent', 'booking_guide', 'embed', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
 		$changed = array();
 		foreach ( $fields as $field ) {
 			if ( $current[ $field ] !== $next[ $field ] ) {

--- a/inc/Core/VenueBookingEmbed.php
+++ b/inc/Core/VenueBookingEmbed.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Secure hosted venue booking embed.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Owns admission, framing policy, and rendering for the hosted embed. */
+final class VenueBookingEmbed {
+	private const QUERY_FLAG   = 'booking-embed';
+	private const QUERY_PARENT = 'parent-origin';
+
+	/** @var array|null Validated request context. */
+	private static $context = null;
+
+	/** Register the embed request lifecycle. */
+	public static function register(): void {
+		add_action( 'template_redirect', array( self::class, 'authorize_request' ), 0 );
+		add_filter( 'extrachill_template_archive', array( self::class, 'template' ), 100 );
+	}
+
+	/**
+	 * Normalize one exact, standard-port HTTPS web origin.
+	 *
+	 * @param mixed $origin Candidate origin.
+	 * @return string|\WP_Error
+	 */
+	public static function normalize_origin( $origin ) {
+		return VenueBookingConfig::normalize_embed_origin( $origin );
+	}
+
+	/**
+	 * Check enabled admission and exact origin membership.
+	 *
+	 * @param array  $config        Private venue booking config.
+	 * @param string $parent_origin Normalized parent origin.
+	 */
+	public static function is_origin_allowed( array $config, string $parent_origin ): bool {
+		return ! empty( $config['enabled'] )
+			&& in_array( $parent_origin, $config['embed']['allowed_parent_origins'] ?? array(), true );
+	}
+
+	/**
+	 * Return the scoped CSP frame-ancestors directive.
+	 *
+	 * @param string $parent_origin Validated parent origin, or empty to deny.
+	 */
+	public static function frame_ancestors_policy( string $parent_origin = '' ): string {
+		return '' === $parent_origin ? "frame-ancestors 'none'" : "frame-ancestors 'self' " . $parent_origin;
+	}
+
+	/** Admit only enabled venue embeds bound to a configured parent origin. */
+	public static function authorize_request(): void {
+		if ( ! self::is_embed_request() ) {
+			return;
+		}
+
+		$venue  = get_queried_object();
+		$config = $venue instanceof \WP_Term ? ( new VenueBookingConfig() )->get( (int) $venue->term_id ) : null;
+		$parent = self::requested_parent_origin();
+		if ( ! is_array( $config ) || is_wp_error( $parent ) || ! self::is_origin_allowed( $config, $parent ) ) {
+			self::$context = array( 'denied' => true );
+			status_header( 403 );
+			nocache_headers();
+			self::send_headers();
+			wp_die( esc_html__( 'This venue booking embed is not authorized for that website.', 'extrachill-events' ), esc_html__( 'Booking embed unavailable', 'extrachill-events' ), array( 'response' => 403 ) );
+		}
+
+		self::$context = array(
+			'parent_origin' => $parent,
+			'venue_id'      => (int) $venue->term_id,
+			'venue_name'    => $venue->name,
+			'booking_url'   => self::booking_url( $venue ),
+		);
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', true );
+		}
+		nocache_headers();
+		self::send_headers();
+	}
+
+	/** Emit headers only after request admission has established context. */
+	public static function send_headers(): void {
+		if ( ! self::is_embed_request() ) {
+			return;
+		}
+		if ( ! empty( self::$context['parent_origin'] ) ) {
+			header_remove( 'X-Frame-Options' );
+			header( 'Content-Security-Policy: ' . self::frame_ancestors_policy( self::$context['parent_origin'] ) );
+			header( 'Referrer-Policy: strict-origin' );
+			header( 'Cache-Control: no-store, private' );
+			return;
+		}
+		header( 'Content-Security-Policy: ' . self::frame_ancestors_policy() );
+	}
+
+	/**
+	 * Select the chrome-free template for an admitted embed.
+	 *
+	 * @param string $template Existing archive template.
+	 */
+	public static function template( string $template ): string {
+		return ! empty( self::$context['parent_origin'] ) ? EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/templates/booking-embed.php' : $template;
+	}
+
+	/** Return the validated template context. */
+	public static function context(): array {
+		return is_array( self::$context ) ? self::$context : array();
+	}
+
+	/**
+	 * Return the canonical hosted booking anchor for a venue.
+	 *
+	 * @param \WP_Term $venue Canonical venue term.
+	 */
+	public static function booking_url( \WP_Term $venue ): string {
+		$url = get_term_link( $venue );
+		return is_wp_error( $url ) ? '' : $url . '#booking-inquiry';
+	}
+
+	/** Detect the exact public embed selector. */
+	private static function is_embed_request(): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Exact scalar flag is compared below; CSP and private config authorize framing.
+		return is_tax( 'venue' ) && isset( $_GET[ self::QUERY_FLAG ] ) && is_scalar( $_GET[ self::QUERY_FLAG ] ) && '1' === (string) wp_unslash( $_GET[ self::QUERY_FLAG ] );
+	}
+
+	/** Return the normalized parent-origin selector. */
+	private static function requested_parent_origin() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Unslashed scalar is strictly parsed and matched to private venue config.
+		$value = isset( $_GET[ self::QUERY_PARENT ] ) && is_scalar( $_GET[ self::QUERY_PARENT ] ) ? wp_unslash( (string) $_GET[ self::QUERY_PARENT ] ) : '';
+		return self::normalize_origin( $value );
+	}
+}

--- a/inc/templates/booking-embed.php
+++ b/inc/templates/booking-embed.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Events-hosted venue booking embed document.
+ *
+ * @package ExtraChillEvents
+ */
+
+use ExtraChillEvents\Core\VenueBookingEmbed;
+
+defined( 'ABSPATH' ) || exit;
+
+$context = VenueBookingEmbed::context();
+$markup  = do_blocks( '<!-- wp:extrachill/venue-booking-inquiry {"venueId":' . absint( $context['venue_id'] ?? 0 ) . '} /-->' );
+?><!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php // translators: %s is the venue name. ?>
+	<title><?php echo esc_html( sprintf( __( 'Book %s', 'extrachill-events' ), $context['venue_name'] ?? '' ) ); ?></title>
+	<?php wp_head(); ?>
+	<style>html,body{margin:0;background:transparent}.ec-booking-embed{padding:1rem;max-width:72rem;margin:0 auto}.ec-booking-embed__fallback{text-align:center}</style>
+</head>
+<body class="ec-booking-embed-document">
+	<main class="ec-booking-embed">
+		<?php echo $markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Trusted dynamic block output. ?>
+		<p class="ec-booking-embed__fallback"><a href="<?php echo esc_url( $context['booking_url'] ?? '' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Open this booking form on Extra Chill', 'extrachill-events' ); ?></a></p>
+	</main>
+	<script>
+	( function () {
+		const parentOrigin = <?php echo wp_json_encode( $context['parent_origin'] ?? '', JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+		const sendHeight = () => window.parent.postMessage( { type: 'extrachill:booking-height', height: Math.ceil( document.documentElement.scrollHeight ) }, parentOrigin );
+		new ResizeObserver( sendHeight ).observe( document.documentElement );
+		window.addEventListener( 'load', sendHeight );
+	}() );
+	</script>
+	<?php wp_footer(); ?>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"test:browser": "node tests/browser/local-support.evidence.js",
 		"test:browser:vendor-request": "node tests/browser/vendor-request.evidence.js",
 		"test:browser:booking-inquiry": "node tests/browser/booking-inquiry.evidence.js",
+		"test:browser:booking-embed": "node tests/browser/booking-embed.evidence.js",
 		"lint:js": "wp-scripts lint-js",
 		"lint:js:fix": "wp-scripts lint-js --fix"
 	},

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -10,6 +10,7 @@ use ExtraChillEvents\Core\BookingLifecycle;
 use ExtraChillEvents\Core\BookingRepository;
 use ExtraChillEvents\Core\BookingSchema;
 use ExtraChillEvents\Core\VenueBookingConfig;
+use ExtraChillEvents\Core\VenueBookingEmbed;
 use ExtraChillEvents\Abilities\VenueBookingAbilities;
 use ExtraChillEvents\Core\VenueAuthorization;
 use PHPUnit\Framework\TestCase;
@@ -599,12 +600,44 @@ final class BookingFoundationTest extends BookingTestCase {
 		$migrated = $service->normalize( array( 'version' => 1, 'enabled' => true ) );
 		$this->assertSame( VenueBookingConfig::VERSION, $migrated['version'] );
 		$this->assertArrayHasKey( 'correspondence', $migrated );
-		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => 5 ) )->get_error_code() );
+		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => 6 ) )->get_error_code() );
 		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => '1junk' ) )->get_error_code() );
 		$this->assertSame( 'booking_config_section_version_unsupported', $service->normalize( array( 'intake' => array( 'version' => 2 ) ) )->get_error_code() );
 		$this->assertSame( 'booking_config_section_version_unsupported', $service->normalize( array( 'correspondence' => array( 'version' => 2 ) ) )->get_error_code() );
 		$GLOBALS['ec_artist_test']['meta'][7][55][ VenueBookingConfig::META_KEY ] = array( 'version' => 99 );
 		$this->assertSame( 'booking_config_version_unsupported', $service->get( 55 )->get_error_code() );
+	}
+
+	public function test_config_normalizes_exact_https_embed_origins_and_migrates_version_four(): void {
+		$service = new VenueBookingConfig();
+		$config  = $service->defaults();
+		$config['embed']['allowed_parent_origins'] = array( 'https://Venue.Example', 'https://venue.example' );
+		$normalized = $service->normalize( $config );
+
+		$this->assertSame( array( 'https://venue.example' ), $normalized['embed']['allowed_parent_origins'] );
+		foreach ( array( 'http://venue.example', 'https://venue.example/path', 'https://user@venue.example', 'https://*.example', 'https://localhost', 'https://127.0.0.1', 'https://venue.example:8443', 'https://venue.example#frame' ) as $origin ) {
+			$config['embed']['allowed_parent_origins'] = array( $origin );
+			$this->assertSame( 'invalid_booking_embed_origin', $service->normalize( $config )->get_error_code(), $origin );
+		}
+
+		$version_four = $service->defaults();
+		$version_four['version'] = 4;
+		unset( $version_four['embed'] );
+		$migrated = $service->normalize( $version_four );
+		$this->assertSame( VenueBookingConfig::VERSION, $migrated['version'] );
+		$this->assertSame( array(), $migrated['embed']['allowed_parent_origins'] );
+	}
+
+	public function test_embed_admission_and_frame_policy_fail_closed(): void {
+		$config = ( new VenueBookingConfig() )->defaults();
+		$config['embed']['allowed_parent_origins'] = array( 'https://venue.example' );
+
+		$this->assertFalse( VenueBookingEmbed::is_origin_allowed( $config, 'https://venue.example' ) );
+		$config['enabled'] = true;
+		$this->assertTrue( VenueBookingEmbed::is_origin_allowed( $config, 'https://venue.example' ) );
+		$this->assertFalse( VenueBookingEmbed::is_origin_allowed( $config, 'https://attacker.example' ) );
+		$this->assertSame( "frame-ancestors 'none'", VenueBookingEmbed::frame_ancestors_policy() );
+		$this->assertSame( "frame-ancestors 'self' https://venue.example", VenueBookingEmbed::frame_ancestors_policy( 'https://venue.example' ) );
 	}
 
 	public function test_config_accepts_fourteen_day_holds_and_rejects_longer_values(): void {

--- a/tests/BookingMarketingTest.php
+++ b/tests/BookingMarketingTest.php
@@ -1300,7 +1300,7 @@ final class BookingMarketingTest extends BookingTestCase {
 	public function test_version_two_configs_migrate_without_implicit_marketing_triggers(): void {
 		$config            = ( new VenueBookingConfig() )->defaults();
 		$config['version'] = VenueBookingConfig::PREVIOUS_VERSION;
-		unset( $config['public_requirements'], $config['consent'], $config['marketing_triggers'], $config['booking_guide'] );
+		unset( $config['public_requirements'], $config['consent'], $config['marketing_triggers'], $config['booking_guide'], $config['embed'] );
 		$normalized = ( new VenueBookingConfig() )->normalize( $config );
 		$this->assertSame( VenueBookingConfig::VERSION, $normalized['version'] );
 		$this->assertSame( array(), $normalized['marketing_triggers'] );

--- a/tests/Support/BookingTestHarness.php
+++ b/tests/Support/BookingTestHarness.php
@@ -2181,6 +2181,7 @@ require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingAttachmentDeliveryReposit
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingAttachmentService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingInquiryAdmissionService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueBookingConfig.php';
+require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueBookingEmbed.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/BookingCorrespondenceAutomationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/TicketReconciliationService.php';
 require_once dirname( __DIR__, 2 ) . '/inc/Core/TicketSettlementService.php';

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -1844,7 +1844,7 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertSame( 'venue_action_forbidden', call_user_func( $get['permission_callback'], array( 'venue_term_id' => 56 ) )->get_error_code() );
 		$config_input  = $update['input_schema']['properties']['config'];
 		$config_output = $get['output_schema'];
-		$this->assertCount( 4, $config_input['oneOf'] );
+		$this->assertCount( 5, $config_input['oneOf'] );
 		$this->assertSame( array( 1 ), $config_input['oneOf'][0]['properties']['version']['enum'] );
 		$this->assertNotContains( 'correspondence', $config_input['oneOf'][0]['required'] );
 		$this->assertNotContains( 'public_requirements', $config_input['oneOf'][0]['required'] );
@@ -1862,7 +1862,10 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertNotContains( 'booking_guide', $config_input['oneOf'][2]['required'] );
 		$this->assertSame( array( 4 ), $config_input['oneOf'][3]['properties']['version']['enum'] );
 		$this->assertContains( 'booking_guide', $config_input['oneOf'][3]['required'] );
-		$this->assertSame( array( 4 ), $config_output['properties']['version']['enum'] );
+		$this->assertNotContains( 'embed', $config_input['oneOf'][3]['required'] );
+		$this->assertSame( array( 5 ), $config_input['oneOf'][4]['properties']['version']['enum'] );
+		$this->assertContains( 'embed', $config_input['oneOf'][4]['required'] );
+		$this->assertSame( array( 5 ), $config_output['properties']['version']['enum'] );
 		$correspondence_output = $config_output['properties']['correspondence'];
 		$this->assertSame( 6, $correspondence_output['properties']['variables']['maxItems'] );
 		$this->assertContains( 'cc_address', $correspondence_output['required'] );
@@ -1889,11 +1892,11 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 
 		$legacy = ( new VenueBookingConfig() )->defaults();
 		$legacy['version'] = 1;
-		unset( $legacy['correspondence'], $legacy['public_requirements'], $legacy['consent'], $legacy['marketing_triggers'], $legacy['booking_guide'] );
+		unset( $legacy['correspondence'], $legacy['public_requirements'], $legacy['consent'], $legacy['marketing_triggers'], $legacy['booking_guide'], $legacy['embed'] );
 		unset( $legacy['revision'], $legacy['updated_by_user_id'], $legacy['updated_at'] );
 		$GLOBALS['venue_membership_test']['term_meta'][55][ VenueBookingConfig::META_KEY ] = $legacy;
 		$current = call_user_func( $get['execute_callback'], array( 'venue_term_id' => 55 ) );
-		$this->assertSame( 4, $current['version'] );
+		$this->assertSame( 5, $current['version'] );
 		$this->assertSame( 'Contact phone', $current['intake']['presentation']['contact_phone_label'] );
 		$this->assertArrayHasKey( 'correspondence', $current );
 		$this->assertSame( array(), $current['marketing_triggers'] );

--- a/tests/browser/booking-embed.evidence.js
+++ b/tests/browser/booking-embed.evidence.js
@@ -1,0 +1,95 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+const assert = require( 'node:assert/strict' );
+const { chromium } = require( 'playwright' );
+
+const child = `<!doctype html><html><body style="margin:0"><main style="height:840px"><h1>Book The Room</h1><a href="https://events.example/venue/the-room/#booking-inquiry" target="_blank">Open this booking form on Extra Chill</a></main><script>(function(){const parentOrigin='https://allowed.example';const sendHeight=()=>window.parent.postMessage({type:'extrachill:booking-height',height:Math.ceil(document.documentElement.scrollHeight)},parentOrigin);new ResizeObserver(sendHeight).observe(document.documentElement);window.addEventListener('load',sendHeight);}());</script></body></html>`;
+const parent = ( childUrl ) =>
+	`<!doctype html><html><body><iframe id="booking" src="${ childUrl }" title="Book The Room" loading="lazy" style="width:100%;min-height:320px;border:0"></iframe><script>(function(){const frame=document.getElementById('booking');window.bookingMessages=[];window.addEventListener('message',function(event){const data=event.data;if(event.source!==frame.contentWindow||event.origin!=='https://events.example'||!data||data.type!=='extrachill:booking-height'||!Number.isInteger(data.height)||data.height<320||data.height>10000){return;}window.bookingMessages.push(data);frame.style.height=data.height+'px';});}());</script></body></html>`;
+
+( async () => {
+	const browser = await chromium.launch( { headless: true } );
+	try {
+		const childUrl =
+			'https://events.example/venue/the-room/?booking-embed=1&parent-origin=https%3A%2F%2Fallowed.example';
+		const allowed = await browser.newPage();
+		await allowed.route( '**/*', async ( route ) => {
+			const url = route.request().url();
+			if ( url.startsWith( 'https://events.example/' ) ) {
+				await route.fulfill( {
+					contentType: 'text/html',
+					headers: {
+						'Content-Security-Policy':
+							"frame-ancestors 'self' https://allowed.example",
+						'Cache-Control': 'no-store, private',
+					},
+					body: child,
+				} );
+				return;
+			}
+			await route.fulfill( {
+				contentType: 'text/html',
+				body: parent( childUrl ),
+			} );
+		} );
+		await allowed.goto( 'https://allowed.example/' );
+		await allowed.waitForFunction(
+			() => window.bookingMessages.length > 0
+		);
+		const evidence = await allowed.evaluate( () => ( {
+			messages: window.bookingMessages,
+			height: document.getElementById( 'booking' ).style.height,
+		} ) );
+		assert.match( evidence.height, /^\d+px$/ );
+		assert.deepEqual( Object.keys( evidence.messages[ 0 ] ).sort(), [
+			'height',
+			'type',
+		] );
+		assert.equal(
+			await allowed
+				.frameLocator( '#booking' )
+				.getByRole( 'link', {
+					name: 'Open this booking form on Extra Chill',
+				} )
+				.count(),
+			1
+		);
+
+		const denied = await browser.newPage();
+		await denied.route( '**/*', async ( route ) => {
+			if (
+				route.request().url().startsWith( 'https://events.example/' )
+			) {
+				await route.fulfill( {
+					contentType: 'text/html',
+					headers: {
+						'Content-Security-Policy':
+							"frame-ancestors 'self' https://allowed.example",
+					},
+					body: child,
+				} );
+				return;
+			}
+			await route.fulfill( {
+				contentType: 'text/html',
+				body: parent( childUrl ),
+			} );
+		} );
+		await denied.goto( 'https://denied.example/' );
+		await denied.waitForTimeout( 250 );
+		assert.equal(
+			await denied.evaluate( () => window.bookingMessages.length ),
+			0
+		);
+		assert.equal(
+			denied.frames().some( ( frame ) => frame.url() === childUrl ),
+			false
+		);
+	} finally {
+		await browser.close();
+	}
+	process.stdout.write( 'Booking embed browser evidence passed.\n' );
+} )().catch( ( error ) => {
+	console.error( error );
+	process.exitCode = 1;
+} );


### PR DESCRIPTION
## Summary
- add an authorized venue-settings generator for canonical booking links, button HTML, and responsive iframe snippets
- add a chrome-free Events-hosted embed document that reuses `extrachill/venue-booking-inquiry` and the existing Extra Chill API availability/inquiry transport
- add fail-closed per-venue HTTPS parent-origin authorization, scoped CSP framing, strict-origin height messaging, and allowed/denied browser coverage

Closes #549.

## Architecture
Events continues to own canonical venue booking configuration, admission state, the venue archive, and the hosted document. The existing booking inquiry block remains the only form implementation, while Extra Chill API remains the owner of protected availability and inquiry HTTP transport, including Turnstile, idempotency, validation, route affinity, and receipt references. No Events REST route, CORS expansion, or parallel write backend was added.

WordPress's existing dynamic block rendering and template selection primitives are reused. Core oEmbed was reviewed but does not provide the required private per-venue parent authorization or strict responsive message contract, so this PR adds only that gap.

## Security Model
- booking config v5 stores up to 20 exact normalized HTTPS parent origins in the existing private revisioned/audited config document
- paths, credentials, wildcards, fragments, localhost, IP literals, and explicit/nonstandard ports are rejected
- version 1-4 documents migrate to an empty allowlist, so framing is denied by default
- embed admission requires booking to be enabled and the requested parent origin to be present in the private allowlist
- admitted responses remove iframe-conflicting X-Frame-Options only for the embed response and emit `frame-ancestors 'self' <selected-origin>`; denied responses emit `frame-ancestors 'none'`
- responsive messages target the selected parent origin and contain only `type` and bounded integer `height`; generated parent code verifies source, Events origin, type, and bounds
- the iframe remains anonymous-compatible with third-party cookies blocked and includes an accessible fallback link, title, lazy loading, strict referrer policy, and a constrained sandbox

## Compatibility
Existing v4 configs normalize to v5 with an empty `embed.allowed_parent_origins` list. The allowlist is omitted from the public booking projection and is available only through the already-authorized venue config ability. Normal archive headers and anti-clickjacking behavior are unchanged.

## Verification
- `vendor/bin/phpunit -c phpunit-booking.xml.dist` (462 tests, 4,842 assertions)
- `npm run test:js -- --runInBand` (87 tests)
- `npm run lint:js`
- `npm run build`
- `npm run test:browser:booking-inquiry` (desktop and mobile)
- `npm run test:browser:booking-embed` (allowed resize/fallback and denied CSP parent)
- PHP syntax checks for all changed production PHP files
- `git diff --check`

The repository's standalone WordPress render test remains dependent on its unavailable `WP_UnitTestCase` bootstrap; the existing complete booking harness and browser fixtures cover this change. No API change or additional browser work is deferred.