### PR TITLE
fix: accept canonical venue ticketing URL output

### DIFF
--- a/inc/Abilities/VenueProfileAbilities.php
+++ b/inc/Abilities/VenueProfileAbilities.php
@@ -183,13 +183,14 @@ class VenueProfileAbilities {
 				'country'     => $text,
 				'phone'       => $text,
 				'website'     => $text,
+				'ticketing_url' => $text,
 				'capacity'    => $text,
 				'revision'    => array(
 					'type'    => 'string',
 					'pattern' => '^[a-f0-9]{64}$',
 				),
 			),
-			'required'             => array( 'term_id', 'name', 'description', 'address', 'city', 'state', 'zip', 'country', 'phone', 'website', 'capacity', 'revision' ),
+			'required'             => array( 'term_id', 'name', 'description', 'address', 'city', 'state', 'zip', 'country', 'phone', 'website', 'ticketing_url', 'capacity', 'revision' ),
 			'additionalProperties' => false,
 		);
 	}

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -2037,6 +2037,8 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertFalse( $get['input_schema']['additionalProperties'] );
 		$this->assertFalse( $update['input_schema']['properties']['profile']['additionalProperties'] );
 		$this->assertSame( 'string', $update['input_schema']['properties']['expected_revision']['type'] );
+		$this->assertSame( 'string', $get['output_schema']['properties']['ticketing_url']['type'] );
+		$this->assertContains( 'ticketing_url', $get['output_schema']['required'] );
 
 		$GLOBALS['venue_membership_test']['current_user_id'] = 4;
 		$this->set_current_user( 4 );


### PR DESCRIPTION
## Summary
- align the venue profile Ability output schema with Data Machine Events' canonical profile contract
- accept the always-returned `ticketing_url` field while retaining strict additional-property validation
- add schema regression assertions

## Production evidence
Authenticated execution for venue 1524 returned `500 ability_invalid_output`: `ticketing_url is not a valid property of Object`. Other GET reads returned 200, isolating this from the transport fix.

## Tests
- `vendor/bin/phpunit tests/VenueMembershipAuthorizationTest.php --filter test_profile_abilities_authorize_exact_active_venue_members` (1 test, 13 assertions)
- `php -l inc/Abilities/VenueProfileAbilities.php`
- `git diff --check`

Closes #578