### PR TITLE
fix: aggregate venue management workspace

### DIFF
--- a/blocks/venue-settings/render.php
+++ b/blocks/venue-settings/render.php
@@ -102,9 +102,22 @@ if ( $is_admin ) {
 	}
 }
 
+foreach ( $managed_venues as &$venue ) {
+	$venue_id                = (int) $venue['id'];
+	$venue_term              = get_term( $venue_id, 'venue' );
+	$venue['can_access']     = true === $authorization->authorize( $user_id, $venue_id, VenueAuthorization::ACTION_ACCESS_VENUE );
+	$venue['can_manage']     = true === $authorization->authorize( $user_id, $venue_id, VenueAuthorization::ACTION_MANAGE_MEMBERS );
+	$venue['booking_url']    = $venue['can_access'] && $venue_term instanceof WP_Term ? \ExtraChillEvents\Core\VenueBookingEmbed::booking_url( $venue_term ) : '';
+	$venue['support_events'] = $venue['can_access'] && function_exists( 'extrachill_events_local_support_organizer_events' )
+		? extrachill_events_local_support_organizer_events( $user_id, $venue_id )
+		: array();
+}
+unset( $venue );
+
 // phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only venue selection; Ability authorization remains authoritative.
-$requested_venue_id   = isset( $_GET['venue_id'] ) && is_scalar( $_GET['venue_id'] ) ? absint( wp_unslash( $_GET['venue_id'] ) ) : 0;
-$requested_booking_id = isset( $_GET['booking_id'] ) && is_scalar( $_GET['booking_id'] ) ? absint( wp_unslash( $_GET['booking_id'] ) ) : 0;
+$requested_venue_id         = isset( $_GET['venue_id'] ) && is_scalar( $_GET['venue_id'] ) ? absint( wp_unslash( $_GET['venue_id'] ) ) : 0;
+$requested_booking_id       = isset( $_GET['booking_id'] ) && is_scalar( $_GET['booking_id'] ) ? absint( wp_unslash( $_GET['booking_id'] ) ) : 0;
+$requested_booking_venue_id = isset( $_GET['booking_venue_id'] ) && is_scalar( $_GET['booking_venue_id'] ) ? absint( wp_unslash( $_GET['booking_venue_id'] ) ) : 0;
 // phpcs:enable WordPress.Security.NonceVerification.Recommended
 $selected = null;
 foreach ( $managed_venues as $venue ) {
@@ -114,9 +127,17 @@ foreach ( $managed_venues as $venue ) {
 	}
 }
 
-$can_access       = $selected && true === $authorization->authorize( $user_id, $selected['id'], VenueAuthorization::ACTION_ACCESS_VENUE );
-$can_manage       = $selected && true === $authorization->authorize( $user_id, $selected['id'], VenueAuthorization::ACTION_MANAGE_MEMBERS );
-$selected_term    = $selected ? get_term( (int) $selected['id'], 'venue' ) : null;
+$can_access       = $selected && $selected['can_access'];
+$can_manage       = $selected && $selected['can_manage'];
+$booking_venue_id = $can_access ? (int) $selected['id'] : 0;
+if ( ! $selected && $requested_booking_id && $requested_booking_venue_id ) {
+	foreach ( $managed_venues as $venue ) {
+		if ( $requested_booking_venue_id === $venue['id'] && $venue['can_access'] ) {
+			$booking_venue_id = $venue['id'];
+			break;
+		}
+	}
+}
 $context          = array(
 	'user'               => array(
 		'id'       => $user_id,
@@ -130,11 +151,10 @@ $context          = array(
 	'can_manage'         => $can_manage,
 	'route_url'          => home_url( '/venue-settings/' ),
 	'requested_venue_id' => in_array( $requested_venue_id, array_column( $claim_venues, 'id' ), true ) ? $requested_venue_id : 0,
-	'booking_id'         => $can_access ? $requested_booking_id : 0,
-	'booking_url'        => $can_access && $selected_term instanceof WP_Term ? \ExtraChillEvents\Core\VenueBookingEmbed::booking_url( $selected_term ) : '',
-	'support_events'     => $can_access && function_exists( 'extrachill_events_local_support_organizer_events' )
-		? extrachill_events_local_support_organizer_events( $user_id, (int) $selected['id'] )
-		: array(),
+	'booking_id'         => $booking_venue_id ? $requested_booking_id : 0,
+	'booking_venue_id'   => $booking_venue_id,
+	'booking_url'        => $selected['booking_url'] ?? '',
+	'support_events'     => $selected['support_events'] ?? array(),
 );
 $context_id       = wp_unique_id( 'ec-venue-settings-context-' );
 $support_requests = $can_access && LocalSupportSchema::is_ready()

--- a/blocks/venue-settings/src/booking-console.js
+++ b/blocks/venue-settings/src/booking-console.js
@@ -116,6 +116,7 @@ export const calendarEntries = ( bookings, events, supportEvents = [] ) => {
 			status: 'published',
 			permalink: event.permalink,
 			support: supportByEvent.get( Number( event.id ) ) || null,
+			venueName: event.venue_name || '',
 		} ) ),
 		...bookings
 			.filter(
@@ -130,6 +131,7 @@ export const calendarEntries = ( bookings, events, supportEvents = [] ) => {
 				title: booking.artist_name,
 				status: booking.status,
 				booking,
+				venueName: booking.venue_name || '',
 			} ) ),
 	];
 };
@@ -146,6 +148,7 @@ export const filterBookings = ( bookings, search ) => {
 			booking.contact_email,
 			booking.public_id,
 			booking.status,
+			booking.venue_name,
 		]
 			.filter( Boolean )
 			.some( ( value ) =>
@@ -651,6 +654,7 @@ function BookingCard( { booking, active, holds, onSelect } ) {
 			<span className="ec-booking-card__title">
 				{ booking.artist_name }
 			</span>
+			{ booking.venue_name && <span>{ booking.venue_name }</span> }
 			<BookingStatus status={ booking.status } />
 			<span>{ formatDate( booking.requested_start_at ) }</span>
 			{ holds.length > 0 && (
@@ -768,6 +772,9 @@ function Calendar( {
 											{ entry.type === 'event'
 												? 'Published event'
 												: statusLabel( entry.status ) }
+											{ entry.venueName
+												? ` - ${ entry.venueName }`
+												: '' }
 											{ entry.type === 'booking' &&
 											activeHoldCounts[ entry.id ]
 												? ` · ${
@@ -1399,8 +1406,52 @@ function BookingDetail( {
 	);
 }
 
-export function BookingConsole( { context, defaultDeal, supportEvents = [] } ) {
-	const venueId = context.selected_venue.id;
+const PAGE_SIZE = 100;
+const MAX_PAGE_COUNT = 100;
+
+async function listAllVenueRecords( name, input, offset = 0, records = [] ) {
+	if ( offset >= PAGE_SIZE * MAX_PAGE_COUNT ) {
+		throw new Error( 'Venue records exceeded the supported page limit.' );
+	}
+	const page = await runAbility( name, {
+		...input,
+		limit: PAGE_SIZE,
+		offset,
+	} );
+	const combined = [ ...records, ...page ];
+	return page.length === PAGE_SIZE
+		? listAllVenueRecords( name, input, offset + PAGE_SIZE, combined )
+		: combined;
+}
+
+async function listAllVenueEvents( venueId, month, page = 1, events = [] ) {
+	if ( page > MAX_PAGE_COUNT ) {
+		throw new Error( 'Venue events exceeded the supported page limit.' );
+	}
+	const result = await runAbility( 'extrachill/events-calendar', {
+		venue_id: venueId,
+		month,
+		page,
+	} );
+	const combined = [
+		...events,
+		...( result.dates || [] ).flatMap( ( date ) => date.events || [] ),
+	];
+	return result.has_more
+		? listAllVenueEvents( venueId, month, page + 1, combined )
+		: combined;
+}
+
+export function BookingConsole( {
+	context,
+	venues = [],
+	defaultDeal,
+	defaultDeals = {},
+	supportEvents = [],
+} ) {
+	const scopeVenues = venues.length ? venues : [ context.selected_venue ];
+	const venueIds = scopeVenues.map( ( venue ) => venue.id );
+	const aggregateScope = ! context.selected_venue && venues.length > 0;
 	const [ bookings, setBookings ] = useState( [] );
 	const [ events, setEvents ] = useState( [] );
 	const [ holds, setHolds ] = useState( [] );
@@ -1427,39 +1478,95 @@ export function BookingConsole( { context, defaultDeal, supportEvents = [] } ) {
 		setLoading( true );
 		setError( '' );
 		try {
-			const input = { venue_term_id: venueId, limit: 100, offset: 0 };
 			const range = monthRange( month );
-			if ( view === 'calendar' ) {
-				input.range_start = range.start;
-				input.range_end = range.end;
+			const results = await Promise.all(
+				scopeVenues.map( async ( venue ) => {
+					const input = {
+						venue_term_id: venue.id,
+					};
+					if ( view === 'calendar' ) {
+						input.range_start = range.start;
+						input.range_end = range.end;
+					}
+					if ( filterStatus ) {
+						input.status = filterStatus;
+					}
+					const [ bookingResult, holdResult, eventResult ] =
+						await Promise.allSettled( [
+							listAllVenueRecords(
+								'extrachill/list-venue-bookings',
+								input
+							),
+							listAllVenueRecords(
+								'extrachill/list-booking-holds',
+								{
+									venue_term_id: venue.id,
+									...( view === 'calendar'
+										? {
+												range_start: range.start,
+												range_end: range.end,
+										  }
+										: {} ),
+								}
+							),
+							view === 'calendar'
+								? listAllVenueEvents( venue.id, month )
+								: Promise.resolve( [] ),
+						] );
+					return {
+						venue,
+						bookingRows:
+							bookingResult.status === 'fulfilled'
+								? bookingResult.value
+								: [],
+						holdRows:
+							holdResult.status === 'fulfilled'
+								? holdResult.value
+								: [],
+						events:
+							eventResult.status === 'fulfilled'
+								? eventResult.value
+								: [],
+						failedSources: [
+							bookingResult,
+							holdResult,
+							eventResult,
+						].filter( ( result ) => result.status === 'rejected' )
+							.length,
+					};
+				} )
+			);
+			const sourceCount = view === 'calendar' ? 3 : 2;
+			if (
+				results.every(
+					( result ) => result.failedSources >= sourceCount
+				)
+			) {
+				throw new Error( 'Venue data unavailable.' );
 			}
-			if ( filterStatus ) {
-				input.status = filterStatus;
-			}
-			const [ bookingRows, holdRows, calendar ] = await Promise.all( [
-				runAbility( 'extrachill/list-venue-bookings', input ),
-				runAbility( 'extrachill/list-booking-holds', {
-					venue_term_id: venueId,
-					...( view === 'calendar'
-						? { range_start: range.start, range_end: range.end }
-						: {} ),
-					limit: 100,
-					offset: 0,
-				} ),
-				view === 'calendar'
-					? runAbility( 'extrachill/events-calendar', {
-							venue_id: venueId,
-							month,
-					  } )
-					: Promise.resolve( { dates: [] } ),
-			] );
 			if ( currentRequest === requestId.current ) {
-				setBookings( bookingRows );
-				setHolds( holdRows );
-				setEvents(
-					( calendar.dates || [] ).flatMap(
-						( date ) => date.events || []
+				setBookings(
+					results.flatMap( ( result ) =>
+						result.bookingRows.map( ( booking ) => ( {
+							...booking,
+							venue_name: result.venue.name,
+						} ) )
 					)
+				);
+				setHolds( results.flatMap( ( result ) => result.holdRows ) );
+				setEvents(
+					results.flatMap( ( result ) =>
+						result.events.map( ( event ) => ( {
+							...event,
+							venue_term_id: result.venue.id,
+							venue_name: result.venue.name,
+						} ) )
+					)
+				);
+				setError(
+					results.some( ( result ) => result.failedSources > 0 )
+						? 'Some venue records could not be loaded.'
+						: ''
 				);
 			}
 		} catch ( caught ) {
@@ -1496,7 +1603,7 @@ export function BookingConsole( { context, defaultDeal, supportEvents = [] } ) {
 					booking_id: bookingId,
 				} ),
 			] );
-			if ( booking.venue_term_id !== venueId ) {
+			if ( ! venueIds.includes( booking.venue_term_id ) ) {
 				throw new Error(
 					'The booking is outside this venue workspace.'
 				);
@@ -1541,7 +1648,17 @@ export function BookingConsole( { context, defaultDeal, supportEvents = [] } ) {
 		selectedIdRef.current = bookingId;
 		setSelectedId( bookingId );
 		const url = new URL( window.location.href );
-		url.searchParams.set( 'venue_id', venueId );
+		const booking = bookings.find( ( item ) => item.id === bookingId );
+		if ( aggregateScope ) {
+			url.searchParams.delete( 'venue_id' );
+			url.searchParams.set(
+				'booking_venue_id',
+				booking?.venue_term_id || context.booking_venue_id
+			);
+		} else if ( booking?.venue_term_id ) {
+			url.searchParams.set( 'venue_id', booking.venue_term_id );
+			url.searchParams.delete( 'booking_venue_id' );
+		}
 		url.searchParams.set( 'booking_id', bookingId );
 		url.hash = 'tab-calendar';
 		window.history.replaceState( {}, '', url );
@@ -1554,6 +1671,7 @@ export function BookingConsole( { context, defaultDeal, supportEvents = [] } ) {
 		setDetailLoading( false );
 		const url = new URL( window.location.href );
 		url.searchParams.delete( 'booking_id' );
+		url.searchParams.delete( 'booking_venue_id' );
 		window.history.replaceState( {}, '', url );
 	};
 	const refreshAfterMutation = async () => {
@@ -1639,7 +1757,7 @@ export function BookingConsole( { context, defaultDeal, supportEvents = [] } ) {
 						<Panel>
 							<PanelHeader
 								title="Booking pipeline"
-								description="A bounded venue-authorized list. Filters are reapplied by canonical abilities."
+								description="A bounded venue-authorized list across the selected venue scope. Filters are reapplied by canonical abilities."
 							/>
 							{ visible.length ? (
 								<Grid
@@ -1661,7 +1779,8 @@ export function BookingConsole( { context, defaultDeal, supportEvents = [] } ) {
 								</Grid>
 							) : (
 								<EmptyState>
-									No bookings match this venue and filter.
+									No bookings match this venue scope and
+									filter.
 								</EmptyState>
 							) }
 						</Panel>
@@ -1691,7 +1810,9 @@ export function BookingConsole( { context, defaultDeal, supportEvents = [] } ) {
 					holds={ selectedHolds }
 					communications={ communications }
 					operations={ operations }
-					defaultDeal={ defaultDeal }
+					defaultDeal={
+						defaultDeals[ selected.venue_term_id ] || defaultDeal
+					}
 					onMutate={ refreshAfterMutation }
 					onClose={ closeDetail }
 					onRefreshCommunications={ loadDetail }

--- a/blocks/venue-settings/src/booking-tab.js
+++ b/blocks/venue-settings/src/booking-tab.js
@@ -27,7 +27,7 @@ import {
 	validateConfig,
 } from './state';
 
-function SpacesEditor( { spaces, onChange } ) {
+function SpacesEditor( { spaces, onChange, idPrefix } ) {
 	const update = ( index, patch ) =>
 		onChange(
 			spaces.map( ( space, current ) => {
@@ -56,11 +56,11 @@ function SpacesEditor( { spaces, onChange } ) {
 					<legend>Space { index + 1 }</legend>
 					<FieldGroup
 						label="Name"
-						htmlFor={ `space-name-${ index }` }
+						htmlFor={ `${ idPrefix }space-name-${ index }` }
 						required
 					>
 						<input
-							id={ `space-name-${ index }` }
+							id={ `${ idPrefix }space-name-${ index }` }
 							value={ space.name }
 							onChange={ ( event ) =>
 								update( index, {
@@ -74,12 +74,12 @@ function SpacesEditor( { spaces, onChange } ) {
 					</FieldGroup>
 					<FieldGroup
 						label="Key"
-						htmlFor={ `space-key-${ index }` }
+						htmlFor={ `${ idPrefix }space-key-${ index }` }
 						help="Stable machine-readable key used by booking records."
 						required
 					>
 						<input
-							id={ `space-key-${ index }` }
+							id={ `${ idPrefix }space-key-${ index }` }
 							value={ space.key }
 							onChange={ ( event ) =>
 								update( index, {
@@ -88,11 +88,11 @@ function SpacesEditor( { spaces, onChange } ) {
 							}
 						/>
 					</FieldGroup>
-					<label htmlFor={ `space-default-${ index }` }>
+					<label htmlFor={ `${ idPrefix }space-default-${ index }` }>
 						<input
-							id={ `space-default-${ index }` }
+							id={ `${ idPrefix }space-default-${ index }` }
 							type="radio"
-							name="default-space"
+							name={ `${ idPrefix }default-space` }
 							checked={ space.is_default }
 							onChange={ () =>
 								update( index, { is_default: true } )
@@ -141,6 +141,7 @@ export function BookingTab( {
 	bookingUrl,
 	venueName,
 	children,
+	idPrefix = '',
 } ) {
 	const [ copied, setCopied ] = useState( '' );
 	const errors = validateConfig( config );
@@ -166,10 +167,10 @@ export function BookingTab( {
 				/>
 				<label
 					className="ec-venue-settings__toggle"
-					htmlFor="venue-booking-enabled"
+					htmlFor={ `${ idPrefix }venue-booking-enabled` }
 				>
 					<input
-						id="venue-booking-enabled"
+						id={ `${ idPrefix }venue-booking-enabled` }
 						type="checkbox"
 						checked={ config.enabled }
 						onChange={ ( event ) =>
@@ -183,11 +184,11 @@ export function BookingTab( {
 				</label>
 				<FieldGroup
 					label="Default hold duration (minutes)"
-					htmlFor="venue-hold-ttl"
+					htmlFor={ `${ idPrefix }venue-hold-ttl` }
 					help="Between 5 minutes and 14 days."
 				>
 					<input
-						id="venue-hold-ttl"
+						id={ `${ idPrefix }venue-hold-ttl` }
 						type="number"
 						min="5"
 						max={ HOLD_TTL_MAX_MINUTES }
@@ -202,11 +203,11 @@ export function BookingTab( {
 				</FieldGroup>
 				<FieldGroup
 					label="Ticket provider reference"
-					htmlFor="venue-ticket-provider"
+					htmlFor={ `${ idPrefix }venue-ticket-provider` }
 					help="Account, venue, or provider reference used when ticket records are connected."
 				>
 					<input
-						id="venue-ticket-provider"
+						id={ `${ idPrefix }venue-ticket-provider` }
 						value={ config.ticket_provider_reference || '' }
 						onChange={ ( event ) =>
 							setConfig( {
@@ -219,11 +220,11 @@ export function BookingTab( {
 				</FieldGroup>
 				<FieldGroup
 					label="Default marketing channels"
-					htmlFor="venue-marketing-channels"
+					htmlFor={ `${ idPrefix }venue-marketing-channels` }
 					help="Comma-separated canonical channel keys, for example instagram, newsletter."
 				>
 					<input
-						id="venue-marketing-channels"
+						id={ `${ idPrefix }venue-marketing-channels` }
 						value={ config.marketing_channels.join( ', ' ) }
 						onChange={ ( event ) =>
 							setConfig( {
@@ -248,10 +249,10 @@ export function BookingTab( {
 				/>
 				<FieldGroup
 					label="Canonical booking link"
-					htmlFor="venue-booking-link"
+					htmlFor={ `${ idPrefix }venue-booking-link` }
 				>
 					<input
-						id="venue-booking-link"
+						id={ `${ idPrefix }venue-booking-link` }
 						readOnly
 						value={ bookingUrl }
 					/>
@@ -275,11 +276,11 @@ export function BookingTab( {
 				</ActionRow>
 				<FieldGroup
 					label="Allowed parent origins"
-					htmlFor="venue-booking-origins"
+					htmlFor={ `${ idPrefix }venue-booking-origins` }
 					help="One exact HTTPS origin per line, such as https://venue.example. Paths, wildcards, ports, credentials, localhost, and IP addresses are rejected. The first origin is used for the generated snippet."
 				>
 					<textarea
-						id="venue-booking-origins"
+						id={ `${ idPrefix }venue-booking-origins` }
 						rows="4"
 						value={ origins.join( '\n' ) }
 						onChange={ ( event ) =>
@@ -299,10 +300,10 @@ export function BookingTab( {
 					<>
 						<FieldGroup
 							label="Responsive iframe snippet"
-							htmlFor="venue-booking-embed-code"
+							htmlFor={ `${ idPrefix }venue-booking-embed-code` }
 						>
 							<textarea
-								id="venue-booking-embed-code"
+								id={ `${ idPrefix }venue-booking-embed-code` }
 								rows="8"
 								readOnly
 								value={ embedSnippet }
@@ -323,6 +324,7 @@ export function BookingTab( {
 			<SpacesEditor
 				spaces={ config.spaces }
 				onChange={ ( spaces ) => setConfig( { ...config, spaces } ) }
+				idPrefix={ idPrefix }
 			/>
 			<Panel>
 				<PanelHeader
@@ -330,9 +332,12 @@ export function BookingTab( {
 					description="Starting terms only; each booking keeps its own negotiated deal."
 				/>
 				<Grid minColumnWidth="16rem" maxColumns={ 2 }>
-					<FieldGroup label="Deal type" htmlFor="venue-deal-type">
+					<FieldGroup
+						label="Deal type"
+						htmlFor={ `${ idPrefix }venue-deal-type` }
+					>
 						<input
-							id="venue-deal-type"
+							id={ `${ idPrefix }venue-deal-type` }
 							value={ deal.type }
 							onChange={ ( event ) =>
 								setDeal( {
@@ -343,11 +348,11 @@ export function BookingTab( {
 					</FieldGroup>
 					<FieldGroup
 						label="Guarantee"
-						htmlFor="venue-guarantee"
+						htmlFor={ `${ idPrefix }venue-guarantee` }
 						help="Amount in major currency units."
 					>
 						<input
-							id="venue-guarantee"
+							id={ `${ idPrefix }venue-guarantee` }
 							type="number"
 							min="0"
 							step="0.01"
@@ -361,9 +366,12 @@ export function BookingTab( {
 							}
 						/>
 					</FieldGroup>
-					<FieldGroup label="Revenue share (%)" htmlFor="venue-share">
+					<FieldGroup
+						label="Revenue share (%)"
+						htmlFor={ `${ idPrefix }venue-share` }
+					>
 						<input
-							id="venue-share"
+							id={ `${ idPrefix }venue-share` }
 							type="number"
 							min="0"
 							max="100"
@@ -380,10 +388,10 @@ export function BookingTab( {
 					</FieldGroup>
 					<FieldGroup
 						label="Revenue basis"
-						htmlFor="venue-share-basis"
+						htmlFor={ `${ idPrefix }venue-share-basis` }
 					>
 						<select
-							id="venue-share-basis"
+							id={ `${ idPrefix }venue-share-basis` }
 							value={ deal.revenue_share_basis }
 							onChange={ ( event ) =>
 								setDeal( {
@@ -400,9 +408,12 @@ export function BookingTab( {
 							<option value="door_receipts">Door receipts</option>
 						</select>
 					</FieldGroup>
-					<FieldGroup label="Currency" htmlFor="venue-currency">
+					<FieldGroup
+						label="Currency"
+						htmlFor={ `${ idPrefix }venue-currency` }
+					>
 						<input
-							id="venue-currency"
+							id={ `${ idPrefix }venue-currency` }
 							maxLength="3"
 							value={ deal.currency }
 							onChange={ ( event ) =>

--- a/blocks/venue-settings/src/intake-public.js
+++ b/blocks/venue-settings/src/intake-public.js
@@ -3,7 +3,11 @@
  */
 import { FieldGroup, Panel, PanelHeader } from '@extrachill/components';
 
-export default function PublicBookingDetails( { config, setConfig } ) {
+export default function PublicBookingDetails( {
+	config,
+	setConfig,
+	idPrefix = '',
+} ) {
 	const presentation = config.intake.presentation;
 	const labels = [
 		[ 'artist_name_label', 'Artist name label' ],
@@ -21,11 +25,11 @@ export default function PublicBookingDetails( { config, setConfig } ) {
 			/>
 			<FieldGroup
 				label="Public requirements"
-				htmlFor="venue-public-requirements"
+				htmlFor={ `${ idPrefix }venue-public-requirements` }
 				help="One plain-text requirement per line. Internal deal and contact details do not belong here."
 			>
 				<textarea
-					id="venue-public-requirements"
+					id={ `${ idPrefix }venue-public-requirements` }
 					rows="5"
 					value={ config.public_requirements.join( '\n' ) }
 					onChange={ ( event ) =>
@@ -41,18 +45,18 @@ export default function PublicBookingDetails( { config, setConfig } ) {
 			</FieldGroup>
 			<FieldGroup
 				label="Built-in field presentation"
-				htmlFor="venue-booking-presentation"
+				htmlFor={ `${ idPrefix }venue-booking-presentation` }
 				help="Venue-specific wording for stable contact and details fields."
 			>
-				<div id="venue-booking-presentation">
+				<div id={ `${ idPrefix }venue-booking-presentation` }>
 					{ labels.map( ( [ key, label ] ) => (
 						<FieldGroup
 							key={ key }
 							label={ label }
-							htmlFor={ `venue-${ key }` }
+							htmlFor={ `${ idPrefix }venue-${ key }` }
 						>
 							<input
-								id={ `venue-${ key }` }
+								id={ `${ idPrefix }venue-${ key }` }
 								value={ presentation[ key ] }
 								onChange={ ( event ) =>
 									setConfig( {
@@ -73,12 +77,12 @@ export default function PublicBookingDetails( { config, setConfig } ) {
 			</FieldGroup>
 			<FieldGroup
 				label="Consent label"
-				htmlFor="venue-booking-consent"
+				htmlFor={ `${ idPrefix }venue-booking-consent` }
 				help="Increment the version whenever this wording or policy changes."
 				required
 			>
 				<textarea
-					id="venue-booking-consent"
+					id={ `${ idPrefix }venue-booking-consent` }
 					rows="3"
 					value={ config.consent.label }
 					onChange={ ( event ) =>
@@ -94,11 +98,11 @@ export default function PublicBookingDetails( { config, setConfig } ) {
 			</FieldGroup>
 			<FieldGroup
 				label="Consent version"
-				htmlFor="venue-consent-version"
+				htmlFor={ `${ idPrefix }venue-consent-version` }
 				required
 			>
 				<input
-					id="venue-consent-version"
+					id={ `${ idPrefix }venue-consent-version` }
 					type="number"
 					min="1"
 					value={ config.consent.version }

--- a/blocks/venue-settings/src/intake-tab.js
+++ b/blocks/venue-settings/src/intake-tab.js
@@ -21,7 +21,7 @@ const INTAKE_TYPES = [
 	'url_list',
 ];
 
-export function IntakeTab( { config, setConfig } ) {
+export function IntakeTab( { config, setConfig, idPrefix = '' } ) {
 	const fields = config.intake.fields;
 	const setFields = ( next ) =>
 		setConfig( { ...config, intake: { ...config.intake, fields: next } } );
@@ -33,7 +33,11 @@ export function IntakeTab( { config, setConfig } ) {
 		);
 	return (
 		<Grid minColumnWidth="100%">
-			<PublicBookingDetails config={ config } setConfig={ setConfig } />
+			<PublicBookingDetails
+				config={ config }
+				setConfig={ setConfig }
+				idPrefix={ idPrefix }
+			/>
 			<Panel>
 				<PanelHeader
 					title="Inquiry fields"
@@ -51,11 +55,11 @@ export function IntakeTab( { config, setConfig } ) {
 						<Grid minColumnWidth="16rem" maxColumns={ 2 }>
 							<FieldGroup
 								label="Label"
-								htmlFor={ `intake-label-${ index }` }
+								htmlFor={ `${ idPrefix }intake-label-${ index }` }
 								required
 							>
 								<input
-									id={ `intake-label-${ index }` }
+									id={ `${ idPrefix }intake-label-${ index }` }
 									value={ field.label }
 									onChange={ ( event ) =>
 										update( index, {
@@ -71,11 +75,11 @@ export function IntakeTab( { config, setConfig } ) {
 							</FieldGroup>
 							<FieldGroup
 								label="Key"
-								htmlFor={ `intake-key-${ index }` }
+								htmlFor={ `${ idPrefix }intake-key-${ index }` }
 								required
 							>
 								<input
-									id={ `intake-key-${ index }` }
+									id={ `${ idPrefix }intake-key-${ index }` }
 									value={ field.key }
 									onChange={ ( event ) =>
 										update( index, {
@@ -88,10 +92,10 @@ export function IntakeTab( { config, setConfig } ) {
 							</FieldGroup>
 							<FieldGroup
 								label="Type"
-								htmlFor={ `intake-type-${ index }` }
+								htmlFor={ `${ idPrefix }intake-type-${ index }` }
 							>
 								<select
-									id={ `intake-type-${ index }` }
+									id={ `${ idPrefix }intake-type-${ index }` }
 									value={ field.type }
 									onChange={ ( event ) =>
 										update( index, {
@@ -110,11 +114,11 @@ export function IntakeTab( { config, setConfig } ) {
 						{ field.type === 'select' && (
 							<FieldGroup
 								label="Options"
-								htmlFor={ `intake-options-${ index }` }
+								htmlFor={ `${ idPrefix }intake-options-${ index }` }
 								help="One option per line."
 							>
 								<textarea
-									id={ `intake-options-${ index }` }
+									id={ `${ idPrefix }intake-options-${ index }` }
 									value={ field.options.join( '\n' ) }
 									onChange={ ( event ) =>
 										update( index, {
@@ -131,11 +135,11 @@ export function IntakeTab( { config, setConfig } ) {
 						) }
 						<FieldGroup
 							label="Show only when"
-							htmlFor={ `intake-condition-field-${ index }` }
+							htmlFor={ `${ idPrefix }intake-condition-field-${ index }` }
 							help="Optional. Conditional fields may depend on an earlier field."
 						>
 							<select
-								id={ `intake-condition-field-${ index }` }
+								id={ `${ idPrefix }intake-condition-field-${ index }` }
 								value={ field.visible_when?.field || '' }
 								onChange={ ( event ) =>
 									update( index, {
@@ -167,11 +171,11 @@ export function IntakeTab( { config, setConfig } ) {
 						{ field.visible_when && (
 							<FieldGroup
 								label="Matching value"
-								htmlFor={ `intake-condition-value-${ index }` }
+								htmlFor={ `${ idPrefix }intake-condition-value-${ index }` }
 								required
 							>
 								<input
-									id={ `intake-condition-value-${ index }` }
+									id={ `${ idPrefix }intake-condition-value-${ index }` }
 									value={ field.visible_when.value }
 									onChange={ ( event ) =>
 										update( index, {
@@ -184,9 +188,11 @@ export function IntakeTab( { config, setConfig } ) {
 								/>
 							</FieldGroup>
 						) }
-						<label htmlFor={ `intake-required-${ index }` }>
+						<label
+							htmlFor={ `${ idPrefix }intake-required-${ index }` }
+						>
 							<input
-								id={ `intake-required-${ index }` }
+								id={ `${ idPrefix }intake-required-${ index }` }
 								type="checkbox"
 								checked={ field.required }
 								onChange={ ( event ) =>

--- a/blocks/venue-settings/src/profile-tab.js
+++ b/blocks/venue-settings/src/profile-tab.js
@@ -44,6 +44,7 @@ export function ProfileTab( {
 	onSave,
 	saving,
 	status,
+	idPrefix = '',
 } ) {
 	const dirty = profile && baseline && ! sameDocument( profile, baseline );
 	return (
@@ -56,12 +57,12 @@ export function ProfileTab( {
 				<FieldGroup
 					key={ key }
 					label={ label }
-					htmlFor={ `venue-profile-${ key }` }
+					htmlFor={ `${ idPrefix }venue-profile-${ key }` }
 					required={ required }
 				>
 					{ key === 'description' ? (
 						<textarea
-							id={ `venue-profile-${ key }` }
+							id={ `${ idPrefix }venue-profile-${ key }` }
 							rows="5"
 							value={ profile[ key ] }
 							onChange={ ( event ) =>
@@ -73,7 +74,7 @@ export function ProfileTab( {
 						/>
 					) : (
 						<input
-							id={ `venue-profile-${ key }` }
+							id={ `${ idPrefix }venue-profile-${ key }` }
 							type={ profileInputType( key ) }
 							value={ profile[ key ] }
 							required={ required }

--- a/blocks/venue-settings/src/team-tab.js
+++ b/blocks/venue-settings/src/team-tab.js
@@ -45,6 +45,7 @@ export function TeamTab( {
 	invitations,
 	subscribers,
 	onRefresh,
+	idPrefix = '',
 } ) {
 	const [ email, setEmail ] = useState( '' );
 	const [ owner, setOwner ] = useState( false );
@@ -138,11 +139,11 @@ export function TeamTab( {
 				<form onSubmit={ invite }>
 					<FieldGroup
 						label="Email"
-						htmlFor="venue-invite-email"
+						htmlFor={ `${ idPrefix }venue-invite-email` }
 						required
 					>
 						<input
-							id="venue-invite-email"
+							id={ `${ idPrefix }venue-invite-email` }
 							type="email"
 							required
 							value={ email }
@@ -151,9 +152,9 @@ export function TeamTab( {
 							}
 						/>
 					</FieldGroup>
-					<label htmlFor="venue-invite-owner">
+					<label htmlFor={ `${ idPrefix }venue-invite-owner` }>
 						<input
-							id="venue-invite-owner"
+							id={ `${ idPrefix }venue-invite-owner` }
 							type="checkbox"
 							checked={ owner }
 							onChange={ ( event ) =>

--- a/blocks/venue-settings/src/venue-workspace-header.js
+++ b/blocks/venue-settings/src/venue-workspace-header.js
@@ -14,7 +14,7 @@ export function VenueWorkspaceHeader( { venues, selected, onSwitchVenue } ) {
 		<>
 			<BlockShellHeader
 				title="Manage venues"
-				description="Choose all venues for an overview or open an individual venue workspace."
+				description="Manage every venue together or filter the workspace to one venue."
 			/>
 			{ venues.length > 0 && (
 				<FieldGroup label="Venue workspace" htmlFor="venue-workspace">
@@ -23,7 +23,7 @@ export function VenueWorkspaceHeader( { venues, selected, onSwitchVenue } ) {
 						value={ selected?.id || 0 }
 						onChange={ onSwitchVenue }
 					>
-						<option value="0">All venues</option>
+						<option value="0">My Venues</option>
 						{ venues.map( ( venue ) => (
 							<option key={ venue.id } value={ venue.id }>
 								{ venue.name }

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -30,105 +30,106 @@ import { editableConfig, profileChanges, sameDocument } from './state';
 
 export { venueSubscriberCsv } from './team-tab';
 
-function AllVenues( { venues, routeUrl } ) {
-	return (
-		<Panel>
-			<h2>All venues</h2>
-			<p>
-				Open a venue to manage its calendar, bookings, profile, and
-				team.
-			</p>
-			<ul className="ec-venue-settings__records">
-				{ venues.map( ( venue ) => {
-					const url = new URL( routeUrl );
-					url.searchParams.set( 'venue_id', venue.id );
-					return (
-						<li key={ venue.id }>
-							<span>
-								<strong>{ venue.name }</strong>{ ' ' }
-								<small>
-									{ venue.status }
-									{ venue.is_owner ? ' - owner' : '' }
-								</small>
-							</span>
-							<a
-								className="button-2 button-small"
-								href={ url.toString() }
-							>
-								Open workspace
-							</a>
-						</li>
-					);
-				} ) }
-			</ul>
-		</Panel>
-	);
-}
-
 export function VenueSettingsApp( { context } ) {
 	const selected = context.selected_venue;
 	const [ activeTab, setActiveTab ] = useState( 'calendar' );
-	const [ loading, setLoading ] = useState( Boolean( context.can_access ) );
 	const [ loadErrors, setLoadErrors ] = useState( {} );
-	const [ profile, setProfile ] = useState( null );
-	const [ profileBaseline, setProfileBaseline ] = useState( null );
-	const [ config, setConfig ] = useState( null );
-	const [ configBaseline, setConfigBaseline ] = useState( null );
-	const [ configRevision, setConfigRevision ] = useState( 0 );
-	const [ members, setMembers ] = useState( [] );
-	const [ invitations, setInvitations ] = useState( [] );
-	const [ subscribers, setSubscribers ] = useState( [] );
+	const [ profiles, setProfiles ] = useState( {} );
+	const [ profileBaselines, setProfileBaselines ] = useState( {} );
+	const [ configs, setConfigs ] = useState( {} );
+	const [ configBaselines, setConfigBaselines ] = useState( {} );
+	const [ configRevisions, setConfigRevisions ] = useState( {} );
+	const [ members, setMembers ] = useState( {} );
+	const [ invitations, setInvitations ] = useState( {} );
+	const [ subscribers, setSubscribers ] = useState( {} );
 	const [ claims, setClaims ] = useState( [] );
-	const [ profileStatus, setProfileStatus ] = useState( null );
-	const [ configStatus, setConfigStatus ] = useState( null );
-	const [ savingProfile, setSavingProfile ] = useState( false );
-	const [ savingConfig, setSavingConfig ] = useState( false );
-	const profileRequestId = useRef( 0 );
-	const configRequestId = useRef( 0 );
-	const dirty =
-		Boolean(
-			profile &&
-				profileBaseline &&
-				! sameDocument( profile, profileBaseline )
-		) ||
-		Boolean(
-			config && configBaseline && ! sameDocument( config, configBaseline )
+	const [ profileStatuses, setProfileStatuses ] = useState( {} );
+	const [ configStatuses, setConfigStatuses ] = useState( {} );
+	const [ savingProfiles, setSavingProfiles ] = useState( {} );
+	const [ savingConfigs, setSavingConfigs ] = useState( {} );
+	const profileRequestIds = useRef( {} );
+	const configRequestIds = useRef( {} );
+	const teamRequestIds = useRef( {} );
+	const scopedVenues = selected ? [ selected ] : context.venues;
+	const canAccess = ( venue ) =>
+		typeof venue.can_access === 'boolean'
+			? venue.can_access
+			: selected?.id === venue.id && Boolean( context.can_access );
+	const canManage = ( venue ) =>
+		typeof venue.can_manage === 'boolean'
+			? venue.can_manage
+			: selected?.id === venue.id && Boolean( context.can_manage );
+	const accessibleVenues = scopedVenues.filter( canAccess );
+	const manageableVenues = scopedVenues.filter( canManage );
+	const setVenueState = ( setter, venueId, value ) =>
+		setter( ( current ) => ( { ...current, [ venueId ]: value } ) );
+	const setVenueError = ( venueId, key, value ) =>
+		setLoadErrors( ( current ) => ( {
+			...current,
+			[ venueId ]: { ...current[ venueId ], [ key ]: value },
+		} ) );
+	const dirty = scopedVenues.some( ( venue ) => {
+		const profile = profiles[ venue.id ];
+		const profileBaseline = profileBaselines[ venue.id ];
+		const config = configs[ venue.id ];
+		const configBaseline = configBaselines[ venue.id ];
+		return (
+			Boolean(
+				profile &&
+					profileBaseline &&
+					! sameDocument( profile, profileBaseline )
+			) ||
+			Boolean(
+				config &&
+					configBaseline &&
+					! sameDocument( config, configBaseline )
+			)
 		);
+	} );
 
-	const loadTeam = async () => {
-		if ( ! selected || ! context.can_manage ) {
+	const loadTeam = async ( venue ) => {
+		if ( ! canManage( venue ) ) {
 			return;
 		}
+		const currentRequest = ( teamRequestIds.current[ venue.id ] || 0 ) + 1;
+		teamRequestIds.current[ venue.id ] = currentRequest;
 		const [ memberResult, invitationResult, subscriberResult ] =
 			await Promise.allSettled( [
 				runAbility( 'extrachill/list-venue-memberships', {
-					venue_term_id: selected.id,
+					venue_term_id: venue.id,
 				} ),
 				runAbility( 'extrachill/list-venue-invitations', {
-					venue_term_id: selected.id,
+					venue_term_id: venue.id,
 				} ),
 				runAbility( 'extrachill/list-venue-email-subscribers', {
-					venue_term_id: selected.id,
+					venue_term_id: venue.id,
 				} ),
 			] );
+		if ( currentRequest !== teamRequestIds.current[ venue.id ] ) {
+			return;
+		}
 		if ( memberResult.status === 'fulfilled' ) {
-			setMembers( memberResult.value );
+			setVenueState( setMembers, venue.id, memberResult.value );
 		}
 		if ( invitationResult.status === 'fulfilled' ) {
-			setInvitations( invitationResult.value );
+			setVenueState( setInvitations, venue.id, invitationResult.value );
 		}
 		if ( subscriberResult.status === 'fulfilled' ) {
-			setSubscribers( subscriberResult.value.subscribers || [] );
+			setVenueState(
+				setSubscribers,
+				venue.id,
+				subscriberResult.value.subscribers || []
+			);
 		}
-		setLoadErrors( ( current ) => ( {
-			...current,
-			team:
-				memberResult.status === 'rejected' ||
+		setVenueError(
+			venue.id,
+			'team',
+			memberResult.status === 'rejected' ||
 				invitationResult.status === 'rejected' ||
 				subscriberResult.status === 'rejected'
-					? 'Some team records could not be loaded.'
-					: null,
-		} ) );
+				? 'Some team records could not be loaded.'
+				: null
+		);
 	};
 	const loadClaims = async () => {
 		if ( ! context.user.is_admin ) {
@@ -144,75 +145,64 @@ export function VenueSettingsApp( { context } ) {
 			} ) );
 		}
 	};
-	const loadProfile = async () => {
-		const currentRequest = ++profileRequestId.current;
-		setLoadErrors( ( current ) => ( { ...current, profile: null } ) );
+	const loadProfile = async ( venue ) => {
+		const currentRequest =
+			( profileRequestIds.current[ venue.id ] || 0 ) + 1;
+		profileRequestIds.current[ venue.id ] = currentRequest;
+		setVenueError( venue.id, 'profile', null );
 		try {
 			const result = await runAbility( 'extrachill/get-venue-profile', {
-				venue_term_id: selected.id,
+				venue_term_id: venue.id,
 			} );
-			if ( currentRequest !== profileRequestId.current ) {
+			if ( currentRequest !== profileRequestIds.current[ venue.id ] ) {
 				return;
 			}
-			setProfile( result );
-			setProfileBaseline( result );
+			setVenueState( setProfiles, venue.id, result );
+			setVenueState( setProfileBaselines, venue.id, result );
 		} catch ( error ) {
-			if ( currentRequest !== profileRequestId.current ) {
+			if ( currentRequest !== profileRequestIds.current[ venue.id ] ) {
 				return;
 			}
-			setLoadErrors( ( current ) => ( {
-				...current,
-				profile: errorDetails( error ).message,
-			} ) );
+			setVenueError( venue.id, 'profile', errorDetails( error ).message );
 		}
 	};
-	const loadConfig = async () => {
-		const currentRequest = ++configRequestId.current;
-		setLoadErrors( ( current ) => ( { ...current, config: null } ) );
+	const loadConfig = async ( venue ) => {
+		const currentRequest =
+			( configRequestIds.current[ venue.id ] || 0 ) + 1;
+		configRequestIds.current[ venue.id ] = currentRequest;
+		setVenueError( venue.id, 'config', null );
 		try {
 			const result = await runAbility(
 				'extrachill/get-venue-booking-config',
 				{
-					venue_term_id: selected.id,
+					venue_term_id: venue.id,
 				}
 			);
-			if ( currentRequest !== configRequestId.current ) {
+			if ( currentRequest !== configRequestIds.current[ venue.id ] ) {
 				return;
 			}
-			setConfigRevision( result.revision );
+			setVenueState( setConfigRevisions, venue.id, result.revision );
 			const editable = editableConfig( result );
-			setConfig( editable );
-			setConfigBaseline( editable );
+			setVenueState( setConfigs, venue.id, editable );
+			setVenueState( setConfigBaselines, venue.id, editable );
 		} catch ( error ) {
-			if ( currentRequest !== configRequestId.current ) {
+			if ( currentRequest !== configRequestIds.current[ venue.id ] ) {
 				return;
 			}
-			setLoadErrors( ( current ) => ( {
-				...current,
-				config: errorDetails( error ).message,
-			} ) );
+			setVenueError( venue.id, 'config', errorDetails( error ).message );
 		}
 	};
-	const loadVenue = async () => {
-		if ( ! selected || ! context.can_access ) {
-			return;
+	const loadVenue = async ( venue ) => {
+		if ( canAccess( venue ) ) {
+			await Promise.all( [ loadProfile( venue ), loadConfig( venue ) ] );
 		}
-		setLoading( true );
-		setLoadErrors( {} );
-		setProfile( null );
-		setConfig( null );
-		await Promise.all( [ loadProfile(), loadConfig() ] );
-		setLoading( false );
-		await Promise.all( [ loadTeam(), loadClaims() ] );
+		await loadTeam( venue );
 	};
 
 	useEffect( () => {
-		if ( context.can_access ) {
-			loadVenue();
-		} else {
-			loadClaims();
-		}
-		// The selected venue is immutable for this mount; switching performs a full route navigation.
+		Promise.all( scopedVenues.map( loadVenue ) );
+		loadClaims();
+		// The scope is immutable for this mount; switching performs a full route navigation.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 	useEffect( () => {
@@ -242,27 +232,29 @@ export function VenueSettingsApp( { context } ) {
 		}
 		window.location.assign( url.toString() );
 	};
-	const saveProfile = async () => {
-		setSavingProfile( true );
-		setProfileStatus( null );
+	const saveProfile = async ( venue ) => {
+		const profile = profiles[ venue.id ];
+		const baseline = profileBaselines[ venue.id ];
+		setVenueState( setSavingProfiles, venue.id, true );
+		setVenueState( setProfileStatuses, venue.id, null );
 		try {
 			const result = await runAbility(
 				'extrachill/update-venue-profile',
 				{
-					venue_term_id: selected.id,
-					expected_revision: profileBaseline.revision,
-					profile: profileChanges( profile, profileBaseline ),
+					venue_term_id: venue.id,
+					expected_revision: baseline.revision,
+					profile: profileChanges( profile, baseline ),
 				}
 			);
-			setProfile( result.profile );
-			setProfileBaseline( result.profile );
-			setProfileStatus( {
+			setVenueState( setProfiles, venue.id, result.profile );
+			setVenueState( setProfileBaselines, venue.id, result.profile );
+			setVenueState( setProfileStatuses, venue.id, {
 				tone: 'success',
 				message: 'Venue profile saved.',
 			} );
 		} catch ( error ) {
 			const details = errorDetails( error );
-			setProfileStatus( {
+			setVenueState( setProfileStatuses, venue.id, {
 				tone: details.status === 409 ? 'warning' : 'error',
 				message:
 					details.status === 409
@@ -270,32 +262,33 @@ export function VenueSettingsApp( { context } ) {
 						: details.message,
 			} );
 		} finally {
-			setSavingProfile( false );
+			setVenueState( setSavingProfiles, venue.id, false );
 		}
 	};
-	const saveConfig = async () => {
-		setSavingConfig( true );
-		setConfigStatus( null );
+	const saveConfig = async ( venue ) => {
+		const config = configs[ venue.id ];
+		setVenueState( setSavingConfigs, venue.id, true );
+		setVenueState( setConfigStatuses, venue.id, null );
 		try {
 			const result = await runAbility(
 				'extrachill/update-venue-booking-config',
 				{
-					venue_term_id: selected.id,
-					expected_revision: configRevision,
+					venue_term_id: venue.id,
+					expected_revision: configRevisions[ venue.id ],
 					config,
 				}
 			);
 			const editable = editableConfig( result );
-			setConfigRevision( result.revision );
-			setConfig( editable );
-			setConfigBaseline( editable );
-			setConfigStatus( {
+			setVenueState( setConfigRevisions, venue.id, result.revision );
+			setVenueState( setConfigs, venue.id, editable );
+			setVenueState( setConfigBaselines, venue.id, editable );
+			setVenueState( setConfigStatuses, venue.id, {
 				tone: 'success',
 				message: 'Venue settings saved.',
 			} );
 		} catch ( error ) {
 			const details = errorDetails( error );
-			setConfigStatus( {
+			setVenueState( setConfigStatuses, venue.id, {
 				tone: details.status === 409 ? 'warning' : 'error',
 				message:
 					details.status === 409
@@ -303,68 +296,82 @@ export function VenueSettingsApp( { context } ) {
 						: details.message,
 			} );
 		} finally {
-			setSavingConfig( false );
+			setVenueState( setSavingConfigs, venue.id, false );
 		}
 	};
 
 	const tabs = [
-		{ id: 'calendar', label: 'Calendar' },
-		{ id: 'venue', label: 'Venue' },
-		{ id: 'settings', label: 'Settings' },
-		...( context.can_manage ? [ { id: 'team', label: 'Team' } ] : [] ),
+		...( accessibleVenues.length
+			? [
+					{ id: 'calendar', label: 'Calendar' },
+					{ id: 'venue', label: 'Venue' },
+					{ id: 'settings', label: 'Settings' },
+			  ]
+			: [] ),
+		...( manageableVenues.length ? [ { id: 'team', label: 'Team' } ] : [] ),
 	];
-	const renderPanel = ( tab ) => {
-		if ( tab === 'calendar' ) {
-			return (
-				<BookingConsole
-					key={ selected.id }
-					context={ context }
-					defaultDeal={ config?.default_deal }
-					supportEvents={ context.support_events }
-				/>
-			);
-		}
+	const resolvedActiveTab = tabs.some( ( tab ) => tab.id === activeTab )
+		? activeTab
+		: tabs[ 0 ]?.id;
+	const renderVenuePanel = ( venue, tab ) => {
+		const venueContext = {
+			...context,
+			selected_venue: venue,
+			can_access: canAccess( venue ),
+			can_manage: canManage( venue ),
+			booking_id: selected?.id === venue.id ? context.booking_id : 0,
+			booking_url: venue.booking_url || context.booking_url || '',
+			support_events:
+				venue.support_events ||
+				( selected?.id === venue.id ? context.support_events : [] ),
+		};
+		const errors = loadErrors[ venue.id ] || {};
+		const config = configs[ venue.id ];
+		const idPrefix = selected ? '' : `venue-${ venue.id }-`;
 		if ( tab === 'venue' ) {
-			if ( loadErrors.profile ) {
+			if ( errors.profile ) {
 				return (
 					<Panel>
 						<InlineStatus tone="error">
-							{ loadErrors.profile }
+							{ errors.profile }
 						</InlineStatus>
 						<button
 							type="button"
 							className="button-2"
-							onClick={ loadProfile }
+							onClick={ () => loadProfile( venue ) }
 						>
 							Retry profile
 						</button>
 					</Panel>
 				);
 			}
-			return profile ? (
+			return profiles[ venue.id ] ? (
 				<ProfileTab
-					profile={ profile }
-					baseline={ profileBaseline }
-					setProfile={ setProfile }
-					onSave={ saveProfile }
-					saving={ savingProfile }
-					status={ profileStatus }
+					profile={ profiles[ venue.id ] }
+					baseline={ profileBaselines[ venue.id ] }
+					setProfile={ ( value ) =>
+						setVenueState( setProfiles, venue.id, value )
+					}
+					onSave={ () => saveProfile( venue ) }
+					saving={ Boolean( savingProfiles[ venue.id ] ) }
+					status={ profileStatuses[ venue.id ] }
+					idPrefix={ idPrefix }
 				/>
 			) : (
 				<LoadingPanel label="Loading profile..." />
 			);
 		}
 		if ( tab === 'settings' ) {
-			if ( loadErrors.config ) {
+			if ( errors.config ) {
 				return (
 					<Panel>
 						<InlineStatus tone="error">
-							{ loadErrors.config }
+							{ errors.config }
 						</InlineStatus>
 						<button
 							type="button"
 							className="button-2"
-							onClick={ loadConfig }
+							onClick={ () => loadConfig( venue ) }
 						>
 							Retry booking settings
 						</button>
@@ -374,15 +381,24 @@ export function VenueSettingsApp( { context } ) {
 			return config ? (
 				<BookingTab
 					config={ config }
-					baseline={ configBaseline }
-					setConfig={ setConfig }
-					onSave={ saveConfig }
-					saving={ savingConfig }
-					status={ configStatus }
-					bookingUrl={ context.booking_url }
-					venueName={ selected.name }
+					baseline={ configBaselines[ venue.id ] }
+					setConfig={ ( value ) =>
+						setVenueState( setConfigs, venue.id, value )
+					}
+					onSave={ () => saveConfig( venue ) }
+					saving={ Boolean( savingConfigs[ venue.id ] ) }
+					status={ configStatuses[ venue.id ] }
+					bookingUrl={ venueContext.booking_url }
+					venueName={ venue.name }
+					idPrefix={ idPrefix }
 				>
-					<IntakeTab config={ config } setConfig={ setConfig } />
+					<IntakeTab
+						config={ config }
+						setConfig={ ( value ) =>
+							setVenueState( setConfigs, venue.id, value )
+						}
+						idPrefix={ idPrefix }
+					/>
 				</BookingTab>
 			) : (
 				<LoadingPanel label="Loading venue settings..." />
@@ -393,64 +409,106 @@ export function VenueSettingsApp( { context } ) {
 				<>
 					<Status
 						state={
-							loadErrors.team
-								? { tone: 'warning', message: loadErrors.team }
+							errors.team
+								? { tone: 'warning', message: errors.team }
 								: null
 						}
-						onRetry={ loadTeam }
+						onRetry={ () => loadTeam( venue ) }
 					/>
 					<TeamTab
-						venueId={ selected.id }
-						members={ members }
-						invitations={ invitations }
-						subscribers={ subscribers }
-						onRefresh={ loadTeam }
+						venueId={ venue.id }
+						members={ members[ venue.id ] || [] }
+						invitations={ invitations[ venue.id ] || [] }
+						subscribers={ subscribers[ venue.id ] || [] }
+						onRefresh={ () => loadTeam( venue ) }
+						idPrefix={ idPrefix }
 					/>
 				</>
 			);
 		}
 		return null;
 	};
-	const claimsQueue =
-		context.user.is_admin && claims.length > 0 ? (
-			<ClaimsTab
-				claims={ claims }
-				venues={ context.claim_venues }
-				onRefresh={ loadClaims }
-			/>
-		) : null;
-	const renderWorkspace = () => {
-		if ( ! selected && context.venues.length > 0 ) {
+	const renderPanel = ( tab ) => {
+		if ( tab === 'calendar' ) {
 			return (
-				<>
-					{ claimsQueue }
-					<AllVenues
-						venues={ context.venues }
-						routeUrl={ context.route_url }
-					/>
-				</>
+				<BookingConsole
+					context={ context }
+					venues={ accessibleVenues }
+					defaultDeals={ Object.fromEntries(
+						accessibleVenues.map( ( venue ) => [
+							venue.id,
+							configs[ venue.id ]?.default_deal,
+						] )
+					) }
+					supportEvents={ accessibleVenues.flatMap( ( venue ) =>
+						(
+							venue.support_events ||
+							( selected?.id === venue.id
+								? context.support_events
+								: [] )
+						).map( ( event ) => ( {
+							...event,
+							venue_term_id: venue.id,
+							venue_name: venue.name,
+						} ) )
+					) }
+				/>
 			);
 		}
-		if ( ! selected || ! context.can_access ) {
+		const venues = tab === 'team' ? manageableVenues : accessibleVenues;
+		return venues.map( ( venue ) => (
+			<section
+				className="ec-venue-settings__venue-scope"
+				key={ venue.id }
+				aria-labelledby={
+					selected ? undefined : `venue-scope-${ tab }-${ venue.id }`
+				}
+			>
+				{ ! selected && (
+					<h2 id={ `venue-scope-${ tab }-${ venue.id }` }>
+						{ venue.name }
+					</h2>
+				) }
+				{ renderVenuePanel( venue, tab ) }
+			</section>
+		) );
+	};
+	const claimsQueue = context.user.is_admin ? (
+		<>
+			<Status
+				state={
+					loadErrors.claims
+						? { tone: 'error', message: loadErrors.claims }
+						: null
+				}
+				onRetry={ loadClaims }
+			/>
+			{ claims.length > 0 && (
+				<ClaimsTab
+					claims={ claims }
+					venues={ context.claim_venues }
+					onRefresh={ loadClaims }
+				/>
+			) }
+		</>
+	) : null;
+	const renderWorkspace = () => {
+		if ( selected && ! canAccess( selected ) && ! canManage( selected ) ) {
 			if ( context.user.is_admin ) {
-				return (
-					<>
-						<Status
-							state={
-								loadErrors.claims
-									? {
-											tone: 'error',
-											message: loadErrors.claims,
-									  }
-									: null
-							}
-							onRetry={ loadClaims }
-						/>
-						{ claimsQueue }
-					</>
-				);
+				return claimsQueue;
 			}
 			return (
+				<ClaimPanel
+					venues={ context.claim_venues }
+					membership={ selected }
+					initialVenueId={ context.requested_venue_id }
+				/>
+			);
+		}
+		if ( tabs.length === 0 ) {
+			return context.user.is_admin ? (
+				claimsQueue
+			) : (
 				<ClaimPanel
 					venues={ context.claim_venues }
 					membership={ selected }
@@ -462,14 +520,9 @@ export function VenueSettingsApp( { context } ) {
 		return (
 			<>
 				{ claimsQueue }
-				{ loading && (
-					<p className="screen-reader-text" aria-live="polite">
-						Loading venue workspace.
-					</p>
-				) }
 				<ResponsiveTabs
 					tabs={ tabs }
-					active={ activeTab }
+					active={ resolvedActiveTab }
 					onChange={ setActiveTab }
 					renderPanel={ renderPanel }
 					mobileBreakpoint={ 720 }

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -336,12 +336,21 @@ describe( 'venue settings authorization-facing states', () => {
 
 	it( 'shows all manageable venues by default', async () => {
 		const venues = [
-			{ id: 44, name: 'Venue 44', status: 'active', is_owner: true },
+			{
+				id: 44,
+				name: 'Venue 44',
+				status: 'active',
+				is_owner: true,
+				can_access: true,
+				can_manage: true,
+			},
 			{
 				id: 45,
 				name: 'Venue 45',
-				status: 'administrator',
+				status: 'active',
 				is_owner: false,
+				can_access: true,
+				can_manage: false,
 			},
 		];
 		const { container, root } = await renderApp(
@@ -354,16 +363,175 @@ describe( 'venue settings authorization-facing states', () => {
 
 		const selector = container.querySelector( '#venue-workspace' );
 		expect( selector.value ).toBe( '0' );
-		expect( selector.options[ 0 ].textContent ).toBe( 'All venues' );
+		expect( selector.options[ 0 ].textContent ).toBe( 'My Venues' );
 		expect( container.textContent ).toContain( 'Venue 44' );
 		expect( container.textContent ).toContain( 'Venue 45' );
-		expect( container.textContent ).toContain( 'owner' );
 		expect(
-			container
-				.querySelector( 'a[href*="venue_id=45"]' )
-				.getAttribute( 'href' )
-		).toBe( 'https://events.example/venue-settings/?venue_id=45' );
-		expect( apiFetch ).not.toHaveBeenCalled();
+			[ ...container.querySelectorAll( 'button' ) ]
+				.slice( 0, 4 )
+				.map( ( button ) => button.textContent )
+		).toEqual( [ 'Calendar', 'Venue', 'Settings', 'Team' ] );
+		expect( container.textContent ).not.toContain( 'Open workspace' );
+		const profileVenueIds = apiFetch.mock.calls
+			.filter( ( [ request ] ) =>
+				request.path.includes( 'get-venue-profile' )
+			)
+			.map( ( [ request ] ) =>
+				request.data?.input
+					? request.data.input.venue_term_id
+					: requestInput( request.path ).venue_term_id
+			);
+		expect( profileVenueIds ).toEqual( [ 44, 45 ] );
+
+		await act( async () => buttonByText( container, 'Venue' ).click() );
+		expect( container.textContent ).toContain( 'Public venue profile' );
+		expect(
+			container.querySelectorAll( '.ec-venue-settings__venue-scope > h2' )
+		).toHaveLength( 2 );
+		for ( const tab of [ 'Venue', 'Settings', 'Team' ] ) {
+			await act( async () => buttonByText( container, tab ).click() );
+			const ids = [ ...container.querySelectorAll( '[id]' ) ].map(
+				( element ) => element.id
+			);
+			expect( new Set( ids ).size ).toBe( ids.length );
+		}
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'combines events, submissions, and holds across My Venues', async () => {
+		apiFetch.mockImplementation( ( request ) => {
+			const input = request.data?.input || requestInput( request.path );
+			const venueId = input.venue_term_id || input.venue_id;
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( venueId ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( venueId ) );
+			}
+			if ( request.path.includes( 'list-venue-bookings' ) ) {
+				return Promise.resolve( [
+					{
+						...booking( 100 + venueId, venueId ),
+						artist_name: `Artist ${ venueId }`,
+						requested_start_at: '2026-08-05 20:00:00',
+					},
+				] );
+			}
+			if ( request.path.includes( 'list-booking-holds' ) ) {
+				return Promise.resolve( [
+					{
+						id: 200 + venueId,
+						booking_id: 100 + venueId,
+						status: 'active',
+					},
+				] );
+			}
+			if ( request.path.includes( 'events-calendar' ) ) {
+				return Promise.resolve( {
+					dates: [
+						{
+							events: [
+								{
+									id: 300 + venueId,
+									title: `Published ${ venueId }`,
+									datetime: '2026-08-06 20:00:00',
+									permalink: `https://events.example/event-${ venueId }/`,
+								},
+							],
+						},
+					],
+				} );
+			}
+			return Promise.resolve( [] );
+		} );
+		const venues = [ 44, 45 ].map( ( id ) => ( {
+			id,
+			name: `Venue ${ id }`,
+			status: 'active',
+			is_owner: false,
+			can_access: true,
+			can_manage: false,
+		} ) );
+		const { container, root } = await renderApp(
+			context( {
+				venues,
+				selected_venue: null,
+				can_access: false,
+			} )
+		);
+
+		for ( const id of [ 44, 45 ] ) {
+			expect( container.textContent ).toContain( `Artist ${ id }` );
+			expect( container.textContent ).toContain( `Published ${ id }` );
+			expect( container.textContent ).toContain( `Venue ${ id }` );
+		}
+		expect( container.textContent.match( /1 active hold/g ) ).toHaveLength(
+			2
+		);
+		window.history.replaceState( {}, '', '/venue-settings/' );
+		await act( async () => {
+			buttonContaining( container, 'Artist 44' ).click();
+			await Promise.resolve();
+		} );
+		const selectedUrl = new URL( window.location.href );
+		expect( selectedUrl.searchParams.get( 'booking_id' ) ).toBe( '144' );
+		expect( selectedUrl.searchParams.get( 'booking_venue_id' ) ).toBe(
+			'44'
+		);
+		expect( selectedUrl.searchParams.has( 'venue_id' ) ).toBe( false );
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'keeps profile edits and saves isolated by venue', async () => {
+		let updateInput;
+		apiFetch.mockImplementation( ( request ) => {
+			const input = request.data?.input || {};
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'update-venue-profile' ) ) {
+				updateInput = input;
+				return Promise.resolve( {
+					profile: {
+						...profile( input.venue_term_id ),
+						...input.profile,
+					},
+				} );
+			}
+			if ( request.path.includes( 'events-calendar' ) ) {
+				return Promise.resolve( { dates: [], has_more: false } );
+			}
+			return Promise.resolve( [] );
+		} );
+		const venues = [ 44, 45 ].map( ( id ) => ( {
+			id,
+			name: `Venue ${ id }`,
+			status: 'active',
+			is_owner: false,
+			can_access: true,
+			can_manage: false,
+		} ) );
+		const { container, root } = await renderApp(
+			context( { venues, selected_venue: null, can_access: false } )
+		);
+		await act( async () => buttonByText( container, 'Venue' ).click() );
+		await setInput(
+			container.querySelector( '#venue-44-venue-profile-name' ),
+			'Edited Venue 44'
+		);
+		await act( async () => {
+			buttonByText( container, 'Save profile' ).click();
+			await Promise.resolve();
+		} );
+
+		expect( updateInput.venue_term_id ).toBe( 44 );
+		expect( updateInput.profile ).toEqual( { name: 'Edited Venue 44' } );
+		expect(
+			container.querySelector( '#venue-45-venue-profile-name' ).value
+		).toBe( 'Venue 45' );
 		await act( async () => root.unmount() );
 	} );
 


### PR DESCRIPTION
## Summary
- make `My Venues` the default selected scope for the existing four-tab management interface instead of a separate overview state
- combine authorized venues' published events, booking submissions, and active holds into one paginated calendar and pipeline with venue labels
- group Venue, Settings, and Team controls by venue while isolating revisions, saves, errors, stale-response guards, subscriber data, and form IDs
- preserve individual venue filtering and aggregate booking deep links without silently changing the selected scope

## Verification
- `npm run test:js -- --runInBand` (96 tests)
- `npm run lint:js`
- `vendor/bin/phpcs --standard=WordPress blocks/venue-settings/render.php`
- `php -l blocks/venue-settings/render.php`
- `npm run build:venue-settings`
- `git diff --check`

Closes #570