### PR TITLE
feat: add venue Booking Form workspace

### DIFF
--- a/blocks/venue-booking-inquiry/render.php
+++ b/blocks/venue-booking-inquiry/render.php
@@ -58,7 +58,9 @@ $canonical = ( static function () use ( $events_blog_id, $venue_id ) {
 			$address    = implode( ', ', array_filter( array( $street, $city_state, $zip ) ) );
 		}
 
-		$profile = function_exists( 'data_machine_events_get_venue_profile' ) ? data_machine_events_get_venue_profile( $venue_id ) : array();
+		$profile  = function_exists( 'data_machine_events_get_venue_profile' ) ? data_machine_events_get_venue_profile( $venue_id ) : array();
+		$logo_url = is_array( $profile ) ? (string) ( $profile['logo_url'] ?? '' ) : '';
+		$logo_url = filter_var( $logo_url, FILTER_VALIDATE_URL ) ? $logo_url : '';
 
 		return array(
 			'booking_config' => $booking_config,
@@ -67,7 +69,7 @@ $canonical = ( static function () use ( $events_blog_id, $venue_id ) {
 				'name'        => $venue->name,
 				'description' => wp_strip_all_tags( $venue->description ),
 				'address'     => $address,
-				'logoUrl'     => is_array( $profile ) ? esc_url_raw( (string) ( $profile['logo_url'] ?? '' ) ) : '',
+				'logoUrl'     => $logo_url,
 			),
 		);
 	} finally {

--- a/blocks/venue-booking-inquiry/render.php
+++ b/blocks/venue-booking-inquiry/render.php
@@ -58,6 +58,8 @@ $canonical = ( static function () use ( $events_blog_id, $venue_id ) {
 			$address    = implode( ', ', array_filter( array( $street, $city_state, $zip ) ) );
 		}
 
+		$profile = function_exists( 'data_machine_events_get_venue_profile' ) ? data_machine_events_get_venue_profile( $venue_id ) : array();
+
 		return array(
 			'booking_config' => $booking_config,
 			'venue'          => array(
@@ -65,6 +67,7 @@ $canonical = ( static function () use ( $events_blog_id, $venue_id ) {
 				'name'        => $venue->name,
 				'description' => wp_strip_all_tags( $venue->description ),
 				'address'     => $address,
+				'logoUrl'     => is_array( $profile ) ? esc_url_raw( (string) ( $profile['logo_url'] ?? '' ) ) : '',
 			),
 		);
 	} finally {
@@ -102,6 +105,7 @@ $public_config = array(
 	'spaces'               => array_values( $booking_config['spaces'] ),
 	'fields'               => array_values( $booking_config['fields'] ),
 	'presentation'         => $booking_config['presentation'],
+	'appearance'           => $booking_config['appearance'],
 	'consent'              => $booking_config['consent'],
 );
 
@@ -109,7 +113,10 @@ $json = $form_enabled ? wp_json_encode( $public_config, JSON_HEX_TAG | JSON_HEX_
 if ( $form_enabled && false === $json ) {
 	return;
 }
-$wrapper_extra = array( 'class' => 'ec-venue-booking-inquiry' );
+$wrapper_extra = array(
+	'class' => 'ec-venue-booking-inquiry',
+	'style' => VenueBookingConfig::appearance_style( $booking_config['appearance'] ),
+);
 if ( (int) get_current_blog_id() === $events_blog_id && is_tax( 'venue' ) ) {
 	$wrapper_extra['id'] = 'booking-inquiry';
 }

--- a/blocks/venue-booking-inquiry/src/style.scss
+++ b/blocks/venue-booking-inquiry/src/style.scss
@@ -1,1 +1,47 @@
 @use "@extrachill/components/styles/components.scss";
+
+.ec-venue-booking-inquiry {
+	background: var(--ec-booking-background);
+	color: var(--ec-booking-text);
+	padding: clamp(0.75rem, 2vw, 1.5rem);
+
+	.ec-block-shell,
+	.ec-block-shell-inner,
+	.ec-panel,
+	.ec-field-group input,
+	.ec-field-group select,
+	.ec-field-group textarea {
+		color: var(--ec-booking-text);
+	}
+
+	.ec-block-shell-inner,
+	.ec-panel,
+	.ec-field-group input,
+	.ec-field-group select,
+	.ec-field-group textarea {
+		background: var(--ec-booking-surface);
+		border-color: var(--ec-booking-border);
+	}
+
+	.button-1 {
+		background: var(--ec-booking-accent);
+		border-color: var(--ec-booking-accent);
+		border-radius: var(--ec-booking-button-radius);
+		color: var(--ec-booking-button-text);
+	}
+}
+
+.ec-booking-inquiry__powered {
+	margin-block: 1rem 0;
+	opacity: 0.58;
+	font-size: 0.78rem;
+	text-align: center;
+}
+
+.ec-booking-inquiry__logo {
+	display: block;
+	max-width: min(12rem, 60%);
+	max-height: 7rem;
+	margin: 0 auto 1rem;
+	object-fit: contain;
+}

--- a/blocks/venue-booking-inquiry/src/style.test.js
+++ b/blocks/venue-booking-inquiry/src/style.test.js
@@ -10,10 +10,12 @@ const styles = readFileSync( path.resolve( __dirname, 'style.scss' ), 'utf8' );
 const view = readFileSync( path.resolve( __dirname, 'view.js' ), 'utf8' );
 
 describe( 'venue booking inquiry styles', () => {
-	it( 'composes the canonical shared component stylesheet', () => {
-		expect( styles.trim() ).toBe(
+	it( 'composes shared components and scopes appearance variables', () => {
+		expect( styles ).toContain(
 			'@use "@extrachill/components/styles/components.scss";'
 		);
+		expect( styles ).toContain( '.ec-venue-booking-inquiry {' );
+		expect( styles ).not.toContain( ':root' );
 	} );
 
 	it( 'relies on shared form components without local decoration', () => {
@@ -23,7 +25,7 @@ describe( 'venue booking inquiry styles', () => {
 		expect( view ).toContain( 'Grid minColumnWidth="16rem"' );
 		expect( view ).not.toContain( '<Badge' );
 		expect( view ).toContain( 'className="taxonomy-badge"' );
-		expect( styles ).not.toContain( '.ec-' );
+		expect( styles ).toContain( '.ec-booking-inquiry__powered' );
 	} );
 
 	it( 'does not duplicate the configured intake before availability', () => {

--- a/blocks/venue-booking-inquiry/src/view.js
+++ b/blocks/venue-booking-inquiry/src/view.js
@@ -124,12 +124,12 @@ const Field = ( { field, value, onChange, prefix } ) => {
 	);
 };
 
-function BookingInquiry( { config, wrapper } ) {
+export function BookingInquiry( { config, wrapper, preview = false } ) {
 	const [ values, setValues ] = useState( () => initialValues( config ) );
 	const [ status, setStatus ] = useState( null );
 	const [ submitting, setSubmitting ] = useState( false );
 	const [ checking, setChecking ] = useState( false );
-	const [ intervalOpen, setIntervalOpen ] = useState( false );
+	const [ intervalOpen, setIntervalOpen ] = useState( preview );
 	const [ receipt, setReceipt ] = useState( null );
 	const key = useRef( newIdempotencyKey() );
 	const turnstileTarget = useRef();
@@ -137,11 +137,14 @@ function BookingInquiry( { config, wrapper } ) {
 	const prefix = config.instanceId;
 
 	useEffect( () => {
+		if ( preview || ! wrapper ) {
+			return;
+		}
 		const source = wrapper.querySelector( '[data-booking-turnstile]' );
 		if ( source && turnstileTarget.current ) {
 			turnstileTarget.current.appendChild( source );
 		}
-	}, [ wrapper, intervalOpen ] );
+	}, [ wrapper, intervalOpen, preview ] );
 	useEffect( () => {
 		if ( status || receipt ) {
 			resultRef.current?.focus();
@@ -212,6 +215,9 @@ function BookingInquiry( { config, wrapper } ) {
 	};
 	const submit = async ( event ) => {
 		event.preventDefault();
+		if ( preview ) {
+			return;
+		}
 		if ( submitting || ! event.currentTarget.reportValidity() ) {
 			return;
 		}
@@ -326,6 +332,13 @@ function BookingInquiry( { config, wrapper } ) {
 
 	return (
 		<BlockShell>
+			{ config.appearance?.show_logo && config.venue.logoUrl && (
+				<img
+					className="ec-booking-inquiry__logo"
+					src={ config.venue.logoUrl }
+					alt=""
+				/>
+			) }
 			<BlockShellHeader
 				title={ `Booking at ${ config.venue.name }` }
 				description={ config.venue.address }
@@ -593,10 +606,12 @@ function BookingInquiry( { config, wrapper } ) {
 									) }
 								</span>
 							</label>
-							<div
-								className="ec-booking-inquiry__turnstile"
-								ref={ turnstileTarget }
-							/>
+							{ ! preview && (
+								<div
+									className="ec-booking-inquiry__turnstile"
+									ref={ turnstileTarget }
+								/>
+							) }
 						</>
 					) }
 					<div ref={ resultRef } tabIndex="-1" aria-live="polite">
@@ -610,7 +625,7 @@ function BookingInquiry( { config, wrapper } ) {
 						<button
 							className="button-1 button-large"
 							type="submit"
-							disabled={ submitting || checking }
+							disabled={ preview || submitting || checking }
 						>
 							{ submitLabel }
 						</button>
@@ -619,6 +634,9 @@ function BookingInquiry( { config, wrapper } ) {
 							the public venue page.
 						</span>
 					</ActionRow>
+					<p className="ec-booking-inquiry__powered">
+						Powered by Extra Chill
+					</p>
 				</form>
 			</BlockShellInner>
 		</BlockShell>

--- a/blocks/venue-settings/src/booking-appearance.js
+++ b/blocks/venue-settings/src/booking-appearance.js
@@ -1,0 +1,31 @@
+export const DEFAULT_BOOKING_APPEARANCE = {
+	mode: 'default',
+	background_color: '#121212',
+	surface_color: '#1f1f1f',
+	text_color: '#e5e5e5',
+	accent_color: '#0b5394',
+	button_text_color: '#ffffff',
+	border_color: '#3a3a3a',
+	button_radius: 8,
+	show_logo: true,
+};
+
+export const bookingAppearanceStyle = ( appearance ) => {
+	const effective =
+		appearance.mode === 'default' ? DEFAULT_BOOKING_APPEARANCE : appearance;
+	return {
+		'--ec-booking-background': effective.background_color,
+		'--ec-booking-surface': effective.surface_color,
+		'--ec-booking-text': effective.text_color,
+		'--ec-booking-accent': effective.accent_color,
+		'--ec-booking-button-text': effective.button_text_color,
+		'--ec-booking-border': effective.border_color,
+		'--ec-booking-button-radius': `${ effective.button_radius }px`,
+	};
+};
+
+export const bookingQrRequest = ( bookingUrl, size ) => ( {
+	path: '/extrachill/v1/tools/qr-code',
+	method: 'POST',
+	data: { url: bookingUrl, size },
+} );

--- a/blocks/venue-settings/src/booking-form-tab.js
+++ b/blocks/venue-settings/src/booking-form-tab.js
@@ -1,0 +1,407 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useState } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import {
+	ActionRow,
+	FieldGroup,
+	Grid,
+	InlineStatus,
+	Panel,
+	PanelHeader,
+} from '@extrachill/components';
+
+/**
+ * Internal dependencies
+ */
+import { BookingInquiry } from '../../venue-booking-inquiry/src/view';
+import {
+	DEFAULT_BOOKING_APPEARANCE,
+	bookingAppearanceStyle,
+	bookingQrRequest,
+} from './booking-appearance';
+import { bookingButtonSnippet, bookingEmbedSnippet } from './booking-embed';
+import { IntakeTab } from './intake-tab';
+import { Status } from './status';
+import { sameDocument, validateConfig } from './state';
+
+const COLOR_FIELDS = [
+	[ 'background_color', 'Background' ],
+	[ 'surface_color', 'Surface / card' ],
+	[ 'text_color', 'Text' ],
+	[ 'accent_color', 'Accent / button' ],
+	[ 'button_text_color', 'Button text' ],
+	[ 'border_color', 'Border' ],
+];
+
+const previewConfig = ( config, venueName, profile, idPrefix ) => ( {
+	instanceId: `${ idPrefix }ec-booking-preview`,
+	endpoint: '',
+	availabilityEndpoint: '',
+	restNonce: '',
+	buttonLabel: 'Send booking inquiry',
+	revision: 0,
+	venue: {
+		id: profile?.term_id || 0,
+		name: venueName,
+		address: [
+			profile?.address,
+			profile?.city,
+			profile?.state,
+			profile?.zip,
+		]
+			.filter( Boolean )
+			.join( ', ' ),
+	},
+	spaces: config.spaces,
+	fields: config.intake.fields,
+	presentation: config.intake.presentation,
+	appearance: config.appearance,
+	consent: config.consent,
+} );
+
+export function BookingFormTab( {
+	config,
+	baseline,
+	setConfig,
+	onSave,
+	saving,
+	status,
+	bookingUrl,
+	venueName,
+	profile,
+	idPrefix = '',
+} ) {
+	const [ copied, setCopied ] = useState( '' );
+	const [ previewDevice, setPreviewDevice ] = useState( 'desktop' );
+	const [ qrState, setQrState ] = useState( { loading: false } );
+	const errors = validateConfig( config );
+	const dirty = ! sameDocument( config, baseline );
+	const origins = config.embed.allowed_parent_origins;
+	const buttonSnippet = bookingButtonSnippet( bookingUrl, venueName );
+	const embedSnippet = origins.length
+		? bookingEmbedSnippet( bookingUrl, venueName, origins[ 0 ] )
+		: '';
+	const setAppearance = ( patch ) =>
+		setConfig( {
+			...config,
+			appearance: { ...config.appearance, ...patch },
+		} );
+	const copy = async ( label, value ) => {
+		await navigator.clipboard.writeText( value );
+		setCopied( label );
+	};
+	const generateQr = async ( size = 300 ) => {
+		setQrState( { loading: true } );
+		try {
+			const result = await apiFetch(
+				bookingQrRequest( bookingUrl, size )
+			);
+			setQrState( { loading: false, imageUrl: result.image_url } );
+			return result.image_url;
+		} catch ( error ) {
+			setQrState( {
+				loading: false,
+				error: error?.message || 'QR code generation failed.',
+			} );
+			return '';
+		}
+	};
+	const downloadQr = async () => {
+		const imageUrl = await generateQr( 1000 );
+		if ( imageUrl ) {
+			const link = document.createElement( 'a' );
+			link.href = imageUrl;
+			link.download = `${ venueName
+				.toLowerCase()
+				.replace( /[^a-z0-9]+/g, '-' ) }-booking-qr.png`;
+			link.click();
+		}
+	};
+
+	return (
+		<Grid minColumnWidth="100%">
+			<IntakeTab
+				config={ config }
+				setConfig={ setConfig }
+				idPrefix={ idPrefix }
+			/>
+			<Panel>
+				<PanelHeader
+					title="Appearance"
+					description="Use Extra Chill defaults or a bounded custom palette shared by the hosted and embedded form."
+				/>
+				<FieldGroup
+					label="Theme"
+					htmlFor={ `${ idPrefix }booking-theme` }
+				>
+					<select
+						id={ `${ idPrefix }booking-theme` }
+						value={ config.appearance.mode }
+						onChange={ ( event ) =>
+							setAppearance( { mode: event.target.value } )
+						}
+					>
+						<option value="default">Extra Chill default</option>
+						<option value="custom">Custom</option>
+					</select>
+				</FieldGroup>
+				{ config.appearance.mode === 'custom' && (
+					<Grid minColumnWidth="12rem" maxColumns={ 3 }>
+						{ COLOR_FIELDS.map( ( [ key, label ] ) => (
+							<FieldGroup
+								key={ key }
+								label={ label }
+								htmlFor={ `${ idPrefix }booking-${ key }` }
+							>
+								<input
+									id={ `${ idPrefix }booking-${ key }` }
+									type="color"
+									value={ config.appearance[ key ] }
+									onChange={ ( event ) =>
+										setAppearance( {
+											[ key ]: event.target.value,
+										} )
+									}
+								/>
+							</FieldGroup>
+						) ) }
+						<FieldGroup
+							label="Button radius"
+							htmlFor={ `${ idPrefix }booking-button-radius` }
+							help={ `${ config.appearance.button_radius }px` }
+						>
+							<input
+								id={ `${ idPrefix }booking-button-radius` }
+								type="range"
+								min="0"
+								max="32"
+								value={ config.appearance.button_radius }
+								onChange={ ( event ) =>
+									setAppearance( {
+										button_radius: Number(
+											event.target.value
+										),
+									} )
+								}
+							/>
+						</FieldGroup>
+					</Grid>
+				) }
+				<label
+					className="ec-venue-settings__toggle"
+					htmlFor={ `${ idPrefix }booking-show-logo` }
+				>
+					<input
+						type="checkbox"
+						checked={ config.appearance.show_logo }
+						disabled={ ! profile?.logo_url }
+						id={ `${ idPrefix }booking-show-logo` }
+						onChange={ ( event ) =>
+							setAppearance( { show_logo: event.target.checked } )
+						}
+					/>{ ' ' }
+					Show canonical venue logo
+				</label>
+				{ ! profile?.logo_url && (
+					<p className="ec-venue-settings__save-note">
+						Logo display will become available when the canonical
+						venue profile supports media.
+					</p>
+				) }
+				<button
+					type="button"
+					className="button-2"
+					onClick={ () =>
+						setConfig( {
+							...config,
+							appearance: { ...DEFAULT_BOOKING_APPEARANCE },
+						} )
+					}
+				>
+					Reset to Extra Chill defaults
+				</button>
+			</Panel>
+			<Panel className="ec-booking-form-preview-panel">
+				<PanelHeader
+					title="Live form preview"
+					description="This is the production booking form component with submissions disabled."
+					actions={
+						<ActionRow>
+							{ [ 'desktop', 'mobile' ].map( ( device ) => (
+								<button
+									key={ device }
+									type="button"
+									className={
+										previewDevice === device
+											? 'button-1'
+											: 'button-2'
+									}
+									onClick={ () => setPreviewDevice( device ) }
+								>
+									{ device[ 0 ].toUpperCase() +
+										device.slice( 1 ) }
+								</button>
+							) ) }
+						</ActionRow>
+					}
+				/>
+				<div
+					className={ `ec-booking-form-preview is-${ previewDevice }` }
+				>
+					<div
+						className="ec-venue-booking-inquiry"
+						style={ bookingAppearanceStyle( config.appearance ) }
+					>
+						<BookingInquiry
+							config={ previewConfig(
+								config,
+								venueName,
+								profile,
+								idPrefix
+							) }
+							wrapper={ null }
+							preview
+						/>
+					</div>
+				</div>
+			</Panel>
+			<Panel>
+				<PanelHeader
+					title="Share and embed"
+					description="Share the canonical booking anchor or authorize exact HTTPS websites to frame the same hosted form."
+				/>
+				<FieldGroup
+					label="Canonical booking link"
+					htmlFor={ `${ idPrefix }venue-booking-link` }
+				>
+					<input
+						id={ `${ idPrefix }venue-booking-link` }
+						readOnly
+						value={ bookingUrl }
+					/>
+				</FieldGroup>
+				<ActionRow>
+					<button
+						type="button"
+						className="button-2"
+						onClick={ () => copy( 'link', bookingUrl ) }
+					>
+						Copy link
+					</button>
+					<button
+						type="button"
+						className="button-2"
+						onClick={ () => copy( 'button HTML', buttonSnippet ) }
+					>
+						Copy button HTML
+					</button>
+					<button
+						type="button"
+						className="button-2"
+						disabled={ qrState.loading }
+						onClick={ () => generateQr() }
+					>
+						{ qrState.loading ? 'Generating QR...' : 'Generate QR' }
+					</button>
+					{ copied && <span role="status">Copied { copied }.</span> }
+				</ActionRow>
+				{ qrState.error && (
+					<InlineStatus tone="error">{ qrState.error }</InlineStatus>
+				) }
+				{ qrState.imageUrl && (
+					<div className="ec-booking-form-qr">
+						<img
+							src={ qrState.imageUrl }
+							alt={ `QR code for ${ venueName } booking form` }
+						/>
+						<button
+							type="button"
+							className="button-2"
+							onClick={ downloadQr }
+						>
+							Download print QR
+						</button>
+					</div>
+				) }
+				<FieldGroup
+					label="Allowed parent origins"
+					htmlFor={ `${ idPrefix }venue-booking-origins` }
+					help="One exact HTTPS origin per line. Paths, wildcards, ports, credentials, localhost, and IP addresses are rejected. The first origin is used for the snippet."
+				>
+					<textarea
+						id={ `${ idPrefix }venue-booking-origins` }
+						rows="4"
+						value={ origins.join( '\n' ) }
+						onChange={ ( event ) =>
+							setConfig( {
+								...config,
+								embed: {
+									allowed_parent_origins: event.target.value
+										.split( /\r?\n/ )
+										.map( ( origin ) => origin.trim() )
+										.filter( Boolean ),
+								},
+							} )
+						}
+					/>
+				</FieldGroup>
+				{ embedSnippet && (
+					<>
+						<FieldGroup
+							label="Responsive iframe snippet"
+							htmlFor={ `${ idPrefix }venue-booking-embed-code` }
+						>
+							<textarea
+								id={ `${ idPrefix }venue-booking-embed-code` }
+								rows="8"
+								readOnly
+								value={ embedSnippet }
+							/>
+						</FieldGroup>
+						<button
+							type="button"
+							className="button-2"
+							onClick={ () =>
+								copy( 'iframe snippet', embedSnippet )
+							}
+						>
+							Copy iframe snippet
+						</button>
+					</>
+				) }
+			</Panel>
+			{ errors.length > 0 && (
+				<InlineStatus tone="error">
+					<strong>Resolve before saving:</strong>
+					<ul>
+						{ errors.map( ( error ) => (
+							<li key={ error }>{ error }</li>
+						) ) }
+					</ul>
+				</InlineStatus>
+			) }
+			<Status state={ status } />
+			<ActionRow>
+				<button
+					type="button"
+					className="button-1"
+					disabled={ ! dirty || saving || errors.length > 0 }
+					onClick={ onSave }
+				>
+					{ saving ? 'Saving...' : 'Save booking form' }
+				</button>
+				{ dirty && (
+					<span className="ec-venue-settings__dirty">
+						Unsaved booking form changes
+					</span>
+				) }
+			</ActionRow>
+		</Grid>
+	);
+}

--- a/blocks/venue-settings/src/booking-form-tab.test.js
+++ b/blocks/venue-settings/src/booking-form-tab.test.js
@@ -1,0 +1,38 @@
+/* global describe, expect, it */
+
+/**
+ * External dependencies
+ */
+import { readFileSync } from 'fs';
+import path from 'path';
+
+/**
+ * Internal dependencies
+ */
+import { bookingQrRequest } from './booking-appearance';
+
+describe( 'booking form workspace', () => {
+	it( 'generates QR codes only for the canonical booking anchor', () => {
+		const url = 'https://events.example/venue/the-room/#booking-inquiry';
+		expect( bookingQrRequest( url, 1000 ) ).toEqual( {
+			path: '/extrachill/v1/tools/qr-code',
+			method: 'POST',
+			data: { url, size: 1000 },
+		} );
+		expect( bookingQrRequest( url, 1000 ).data.url ).not.toContain(
+			'booking-embed'
+		);
+	} );
+
+	it( 'previews through the production booking form component', () => {
+		const source = readFileSync(
+			path.resolve( __dirname, 'booking-form-tab.js' ),
+			'utf8'
+		);
+		expect( source ).toContain(
+			"import { BookingInquiry } from '../../venue-booking-inquiry/src/view';"
+		);
+		expect( source ).toContain( '<BookingInquiry' );
+		expect( source ).not.toContain( 'booking-embed=1' );
+	} );
+} );

--- a/blocks/venue-settings/src/booking-tab.js
+++ b/blocks/venue-settings/src/booking-tab.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { useState } from '@wordpress/element';
-
-/**
  * External dependencies
  */
 import {
@@ -19,7 +14,6 @@ import {
  * Internal dependencies
  */
 import { Status } from './status';
-import { bookingButtonSnippet, bookingEmbedSnippet } from './booking-embed';
 import {
 	HOLD_TTL_MAX_MINUTES,
 	normalizeKey,
@@ -138,26 +132,13 @@ export function BookingTab( {
 	onSave,
 	saving,
 	status,
-	bookingUrl,
-	venueName,
-	children,
 	idPrefix = '',
 } ) {
-	const [ copied, setCopied ] = useState( '' );
 	const errors = validateConfig( config );
 	const dirty = ! sameDocument( config, baseline );
 	const deal = config.default_deal;
 	const setDeal = ( patch ) =>
 		setConfig( { ...config, default_deal: { ...deal, ...patch } } );
-	const origins = config.embed.allowed_parent_origins;
-	const buttonSnippet = bookingButtonSnippet( bookingUrl, venueName );
-	const embedSnippet = origins.length
-		? bookingEmbedSnippet( bookingUrl, venueName, origins[ 0 ] )
-		: '';
-	const copy = async ( label, value ) => {
-		await navigator.clipboard.writeText( value );
-		setCopied( label );
-	};
 	return (
 		<Grid minColumnWidth="100%">
 			<Panel>
@@ -241,85 +222,6 @@ export function BookingTab( {
 						}
 					/>
 				</FieldGroup>
-			</Panel>
-			<Panel>
-				<PanelHeader
-					title="Booking link and embed"
-					description="Share the canonical booking page or authorize one exact HTTPS website to frame the hosted form."
-				/>
-				<FieldGroup
-					label="Canonical booking link"
-					htmlFor={ `${ idPrefix }venue-booking-link` }
-				>
-					<input
-						id={ `${ idPrefix }venue-booking-link` }
-						readOnly
-						value={ bookingUrl }
-					/>
-				</FieldGroup>
-				<ActionRow>
-					<button
-						type="button"
-						className="button-2"
-						onClick={ () => copy( 'link', bookingUrl ) }
-					>
-						Copy link
-					</button>
-					<button
-						type="button"
-						className="button-2"
-						onClick={ () => copy( 'button', buttonSnippet ) }
-					>
-						Copy button HTML
-					</button>
-					{ copied && <span role="status">Copied { copied }.</span> }
-				</ActionRow>
-				<FieldGroup
-					label="Allowed parent origins"
-					htmlFor={ `${ idPrefix }venue-booking-origins` }
-					help="One exact HTTPS origin per line, such as https://venue.example. Paths, wildcards, ports, credentials, localhost, and IP addresses are rejected. The first origin is used for the generated snippet."
-				>
-					<textarea
-						id={ `${ idPrefix }venue-booking-origins` }
-						rows="4"
-						value={ origins.join( '\n' ) }
-						onChange={ ( event ) =>
-							setConfig( {
-								...config,
-								embed: {
-									allowed_parent_origins: event.target.value
-										.split( /\r?\n/ )
-										.map( ( origin ) => origin.trim() )
-										.filter( Boolean ),
-								},
-							} )
-						}
-					/>
-				</FieldGroup>
-				{ embedSnippet && (
-					<>
-						<FieldGroup
-							label="Responsive iframe snippet"
-							htmlFor={ `${ idPrefix }venue-booking-embed-code` }
-						>
-							<textarea
-								id={ `${ idPrefix }venue-booking-embed-code` }
-								rows="8"
-								readOnly
-								value={ embedSnippet }
-							/>
-						</FieldGroup>
-						<button
-							type="button"
-							className="button-2"
-							onClick={ () =>
-								copy( 'embed snippet', embedSnippet )
-							}
-						>
-							Copy iframe snippet
-						</button>
-					</>
-				) }
 			</Panel>
 			<SpacesEditor
 				spaces={ config.spaces }
@@ -425,7 +327,6 @@ export function BookingTab( {
 					</FieldGroup>
 				</Grid>
 			</Panel>
-			{ children }
 			{ errors.length > 0 && (
 				<InlineStatus tone="error">
 					<strong>Resolve before saving:</strong>

--- a/blocks/venue-settings/src/state.js
+++ b/blocks/venue-settings/src/state.js
@@ -51,6 +51,32 @@ export const validateConfig = ( config ) => {
 	if ( config.public_requirements.length > 20 ) {
 		errors.push( 'Use no more than 20 public requirements.' );
 	}
+	if (
+		! config.appearance ||
+		! [ 'default', 'custom' ].includes( config.appearance.mode ) ||
+		! Number.isInteger( config.appearance.button_radius ) ||
+		config.appearance.button_radius < 0 ||
+		config.appearance.button_radius > 32
+	) {
+		errors.push( 'Booking appearance settings are invalid.' );
+	}
+	if (
+		config.appearance?.mode === 'custom' &&
+		[
+			'background_color',
+			'surface_color',
+			'text_color',
+			'accent_color',
+			'button_text_color',
+			'border_color',
+		].some(
+			( key ) => ! /^#[0-9a-f]{6}$/i.test( config.appearance[ key ] )
+		)
+	) {
+		errors.push(
+			'Custom appearance colors must use six-digit hex values.'
+		);
+	}
 	if ( ! config.consent.label.trim() || config.consent.version < 1 ) {
 		errors.push( 'Consent needs public wording and a positive version.' );
 	}

--- a/blocks/venue-settings/src/state.test.js
+++ b/blocks/venue-settings/src/state.test.js
@@ -11,7 +11,7 @@ import {
 } from './state';
 
 const validConfig = () => ( {
-	version: 6,
+	version: 7,
 	enabled: true,
 	intake: { version: 1, fields: [] },
 	public_requirements: [],
@@ -20,6 +20,17 @@ const validConfig = () => ( {
 		version: 1,
 		label: 'I agree.',
 		required: true,
+	},
+	appearance: {
+		mode: 'default',
+		background_color: '#121212',
+		surface_color: '#1f1f1f',
+		text_color: '#e5e5e5',
+		accent_color: '#0b5394',
+		button_text_color: '#ffffff',
+		border_color: '#3a3a3a',
+		button_radius: 8,
+		show_logo: true,
 	},
 	embed: { allowed_parent_origins: [] },
 	spaces: [ { key: 'main_room', name: 'Main Room', is_default: true } ],

--- a/blocks/venue-settings/src/style.scss
+++ b/blocks/venue-settings/src/style.scss
@@ -1,4 +1,5 @@
 @use "@extrachill/components/styles/components.scss";
+@use "../../venue-booking-inquiry/src/style.scss" as booking-inquiry;
 
 .ec-venue-settings-page {
 	padding-block: var(--wp--preset--spacing--40, 2rem);
@@ -84,6 +85,35 @@
 	margin-block-start: 1rem;
 	font-size: 0.9rem;
 	font-style: italic;
+}
+
+.ec-booking-form-preview {
+	margin-inline: auto;
+	width: 100%;
+	transition: max-width 160ms ease;
+}
+
+.ec-booking-form-preview.is-mobile {
+	max-width: 24rem;
+}
+
+.ec-booking-form-preview .ec-venue-booking-inquiry {
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	overflow: hidden;
+}
+
+.ec-booking-form-qr {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 1rem;
+	margin-block: 1rem;
+}
+
+.ec-booking-form-qr img {
+	width: 12rem;
+	height: 12rem;
 }
 
 .ec-inline-status .button-link {

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -19,9 +19,9 @@ import {
  */
 import { errorDetails, runAbility } from './api';
 import { BookingConsole } from './booking-console';
+import { BookingFormTab } from './booking-form-tab';
 import { BookingTab } from './booking-tab';
 import { ClaimPanel, ClaimsTab } from './claims-tab';
-import { IntakeTab } from './intake-tab';
 import { ProfileTab } from './profile-tab';
 import { LoadingPanel, Status } from './status';
 import { TeamTab } from './team-tab';
@@ -309,6 +309,7 @@ export function VenueSettingsApp( { context } ) {
 			? [
 					{ id: 'calendar', label: 'Calendar' },
 					{ id: 'venue', label: 'Venue' },
+					{ id: 'booking-form', label: 'Booking Form' },
 					{ id: 'settings', label: 'Settings' },
 			  ]
 			: [] ),
@@ -365,7 +366,7 @@ export function VenueSettingsApp( { context } ) {
 				<LoadingPanel label="Loading profile..." />
 			);
 		}
-		if ( tab === 'settings' ) {
+		if ( tab === 'settings' || tab === 'booking-form' ) {
 			if ( errors.config ) {
 				return (
 					<Panel>
@@ -382,8 +383,11 @@ export function VenueSettingsApp( { context } ) {
 					</Panel>
 				);
 			}
-			return config ? (
-				<BookingTab
+			if ( ! config ) {
+				return <LoadingPanel label="Loading venue settings..." />;
+			}
+			return tab === 'booking-form' ? (
+				<BookingFormTab
 					config={ config }
 					baseline={ configBaselines[ venue.id ] }
 					setConfig={ ( value ) =>
@@ -394,18 +398,21 @@ export function VenueSettingsApp( { context } ) {
 					status={ configStatuses[ venue.id ] }
 					bookingUrl={ venueContext.booking_url }
 					venueName={ venue.name }
+					profile={ profiles[ venue.id ] }
 					idPrefix={ idPrefix }
-				>
-					<IntakeTab
-						config={ config }
-						setConfig={ ( value ) =>
-							setVenueState( setConfigs, venue.id, value )
-						}
-						idPrefix={ idPrefix }
-					/>
-				</BookingTab>
+				/>
 			) : (
-				<LoadingPanel label="Loading venue settings..." />
+				<BookingTab
+					config={ config }
+					baseline={ configBaselines[ venue.id ] }
+					setConfig={ ( value ) =>
+						setVenueState( setConfigs, venue.id, value )
+					}
+					onSave={ () => saveConfig( venue ) }
+					saving={ Boolean( savingConfigs[ venue.id ] ) }
+					status={ configStatuses[ venue.id ] }
+					idPrefix={ idPrefix }
+				/>
 			);
 		}
 		if ( tab === 'team' ) {

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -116,7 +116,7 @@ const profile = ( id ) => ( {
 	revision: String( id ).padStart( 64, '0' ),
 } );
 const config = ( id ) => ( {
-	version: 6,
+	version: 7,
 	revision: id,
 	updated_by_user_id: null,
 	updated_at: null,
@@ -139,6 +139,17 @@ const config = ( id ) => ( {
 		version: 1,
 		label: 'I agree.',
 		required: true,
+	},
+	appearance: {
+		mode: 'default',
+		background_color: '#121212',
+		surface_color: '#1f1f1f',
+		text_color: '#e5e5e5',
+		accent_color: '#0b5394',
+		button_text_color: '#ffffff',
+		border_color: '#3a3a3a',
+		button_radius: 8,
+		show_logo: true,
 	},
 	embed: { allowed_parent_origins: [] },
 	spaces: [],
@@ -413,9 +424,15 @@ describe( 'venue settings authorization-facing states', () => {
 		expect( container.textContent ).toContain( 'Venue 45' );
 		expect(
 			[ ...container.querySelectorAll( 'button' ) ]
-				.slice( 0, 4 )
+				.slice( 0, 5 )
 				.map( ( button ) => button.textContent )
-		).toEqual( [ 'Calendar', 'Venue', 'Settings', 'Team' ] );
+		).toEqual( [
+			'Calendar',
+			'Venue',
+			'Booking Form',
+			'Settings',
+			'Team',
+		] );
 		expect( container.textContent ).not.toContain( 'Open workspace' );
 		const profileVenueIds = apiFetch.mock.calls
 			.filter( ( [ request ] ) =>
@@ -433,7 +450,7 @@ describe( 'venue settings authorization-facing states', () => {
 		expect(
 			container.querySelectorAll( '.ec-venue-settings__venue-scope > h2' )
 		).toHaveLength( 2 );
-		for ( const tab of [ 'Venue', 'Settings', 'Team' ] ) {
+		for ( const tab of [ 'Venue', 'Booking Form', 'Settings', 'Team' ] ) {
 			await act( async () => buttonByText( container, tab ).click() );
 			const ids = [ ...container.querySelectorAll( '[id]' ) ].map(
 				( element ) => element.id
@@ -585,9 +602,9 @@ describe( 'venue settings authorization-facing states', () => {
 		expect( container.textContent ).not.toContain( 'Team' );
 		expect(
 			[ ...container.querySelectorAll( 'button' ) ]
-				.slice( 0, 3 )
+				.slice( 0, 4 )
 				.map( ( button ) => button.textContent )
-		).toEqual( [ 'Calendar', 'Venue', 'Settings' ] );
+		).toEqual( [ 'Calendar', 'Venue', 'Booking Form', 'Settings' ] );
 		for ( const retired of [
 			'Bookings',
 			'Local Support',
@@ -646,7 +663,7 @@ describe( 'venue settings authorization-facing states', () => {
 		await act( async () => root.unmount() );
 	} );
 
-	it( 'shows exactly four venue tabs to authorized managers', async () => {
+	it( 'shows exactly five venue tabs to authorized managers', async () => {
 		const { container, root } = await renderApp(
 			context( {
 				user: { id: 1, name: 'Admin', is_admin: true },
@@ -655,9 +672,15 @@ describe( 'venue settings authorization-facing states', () => {
 		);
 		expect(
 			[ ...container.querySelectorAll( 'button' ) ]
-				.slice( 0, 4 )
+				.slice( 0, 5 )
 				.map( ( button ) => button.textContent )
-		).toEqual( [ 'Calendar', 'Venue', 'Settings', 'Team' ] );
+		).toEqual( [
+			'Calendar',
+			'Venue',
+			'Booking Form',
+			'Settings',
+			'Team',
+		] );
 		expect( container.textContent ).not.toContain( 'Venue claims' );
 		await act( async () => buttonByText( container, 'List' ).click() );
 		expect( container.textContent ).toContain( 'Booking pipeline' );
@@ -1494,6 +1517,9 @@ describe( 'venue settings authorization-facing states', () => {
 			'venue-account'
 		);
 		await act( async () =>
+			buttonByText( container, 'Booking Form' ).click()
+		);
+		await act( async () =>
 			buttonByText( container, 'Add intake field' ).click()
 		);
 		await setInput(
@@ -1501,7 +1527,7 @@ describe( 'venue settings authorization-facing states', () => {
 			'Recent draw'
 		);
 		await act( async () =>
-			buttonByText( container, 'Save settings' ).click()
+			buttonByText( container, 'Save booking form' ).click()
 		);
 
 		const request = apiFetch.mock.calls.find( ( [ call ] ) =>

--- a/inc/Abilities/VenueBookingConfigAbilities.php
+++ b/inc/Abilities/VenueBookingConfigAbilities.php
@@ -243,6 +243,47 @@ class VenueBookingConfigAbilities {
 			'required'             => array( 'artist_name_label', 'contact_name_label', 'contact_email_label', 'contact_phone_label', 'message_label', 'message_help' ),
 			'additionalProperties' => false,
 		);
+		$appearance_schema = array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'mode'              => array(
+					'type' => 'string',
+					'enum' => array( 'default', 'custom' ),
+				),
+				'background_color'  => array(
+					'type'    => 'string',
+					'pattern' => '^#[0-9a-fA-F]{6}$',
+				),
+				'surface_color'     => array(
+					'type'    => 'string',
+					'pattern' => '^#[0-9a-fA-F]{6}$',
+				),
+				'text_color'        => array(
+					'type'    => 'string',
+					'pattern' => '^#[0-9a-fA-F]{6}$',
+				),
+				'accent_color'      => array(
+					'type'    => 'string',
+					'pattern' => '^#[0-9a-fA-F]{6}$',
+				),
+				'button_text_color' => array(
+					'type'    => 'string',
+					'pattern' => '^#[0-9a-fA-F]{6}$',
+				),
+				'border_color'      => array(
+					'type'    => 'string',
+					'pattern' => '^#[0-9a-fA-F]{6}$',
+				),
+				'button_radius'     => array(
+					'type'    => 'integer',
+					'minimum' => 0,
+					'maximum' => 32,
+				),
+				'show_logo'         => array( 'type' => 'boolean' ),
+			),
+			'required'             => array( 'mode', 'background_color', 'surface_color', 'text_color', 'accent_color', 'button_text_color', 'border_color', 'button_radius', 'show_logo' ),
+			'additionalProperties' => false,
+		);
 		$properties          = array(
 			'version'                   => array(
 				'type' => 'integer',
@@ -275,6 +316,7 @@ class VenueBookingConfigAbilities {
 					'maxLength' => 500,
 				),
 			),
+			'appearance'                => $appearance_schema,
 			'consent'                   => array(
 				'type'                 => 'object',
 				'properties'           => array(
@@ -389,7 +431,7 @@ class VenueBookingConfigAbilities {
 			),
 			'correspondence'            => $this->correspondence_schema(),
 		);
-		$required            = array( 'version', 'enabled', 'intake', 'public_requirements', 'consent', 'embed', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
+		$required            = array( 'version', 'enabled', 'intake', 'public_requirements', 'consent', 'appearance', 'embed', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
 		if ( $include_metadata ) {
 			$properties['revision']           = array(
 				'type'    => 'integer',
@@ -414,7 +456,11 @@ class VenueBookingConfigAbilities {
 		if ( ! $accept_legacy ) {
 			return $schema;
 		}
-		$embedded_guide                                  = $schema;
+		$operational                                  = $schema;
+		$operational['properties']['version']['enum'] = array( VenueBookingConfig::OPERATIONAL_CONFIG_VERSION );
+		$operational['required']                      = array_values( array_diff( $operational['required'], array( 'appearance' ) ) );
+		unset( $operational['properties']['appearance'] );
+		$embedded_guide                                  = $operational;
 		$embedded_guide['properties']['version']['enum'] = array( VenueBookingConfig::EMBED_CONFIG_VERSION );
 		$embedded_guide['properties']['booking_guide']   = array( 'type' => 'object' );
 		$embedded_guide['required'][]                    = 'booking_guide';
@@ -435,7 +481,7 @@ class VenueBookingConfigAbilities {
 		$legacy['properties']['version']['enum'] = array( VenueBookingConfig::LEGACY_VERSION );
 		$legacy['required']                      = array_values( array_diff( $legacy['required'], array( 'correspondence' ) ) );
 		unset( $legacy['properties']['correspondence'] );
-		return array( 'oneOf' => array( $legacy, $previous, $public_intake, $legacy_guide, $embedded_guide, $schema ) );
+		return array( 'oneOf' => array( $legacy, $previous, $public_intake, $legacy_guide, $embedded_guide, $operational, $schema ) );
 	}
 
 	/** Return the strict correspondence configuration schema. */

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -16,7 +16,8 @@ class VenueBookingConfig {
 
 	public const META_KEY                     = '_extrachill_booking_config';
 	public const HISTORY_META_KEY             = '_extrachill_booking_config_history';
-	public const VERSION                      = 6;
+	public const VERSION                      = 7;
+	public const OPERATIONAL_CONFIG_VERSION   = 6;
 	public const RETIRED_GUIDE_CONFIG_VERSION = 4;
 	public const EMBED_CONFIG_VERSION         = 5;
 	public const PUBLIC_INTAKE_VERSION        = 3;
@@ -98,7 +99,7 @@ class VenueBookingConfig {
 		}
 
 		$stored = get_term_meta( $venue_term_id, self::META_KEY, true );
-		if ( ! is_array( $stored ) || ! in_array( $stored['version'] ?? null, array( self::PUBLIC_INTAKE_VERSION, self::RETIRED_GUIDE_CONFIG_VERSION, self::EMBED_CONFIG_VERSION, self::VERSION ), true ) ) {
+		if ( ! is_array( $stored ) || ! in_array( $stored['version'] ?? null, array( self::PUBLIC_INTAKE_VERSION, self::RETIRED_GUIDE_CONFIG_VERSION, self::EMBED_CONFIG_VERSION, self::OPERATIONAL_CONFIG_VERSION, self::VERSION ), true ) ) {
 			return new \WP_Error( 'invalid_booking_public_config', __( 'The public venue booking configuration is unavailable.', 'extrachill-events' ) );
 		}
 
@@ -112,10 +113,11 @@ class VenueBookingConfig {
 
 		$fields       = $this->normalize_intake_fields( $stored['intake']['fields'] ?? null );
 		$presentation = $this->normalize_intake_presentation( $stored['intake']['presentation'] ?? array() );
+		$appearance   = $this->normalize_appearance( $stored['appearance'] ?? array() );
 		$requirements = $this->normalize_public_requirements( $stored['public_requirements'] ?? null );
 		$consent      = $this->normalize_consent( $stored['consent'] ?? null );
 		$spaces       = $this->normalize_spaces( $stored['spaces'] ?? null );
-		foreach ( array( $fields, $presentation, $requirements, $consent, $spaces ) as $section ) {
+		foreach ( array( $fields, $presentation, $appearance, $requirements, $consent, $spaces ) as $section ) {
 			if ( is_wp_error( $section ) ) {
 				return $section;
 			}
@@ -126,6 +128,7 @@ class VenueBookingConfig {
 			'revision'            => $revision,
 			'fields'              => $fields,
 			'presentation'        => $presentation,
+			'appearance'          => $appearance,
 			'public_requirements' => $requirements,
 			'consent'             => $consent,
 			'spaces'              => $spaces,
@@ -280,7 +283,7 @@ class VenueBookingConfig {
 	/** Normalize and validate the complete versioned contract. */
 	public function normalize( array $config ) {
 		$version = $config['version'] ?? self::LEGACY_VERSION;
-		if ( ! is_int( $version ) || ! in_array( $version, array( self::LEGACY_VERSION, self::PREVIOUS_VERSION, self::PUBLIC_INTAKE_VERSION, self::RETIRED_GUIDE_CONFIG_VERSION, self::EMBED_CONFIG_VERSION, self::VERSION ), true ) ) {
+		if ( ! is_int( $version ) || ! in_array( $version, array( self::LEGACY_VERSION, self::PREVIOUS_VERSION, self::PUBLIC_INTAKE_VERSION, self::RETIRED_GUIDE_CONFIG_VERSION, self::EMBED_CONFIG_VERSION, self::OPERATIONAL_CONFIG_VERSION, self::VERSION ), true ) ) {
 			return new \WP_Error( 'booking_config_version_unsupported', __( 'The venue booking configuration version is unsupported.', 'extrachill-events' ), array( 'version' => $version ) );
 		}
 		$version_three_fields = array( 'public_requirements', 'consent', 'marketing_triggers' );
@@ -348,6 +351,10 @@ class VenueBookingConfig {
 		if ( is_wp_error( $embed ) ) {
 			return $embed;
 		}
+		$appearance = $this->normalize_appearance( $config['appearance'] ?? array() );
+		if ( is_wp_error( $appearance ) ) {
+			return $appearance;
+		}
 		$channels = $this->normalize_channels( $config['marketing_channels'] ?? array() );
 		if ( is_wp_error( $channels ) ) {
 			return $channels;
@@ -391,6 +398,7 @@ class VenueBookingConfig {
 			),
 			'public_requirements'       => $requirements,
 			'consent'                   => $consent,
+			'appearance'                => $appearance,
 			'embed'                     => $embed,
 			'spaces'                    => $spaces,
 			'default_deal'              => array(
@@ -429,6 +437,7 @@ class VenueBookingConfig {
 				'label'    => __( 'I agree that this venue may use these details to review and respond to my booking inquiry.', 'extrachill-events' ),
 				'required' => true,
 			),
+			'appearance'                => $this->normalize_appearance( array() ),
 			'embed'                     => array( 'allowed_parent_origins' => array() ),
 			'spaces'                    => array(),
 			'default_deal'              => array(
@@ -492,6 +501,26 @@ class VenueBookingConfig {
 					),
 				),
 			),
+		);
+	}
+
+	/**
+	 * Return scoped custom properties for one normalized appearance.
+	 *
+	 * @param array $appearance Normalized appearance contract.
+	 */
+	public static function appearance_style( array $appearance ): string {
+		return implode(
+			';',
+			array(
+				'--ec-booking-background:' . $appearance['background_color'],
+				'--ec-booking-surface:' . $appearance['surface_color'],
+				'--ec-booking-text:' . $appearance['text_color'],
+				'--ec-booking-accent:' . $appearance['accent_color'],
+				'--ec-booking-button-text:' . $appearance['button_text_color'],
+				'--ec-booking-border:' . $appearance['border_color'],
+				'--ec-booking-button-radius:' . (int) $appearance['button_radius'] . 'px',
+			)
 		);
 	}
 
@@ -655,6 +684,51 @@ class VenueBookingConfig {
 			$defaults[ $key ] = '' === $value ? $default : $value;
 		}
 		return $defaults;
+	}
+
+	/**
+	 * Normalize the bounded public booking-form appearance contract.
+	 *
+	 * @param mixed $appearance Proposed appearance contract.
+	 * @return array|\WP_Error
+	 */
+	private function normalize_appearance( $appearance ) {
+		$defaults = array(
+			'mode'              => 'default',
+			'background_color'  => '#121212',
+			'surface_color'     => '#1f1f1f',
+			'text_color'        => '#e5e5e5',
+			'accent_color'      => '#0b5394',
+			'button_text_color' => '#ffffff',
+			'border_color'      => '#3a3a3a',
+			'button_radius'     => 8,
+			'show_logo'         => true,
+		);
+		$appearance = is_array( $appearance ) ? $appearance : array();
+		$mode       = sanitize_key( (string) ( $appearance['mode'] ?? 'default' ) );
+		if ( ! in_array( $mode, array( 'default', 'custom' ), true ) ) {
+			return new \WP_Error( 'invalid_booking_appearance_mode', __( 'Booking appearance mode must be default or custom.', 'extrachill-events' ) );
+		}
+		if ( 'default' === $mode ) {
+			$defaults['show_logo'] = ! array_key_exists( 'show_logo', $appearance ) || ! empty( $appearance['show_logo'] );
+			return $defaults;
+		}
+		$normalized         = $defaults;
+		$normalized['mode'] = 'custom';
+		foreach ( array( 'background_color', 'surface_color', 'text_color', 'accent_color', 'button_text_color', 'border_color' ) as $field ) {
+			$value = strtolower( (string) ( $appearance[ $field ] ?? $defaults[ $field ] ) );
+			if ( ! preg_match( '/^#[0-9a-f]{6}$/', $value ) ) {
+				return new \WP_Error( 'invalid_booking_appearance_color', __( 'Booking appearance colors must use six-digit hex values.', 'extrachill-events' ), array( 'field' => $field ) );
+			}
+			$normalized[ $field ] = $value;
+		}
+		$radius = $appearance['button_radius'] ?? $defaults['button_radius'];
+		if ( ! is_int( $radius ) || $radius < 0 || $radius > 32 ) {
+			return new \WP_Error( 'invalid_booking_appearance_radius', __( 'Booking button radius must be between 0 and 32 pixels.', 'extrachill-events' ) );
+		}
+		$normalized['button_radius'] = $radius;
+		$normalized['show_logo']     = ! array_key_exists( 'show_logo', $appearance ) || ! empty( $appearance['show_logo'] );
+		return $normalized;
 	}
 
 	/** Normalize public, non-operational requirements shown before inquiry intake. */

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -628,7 +628,7 @@ final class BookingFoundationTest extends BookingTestCase {
 		$migrated = $service->normalize( array( 'version' => 1, 'enabled' => true ) );
 		$this->assertSame( VenueBookingConfig::VERSION, $migrated['version'] );
 		$this->assertArrayHasKey( 'correspondence', $migrated );
-		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => 7 ) )->get_error_code() );
+		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => 8 ) )->get_error_code() );
 		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => '1junk' ) )->get_error_code() );
 		$this->assertSame( 'booking_config_section_version_unsupported', $service->normalize( array( 'intake' => array( 'version' => 2 ) ) )->get_error_code() );
 		$this->assertSame( 'booking_config_section_version_unsupported', $service->normalize( array( 'correspondence' => array( 'version' => 2 ) ) )->get_error_code() );
@@ -679,6 +679,36 @@ final class BookingFoundationTest extends BookingTestCase {
 		$stored = $GLOBALS['ec_artist_test']['meta'][7][55][ VenueBookingConfig::META_KEY ];
 		$this->assertSame( VenueBookingConfig::VERSION, $stored['version'] );
 		$this->assertArrayNotHasKey( 'booking_guide', $stored );
+	}
+
+	public function test_config_migrates_version_six_to_bounded_default_appearance(): void {
+		$service             = new VenueBookingConfig();
+		$version_six         = $service->defaults();
+		$version_six['version'] = VenueBookingConfig::OPERATIONAL_CONFIG_VERSION;
+		unset( $version_six['appearance'] );
+
+		$migrated = $service->normalize( $version_six );
+
+		$this->assertSame( VenueBookingConfig::VERSION, $migrated['version'] );
+		$this->assertSame( 'default', $migrated['appearance']['mode'] );
+		$this->assertSame( '#121212', $migrated['appearance']['background_color'] );
+		$this->assertSame( 8, $migrated['appearance']['button_radius'] );
+		$this->assertTrue( $migrated['appearance']['show_logo'] );
+	}
+
+	public function test_config_rejects_unbounded_appearance_values_and_scopes_output(): void {
+		$service = new VenueBookingConfig();
+		$config  = $service->defaults();
+		$config['appearance']['mode']             = 'custom';
+		$config['appearance']['background_color'] = 'linear-gradient(red, blue)';
+		$this->assertSame( 'invalid_booking_appearance_color', $service->normalize( $config )->get_error_code() );
+
+		$config                                      = $service->defaults();
+		$config['appearance']['mode']                 = 'custom';
+		$config['appearance']['button_radius']        = 33;
+		$this->assertSame( 'invalid_booking_appearance_radius', $service->normalize( $config )->get_error_code() );
+		$this->assertStringContainsString( '--ec-booking-background:#121212', VenueBookingConfig::appearance_style( $service->defaults()['appearance'] ) );
+		$this->assertStringNotContainsString( ':root', VenueBookingConfig::appearance_style( $service->defaults()['appearance'] ) );
 	}
 
 	public function test_embed_admission_and_frame_policy_fail_closed(): void {

--- a/tests/Unit/Core/BookingConsoleTest.php
+++ b/tests/Unit/Core/BookingConsoleTest.php
@@ -97,16 +97,27 @@ final class BookingConsoleTest extends TestCase {
 
 	/** Ensure administrators receive one canonical venue workspace link. */
 	public function test_administrator_receives_one_manage_venue_header_action(): void {
-		$this->assertSame(
-			array(
+		$events_blog_id = (int) ec_get_blog_id( 'events' );
+		$switched       = ! ec_is_events_site() && function_exists( 'switch_to_blog' );
+		if ( $switched ) {
+			switch_to_blog( $events_blog_id );
+		}
+		try {
+			$this->assertSame(
 				array(
-					'url'      => ec_events_get_booking_console_url( 0 ),
-					'label'    => 'Manage Venue',
-					'priority' => 8,
+					array(
+						'url'      => ec_events_get_booking_console_url( 0 ),
+						'label'    => 'Manage Venue',
+						'priority' => 8,
+					),
 				),
-			),
-			ec_events_add_venue_workspace_header_item( array() )
-		);
+				ec_events_add_venue_workspace_header_item( array() )
+			);
+		} finally {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+		}
 	}
 
 	/**

--- a/tests/Unit/VenueBookingInquiryRenderTest.php
+++ b/tests/Unit/VenueBookingInquiryRenderTest.php
@@ -215,6 +215,7 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 				};
 			};
 			add_filter( 'wp_die_handler', $die_handler );
+			$buffer_level = ob_get_level();
 			try {
 				activate_plugin( $plugin, '', true, false );
 				$this->fail( 'Site-only dependencies must not permit network activation.' );
@@ -222,6 +223,9 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 				$this->assertStringContainsString( 'Network-activate these required plugins first', $error->getMessage() );
 			} finally {
 				remove_filter( 'wp_die_handler', $die_handler );
+				while ( ob_get_level() > $buffer_level ) {
+					ob_end_clean();
+				}
 			}
 			$this->assertFalse( is_plugin_active_for_network( $plugin ) );
 		} finally {

--- a/tests/Unit/VenueBookingInquiryRenderTest.php
+++ b/tests/Unit/VenueBookingInquiryRenderTest.php
@@ -61,6 +61,8 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 			),
 		);
 		$config['intake']['presentation']['contact_phone_label'] = 'Phone (Emergency use only)';
+		$config['appearance']['mode']                    = 'custom';
+		$config['appearance']['background_color']        = '#112233';
 		$config['ticket_provider_reference']         = 'private-provider-account';
 		$config['correspondence']['booking_address'] = 'private-booking@example.com';
 		update_term_meta( $this->venue_id, VenueBookingConfig::META_KEY, $config );
@@ -82,6 +84,8 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'Booking guide', $output );
 		$this->assertStringContainsString( '"revision":4', $output );
 		$this->assertStringContainsString( 'Phone (Emergency use only)', $output );
+		$this->assertStringContainsString( '--ec-booking-background:#112233', $output );
+		$this->assertStringNotContainsString( ':root', $output );
 		$this->assertStringNotContainsString( 'manage-link-page', $output );
 		$this->assertStringNotContainsString( '"hasPage"', $output );
 		$this->assertStringNotContainsString( 'private-provider-account', $output );

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -1844,7 +1844,7 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertSame( 'venue_action_forbidden', call_user_func( $get['permission_callback'], array( 'venue_term_id' => 56 ) )->get_error_code() );
 		$config_input  = $update['input_schema']['properties']['config'];
 		$config_output = $get['output_schema'];
-		$this->assertCount( 6, $config_input['oneOf'] );
+		$this->assertCount( 7, $config_input['oneOf'] );
 		$this->assertSame( array( 1 ), $config_input['oneOf'][0]['properties']['version']['enum'] );
 		$this->assertNotContains( 'correspondence', $config_input['oneOf'][0]['required'] );
 		$this->assertNotContains( 'public_requirements', $config_input['oneOf'][0]['required'] );
@@ -1868,7 +1868,10 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertContains( 'booking_guide', $config_input['oneOf'][4]['required'] );
 		$this->assertSame( array( 6 ), $config_input['oneOf'][5]['properties']['version']['enum'] );
 		$this->assertNotContains( 'booking_guide', $config_input['oneOf'][5]['required'] );
-		$this->assertSame( array( 6 ), $config_output['properties']['version']['enum'] );
+		$this->assertNotContains( 'appearance', $config_input['oneOf'][5]['required'] );
+		$this->assertSame( array( 7 ), $config_input['oneOf'][6]['properties']['version']['enum'] );
+		$this->assertContains( 'appearance', $config_input['oneOf'][6]['required'] );
+		$this->assertSame( array( 7 ), $config_output['properties']['version']['enum'] );
 		$correspondence_output = $config_output['properties']['correspondence'];
 		$this->assertSame( 6, $correspondence_output['properties']['variables']['maxItems'] );
 		$this->assertContains( 'cc_address', $correspondence_output['required'] );
@@ -1888,6 +1891,7 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertContains( 'correspondence', $config_output['required'] );
 		$this->assertContains( 'public_requirements', $config_output['required'] );
 		$this->assertContains( 'consent', $config_output['required'] );
+		$this->assertContains( 'appearance', $config_output['required'] );
 		$this->assertContains( 'marketing_triggers', $config_output['required'] );
 		$this->assertNotContains( 'booking_guide', $config_output['required'] );
 		$this->assertArrayNotHasKey( 'booking_guide', $config_output['properties'] );
@@ -1900,7 +1904,8 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		unset( $legacy['revision'], $legacy['updated_by_user_id'], $legacy['updated_at'] );
 		$GLOBALS['venue_membership_test']['term_meta'][55][ VenueBookingConfig::META_KEY ] = $legacy;
 		$current = call_user_func( $get['execute_callback'], array( 'venue_term_id' => 55 ) );
-		$this->assertSame( 6, $current['version'] );
+		$this->assertSame( VenueBookingConfig::VERSION, $current['version'] );
+		$this->assertSame( 'default', $current['appearance']['mode'] );
 		$this->assertSame( 'Contact phone', $current['intake']['presentation']['contact_phone_label'] );
 		$this->assertArrayHasKey( 'correspondence', $current );
 		$this->assertSame( array(), $current['marketing_triggers'] );


### PR DESCRIPTION
## Summary

- Adds a deep-linkable top-level **Booking Form** workspace between Venue and Settings.
- Moves public inquiry copy/fields, bounded appearance, real-form preview, canonical link/QR/button distribution, and secure iframe setup into one workflow.
- Keeps operational controls in Settings and preserves the existing exact-origin embed admission/CSP/postMessage contract.

## User-facing workflow

Venue operators now navigate **Calendar → Venue → Booking Form → Settings → Team**. Booking Form contains:

- Public requirements, built-in field copy, consent, and custom inquiry fields.
- Extra Chill default or bounded custom colors, button radius, logo visibility preference, reset defaults, and subtle Powered by Extra Chill treatment.
- Desktop/mobile live preview using the exported production `BookingInquiry` component with network submission and Turnstile disabled in preview mode.
- Canonical `#booking-inquiry` link, button HTML, QR generation/download, exact HTTPS parent-origin authorization, and responsive iframe HTML.

Settings retains inquiry enablement, spaces, hold duration, default deal, ticketing reference, and marketing/correspondence-owned operational configuration.

## Appearance contract and migration

`VenueBookingConfig` advances its document contract from version 6 to 7 and adds strict `appearance` data:

- `mode`: `default` or `custom`
- six bounded six-digit hex colors: background, surface, text, accent/button, button text, border
- integer button radius from 0–32px
- `show_logo` boolean

Version 6 remains accepted by the update Ability schema and normalizes/persists to version 7 with Extra Chill defaults. Default mode always resolves to the canonical Extra Chill palette. PHP and JS validation reject unsupported modes, arbitrary CSS/gradients, malformed colors, and out-of-range radii.

Hosted archive and authorized iframe rendering both continue through the same dynamic block and now receive the same public appearance projection. CSS custom properties are emitted only on `.ec-venue-booking-inquiry`; no `:root`, scripts, unrestricted fonts, or arbitrary CSS are accepted.

## Preview and QR architecture

- Preview imports and renders `BookingInquiry` from the production booking block source rather than maintaining lookalike form markup.
- Preview starts on the complete form state, remains interactive for responsive inspection, and cannot submit or invoke Turnstile/network requests.
- QR uses the already-loaded Extra Chill `/extrachill/v1/tools/qr-code` primitive. No QR library or new infrastructure was added.
- Both preview and print downloads encode the canonical venue URL ending in `#booking-inquiry`, never the iframe URL.

## Canonical logo ownership

Data Machine Events currently has no canonical venue logo/media field in `Venue_Taxonomy::$meta_fields`, `VenueProfileMutations`, or its public profile contract. The upstream owner gap is tracked in Extra-Chill/data-machine-events#672.

This PR does not add booking-only logo storage. It stores only the Events-owned display preference and conditionally reads/renders `logo_url` from the canonical profile contract when that owner adds it.

## Security invariants

- Exact normalized HTTPS parent-origin validation is unchanged.
- Wildcards, paths, ports, credentials, localhost, and IP origins remain rejected.
- Embed admission still fails closed unless inquiries are enabled and the exact origin is configured.
- CSP `frame-ancestors`, strict referrer policy, no-store response policy, iframe sandbox, parent postMessage target, source/origin checks, message type, and bounded integer height checks are unchanged.
- QR and button HTML expose only the canonical public booking anchor.

## Files and architecture

- `blocks/venue-settings/src/booking-form-tab.js`: dedicated workspace and distribution controls.
- `blocks/venue-settings/src/booking-appearance.js`: shared preview variables, defaults, and QR request shape.
- `blocks/venue-booking-inquiry/src/view.js`: exported production component plus safe preview mode, logo seam, and attribution.
- `blocks/venue-booking-inquiry/render.php` and styles: public appearance projection and wrapper-scoped variables.
- `VenueBookingConfig` and Ability schemas: version 7 migration, defaults, sanitization, and strict contract.
- Focused JS/PHP coverage: navigation, document round trip, migration/schema/sanitization, scoped output, production preview path, QR target, and existing embed security.

## Verification

Passed:

- `npm run test:js -- --runInBand` — 17 suites, 97 tests
- `npm run lint:js`
- `npm run build`
- `vendor/bin/phpunit -c phpunit-booking.xml.dist` — 464 tests, 4,848 assertions
- `vendor/bin/phpunit -c phpunit-venue-unit.xml.dist` — 50 tests, 381 assertions
- changed PHP file `php -l`
- `npm run test:browser:booking-embed`
- `npm run test:browser:booking-inquiry` — desktop 1280×900 and mobile 390×844
- `git diff --check`

Baseline tooling notes:

- `composer test` invokes the default PHPUnit config without the WordPress test bootstrap and fatals on the existing `WP_UnitTestCase` suite. The canonical focused WordPress-aware configs above pass.
- Changed-file WordPress PHPCS remains red on longstanding repository filename/docblock conventions in the legacy class/test files; no syntax failure is present. Newly added JS lint and all behavior suites pass.

Closes #584