### PR TITLE
fix: restore and simplify venue booking

### DIFF
--- a/blocks/venue-settings/src/api.js
+++ b/blocks/venue-settings/src/api.js
@@ -10,8 +10,6 @@ const METHODS = {
 	'extrachill/list-venue-invitations': 'GET',
 	'extrachill/list-venue-email-subscribers': 'GET',
 	'extrachill/list-venue-claims': 'GET',
-	'extrachill/list-venue-bookings': 'GET',
-	'extrachill/get-venue-booking': 'GET',
 	'extrachill/get-venue-booking-activity': 'GET',
 	'extrachill/list-booking-holds': 'GET',
 	'extrachill/list-booking-communications': 'GET',

--- a/blocks/venue-settings/src/api.test.js
+++ b/blocks/venue-settings/src/api.test.js
@@ -32,6 +32,19 @@ describe( 'venue settings ability transport', () => {
 		);
 	} );
 
+	it.each( [
+		'extrachill/list-venue-bookings',
+		'extrachill/get-venue-booking',
+	] )( 'uses POST for reconciliation read %s', async ( ability ) => {
+		const input = { venue_term_id: 44 };
+		await runAbility( ability, input );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: `/wp-abilities/v1/abilities/${ ability }/run`,
+			method: 'POST',
+			data: { input },
+		} );
+	} );
+
 	it( 'uses DELETE for idempotent destructive cancellation', async () => {
 		await runAbility( 'extrachill/cancel-venue-invitation', {
 			invitation_id: 9,

--- a/blocks/venue-settings/src/booking-console.js
+++ b/blocks/venue-settings/src/booking-console.js
@@ -590,7 +590,11 @@ function ErrorState( { message, onRetry } ) {
 	return (
 		<InlineStatus tone="error">
 			{ message }
-			<button type="button" className="button-link" onClick={ onRetry }>
+			<button
+				type="button"
+				className="button-2 button-small"
+				onClick={ onRetry }
+			>
 				Retry
 			</button>
 		</InlineStatus>

--- a/blocks/venue-settings/src/status.js
+++ b/blocks/venue-settings/src/status.js
@@ -17,7 +17,7 @@ export const Status = ( { state, onRetry } ) => {
 				{ onRetry && (
 					<button
 						type="button"
-						className="button-link"
+						className="button-2 button-small"
 						onClick={ onRetry }
 					>
 						Retry

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -573,6 +573,9 @@ describe( 'venue settings authorization-facing states', () => {
 			} )
 		);
 		expect( container.textContent ).toContain( 'Claims unavailable.' );
+		expect( buttonByText( container, 'Retry' ).className ).toBe(
+			'button-2 button-small'
+		);
 		await act( async () => {
 			buttonByText( container, 'Retry' ).click();
 			await Promise.resolve();

--- a/inc/core/page-cache.php
+++ b/inc/core/page-cache.php
@@ -10,6 +10,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 add_filter( 'extrachill_cache_post_change_urls', 'extrachill_events_cache_invalidation_urls', 10, 3 );
+add_action( 'extrachill_events_venue_booking_config_updated', 'extrachill_events_purge_booking_archive_cache', 10, 1 );
+
+/** Purge the public venue archive after its booking form configuration changes. */
+function extrachill_events_purge_booking_archive_cache( $venue_term_id ) {
+	if ( ! function_exists( 'extrachill_cache_delete_url' ) ) {
+		return;
+	}
+
+	$venue_url = get_term_link( absint( $venue_term_id ), 'venue' );
+	if ( ! is_wp_error( $venue_url ) ) {
+		extrachill_cache_delete_url( $venue_url, get_current_blog_id() );
+	}
+}
 
 /**
  * Return event pages affected by an event save.


### PR DESCRIPTION
## Summary
- restore the operator console by sending reconciliation reads through POST
- invalidate venue archive cache when booking configuration changes
- replace wp-admin Retry styling with existing Extra Chill button classes
- make public intake date-only, with single-space venues implicit
- surface the configured application requirements before availability
- group the application into contact, event, media, and final-detail sections
- remove all booking-specific CSS and use shared components plus theme badge/checkbox primitives

## Production evidence
- Lo-Fi term 1524 was enabled while anonymous cache served the pre-launch archive without the form
- the stale cache entry was purged and anonymous HTML now contains `#booking-inquiry`
- original browser evidence only validated overflow and selector existence, not useful field visibility or hierarchy

## Verification
- venue settings focused tests: 32 passed
- booking inquiry focused tests: 8 passed
- desktop/mobile Playwright evidence passed with no overflow
- `npm run build:venue-settings`
- `npm run build:venue-booking-inquiry`
- `php -l inc/core/page-cache.php`
- `git diff --check`

Closes #555
Closes #558