### PR TITLE
fix: include published events in venue calendar

### DIFF
--- a/blocks/venue-settings/src/api.js
+++ b/blocks/venue-settings/src/api.js
@@ -15,6 +15,7 @@ const METHODS = {
 	'extrachill/get-venue-booking-activity': 'GET',
 	'extrachill/list-booking-holds': 'GET',
 	'extrachill/list-booking-communications': 'GET',
+	'extrachill/events-calendar': 'GET',
 	'extrachill/review-venue-claim': 'DELETE',
 	'extrachill/cancel-venue-invitation': 'DELETE',
 	'extrachill/cancel-venue-claim': 'DELETE',

--- a/blocks/venue-settings/src/booking-console.js
+++ b/blocks/venue-settings/src/booking-console.js
@@ -71,6 +71,11 @@ export const moveMonth = ( month, amount ) => {
 	return monthKey( new Date( year, index - 1 + amount, 1 ) );
 };
 
+export const monthRange = ( month ) => ( {
+	start: `${ month }-01 00:00:00`,
+	end: `${ moveMonth( month, 1 ) }-01 00:00:00`,
+} );
+
 export const calendarDays = ( month ) => {
 	const [ year, index ] = month.split( '-' ).map( Number );
 	const first = new Date( year, index - 1, 1 );
@@ -96,6 +101,34 @@ const bookingDate = ( booking ) =>
 		0,
 		10
 	);
+
+export const calendarEntries = ( bookings, events ) => {
+	const eventIds = new Set( events.map( ( event ) => Number( event.id ) ) );
+	return [
+		...events.map( ( event ) => ( {
+			type: 'event',
+			id: event.id,
+			date: ( event.datetime || '' ).slice( 0, 10 ),
+			title: event.title,
+			status: 'published',
+			permalink: event.permalink,
+		} ) ),
+		...bookings
+			.filter(
+				( booking ) =>
+					! booking.event_id ||
+					! eventIds.has( Number( booking.event_id ) )
+			)
+			.map( ( booking ) => ( {
+				type: 'booking',
+				id: booking.id,
+				date: bookingDate( booking ),
+				title: booking.artist_name,
+				status: booking.status,
+				booking,
+			} ) ),
+	];
+};
 
 export const filterBookings = ( bookings, search ) => {
 	const query = search.trim().toLowerCase();
@@ -627,11 +660,21 @@ function BookingCard( { booking, active, holds, onSelect } ) {
 	);
 }
 
-function Calendar( { bookings, holds, month, onMonthChange, onSelect } ) {
-	const byDay = bookings.reduce( ( grouped, booking ) => {
-		const day = bookingDate( booking );
-		if ( day ) {
-			grouped[ day ] = [ ...( grouped[ day ] || [] ), booking ];
+function Calendar( {
+	bookings,
+	events,
+	holds,
+	month,
+	onMonthChange,
+	onSelect,
+} ) {
+	const entries = calendarEntries( bookings, events );
+	const byDay = entries.reduce( ( grouped, entry ) => {
+		if ( entry.date ) {
+			grouped[ entry.date ] = [
+				...( grouped[ entry.date ] || [] ),
+				entry,
+			];
 		}
 		return grouped;
 	}, {} );
@@ -684,6 +727,11 @@ function Calendar( { bookings, holds, month, onMonthChange, onSelect } ) {
 					</ActionRow>
 				}
 			/>
+			{ entries.length === 0 && (
+				<EmptyState>
+					No bookings, holds, or published events this month.
+				</EmptyState>
+			) }
 			<div className="ec-booking-calendar__weekdays" aria-hidden="true">
 				{ [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ].map(
 					( day ) => (
@@ -708,32 +756,51 @@ function Calendar( { bookings, holds, month, onMonthChange, onSelect } ) {
 							{ day.day }
 						</span>
 						<div className="ec-booking-calendar__items">
-							{ ( byDay[ day.key ] || [] ).map( ( booking ) => (
-								<button
-									type="button"
-									key={ booking.id }
-									className={ `ec-booking-calendar__item ec-booking-calendar__item--${ booking.status }` }
-									onClick={ () => onSelect( booking.id ) }
-								>
-									<span>{ booking.artist_name }</span>
-									<small>
-										{ statusLabel( booking.status ) }
-										{ activeHoldCounts[ booking.id ]
-											? ` · ${
-													activeHoldCounts[
-														booking.id
-													]
-											  } active hold${
-													activeHoldCounts[
-														booking.id
-													] === 1
-														? ''
-														: 's'
-											  }`
-											: '' }
-									</small>
-								</button>
-							) ) }
+							{ ( byDay[ day.key ] || [] ).map( ( entry ) => {
+								const content = (
+									<>
+										<span>{ entry.title }</span>
+										<small>
+											{ entry.type === 'event'
+												? 'Published event'
+												: statusLabel( entry.status ) }
+											{ entry.type === 'booking' &&
+											activeHoldCounts[ entry.id ]
+												? ` · ${
+														activeHoldCounts[
+															entry.id
+														]
+												  } active hold${
+														activeHoldCounts[
+															entry.id
+														] === 1
+															? ''
+															: 's'
+												  }`
+												: '' }
+										</small>
+									</>
+								);
+								const className = `ec-booking-calendar__item ec-booking-calendar__item--${ entry.status }`;
+								return entry.type === 'event' ? (
+									<a
+										key={ `event-${ entry.id }` }
+										className={ className }
+										href={ entry.permalink }
+									>
+										{ content }
+									</a>
+								) : (
+									<button
+										type="button"
+										key={ `booking-${ entry.id }` }
+										className={ className }
+										onClick={ () => onSelect( entry.id ) }
+									>
+										{ content }
+									</button>
+								);
+							} ) }
 						</div>
 					</div>
 				) ) }
@@ -1379,6 +1446,7 @@ function BookingDetail( {
 export function BookingConsole( { context, members, defaultDeal, view } ) {
 	const venueId = context.selected_venue.id;
 	const [ bookings, setBookings ] = useState( [] );
+	const [ events, setEvents ] = useState( [] );
 	const [ holds, setHolds ] = useState( [] );
 	const [ communications, setCommunications ] = useState( [] );
 	const [ operations, setOperations ] = useState( null );
@@ -1404,23 +1472,42 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 		setError( '' );
 		try {
 			const input = { venue_term_id: venueId, limit: 100, offset: 0 };
+			const range = monthRange( month );
+			if ( view === 'calendar' ) {
+				input.range_start = range.start;
+				input.range_end = range.end;
+			}
 			if ( filterStatus ) {
 				input.status = filterStatus;
 			}
 			if ( filterAssignee ) {
 				input.assignee_user_id = Number( filterAssignee );
 			}
-			const [ bookingRows, holdRows ] = await Promise.all( [
+			const [ bookingRows, holdRows, calendar ] = await Promise.all( [
 				runAbility( 'extrachill/list-venue-bookings', input ),
 				runAbility( 'extrachill/list-booking-holds', {
 					venue_term_id: venueId,
+					...( view === 'calendar'
+						? { range_start: range.start, range_end: range.end }
+						: {} ),
 					limit: 100,
 					offset: 0,
 				} ),
+				view === 'calendar'
+					? runAbility( 'extrachill/events-calendar', {
+							venue_id: venueId,
+							month,
+					  } )
+					: Promise.resolve( { dates: [] } ),
 			] );
 			if ( currentRequest === requestId.current ) {
 				setBookings( bookingRows );
 				setHolds( holdRows );
+				setEvents(
+					( calendar.dates || [] ).flatMap(
+						( date ) => date.events || []
+					)
+				);
 			}
 		} catch ( caught ) {
 			if ( currentRequest === requestId.current ) {
@@ -1492,7 +1579,7 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 
 	useEffect( () => {
 		loadList();
-	}, [ filterStatus, filterAssignee ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ filterStatus, filterAssignee, month ] ); // eslint-disable-line react-hooks/exhaustive-deps
 	useEffect( () => {
 		loadDetail();
 	}, [ selectedId ] ); // eslint-disable-line react-hooks/exhaustive-deps
@@ -1585,6 +1672,7 @@ export function BookingConsole( { context, members, defaultDeal, view } ) {
 					{ view === 'calendar' ? (
 						<Calendar
 							bookings={ visible }
+							events={ events }
 							holds={ holds }
 							month={ month }
 							onMonthChange={ setMonth }

--- a/blocks/venue-settings/src/booking-console.test.js
+++ b/blocks/venue-settings/src/booking-console.test.js
@@ -7,8 +7,10 @@ jest.mock( '@extrachill/components', () => ( {} ) );
  */
 import {
 	calendarDays,
+	calendarEntries,
 	filterBookings,
 	monthKey,
+	monthRange,
 	moveMonth,
 } from './booking-console';
 
@@ -28,6 +30,66 @@ describe( 'venue booking console state helpers', () => {
 		expect( moveMonth( '2026-01', -1 ) ).toBe( '2025-12' );
 		expect( moveMonth( '2026-12', 1 ) ).toBe( '2027-01' );
 		expect( monthKey( new Date( 2026, 6, 1 ) ) ).toBe( '2026-07' );
+		expect( monthRange( '2026-12' ) ).toEqual( {
+			start: '2026-12-01 00:00:00',
+			end: '2027-01-01 00:00:00',
+		} );
+	} );
+
+	it( 'keeps standalone events and unconverted bookings', () => {
+		const events = [
+			{
+				id: 900,
+				title: 'Standalone Show',
+				datetime: '2026-08-08T19:00:00',
+			},
+		];
+		const bookings = [
+			{
+				id: 10,
+				artist_name: 'Unconverted Artist',
+				requested_start_at: '2026-08-09 20:00:00',
+				event_id: null,
+				status: 'held',
+			},
+		];
+
+		expect( calendarEntries( bookings, events ) ).toEqual( [
+			expect.objectContaining( {
+				type: 'event',
+				id: 900,
+				date: '2026-08-08',
+			} ),
+			expect.objectContaining( {
+				type: 'booking',
+				id: 10,
+				date: '2026-08-09',
+			} ),
+		] );
+	} );
+
+	it( 'deduplicates a converted booking against its canonical event', () => {
+		const events = [
+			{
+				id: 900,
+				title: 'Canonical Show',
+				datetime: '2026-08-08T19:00:00',
+			},
+		];
+		const bookings = [
+			{
+				id: 10,
+				artist_name: 'Converted Artist',
+				requested_start_at: '2026-08-08 19:00:00',
+				event_id: 900,
+				status: 'confirmed',
+			},
+		];
+
+		expect( calendarEntries( bookings, events ) ).toHaveLength( 1 );
+		expect( calendarEntries( bookings, events )[ 0 ] ).toEqual(
+			expect.objectContaining( { type: 'event', id: 900 } )
+		);
 	} );
 
 	it( 'searches only the bounded venue response', () => {

--- a/blocks/venue-settings/src/style.scss
+++ b/blocks/venue-settings/src/style.scss
@@ -200,6 +200,12 @@
 	background: color-mix(in srgb, var(--success-color) 10%, transparent);
 }
 
+.ec-booking-calendar__item--published {
+	border-left-color: var(--success-color);
+	background: color-mix(in srgb, var(--success-color) 16%, transparent);
+	text-decoration: none;
+}
+
 .ec-booking-calendar__item--needs_info,
 .ec-booking-calendar__item--declined,
 .ec-booking-calendar__item--withdrawn,

--- a/inc/Abilities/VenueBookingAbilities.php
+++ b/inc/Abilities/VenueBookingAbilities.php
@@ -397,6 +397,8 @@ class VenueBookingAbilities {
 			'assignee_user_id'   => $input['assignee_user_id'] ?? null,
 			'requested_start_at' => $input['requested_from'] ?? null,
 			'requested_end_at'   => $input['requested_to'] ?? null,
+			'range_start'        => $input['range_start'] ?? null,
+			'range_end'          => $input['range_end'] ?? null,
 			'limit'              => $input['limit'] ?? 50,
 			'offset'             => $input['offset'] ?? 0,
 		);
@@ -682,6 +684,8 @@ class VenueBookingAbilities {
 				),
 				'requested_from'   => $this->nullable_datetime_schema(),
 				'requested_to'     => $this->nullable_datetime_schema(),
+				'range_start'      => $this->nullable_datetime_schema(),
+				'range_end'        => $this->nullable_datetime_schema(),
 				'limit'            => array(
 					'type'    => 'integer',
 					'minimum' => 1,

--- a/inc/Core/BookingRepository.php
+++ b/inc/Core/BookingRepository.php
@@ -333,6 +333,20 @@ class BookingRepository {
 			$where[]  = "{$field} {$operator} %s";
 			$values[] = $date;
 		}
+		if ( ! empty( $filters['range_start'] ) && ! empty( $filters['range_end'] ) ) {
+			$range_start = $this->datetime( $filters['range_start'], 'range_start' );
+			$range_end   = $this->datetime( $filters['range_end'], 'range_end' );
+			if ( is_wp_error( $range_start ) ) {
+				return $range_start;
+			}
+			if ( is_wp_error( $range_end ) ) {
+				return $range_end;
+			}
+			$where[]  = 'COALESCE(performance_start_at, requested_start_at) < %s';
+			$values[] = $range_end;
+			$where[]  = 'COALESCE(performance_end_at, requested_end_at) > %s';
+			$values[] = $range_start;
+		}
 
 		$limit    = max( 1, min( 100, absint( $filters['limit'] ?? 50 ) ) );
 		$offset   = max( 0, absint( $filters['offset'] ?? 0 ) );

--- a/inc/abilities/events-calendar.php
+++ b/inc/abilities/events-calendar.php
@@ -38,9 +38,19 @@ function extrachill_events_register_calendar_ability(): void {
 						'default'     => 1,
 						'minimum'     => 1,
 					),
+					'month'    => array(
+						'type'        => 'string',
+						'description' => 'Visible month in YYYY-MM format.',
+						'pattern'     => '^\\d{4}-(0[1-9]|1[0-2])$',
+					),
 					'venue'    => array(
 						'type'        => 'string',
 						'description' => 'Filter by venue taxonomy slug.',
+					),
+					'venue_id' => array(
+						'type'        => 'integer',
+						'description' => 'Filter by an exact authorized venue term ID.',
+						'minimum'     => 1,
 					),
 					'promoter' => array(
 						'type'        => 'string',
@@ -99,7 +109,7 @@ function extrachill_events_register_calendar_ability(): void {
 				),
 			),
 			'execute_callback'    => 'extrachill_events_ability_calendar',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_events_can_run_calendar',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -108,6 +118,25 @@ function extrachill_events_register_calendar_ability(): void {
 				),
 			),
 		)
+	);
+}
+
+/**
+ * Require venue workspace access when an exact management venue is requested.
+ *
+ * @param array $input Ability input.
+ * @return bool|WP_Error
+ */
+function extrachill_events_can_run_calendar( array $input ): bool|\WP_Error {
+	if ( empty( $input['venue_id'] ) ) {
+		return true;
+	}
+
+	$authorization = new \ExtraChillEvents\Core\VenueAuthorization();
+	return $authorization->authorize(
+		get_current_user_id(),
+		absint( $input['venue_id'] ),
+		\ExtraChillEvents\Core\VenueAuthorization::ACTION_ACCESS_VENUE
 	);
 }
 
@@ -138,12 +167,19 @@ function extrachill_events_ability_calendar( array $input ): array|\WP_Error {
 		$delegate_input['scope'] = sanitize_text_field( $input['scope'] );
 	}
 
+	if ( ! empty( $input['month'] ) ) {
+		$delegate_input['month'] = sanitize_text_field( $input['month'] );
+	}
+
 	if ( ! empty( $input['search'] ) ) {
 		$delegate_input['event_search'] = sanitize_text_field( $input['search'] );
 	}
 
 	// Build taxonomy filter from slug params.
 	$tax_filter = array();
+	if ( ! empty( $input['venue_id'] ) ) {
+		$tax_filter['venue'] = array( absint( $input['venue_id'] ) );
+	}
 	$mappings   = array(
 		'venue'    => 'venue',
 		'promoter' => 'promoter',
@@ -151,6 +187,9 @@ function extrachill_events_ability_calendar( array $input ): array|\WP_Error {
 	);
 
 	foreach ( $mappings as $param => $taxonomy ) {
+		if ( 'venue' === $taxonomy && isset( $tax_filter['venue'] ) ) {
+			continue;
+		}
 		$slug = $input[ $param ] ?? '';
 		if ( empty( $slug ) ) {
 			continue;


### PR DESCRIPTION
## Summary
- query canonical published events for the exact authorized venue and selected calendar month
- retain month-overlapping unconverted bookings and holds while deduplicating converted bookings by `event_id`
- visually distinguish published events and cover standalone, unconverted, and deduplicated calendar entries

## Tests
- `npm run test:js -- --runInBand` (16 suites, 89 tests)
- `npm run lint:js`
- `npm run build:venue-settings`
- `DME_CALENDAR_CONTRACT_ROOT=/var/www/extrachill.com/wp-content/plugins/data-machine-events/contracts vendor/bin/phpunit tests/Unit/Abilities/CanonicalAdapterContractsTest.php` (5 tests, 71 assertions)
- `vendor/bin/phpunit tests/BookingFoundationTest.php --filter test_repository_list_applies_filters_order_and_bounds` (1 test, 4 assertions)
- PHP syntax checks and `git diff --check`

Closes #554