### PR TITLE
fix: defer booking admission service construction

### DIFF
--- a/inc/Abilities/VenueBookingAbilities.php
+++ b/inc/Abilities/VenueBookingAbilities.php
@@ -39,7 +39,11 @@ class VenueBookingAbilities {
 	 * @var BookingLifecycle
 	 */
 	private $lifecycle;
-	/** @var BookingInquiryAdmissionService */
+	/**
+	 * Inquiry admission service, constructed only when an inquiry executes.
+	 *
+	 * @var BookingInquiryAdmissionService|null
+	 */
 	private $inquiry_admission;
 	/**
 	 * Exact venue authorization policy.
@@ -94,7 +98,7 @@ class VenueBookingAbilities {
 		$this->authorization     = $authorization ? $authorization : new VenueAuthorization();
 		$this->holds             = $holds ? $holds : new BookingHoldRepository( $this->bookings, null, $this->authorization );
 		$this->lifecycle         = $lifecycle ? $lifecycle : new BookingLifecycle( $this->bookings, null, $this->authorization, null, $this->holds );
-		$this->inquiry_admission = $inquiry_admission ? $inquiry_admission : new BookingInquiryAdmissionService( $this->lifecycle );
+		$this->inquiry_admission = $inquiry_admission;
 		if ( ! self::$registered ) {
 			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
 			self::$registered = true;
@@ -360,6 +364,9 @@ class VenueBookingAbilities {
 	 * @param array $input Ability input.
 	 */
 	public function create_inquiry( array $input ) {
+		if ( null === $this->inquiry_admission ) {
+			$this->inquiry_admission = new BookingInquiryAdmissionService( $this->lifecycle );
+		}
 		$user_id = get_current_user_id();
 		return $this->inquiry_admission->admit( $input, $user_id > 0 ? $user_id : null );
 	}

--- a/tests/AbilityRegistrationLifecycleTest.php
+++ b/tests/AbilityRegistrationLifecycleTest.php
@@ -49,7 +49,10 @@ final class AbilityRegistrationLifecycleTest extends BookingTestCase {
 		$this->assertStringContainsString( 'BookingSchema::is_ready()', $bootstrap );
 		$this->assertStringContainsString( 'LocalSupportSchema::is_ready()', $bootstrap );
 
-		new VenueBookingAbilities();
+		$booking_abilities = new VenueBookingAbilities();
+		$admission_service = new ReflectionProperty( VenueBookingAbilities::class, 'inquiry_admission' );
+		$admission_service->setAccessible( true );
+		$this->assertNull( $admission_service->getValue( $booking_abilities ) );
 		new VenueMembershipAbilities();
 		new VenueBookingHoldAbilities();
 		new VenueBookingEventAbilities();


### PR DESCRIPTION
## Summary
- lazily construct the booking inquiry admission service when an inquiry executes
- preserve early ability hook registration without initializing translated private-file validation during `plugins_loaded`
- cover the bootstrap lifecycle by asserting the admission service remains unconstructed

## Root cause
`ExtraChillEvents::init_abilities()` constructs `VenueBookingAbilities` on `plugins_loaded`. Its constructor eagerly created `BookingInquiryAdmissionService`, which resolved `LocalBookingPrivateFileProvider`; root validation then called `__()` before WordPress allowed just-in-time translation loading.

## Verification
- `vendor/bin/phpunit tests/AbilityRegistrationLifecycleTest.php` (1 test, 15 assertions)
- `vendor/bin/phpunit tests/BookingFoundationTest.php` (41 tests, 403 assertions)
- `git diff --check`
- changed-file PHPCS reports only pre-existing filename and unrelated docblock violations

Closes #520
