### PR TITLE
fix: send valid venue claims input

### DIFF
--- a/blocks/venue-settings/src/api.test.js
+++ b/blocks/venue-settings/src/api.test.js
@@ -42,6 +42,16 @@ describe( 'venue settings ability transport', () => {
 		} );
 	} );
 
+	it( 'serializes the pending claims filter as object input', async () => {
+		await runAbility( 'extrachill/list-venue-claims', {
+			status: 'pending',
+		} );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp-abilities/v1/abilities/extrachill/list-venue-claims/run?input%5Bstatus%5D=pending',
+			method: 'GET',
+		} );
+	} );
+
 	it( 'uses POST with JSON object input for updates', async () => {
 		const input = { venue_term_id: 44, config: {} };
 		await runAbility( 'extrachill/update-venue-booking-config', input );

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -136,7 +136,11 @@ export function VenueSettingsApp( { context } ) {
 			return;
 		}
 		try {
-			setClaims( await runAbility( 'extrachill/list-venue-claims' ) );
+			setClaims(
+				await runAbility( 'extrachill/list-venue-claims', {
+					status: 'pending',
+				} )
+			);
 			setLoadErrors( ( current ) => ( { ...current, claims: null } ) );
 		} catch ( error ) {
 			setLoadErrors( ( current ) => ( {

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -741,6 +741,12 @@ describe( 'venue settings authorization-facing states', () => {
 		);
 		expect( container.textContent ).toContain( 'Claimant user #19' );
 		expect( buttonByText( container, 'Claims' ) ).toBeUndefined();
+		const claimsRequest = apiFetch.mock.calls.find( ( [ request ] ) =>
+			request.path.includes( 'list-venue-claims' )
+		)[ 0 ];
+		expect( requestInput( claimsRequest ) ).toEqual( {
+			status: 'pending',
+		} );
 		expect(
 			apiFetch.mock.calls.some( ( [ request ] ) =>
 				request.path.includes( 'get-venue-profile' )


### PR DESCRIPTION
## Summary
- request the actionable `pending` claims state explicitly instead of sending an empty object through the readonly GET transport
- verify the nested claims filter serializes as valid WordPress Abilities object input
- cover the administrator claims queue and Retry path with the canonical filter

## Verification
- `npm run test:js -- --runInBand` (95 tests)
- `npm run lint:js`
- `npm run build:venue-settings`
- `git diff --check`

Closes #582