### PR TITLE
fix: compose venue workspace primitives

### DIFF
--- a/blocks/venue-settings/render.php
+++ b/blocks/venue-settings/render.php
@@ -117,6 +117,11 @@ foreach ( $managed_venues as $venue ) {
 $can_access       = $selected && true === $authorization->authorize( $user_id, $selected['id'], VenueAuthorization::ACTION_ACCESS_VENUE );
 $can_manage       = $selected && true === $authorization->authorize( $user_id, $selected['id'], VenueAuthorization::ACTION_MANAGE_MEMBERS );
 $selected_term    = $selected ? get_term( (int) $selected['id'], 'venue' ) : null;
+if ( $selected && $selected_term instanceof WP_Term ) {
+	$archive_url             = get_term_link( $selected_term );
+	$selected['slug']        = $selected_term->slug;
+	$selected['archive_url'] = is_wp_error( $archive_url ) ? '' : $archive_url;
+}
 $context          = array(
 	'user'               => array(
 		'id'       => $user_id,

--- a/blocks/venue-settings/src/booking-console.js
+++ b/blocks/venue-settings/src/booking-console.js
@@ -15,6 +15,7 @@ import {
 	Panel,
 	PanelHeader,
 	SearchBox,
+	Tabs,
 } from '@extrachill/components';
 
 /**
@@ -1571,24 +1572,14 @@ export function BookingConsole( { context, defaultDeal, supportEvents = [] } ) {
 
 	return (
 		<div className="ec-booking-console">
-			<ActionRow>
-				<button
-					type="button"
-					className="button-2"
-					aria-pressed={ view === 'calendar' }
-					onClick={ () => setView( 'calendar' ) }
-				>
-					Calendar
-				</button>
-				<button
-					type="button"
-					className="button-2"
-					aria-pressed={ view === 'list' }
-					onClick={ () => setView( 'list' ) }
-				>
-					List
-				</button>
-			</ActionRow>
+			<Tabs
+				tabs={ [
+					{ id: 'calendar', label: 'Calendar' },
+					{ id: 'list', label: 'List' },
+				] }
+				active={ view }
+				onChange={ setView }
+			/>
 			<Grid
 				className="ec-booking-console__toolbar"
 				minColumnWidth="12rem"

--- a/blocks/venue-settings/src/style.test.js
+++ b/blocks/venue-settings/src/style.test.js
@@ -19,6 +19,8 @@ describe( 'venue booking workspace composition', () => {
 		);
 		expect( consoleSource ).toContain( '<Badge tone=' );
 		expect( consoleSource ).toContain( '<PanelHeader' );
+		expect( consoleSource ).toContain( '<Tabs' );
+		expect( consoleSource ).not.toContain( 'aria-pressed={ view ===' );
 		expect( consoleSource ).toContain(
 			'className="ec-booking-console__toolbar"'
 		);

--- a/blocks/venue-settings/src/venue-workspace-header.js
+++ b/blocks/venue-settings/src/venue-workspace-header.js
@@ -9,7 +9,17 @@ import {
 	Panel,
 } from '@extrachill/components';
 
+const STATUS_TONES = {
+	administrator: 'info',
+	active: 'success',
+};
+
 export function VenueWorkspaceHeader( { venues, selected, onSwitchVenue } ) {
+	const statusTone = STATUS_TONES[ selected?.status ] || 'warning';
+	const statusLabel = selected?.status
+		? selected.status.charAt( 0 ).toUpperCase() + selected.status.slice( 1 )
+		: '';
+
 	return (
 		<>
 			<BlockShellHeader
@@ -38,11 +48,20 @@ export function VenueWorkspaceHeader( { venues, selected, onSwitchVenue } ) {
 			{ selected && (
 				<Panel compact depth={ 2 }>
 					<ActionRow align="between">
-						<strong>{ selected.name }</strong>
+						<a
+							href={ selected.archive_url }
+							className={ `taxonomy-badge venue-badge venue-${ selected.slug }` }
+						>
+							{ selected.name }
+						</a>
 						<span>
-							<Badge>{ selected.status }</Badge>{ ' ' }
+							<Badge tone={ statusTone } variant="solid">
+								{ statusLabel }
+							</Badge>{ ' ' }
 							{ selected.is_owner && (
-								<Badge tone="success">owner</Badge>
+								<Badge tone="success" variant="solid">
+									Owner
+								</Badge>
 							) }
 						</span>
 					</ActionRow>

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -28,7 +28,14 @@ jest.mock( '@extrachill/components', () => {
 		React.createElement( 'div', null, children );
 	return {
 		ActionRow: Wrapper,
-		Badge: Wrapper,
+		Badge: ( { children, tone = 'default', variant = 'subtle' } ) =>
+			React.createElement(
+				'span',
+				{
+					className: `ec-badge ec-badge--${ tone } ec-badge--${ variant }`,
+				},
+				children
+			),
 		BlockShell: Wrapper,
 		BlockShellHeader: ( { title } ) =>
 			React.createElement( 'h1', null, title ),
@@ -58,6 +65,26 @@ jest.mock( '@extrachill/components', () => {
 				onChange: ( event ) => onSearch( event.target.value ),
 				placeholder,
 			} ),
+		Tabs: ( { tabs, active, onChange } ) =>
+			React.createElement(
+				'div',
+				{ role: 'tablist' },
+				tabs.map( ( tab ) =>
+					React.createElement(
+						'button',
+						{
+							key: tab.id,
+							role: 'tab',
+							'aria-selected': active === tab.id,
+							className: `ec-tabs__tab${
+								active === tab.id ? ' is-active' : ''
+							}`,
+							onClick: () => onChange( tab.id ),
+						},
+						tab.label
+					)
+				)
+			),
 		ResponsiveTabs: ( { tabs, active, onChange, renderPanel } ) =>
 			React.createElement(
 				'div',
@@ -184,6 +211,8 @@ const context = ( overrides = {} ) => ( {
 	selected_venue: {
 		id: 44,
 		name: 'Venue 44',
+		slug: 'venue-44',
+		archive_url: 'https://events.example/venue/venue-44/',
 		status: 'active',
 		is_owner: false,
 	},
@@ -464,6 +493,51 @@ describe( 'venue settings authorization-facing states', () => {
 		expect( container.textContent ).not.toContain( 'Venue claims' );
 		await act( async () => buttonByText( container, 'List' ).click() );
 		expect( container.textContent ).toContain( 'Booking pipeline' );
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'composes the selected venue identity and calendar view controls from shared primitives', async () => {
+		const { container, root } = await renderApp(
+			context( {
+				user: { id: 1, name: 'Admin', is_admin: true },
+				selected_venue: {
+					id: 44,
+					name: 'Venue 44',
+					slug: 'venue-44',
+					archive_url: 'https://events.example/venue/venue-44/',
+					status: 'administrator',
+					is_owner: false,
+				},
+			} )
+		);
+
+		const venueBadge = container.querySelector(
+			'a.taxonomy-badge.venue-badge.venue-venue-44'
+		);
+		expect( venueBadge.getAttribute( 'href' ) ).toBe(
+			'https://events.example/venue/venue-44/'
+		);
+		const administrator = [
+			...container.querySelectorAll( '.ec-badge' ),
+		].find( ( badge ) => badge.textContent === 'Administrator' );
+		expect( administrator.classList.contains( 'ec-badge--info' ) ).toBe(
+			true
+		);
+		expect( administrator.classList.contains( 'ec-badge--solid' ) ).toBe(
+			true
+		);
+		const viewTabs = [
+			...container.querySelectorAll( '[role="tab"]' ),
+		].filter( ( tab ) =>
+			[ 'Calendar', 'List' ].includes( tab.textContent )
+		);
+		expect( viewTabs ).toHaveLength( 2 );
+		expect( buttonByText( container, 'List' ).className ).toContain(
+			'ec-tabs__tab'
+		);
+		expect( buttonByText( container, 'List' ).className ).not.toContain(
+			'button-2'
+		);
 		await act( async () => root.unmount() );
 	} );
 


### PR DESCRIPTION
## Summary
- render the selected venue as the canonical linked venue taxonomy badge
- give administrator and owner labels explicit semantic shared Badge variants
- replace the hand-rolled Calendar/List buttons with the shared Tabs primitive
- resolve the aggregate workspace merge while preserving multi-venue context
- update the aggregate profile fixture for canonical query-serialized read input
- add no local visual styles or replacement primitives

## Verification
- JavaScript tests: 16 suites, 94 tests passed
- full JavaScript lint passed
- production block build passed before the main merge
- PHP syntax check passed
- `git diff --check`

Closes #577
Closes #581