### PR TITLE
fix: show all venues by default

### DIFF
--- a/blocks/venue-settings/render.php
+++ b/blocks/venue-settings/render.php
@@ -108,7 +108,7 @@ $requested_booking_id = isset( $_GET['booking_id'] ) && is_scalar( $_GET['bookin
 // phpcs:enable WordPress.Security.NonceVerification.Recommended
 $selected = null;
 foreach ( $managed_venues as $venue ) {
-	if ( $requested_venue_id === $venue['id'] || ( ! $requested_venue_id && 'active' === $venue['status'] ) ) {
+	if ( $requested_venue_id === $venue['id'] ) {
 		$selected = $venue;
 		break;
 	}

--- a/blocks/venue-settings/src/venue-workspace-header.js
+++ b/blocks/venue-settings/src/venue-workspace-header.js
@@ -13,8 +13,8 @@ export function VenueWorkspaceHeader( { venues, selected, onSwitchVenue } ) {
 	return (
 		<>
 			<BlockShellHeader
-				title="Manage venue"
-				description="Calendar, booking operations, profile, Local Support, access, and onboarding in one venue-scoped workspace."
+				title="Manage venues"
+				description="Choose all venues for an overview or open an individual venue workspace."
 			/>
 			{ venues.length > 0 && (
 				<FieldGroup label="Venue workspace" htmlFor="venue-workspace">
@@ -23,7 +23,7 @@ export function VenueWorkspaceHeader( { venues, selected, onSwitchVenue } ) {
 						value={ selected?.id || 0 }
 						onChange={ onSwitchVenue }
 					>
-						<option value="0">Choose a venue</option>
+						<option value="0">All venues</option>
 						{ venues.map( ( venue ) => (
 							<option key={ venue.id } value={ venue.id }>
 								{ venue.name }

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -32,6 +32,41 @@ import { editableConfig, profileChanges, sameDocument } from './state';
 
 export { venueSubscriberCsv } from './team-tab';
 
+function AllVenues( { venues, routeUrl } ) {
+	return (
+		<Panel>
+			<h2>All venues</h2>
+			<p>
+				Open a venue to manage its calendar, bookings, profile, and
+				team.
+			</p>
+			<ul className="ec-venue-settings__records">
+				{ venues.map( ( venue ) => {
+					const url = new URL( routeUrl );
+					url.searchParams.set( 'venue_id', venue.id );
+					return (
+						<li key={ venue.id }>
+							<span>
+								<strong>{ venue.name }</strong>{ ' ' }
+								<small>
+									{ venue.status }
+									{ venue.is_owner ? ' - owner' : '' }
+								</small>
+							</span>
+							<a
+								className="button-2 button-small"
+								href={ url.toString() }
+							>
+								Open workspace
+							</a>
+						</li>
+					);
+				} ) }
+			</ul>
+		</Panel>
+	);
+}
+
 export function VenueSettingsApp( { context } ) {
 	const selected = context.selected_venue;
 	const [ activeTab, setActiveTab ] = useState( 'calendar' );
@@ -425,6 +460,14 @@ export function VenueSettingsApp( { context } ) {
 		);
 	};
 	const renderWorkspace = () => {
+		if ( ! selected && context.venues.length > 0 ) {
+			return (
+				<AllVenues
+					venues={ context.venues }
+					routeUrl={ context.route_url }
+				/>
+			);
+		}
 		if ( ! selected || ! context.can_access ) {
 			if ( context.user.is_admin ) {
 				return (

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -321,6 +321,39 @@ describe( 'venue settings authorization-facing states', () => {
 		await act( async () => root.unmount() );
 	} );
 
+	it( 'shows all manageable venues by default', async () => {
+		const venues = [
+			{ id: 44, name: 'Venue 44', status: 'active', is_owner: true },
+			{
+				id: 45,
+				name: 'Venue 45',
+				status: 'administrator',
+				is_owner: false,
+			},
+		];
+		const { container, root } = await renderApp(
+			context( {
+				venues,
+				selected_venue: null,
+				can_access: false,
+			} )
+		);
+
+		const selector = container.querySelector( '#venue-workspace' );
+		expect( selector.value ).toBe( '0' );
+		expect( selector.options[ 0 ].textContent ).toBe( 'All venues' );
+		expect( container.textContent ).toContain( 'Venue 44' );
+		expect( container.textContent ).toContain( 'Venue 45' );
+		expect( container.textContent ).toContain( 'owner' );
+		expect(
+			container
+				.querySelector( 'a[href*="venue_id=45"]' )
+				.getAttribute( 'href' )
+		).toBe( 'https://events.example/venue-settings/?venue_id=45' );
+		expect( apiFetch ).not.toHaveBeenCalled();
+		await act( async () => root.unmount() );
+	} );
+
 	it( 'hides team controls from active non-owners', async () => {
 		const { container, root } = await renderApp( context() );
 		expect( container.textContent ).not.toContain( 'Team' );


### PR DESCRIPTION
## Summary
- make `All venues` the default venue-settings selection when no venue is requested
- render every server-authorized manageable venue with a link to its individual workspace
- preserve explicit `venue_id` deep links and add regression coverage for the aggregate state

## Verification
- `npm run test:js -- blocks/venue-settings/src/view.test.js --runInBand`
- `npm run lint:js -- blocks/venue-settings/src/view.js blocks/venue-settings/src/venue-workspace-header.js blocks/venue-settings/src/view.test.js`
- `php -l blocks/venue-settings/render.php`
- `npm run build:venue-settings`

Closes #561