### PR TITLE
fix: remove public booking noise

### DIFF
--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -104,35 +104,6 @@
     flex-shrink: 0;
 }
 
-.events-venue-preferences {
-    align-items: flex-start;
-}
-
-.events-venue-preferences__controls,
-.events-venue-preferences__control,
-.events-venue-preferences__label {
-    display: flex;
-}
-
-.events-venue-preferences__controls {
-    align-items: flex-end;
-}
-
-.events-venue-preferences__control {
-    align-items: center;
-    gap: var(--spacing-sm);
-}
-
-.events-venue-preferences__label {
-    flex-direction: column;
-    gap: var(--spacing-xs);
-}
-
-.events-venue-preferences__label span {
-    color: var(--muted-text);
-    font-size: var(--font-size-sm);
-}
-
 /* Progressive homepage router: search, preferred market, sample, directories. */
 .events-home-router {
     display: grid;
@@ -222,17 +193,6 @@
 
     .events-market-context__actions {
         gap: var(--spacing-sm) var(--spacing-md);
-    }
-
-    .events-venue-preferences,
-    .events-venue-preferences__controls,
-    .events-venue-preferences__control {
-        align-items: stretch;
-        flex-direction: column;
-    }
-
-    .events-venue-preferences__control .button-1 {
-        align-self: flex-start;
     }
 
     .events-primary-market {

--- a/assets/js/venue-email-sharing.js
+++ b/assets/js/venue-email-sharing.js
@@ -6,23 +6,17 @@
 		return;
 	}
 
-	const status = button
-		.closest( '[data-venue-email-sharing-control]' )
-		.querySelector( '[data-venue-email-sharing-status]' );
 	const input = {
 		entity_type: 'venue-email-sharing',
 		taxonomy: 'venue',
 		slug: button.dataset.slug,
 	};
 
-	function setState( subscribed, message ) {
+	function setState( subscribed ) {
 		button.setAttribute( 'aria-pressed', subscribed ? 'true' : 'false' );
-		button.textContent = subscribed ? 'Stop sharing' : 'Share email';
-		status.textContent =
-			message ||
-			( subscribed
-				? 'Shared with this venue'
-				: 'Not shared with this venue' );
+		button.classList.toggle( 'button-2', subscribed );
+		button.classList.toggle( 'button-3', ! subscribed );
+		button.textContent = subscribed ? 'Email shared' : 'Share email';
 	}
 
 	function request( ability, method ) {
@@ -58,8 +52,7 @@
 			button.disabled = false;
 		} )
 		.catch( () => {
-			status.textContent =
-				"Couldn't load this setting. Refresh to try again.";
+			button.textContent = 'Email sharing unavailable';
 		} );
 
 	button.addEventListener( 'click', () => {
@@ -71,8 +64,7 @@
 		)
 			.then( ( data ) => setState( Boolean( data.subscribed ) ) )
 			.catch( () => {
-				status.textContent =
-					'Unable to update email sharing. Please try again.';
+				button.textContent = 'Try email sharing again';
 			} )
 			.finally( () => {
 				button.disabled = false;

--- a/assets/js/venue-email-sharing.test.js
+++ b/assets/js/venue-email-sharing.test.js
@@ -9,12 +9,9 @@ describe( 'Venue email sharing', () => {
 	beforeEach( () => {
 		jest.resetModules();
 		document.body.innerHTML = `
-			<div data-venue-email-sharing-control>
-				<span data-venue-email-sharing-status></span>
-				<button disabled aria-pressed="false" data-venue-email-sharing
-					data-endpoint="https://example.com/wp-json/wp-abilities/v1/abilities/"
-					data-nonce="nonce" data-slug="the-royal-american"></button>
-			</div>`;
+			<button class="button-3" disabled aria-pressed="false" data-venue-email-sharing
+				data-endpoint="https://example.com/wp-json/wp-abilities/v1/abilities/"
+				data-nonce="nonce" data-slug="the-royal-american"></button>`;
 		global.fetch = jest.fn();
 	} );
 
@@ -31,11 +28,10 @@ describe( 'Venue email sharing', () => {
 		expect( fetch.mock.calls[ 0 ][ 0 ] ).toContain(
 			'entity-subscription-status'
 		);
-		expect(
-			document.querySelector( '[data-venue-email-sharing-status]' )
-				.textContent
-		).toBe( 'Not shared with this venue' );
-		expect( document.querySelector( 'button' ).disabled ).toBe( false );
+		const button = document.querySelector( 'button' );
+		expect( button.textContent ).toBe( 'Share email' );
+		expect( button.classList.contains( 'button-3' ) ).toBe( true );
+		expect( button.disabled ).toBe( false );
 	} );
 
 	it( 'uses only the scoped venue email-sharing identity', async () => {
@@ -62,8 +58,11 @@ describe( 'Venue email sharing', () => {
 			'"entity_type":"venue"'
 		);
 		expect( document.querySelector( 'button' ).textContent ).toBe(
-			'Stop sharing'
+			'Email shared'
 		);
+		expect(
+			document.querySelector( 'button' ).classList.contains( 'button-2' )
+		).toBe( true );
 	} );
 
 	it( 'revokes only after an explicit second click', async () => {
@@ -95,9 +94,8 @@ describe( 'Venue email sharing', () => {
 		await flushPromises();
 
 		expect( document.querySelector( 'button' ).disabled ).toBe( true );
-		expect(
-			document.querySelector( '[data-venue-email-sharing-status]' )
-				.textContent
-		).toBe( "Couldn't load this setting. Refresh to try again." );
+		expect( document.querySelector( 'button' ).textContent ).toBe(
+			'Email sharing unavailable'
+		);
 	} );
 } );

--- a/assets/js/venue-update-subscriptions.js
+++ b/assets/js/venue-update-subscriptions.js
@@ -6,19 +6,19 @@
 		return;
 	}
 
-	const status = button
-		.closest( '[data-venue-update-control]' )
-		.querySelector( '[data-venue-update-status]' );
 	const input = {
 		entity_type: 'venue',
 		taxonomy: 'venue',
 		slug: button.dataset.slug,
 	};
 
-	function setState( subscribed, message ) {
+	function setState( subscribed ) {
 		button.setAttribute( 'aria-pressed', subscribed ? 'true' : 'false' );
-		button.textContent = subscribed ? 'Turn off' : 'Turn on';
-		status.textContent = message || ( subscribed ? 'On' : 'Off' );
+		button.classList.toggle( 'button-2', subscribed );
+		button.classList.toggle( 'button-3', ! subscribed );
+		button.textContent = subscribed
+			? 'Event alerts on'
+			: 'Get event alerts';
 	}
 
 	function request( ability, method ) {
@@ -54,8 +54,7 @@
 			button.disabled = false;
 		} )
 		.catch( () => {
-			status.textContent =
-				"Couldn't load this setting. Refresh to try again.";
+			button.textContent = 'Event alerts unavailable';
 		} );
 
 	button.addEventListener( 'click', () => {
@@ -67,8 +66,7 @@
 		)
 			.then( ( data ) => setState( Boolean( data.subscribed ) ) )
 			.catch( () => {
-				status.textContent =
-					'Unable to update your subscription. Please try again.';
+				button.textContent = 'Try event alerts again';
 			} )
 			.finally( () => {
 				button.disabled = false;

--- a/assets/js/venue-update-subscriptions.test.js
+++ b/assets/js/venue-update-subscriptions.test.js
@@ -9,12 +9,9 @@ describe( 'Venue update subscriptions', () => {
 	beforeEach( () => {
 		jest.resetModules();
 		document.body.innerHTML = `
-			<div data-venue-update-control>
-				<span data-venue-update-status></span>
-				<button disabled aria-pressed="false" data-venue-update-subscription
-					data-endpoint="https://example.com/wp-json/wp-abilities/v1/abilities/"
-					data-nonce="nonce" data-slug="the-royal-american"></button>
-			</div>`;
+			<button class="button-3" disabled aria-pressed="false" data-venue-update-subscription
+				data-endpoint="https://example.com/wp-json/wp-abilities/v1/abilities/"
+				data-nonce="nonce" data-slug="the-royal-american"></button>`;
 		global.fetch = jest.fn();
 	} );
 
@@ -34,10 +31,10 @@ describe( 'Venue update subscriptions', () => {
 		expect( fetch.mock.calls[ 0 ][ 0 ] ).not.toContain(
 			'entity-subscribe/run'
 		);
-		expect(
-			document.querySelector( '[data-venue-update-status]' ).textContent
-		).toBe( 'Off' );
-		expect( document.querySelector( 'button' ).disabled ).toBe( false );
+		const button = document.querySelector( 'button' );
+		expect( button.textContent ).toBe( 'Get event alerts' );
+		expect( button.classList.contains( 'button-3' ) ).toBe( true );
+		expect( button.disabled ).toBe( false );
 	} );
 
 	it( 'subscribes with the exact venue identity after a click', async () => {
@@ -64,11 +61,11 @@ describe( 'Venue update subscriptions', () => {
 			slug: 'the-royal-american',
 		} );
 		expect( document.querySelector( 'button' ).textContent ).toBe(
-			'Turn off'
+			'Event alerts on'
 		);
 		expect(
-			document.querySelector( '[data-venue-update-status]' ).textContent
-		).toBe( 'On' );
+			document.querySelector( 'button' ).classList.contains( 'button-2' )
+		).toBe( true );
 	} );
 
 	it( 'unsubscribes only after an explicit second click', async () => {
@@ -90,7 +87,7 @@ describe( 'Venue update subscriptions', () => {
 			'entity-unsubscribe/run'
 		);
 		expect( document.querySelector( 'button' ).textContent ).toBe(
-			'Turn on'
+			'Get event alerts'
 		);
 	} );
 
@@ -100,8 +97,8 @@ describe( 'Venue update subscriptions', () => {
 		await flushPromises();
 
 		expect( document.querySelector( 'button' ).disabled ).toBe( true );
-		expect(
-			document.querySelector( '[data-venue-update-status]' ).textContent
-		).toBe( "Couldn't load this setting. Refresh to try again." );
+		expect( document.querySelector( 'button' ).textContent ).toBe(
+			'Event alerts unavailable'
+		);
 	} );
 } );

--- a/blocks/venue-booking-inquiry/render.php
+++ b/blocks/venue-booking-inquiry/render.php
@@ -81,12 +81,6 @@ $booking_config       = $canonical['booking_config'];
 $instance             = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'ec-booking-' ) : 'ec-booking-' . $venue_id;
 $logged_in            = is_user_logged_in();
 $form_enabled         = ! empty( $booking_config['enabled'] );
-$manage_link_page_url = function_exists( 'ec_get_site_url' ) ? trailingslashit( ec_get_site_url( 'artist' ) ) . 'manage-link-page/' : '';
-$link_page_count      = $logged_in && function_exists( 'ec_get_link_page_count_for_user' ) ? ec_get_link_page_count_for_user( get_current_user_id() ) : 0;
-$link_page_url        = $manage_link_page_url;
-if ( ! $logged_in && '' !== $manage_link_page_url && function_exists( 'ec_users_login_url_with_redirect' ) && function_exists( 'ec_get_site_url' ) ) {
-	$link_page_url = ec_users_login_url_with_redirect( trailingslashit( ec_get_site_url( 'community' ) ) . 'login/', $manage_link_page_url );
-}
 if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 	define( 'DONOTCACHEPAGE', true );
 }
@@ -102,21 +96,13 @@ $public_config = array(
 	'endpoint'             => rest_url( 'extrachill/v1/venues/' . $venue_id . '/booking-inquiries' ),
 	'availabilityEndpoint' => rest_url( 'extrachill/v1/venues/' . $venue_id . '/booking-availability' ),
 	'restNonce'            => $logged_in ? wp_create_nonce( 'wp_rest' ) : '',
-	'authenticated'        => $logged_in,
-	'heading'              => sanitize_text_field( (string) ( $attributes['heading'] ?? __( 'Booking inquiries', 'extrachill-events' ) ) ),
 	'buttonLabel'          => sanitize_text_field( (string) ( $attributes['buttonLabel'] ?? __( 'Send booking inquiry', 'extrachill-events' ) ) ),
 	'revision'             => (int) $booking_config['revision'],
 	'venue'                => $canonical['venue'],
-	'requirements'         => array_values( $booking_config['public_requirements'] ),
 	'spaces'               => array_values( $booking_config['spaces'] ),
 	'fields'               => array_values( $booking_config['fields'] ),
 	'presentation'         => $booking_config['presentation'],
 	'consent'              => $booking_config['consent'],
-	'linkPage'             => array(
-		'url'           => (string) $link_page_url,
-		'hasPage'       => $link_page_count > 0,
-		'authenticated' => $logged_in,
-	),
 );
 
 $json = $form_enabled ? wp_json_encode( $public_config, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ) : '';

--- a/blocks/venue-booking-inquiry/src/style.test.js
+++ b/blocks/venue-booking-inquiry/src/style.test.js
@@ -16,20 +16,22 @@ describe( 'venue booking inquiry styles', () => {
 		);
 	} );
 
-	it( 'relies on shared components and the theme badge system', () => {
+	it( 'relies on shared form components without local decoration', () => {
 		expect( view ).toContain(
 			'<BlockShellInner className="ec-panel ec-booking-inquiry__panel">'
 		);
 		expect( view ).toContain( 'Grid minColumnWidth="16rem"' );
-		expect( view ).toContain( 'className="taxonomy-badge"' );
 		expect( view ).not.toContain( '<Badge' );
+		expect( view ).toContain( 'className="taxonomy-badge"' );
 		expect( styles ).not.toContain( '.ec-' );
 	} );
 
-	it( 'surfaces configured intake requirements before availability', () => {
-		expect( view ).toContain( 'Have your pitch ready' );
-		expect( view ).toContain( 'config.fields.map( ( field ) =>' );
-		expect( view ).toContain( "field.required ? ' (required)' : ''" );
+	it( 'does not duplicate the configured intake before availability', () => {
+		expect( view ).not.toContain( 'Have your pitch ready' );
+		expect( view ).not.toContain( 'ec-booking-inquiry__field-preview' );
+		expect( view ).not.toContain( 'submission notes' );
+		expect( view ).not.toContain( 'Link Page' );
+		expect( view ).not.toContain( 'Accepting inquiries' );
 	} );
 
 	it( 'asks for one date without exposing time controls', () => {

--- a/blocks/venue-booking-inquiry/src/view.js
+++ b/blocks/venue-booking-inquiry/src/view.js
@@ -311,9 +311,6 @@ function BookingInquiry( { config, wrapper } ) {
 			field.visible_when.value
 		);
 	} );
-	const hasLinkFields = visibleFields.some( ( field ) =>
-		[ 'url', 'url_list' ].includes( field.type )
-	);
 	const proposalFields = visibleFields.filter(
 		( field ) => ! [ 'url', 'url_list' ].includes( field.type )
 	);
@@ -334,58 +331,6 @@ function BookingInquiry( { config, wrapper } ) {
 				description={ config.venue.address }
 			/>
 			<BlockShellInner className="ec-panel ec-booking-inquiry__panel">
-				<div className="ec-booking-inquiry__intro">
-					<div>
-						<span className="taxonomy-badge">
-							Accepting inquiries
-						</span>
-						<p className="ec-booking-inquiry__lede">
-							Request a date and send the details the venue needs
-							to evaluate your event. This is an inquiry, not a
-							confirmed booking.
-						</p>
-					</div>
-					{ config.authenticated && (
-						<span className="taxonomy-badge">Signed in</span>
-					) }
-				</div>
-				{ config.venue.description && (
-					<p className="ec-booking-inquiry__description">
-						{ config.venue.description }
-					</p>
-				) }
-				<Panel>
-					<div className="ec-booking-inquiry__prepare-copy">
-						<p className="ec-booking-inquiry__eyebrow">
-							Before you start
-						</p>
-						<h3>Have your pitch ready</h3>
-						<p>
-							You will check a date first. If it is open, the
-							application asks for:
-						</p>
-					</div>
-					<ul className="ec-booking-inquiry__field-preview">
-						<li>Artist or project and booking contact</li>
-						{ config.fields.map( ( field ) => (
-							<li key={ field.key }>
-								{ field.label }
-								{ field.required ? ' (required)' : '' }
-							</li>
-						) ) }
-						<li>Routing, scheduling, and event details</li>
-					</ul>
-				</Panel>
-				{ config.requirements.length > 0 && (
-					<section className="ec-booking-inquiry__venue-notes">
-						<h3>{ config.venue.name } submission notes</h3>
-						<ul className="ec-booking-inquiry__requirements">
-							{ config.requirements.map( ( requirement ) => (
-								<li key={ requirement }>{ requirement }</li>
-							) ) }
-						</ul>
-					</section>
-				) }
 				<form
 					className="ec-booking-inquiry__form"
 					onSubmit={ submit }
@@ -393,10 +338,6 @@ function BookingInquiry( { config, wrapper } ) {
 				>
 					<section className="ec-booking-inquiry__step">
 						<h3>1. Check your requested date</h3>
-						<p>
-							Choose the date you want to play. Timing and
-							schedule details can be worked out with the venue.
-						</p>
 						<Grid minColumnWidth="16rem" maxColumns={ 2 }>
 							{ config.spaces.length > 1 && (
 								<FieldGroup
@@ -456,16 +397,8 @@ function BookingInquiry( { config, wrapper } ) {
 						<>
 							<section className="ec-booking-inquiry__step">
 								<h3>2. Complete your booking inquiry</h3>
-								<p>
-									Provide the full decision-making details
-									requested by this venue.
-								</p>
 								<section className="ec-booking-inquiry__section">
 									<h3>Your contact</h3>
-									<p>
-										Who should the venue contact about this
-										request?
-									</p>
 									<Grid
 										minColumnWidth="16rem"
 										maxColumns={ 2 }
@@ -562,11 +495,7 @@ function BookingInquiry( { config, wrapper } ) {
 								</section>
 								{ proposalFields.length > 0 && (
 									<section className="ec-booking-inquiry__section">
-										<h3>About the event</h3>
-										<p>
-											Give the venue the context it needs
-											to decide whether this is a fit.
-										</p>
+										<h3>Event details</h3>
 										<Grid
 											minColumnWidth="16rem"
 											maxColumns={ 2 }
@@ -594,11 +523,7 @@ function BookingInquiry( { config, wrapper } ) {
 								) }
 								{ linkFields.length > 0 && (
 									<section className="ec-booking-inquiry__section">
-										<h3>Music, video, and press</h3>
-										<p>
-											Share public links the venue can
-											review without requesting access.
-										</p>
+										<h3>Links</h3>
 										<Grid
 											minColumnWidth="16rem"
 											maxColumns={ 2 }
@@ -625,28 +550,7 @@ function BookingInquiry( { config, wrapper } ) {
 									</section>
 								) }
 							</section>
-							{ hasLinkFields && config.linkPage.url && (
-								<aside className="ec-booking-inquiry__link-page">
-									<h3>
-										Already have an Extra Chill Link Page?
-									</h3>
-									<p>
-										Keep it current, then paste its URL into
-										the relevant link field above. Using one
-										does not affect booking priority.
-									</p>
-									<a
-										href={ config.linkPage.url }
-										className="button-2"
-									>
-										{ config.linkPage.hasPage
-											? 'Use or manage your Link Page'
-											: 'Create a free Link Page' }
-									</a>
-								</aside>
-							) }
 							<section className="ec-booking-inquiry__section">
-								<h3>Final details</h3>
 								<FieldGroup
 									label={ config.presentation.message_label }
 									htmlFor={ `${ prefix }-message` }

--- a/inc/core/booking-console.php
+++ b/inc/core/booking-console.php
@@ -234,4 +234,3 @@ function ec_events_render_venue_archive_workspace_action(): void {
 	</aside>
 	<?php
 }
-add_action( 'extrachill_archive_below_description', 'ec_events_render_venue_archive_workspace_action', 8 );

--- a/inc/core/venue-email-sharing.php
+++ b/inc/core/venue-email-sharing.php
@@ -51,20 +51,14 @@ function extrachill_events_authorize_venue_email_sharing_producer( $authorized, 
 		&& 'venue' === ( $entity['taxonomy'] ?? '' );
 }
 
-/** Render the explicit email-sharing row inside venue preferences. */
+/** Render the compact email-sharing action inside venue preferences. */
 function extrachill_events_render_venue_email_sharing_control(): void {
 	$term = function_exists( 'extrachill_events_get_venue_archive_term' ) ? extrachill_events_get_venue_archive_term() : null;
 	if ( null === $term || ! is_user_logged_in() ) {
 		return;
 	}
 	?>
-	<div class="events-venue-preferences__control" data-venue-email-sharing-control>
-		<div class="events-venue-preferences__label">
-			<strong><?php esc_html_e( 'Venue email list', 'extrachill-events' ); ?></strong>
-			<span data-venue-email-sharing-status aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-events' ); ?></span>
-		</div>
-		<button class="button-1 button-small" type="button" disabled aria-pressed="false" data-venue-email-sharing data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Share email', 'extrachill-events' ); ?></button>
-	</div>
+	<button class="button-3 button-small" type="button" disabled aria-live="polite" aria-pressed="false" data-venue-email-sharing data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Loading email sharing...', 'extrachill-events' ); ?></button>
 	<?php
 }
 

--- a/inc/core/venue-update-subscriptions.php
+++ b/inc/core/venue-update-subscriptions.php
@@ -10,12 +10,10 @@ defined( 'ABSPATH' ) || exit;
 const EXTRACHILL_EVENTS_VENUE_UPDATE_PRODUCER  = 'extrachill-events-venue-updates';
 const EXTRACHILL_EVENTS_VENUE_UPDATE_SENT_META = '_extrachill_events_venue_update_notification_sent';
 
-/** Register venue archive controls and private notification delivery. */
+/** Register private venue notification delivery. */
 function extrachill_events_init_venue_update_subscriptions(): void {
 	add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_events_authorize_venue_update_producer', 10, 4 );
 	add_action( 'transition_post_status', 'extrachill_events_notify_venue_subscribers', 10, 3 );
-	add_action( 'extrachill_archive_below_description', 'extrachill_events_render_venue_update_control', 5 );
-	add_action( 'wp_enqueue_scripts', 'extrachill_events_venue_update_scripts' );
 }
 
 /**

--- a/inc/core/venue-update-subscriptions.php
+++ b/inc/core/venue-update-subscriptions.php
@@ -10,10 +10,12 @@ defined( 'ABSPATH' ) || exit;
 const EXTRACHILL_EVENTS_VENUE_UPDATE_PRODUCER  = 'extrachill-events-venue-updates';
 const EXTRACHILL_EVENTS_VENUE_UPDATE_SENT_META = '_extrachill_events_venue_update_notification_sent';
 
-/** Register private venue notification delivery. */
+/** Register compact venue archive controls and private notification delivery. */
 function extrachill_events_init_venue_update_subscriptions(): void {
 	add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_events_authorize_venue_update_producer', 10, 4 );
 	add_action( 'transition_post_status', 'extrachill_events_notify_venue_subscribers', 10, 3 );
+	add_action( 'extrachill_archive_below_description', 'extrachill_events_render_venue_update_control', 5 );
+	add_action( 'wp_enqueue_scripts', 'extrachill_events_venue_update_scripts' );
 }
 
 /**
@@ -58,21 +60,11 @@ function extrachill_events_render_venue_update_control(): void {
 	}
 
 	$archive_url = get_term_link( $term );
-	$docs_url    = function_exists( 'ec_get_site_url' ) ? trailingslashit( ec_get_site_url( 'docs' ) ) . 'events-calendar/venue-preferences/' : '';
 	if ( ! is_user_logged_in() ) {
 		?>
-		<aside class="events-market-context events-market-context--quiet" data-venue-preferences>
-			<div class="events-market-context__copy">
-				<strong><?php esc_html_e( 'Venue preferences', 'extrachill-events' ); ?></strong>
-				<span>
-					<?php esc_html_e( 'Control event alerts and email access.', 'extrachill-events' ); ?>
-					<?php if ( $docs_url ) : ?>
-						<a href="<?php echo esc_url( $docs_url ); ?>"><?php esc_html_e( 'How preferences work', 'extrachill-events' ); ?></a>
-					<?php endif; ?>
-				</span>
-			</div>
-			<a href="<?php echo esc_url( wp_login_url( $archive_url ) ); ?>"><?php esc_html_e( 'Sign in to manage', 'extrachill-events' ); ?></a>
-		</aside>
+		<div class="ec-action-row" data-venue-preferences aria-label="<?php esc_attr_e( 'Venue preferences', 'extrachill-events' ); ?>">
+			<a class="button-3 button-small" href="<?php echo esc_url( wp_login_url( $archive_url ) ); ?>"><?php esc_html_e( 'Sign in for venue alerts', 'extrachill-events' ); ?></a>
+		</div>
 		<?php
 		return;
 	}
@@ -82,27 +74,10 @@ function extrachill_events_render_venue_update_control(): void {
 	}
 	nocache_headers();
 	?>
-	<aside class="events-market-context events-venue-preferences" data-venue-preferences>
-		<div class="events-market-context__copy">
-			<strong><?php esc_html_e( 'Venue preferences', 'extrachill-events' ); ?></strong>
-			<span>
-				<?php esc_html_e( 'Control event alerts and email access.', 'extrachill-events' ); ?>
-				<?php if ( $docs_url ) : ?>
-					<a href="<?php echo esc_url( $docs_url ); ?>"><?php esc_html_e( 'How preferences work', 'extrachill-events' ); ?></a>
-				<?php endif; ?>
-			</span>
-		</div>
-		<div class="events-market-context__actions events-venue-preferences__controls">
-			<div class="events-venue-preferences__control" data-venue-update-control>
-				<div class="events-venue-preferences__label">
-					<strong><?php esc_html_e( 'Event notifications', 'extrachill-events' ); ?></strong>
-					<span data-venue-update-status aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-events' ); ?></span>
-				</div>
-				<button class="button-1 button-small" type="button" disabled aria-pressed="false" data-venue-update-subscription data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Turn on', 'extrachill-events' ); ?></button>
-			</div>
-			<?php extrachill_events_render_venue_email_sharing_control(); ?>
-		</div>
-	</aside>
+	<div class="ec-action-row" data-venue-preferences aria-label="<?php esc_attr_e( 'Venue preferences', 'extrachill-events' ); ?>">
+		<button class="button-3 button-small" type="button" disabled aria-live="polite" aria-pressed="false" data-venue-update-subscription data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Loading alerts...', 'extrachill-events' ); ?></button>
+		<?php extrachill_events_render_venue_email_sharing_control(); ?>
+	</div>
 	<?php
 }
 

--- a/tests/Unit/VenueBookingInquiryRenderTest.php
+++ b/tests/Unit/VenueBookingInquiryRenderTest.php
@@ -78,12 +78,12 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'ec-venue-booking-inquiry', $output );
 		$this->assertStringContainsString( 'Test Room', $output );
 		$this->assertStringContainsString( '42 Test Street, Charleston, SC, 29403', $output );
-		$this->assertStringContainsString( 'Include recent draw and routing.', $output );
+		$this->assertStringNotContainsString( 'Include recent draw and routing.', $output );
 		$this->assertStringNotContainsString( 'Booking guide', $output );
 		$this->assertStringContainsString( '"revision":4', $output );
 		$this->assertStringContainsString( 'Phone (Emergency use only)', $output );
-		$this->assertStringContainsString( 'manage-link-page', $output );
-		$this->assertStringContainsString( '"hasPage":false', $output );
+		$this->assertStringNotContainsString( 'manage-link-page', $output );
+		$this->assertStringNotContainsString( '"hasPage"', $output );
 		$this->assertStringNotContainsString( 'private-provider-account', $output );
 		$this->assertStringNotContainsString( 'private-booking@example.com', $output );
 		$this->assertStringNotContainsString( 'attachment', strtolower( $output ) );

--- a/tests/Unit/VenueUpdateSubscriptionsTest.php
+++ b/tests/Unit/VenueUpdateSubscriptionsTest.php
@@ -88,7 +88,7 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		$this->assertFalse( extrachill_events_authorize_venue_email_sharing_producer( false, EXTRACHILL_EVENTS_VENUE_EMAIL_SHARING_PRODUCER, array( 'entity_type' => 'venue', 'taxonomy' => 'venue' ), 'email' ) );
 	}
 
-	/** Anonymous archives offer sign-in without exposing a mutation control. */
+	/** Anonymous archives offer one compact sign-in action without mutation controls. */
 	public function test_anonymous_archive_renders_sign_in_without_mutation_control(): void {
 		$this->venue_archive();
 		wp_set_current_user( 0 );
@@ -97,10 +97,9 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		extrachill_events_render_venue_update_control();
 		$html = ob_get_clean();
 
-		$this->assertStringContainsString( 'Venue preferences', $html );
-		$this->assertStringContainsString( 'Control event alerts and email access.', $html );
-		$this->assertStringContainsString( 'events-calendar/venue-preferences/', $html );
-		$this->assertStringContainsString( 'Sign in to manage', $html );
+		$this->assertStringContainsString( 'ec-action-row', $html );
+		$this->assertStringContainsString( 'Sign in for venue alerts', $html );
+		$this->assertStringNotContainsString( '<aside', $html );
 		$this->assertStringNotContainsString( 'data-venue-update-subscription', $html );
 		$this->assertStringNotContainsString( 'data-venue-email-sharing', $html );
 	}
@@ -115,13 +114,13 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		$html = ob_get_clean();
 
 		$this->assertStringContainsString( 'data-venue-update-subscription', $html );
-		$this->assertStringContainsString( 'Event notifications', $html );
+		$this->assertStringContainsString( 'Loading alerts...', $html );
 		$this->assertStringContainsString( 'aria-live="polite"', $html );
 		$this->assertStringContainsString( 'data-slug="the-royal-american"', $html );
 	}
 
-	/** Archive preferences compose two explicit controls in one notice. */
-	public function test_archive_composes_independent_controls_in_one_panel(): void {
+	/** Archive preferences compose two compact actions without a standalone card. */
+	public function test_archive_composes_independent_controls_in_one_action_row(): void {
 		$this->venue_archive();
 		wp_set_current_user( self::factory()->user->create() );
 
@@ -129,14 +128,12 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		extrachill_events_render_venue_update_control();
 		$html = ob_get_clean();
 
-		$this->assertSame( 1, substr_count( $html, '<aside' ) );
-		$this->assertSame( 0, substr_count( $html, 'events-venue-preferences__row' ) );
+		$this->assertSame( 0, substr_count( $html, '<aside' ) );
+		$this->assertStringContainsString( 'ec-action-row', $html );
 		$this->assertStringContainsString( 'data-venue-preferences', $html );
-		$this->assertStringContainsString( 'events-calendar/venue-preferences/', $html );
 		$this->assertStringContainsString( 'data-venue-update-subscription', $html );
 		$this->assertStringContainsString( 'data-venue-email-sharing', $html );
-		$this->assertStringContainsString( 'Venue email list', $html );
-		$this->assertStringContainsString( 'Share email', $html );
+		$this->assertStringContainsString( 'Loading email sharing...', $html );
 	}
 
 	/** First publication deduplicates subscribers across all assigned venues. */

--- a/tests/browser/booking-inquiry.evidence.js
+++ b/tests/browser/booking-inquiry.evidence.js
@@ -208,18 +208,18 @@ const measure = ( page ) =>
 		);
 		assert.equal(
 			await page.getByText( 'Accepting inquiries' ).count(),
-			1
+			0
 		);
-		assert.equal( await page.getByText( 'Signed in' ).count(), 1 );
+		assert.equal( await page.getByText( 'Signed in' ).count(), 0 );
 		assert.equal(
 			await page.getByText( 'Have your pitch ready' ).count(),
-			1
+			0
 		);
 		assert.equal(
 			await page.getByText( 'Event type (required)' ).count(),
-			1
+			0
 		);
-		assert.equal( await page.getByText( 'Press links' ).count(), 1 );
+		assert.equal( await page.getByText( 'Press links' ).count(), 0 );
 		assert.equal(
 			await page.getByLabel( 'Artist or project name' ).count(),
 			0
@@ -263,11 +263,7 @@ const measure = ( page ) =>
 		await page.getByLabel( 'Event type' ).selectOption( 'Other' );
 		assert.ok( await page.getByLabel( 'Other event details' ).count() );
 		await page.getByLabel( 'Event type' ).selectOption( 'Concert' );
-		assert.ok(
-			await page
-				.getByRole( 'link', { name: 'Use or manage your Link Page' } )
-				.count()
-		);
+		assert.equal( await page.getByText( /Link Page/ ).count(), 0 );
 		assert.equal(
 			await page
 				.locator( '.ec-booking-inquiry__turnstile .cf-turnstile' )


### PR DESCRIPTION
## Summary
- remove workspace promotion from public venue archives where the established Manage Venue navigation already provides access
- retain venue preferences as a compact `ec-action-row` using existing small outlined and active button primitives
- remove generated intake previews, requirement dumps, status decoration, and explanatory copy
- remove the Link Page promotion and its public payload data
- keep the established calendar, date-first form, configured fields, consent, security, and submit primitives
- preserve private notification delivery and dedicated authenticated venue management

## Verification
- JavaScript tests: 16 suites, 92 tests passed
- focused JavaScript lint passed
- desktop/mobile Playwright evidence passed with no overflow
- PHP syntax checks passed
- `git diff --check`

Closes #569