### PR TITLE
fix: send venue ability input through POST

### DIFF
--- a/blocks/venue-settings/src/api.js
+++ b/blocks/venue-settings/src/api.js
@@ -3,35 +3,11 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 
-const METHODS = {
-	'extrachill/get-venue-profile': 'GET',
-	'extrachill/get-venue-booking-config': 'GET',
-	'extrachill/list-venue-memberships': 'GET',
-	'extrachill/list-venue-invitations': 'GET',
-	'extrachill/list-venue-email-subscribers': 'GET',
-	'extrachill/list-venue-claims': 'GET',
-	'extrachill/get-venue-booking-activity': 'GET',
-	'extrachill/list-booking-holds': 'GET',
-	'extrachill/list-booking-communications': 'GET',
-	'extrachill/events-calendar': 'GET',
-	'extrachill/review-venue-claim': 'DELETE',
-	'extrachill/cancel-venue-invitation': 'DELETE',
-	'extrachill/cancel-venue-claim': 'DELETE',
-};
-
 export const runAbility = ( name, input = {} ) => {
-	const method = METHODS[ name ] || 'POST';
-	const path = `/wp-abilities/v1/abilities/${ name }/run`;
-
-	if ( method === 'POST' ) {
-		return apiFetch( { path, method, data: { input } } );
-	}
-
 	return apiFetch( {
-		path: `${ path }?input=${ encodeURIComponent(
-			JSON.stringify( input )
-		) }`,
-		method,
+		path: `/wp-abilities/v1/abilities/${ name }/run`,
+		method: 'POST',
+		data: { input },
 	} );
 };
 

--- a/blocks/venue-settings/src/api.test.js
+++ b/blocks/venue-settings/src/api.test.js
@@ -18,24 +18,17 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 describe( 'venue settings ability transport', () => {
 	beforeEach( () => apiFetch.mockResolvedValue( {} ) );
 
-	it( 'uses GET with JSON input for canonical reads', async () => {
-		await runAbility( 'extrachill/get-venue-profile', {
-			venue_term_id: 44,
-		} );
-		expect( apiFetch ).toHaveBeenCalledWith(
-			expect.objectContaining( {
-				method: 'GET',
-				path: expect.stringContaining(
-					'input=%7B%22venue_term_id%22%3A44%7D'
-				),
-			} )
-		);
-	} );
-
 	it.each( [
+		'extrachill/get-venue-profile',
+		'extrachill/get-venue-booking-config',
+		'extrachill/list-venue-memberships',
+		'extrachill/list-booking-holds',
 		'extrachill/list-venue-bookings',
 		'extrachill/get-venue-booking',
-	] )( 'uses POST for reconciliation read %s', async ( ability ) => {
+		'extrachill/update-venue-booking-config',
+		'extrachill/review-venue-claim',
+		'extrachill/cancel-venue-invitation',
+	] )( 'sends object input through POST for %s', async ( ability ) => {
 		const input = { venue_term_id: 44 };
 		await runAbility( ability, input );
 		expect( apiFetch ).toHaveBeenCalledWith( {
@@ -43,40 +36,5 @@ describe( 'venue settings ability transport', () => {
 			method: 'POST',
 			data: { input },
 		} );
-	} );
-
-	it( 'uses DELETE for idempotent destructive cancellation', async () => {
-		await runAbility( 'extrachill/cancel-venue-invitation', {
-			invitation_id: 9,
-		} );
-		expect( apiFetch ).toHaveBeenCalledWith(
-			expect.objectContaining( { method: 'DELETE' } )
-		);
-	} );
-
-	it.each( [ 'approved', 'rejected' ] )(
-		'uses DELETE when a claim is %s',
-		async ( decision ) => {
-			const input = {
-				claim_id: 12,
-				decision,
-				expected_version: 3,
-			};
-			await runAbility( 'extrachill/review-venue-claim', input );
-			expect( apiFetch ).toHaveBeenCalledWith( {
-				method: 'DELETE',
-				path: expect.stringContaining(
-					encodeURIComponent( JSON.stringify( input ) )
-				),
-			} );
-		}
-	);
-
-	it( 'wraps mutation input in the WordPress ability request envelope', async () => {
-		const input = { venue_term_id: 44, expected_revision: 2, config: {} };
-		await runAbility( 'extrachill/update-venue-booking-config', input );
-		expect( apiFetch ).toHaveBeenCalledWith(
-			expect.objectContaining( { method: 'POST', data: { input } } )
-		);
 	} );
 } );

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -196,7 +196,11 @@ const context = ( overrides = {} ) => ( {
 	...overrides,
 } );
 
-const requestInput = ( path ) => {
+const requestInput = ( request ) => {
+	if ( request.data?.input ) {
+		return request.data.input;
+	}
+	const path = request.path || request;
 	const input = new URL( `https://events.example${ path }` ).searchParams.get(
 		'input'
 	);
@@ -205,7 +209,7 @@ const requestInput = ( path ) => {
 
 const installApi = () =>
 	apiFetch.mockImplementation( ( request ) => {
-		const input = requestInput( request.path );
+		const input = requestInput( request );
 		if ( request.path.includes( 'get-venue-profile' ) ) {
 			return Promise.resolve( profile( input.venue_term_id ) );
 		}
@@ -397,7 +401,7 @@ describe( 'venue settings authorization-facing states', () => {
 
 	it( 'shows exact current venue email subscribers only to owners', async () => {
 		apiFetch.mockImplementation( ( request ) => {
-			const input = requestInput( request.path );
+			const input = requestInput( request );
 			if ( request.path.includes( 'get-venue-profile' ) ) {
 				return Promise.resolve( profile( input.venue_term_id ) );
 			}
@@ -425,7 +429,7 @@ describe( 'venue settings authorization-facing states', () => {
 		const request = apiFetch.mock.calls.find( ( [ call ] ) =>
 			call.path.includes( 'list-venue-email-subscribers' )
 		)[ 0 ];
-		expect( requestInput( request.path ) ).toEqual( { venue_term_id: 44 } );
+		expect( requestInput( request ) ).toEqual( { venue_term_id: 44 } );
 		await act( async () => root.unmount() );
 	} );
 
@@ -489,7 +493,7 @@ describe( 'venue settings authorization-facing states', () => {
 
 	it( 'surfaces local-support actions on matching calendar events', async () => {
 		apiFetch.mockImplementation( ( request ) => {
-			const input = requestInput( request.path );
+			const input = requestInput( request );
 			if ( request.path.includes( 'get-venue-profile' ) ) {
 				return Promise.resolve( profile( input.venue_term_id ) );
 			}
@@ -546,7 +550,7 @@ describe( 'venue settings authorization-facing states', () => {
 				return Promise.reject( { message: 'Profile unavailable.' } );
 			}
 			if ( request.path.includes( 'get-venue-booking-config' ) ) {
-				const input = requestInput( request.path );
+				const input = requestInput( request );
 				return Promise.resolve( config( input.venue_term_id ) );
 			}
 			return Promise.resolve( [] );
@@ -575,7 +579,7 @@ describe( 'venue settings authorization-facing states', () => {
 		let profileAttempts = 0;
 		let configAttempts = 0;
 		apiFetch.mockImplementation( ( request ) => {
-			const input = requestInput( request.path );
+			const input = requestInput( request );
 			if ( request.path.includes( 'get-venue-profile' ) ) {
 				profileAttempts += 1;
 				return profileAttempts === 1
@@ -612,7 +616,7 @@ describe( 'venue settings authorization-facing states', () => {
 		let profileAttempts = 0;
 		let configAttempts = 0;
 		apiFetch.mockImplementation( ( request ) => {
-			const input = requestInput( request.path );
+			const input = requestInput( request );
 			if ( request.path.includes( 'get-venue-profile' ) ) {
 				profileAttempts += 1;
 				return Promise.resolve( profile( input.venue_term_id ) );
@@ -686,7 +690,7 @@ describe( 'venue settings authorization-facing states', () => {
 
 	it( 'preserves dirty profile data and reports a stale-write conflict', async () => {
 		apiFetch.mockImplementation( ( request ) => {
-			const input = requestInput( request.path );
+			const input = requestInput( request );
 			if ( request.path.includes( 'get-venue-profile' ) ) {
 				return Promise.resolve( profile( input.venue_term_id ) );
 			}
@@ -745,9 +749,7 @@ describe( 'venue settings authorization-facing states', () => {
 		expect( second.container.textContent ).not.toContain( 'Venue 44' );
 		const venueInputs = apiFetch.mock.calls
 			.filter( ( [ request ] ) => request.path.includes( 'get-venue-' ) )
-			.map(
-				( [ request ] ) => requestInput( request.path ).venue_term_id
-			);
+			.map( ( [ request ] ) => requestInput( request ).venue_term_id );
 		expect( venueInputs ).toEqual( [ 44, 44, 88, 88 ] );
 		await act( async () => second.root.unmount() );
 	} );


### PR DESCRIPTION
## Summary
- remove the invalid per-ability GET/DELETE method map from the venue workspace client
- send every Ability run through the canonical POST endpoint with an object `input` envelope
- update transport and workspace tests to assert/read the actual request body

## Production regression
Fixes v0.58.2 errors including `input is not of type object` for booking config, holds, and team reads, plus update abilities rejecting non-POST methods.

## Tests
- `npm run test:js -- --runInBand blocks/venue-settings/src/api.test.js blocks/venue-settings/src/view.test.js` (36 tests)
- `npm run lint:js`
- `npm run build:venue-settings && npm run copy:venue-settings`
- `git diff --check`

Closes #572