### PR TITLE
fix: serialize read ability input as query data

### DIFF
--- a/blocks/venue-settings/src/api.js
+++ b/blocks/venue-settings/src/api.js
@@ -2,11 +2,38 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+
+const METHODS = {
+	'extrachill/get-venue-profile': 'GET',
+	'extrachill/get-venue-booking-config': 'GET',
+	'extrachill/list-venue-memberships': 'GET',
+	'extrachill/list-venue-invitations': 'GET',
+	'extrachill/list-venue-email-subscribers': 'GET',
+	'extrachill/list-venue-claims': 'GET',
+	'extrachill/get-venue-booking-activity': 'GET',
+	'extrachill/list-booking-holds': 'GET',
+	'extrachill/list-booking-communications': 'GET',
+	'extrachill/events-calendar': 'GET',
+	'extrachill/review-venue-claim': 'DELETE',
+	'extrachill/cancel-venue-invitation': 'DELETE',
+	'extrachill/cancel-venue-claim': 'DELETE',
+};
 
 export const runAbility = ( name, input = {} ) => {
+	const method = METHODS[ name ] || 'POST';
+	const path = `/wp-abilities/v1/abilities/${ name }/run`;
+
+	if ( method !== 'POST' ) {
+		return apiFetch( {
+			path: addQueryArgs( path, { input } ),
+			method,
+		} );
+	}
+
 	return apiFetch( {
-		path: `/wp-abilities/v1/abilities/${ name }/run`,
-		method: 'POST',
+		path,
+		method,
 		data: { input },
 	} );
 };

--- a/blocks/venue-settings/src/api.test.js
+++ b/blocks/venue-settings/src/api.test.js
@@ -23,16 +23,30 @@ describe( 'venue settings ability transport', () => {
 		'extrachill/get-venue-booking-config',
 		'extrachill/list-venue-memberships',
 		'extrachill/list-booking-holds',
-		'extrachill/list-venue-bookings',
-		'extrachill/get-venue-booking',
-		'extrachill/update-venue-booking-config',
-		'extrachill/review-venue-claim',
-		'extrachill/cancel-venue-invitation',
-	] )( 'sends object input through POST for %s', async ( ability ) => {
+	] )( 'sends object input through GET for %s', async ( ability ) => {
 		const input = { venue_term_id: 44 };
 		await runAbility( ability, input );
 		expect( apiFetch ).toHaveBeenCalledWith( {
-			path: `/wp-abilities/v1/abilities/${ ability }/run`,
+			path: `/wp-abilities/v1/abilities/${ ability }/run?input%5Bvenue_term_id%5D=44`,
+			method: 'GET',
+		} );
+	} );
+
+	it( 'uses DELETE with nested object input for destructive actions', async () => {
+		await runAbility( 'extrachill/cancel-venue-invitation', {
+			invitation_id: 9,
+		} );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp-abilities/v1/abilities/extrachill/cancel-venue-invitation/run?input%5Binvitation_id%5D=9',
+			method: 'DELETE',
+		} );
+	} );
+
+	it( 'uses POST with JSON object input for updates', async () => {
+		const input = { venue_term_id: 44, config: {} };
+		await runAbility( 'extrachill/update-venue-booking-config', input );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp-abilities/v1/abilities/extrachill/update-venue-booking-config/run',
 			method: 'POST',
 			data: { input },
 		} );

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -4,6 +4,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { getQueryArgs } from '@wordpress/url';
 import { createRoot } from '@wordpress/element';
 
 /**
@@ -196,15 +197,30 @@ const context = ( overrides = {} ) => ( {
 	...overrides,
 } );
 
+const normalizeQueryInput = ( value ) => {
+	if ( Array.isArray( value ) ) {
+		return value.map( normalizeQueryInput );
+	}
+	if ( value && typeof value === 'object' ) {
+		return Object.fromEntries(
+			Object.entries( value ).map( ( [ key, item ] ) => [
+				key,
+				normalizeQueryInput( item ),
+			] )
+		);
+	}
+	return typeof value === 'string' && /^-?\d+(?:\.\d+)?$/.test( value )
+		? Number( value )
+		: value;
+};
+
 const requestInput = ( request ) => {
 	if ( request.data?.input ) {
 		return request.data.input;
 	}
-	const path = request.path || request;
-	const input = new URL( `https://events.example${ path }` ).searchParams.get(
-		'input'
+	return normalizeQueryInput(
+		getQueryArgs( request.path || request ).input || {}
 	);
-	return input ? JSON.parse( input ) : {};
 };
 
 const installApi = () =>


### PR DESCRIPTION
## Summary
- restore Ability annotation-matched GET, POST, and DELETE methods
- serialize GET/DELETE object input with WordPress `addQueryArgs()` so core receives native nested query data
- test exact methods and request shapes while making workspace mocks mirror core schema normalization

## Root cause
The original client used the correct method map but sent GET input as a JSON string. v0.58.3 overcorrected by sending everything through POST, which core rejects for read-only Abilities. Core requires read input in nested query parameters such as `input[venue_term_id]=1524`.

## Tests
- `npm run test:js -- --runInBand blocks/venue-settings/src/api.test.js blocks/venue-settings/src/view.test.js` (33 tests)
- `npm run lint:js`
- `npm run build:venue-settings && npm run copy:venue-settings`
- `git diff --check`

Closes #574