### PR TITLE
fix: clarify venue archive preferences

### DIFF
--- a/assets/js/venue-email-sharing.js
+++ b/assets/js/venue-email-sharing.js
@@ -16,7 +16,9 @@
 		button.setAttribute( 'aria-pressed', subscribed ? 'true' : 'false' );
 		button.classList.toggle( 'button-2', subscribed );
 		button.classList.toggle( 'button-3', ! subscribed );
-		button.textContent = subscribed ? 'Email shared' : 'Share email';
+		button.textContent = subscribed
+			? 'Email shared with venue'
+			: 'Share my email with this venue';
 	}
 
 	function request( ability, method ) {
@@ -52,7 +54,7 @@
 			button.disabled = false;
 		} )
 		.catch( () => {
-			button.textContent = 'Email sharing unavailable';
+			button.textContent = 'Email preference unavailable';
 		} );
 
 	button.addEventListener( 'click', () => {
@@ -64,7 +66,7 @@
 		)
 			.then( ( data ) => setState( Boolean( data.subscribed ) ) )
 			.catch( () => {
-				button.textContent = 'Try email sharing again';
+				button.textContent = 'Try email preference again';
 			} )
 			.finally( () => {
 				button.disabled = false;

--- a/assets/js/venue-email-sharing.test.js
+++ b/assets/js/venue-email-sharing.test.js
@@ -29,7 +29,7 @@ describe( 'Venue email sharing', () => {
 			'entity-subscription-status'
 		);
 		const button = document.querySelector( 'button' );
-		expect( button.textContent ).toBe( 'Share email' );
+		expect( button.textContent ).toBe( 'Share my email with this venue' );
 		expect( button.classList.contains( 'button-3' ) ).toBe( true );
 		expect( button.disabled ).toBe( false );
 	} );
@@ -58,7 +58,7 @@ describe( 'Venue email sharing', () => {
 			'"entity_type":"venue"'
 		);
 		expect( document.querySelector( 'button' ).textContent ).toBe(
-			'Email shared'
+			'Email shared with venue'
 		);
 		expect(
 			document.querySelector( 'button' ).classList.contains( 'button-2' )
@@ -84,7 +84,7 @@ describe( 'Venue email sharing', () => {
 			'entity-unsubscribe/run'
 		);
 		expect( document.querySelector( 'button' ).textContent ).toBe(
-			'Share email'
+			'Share my email with this venue'
 		);
 	} );
 
@@ -95,7 +95,7 @@ describe( 'Venue email sharing', () => {
 
 		expect( document.querySelector( 'button' ).disabled ).toBe( true );
 		expect( document.querySelector( 'button' ).textContent ).toBe(
-			'Email sharing unavailable'
+			'Email preference unavailable'
 		);
 	} );
 } );

--- a/inc/core/venue-email-sharing.php
+++ b/inc/core/venue-email-sharing.php
@@ -7,6 +7,10 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use ExtraChillEvents\Core\BookingSchema;
+use ExtraChillEvents\Core\VenueAuthorization;
+use ExtraChillEvents\Core\VenueMembershipRepository;
+
 const EXTRACHILL_EVENTS_VENUE_EMAIL_SHARING_PRODUCER = 'extrachill-events-venue-email-sharing';
 
 /** Register the feature-owned identity, archive control, and private producer. */
@@ -51,20 +55,52 @@ function extrachill_events_authorize_venue_email_sharing_producer( $authorized, 
 		&& 'venue' === ( $entity['taxonomy'] ?? '' );
 }
 
+/**
+ * Whether the venue has an active verified owner who can resolve consent.
+ *
+ * @param WP_Term $term Canonical venue term.
+ * @return bool
+ */
+function extrachill_events_venue_email_sharing_available( WP_Term $term ): bool {
+	static $available = array();
+
+	$term_id = (int) $term->term_id;
+	if ( isset( $available[ $term_id ] ) ) {
+		return $available[ $term_id ];
+	}
+	if ( ! BookingSchema::is_ready() ) {
+		$available[ $term_id ] = false;
+		return false;
+	}
+
+	$memberships           = new VenueMembershipRepository();
+	$owners                = $memberships->list_for_venue(
+		$term_id,
+		array(
+			'is_owner' => true,
+			'status'   => VenueAuthorization::STATUS_ACTIVE,
+			'limit'    => 1,
+		)
+	);
+	$available[ $term_id ] = is_array( $owners ) && ! empty( $owners );
+	return $available[ $term_id ];
+}
+
 /** Render the compact email-sharing action inside venue preferences. */
 function extrachill_events_render_venue_email_sharing_control(): void {
 	$term = function_exists( 'extrachill_events_get_venue_archive_term' ) ? extrachill_events_get_venue_archive_term() : null;
-	if ( null === $term || ! is_user_logged_in() ) {
+	if ( null === $term || ! is_user_logged_in() || ! extrachill_events_venue_email_sharing_available( $term ) ) {
 		return;
 	}
 	?>
-	<button class="button-3 button-small" type="button" disabled aria-live="polite" aria-pressed="false" data-venue-email-sharing data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Loading email sharing...', 'extrachill-events' ); ?></button>
+	<button class="button-3 button-small" type="button" disabled aria-live="polite" aria-pressed="false" data-venue-email-sharing data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Loading email preference...', 'extrachill-events' ); ?></button>
 	<?php
 }
 
 /** Enqueue the progressive control only for authenticated venue archives. */
 function extrachill_events_venue_email_sharing_scripts(): void {
-	if ( ! function_exists( 'extrachill_events_get_venue_archive_term' ) || null === extrachill_events_get_venue_archive_term() || ! is_user_logged_in() ) {
+	$term = function_exists( 'extrachill_events_get_venue_archive_term' ) ? extrachill_events_get_venue_archive_term() : null;
+	if ( null === $term || ! is_user_logged_in() || ! extrachill_events_venue_email_sharing_available( $term ) ) {
 		return;
 	}
 

--- a/inc/core/venue-update-subscriptions.php
+++ b/inc/core/venue-update-subscriptions.php
@@ -14,7 +14,7 @@ const EXTRACHILL_EVENTS_VENUE_UPDATE_SENT_META = '_extrachill_events_venue_updat
 function extrachill_events_init_venue_update_subscriptions(): void {
 	add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_events_authorize_venue_update_producer', 10, 4 );
 	add_action( 'transition_post_status', 'extrachill_events_notify_venue_subscribers', 10, 3 );
-	add_action( 'extrachill_archive_below_description', 'extrachill_events_render_venue_update_control', 5 );
+	add_action( 'extrachill_archive_below_description', 'extrachill_events_render_venue_update_control', 15 );
 	add_action( 'wp_enqueue_scripts', 'extrachill_events_venue_update_scripts' );
 }
 
@@ -62,9 +62,16 @@ function extrachill_events_render_venue_update_control(): void {
 	$archive_url = get_term_link( $term );
 	if ( ! is_user_logged_in() ) {
 		?>
-		<div class="ec-action-row" data-venue-preferences aria-label="<?php esc_attr_e( 'Venue preferences', 'extrachill-events' ); ?>">
-			<a class="button-3 button-small" href="<?php echo esc_url( wp_login_url( $archive_url ) ); ?>"><?php esc_html_e( 'Sign in for venue alerts', 'extrachill-events' ); ?></a>
-		</div>
+		<aside class="events-market-context" data-venue-preferences aria-label="<?php esc_attr_e( 'Venue preferences', 'extrachill-events' ); ?>">
+			<div class="events-market-context__copy">
+				<?php /* translators: %s: venue name. */ ?>
+				<strong><?php echo esc_html( sprintf( __( 'Follow %s', 'extrachill-events' ), $term->name ) ); ?></strong>
+				<span><?php esc_html_e( 'Sign in to get alerts when new events are added.', 'extrachill-events' ); ?></span>
+			</div>
+			<div class="events-market-context__actions">
+				<a class="button-3 button-small" href="<?php echo esc_url( wp_login_url( $archive_url ) ); ?>"><?php esc_html_e( 'Sign in for venue alerts', 'extrachill-events' ); ?></a>
+			</div>
+		</aside>
 		<?php
 		return;
 	}
@@ -73,11 +80,27 @@ function extrachill_events_render_venue_update_control(): void {
 		define( 'DONOTCACHEPAGE', true );
 	}
 	nocache_headers();
+	$email_sharing_available = extrachill_events_venue_email_sharing_available( $term );
 	?>
-	<div class="ec-action-row" data-venue-preferences aria-label="<?php esc_attr_e( 'Venue preferences', 'extrachill-events' ); ?>">
-		<button class="button-3 button-small" type="button" disabled aria-live="polite" aria-pressed="false" data-venue-update-subscription data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Loading alerts...', 'extrachill-events' ); ?></button>
-		<?php extrachill_events_render_venue_email_sharing_control(); ?>
-	</div>
+	<aside class="events-market-context" data-venue-preferences aria-label="<?php esc_attr_e( 'Venue preferences', 'extrachill-events' ); ?>">
+		<div class="events-market-context__copy">
+			<?php /* translators: %s: venue name. */ ?>
+			<strong><?php echo esc_html( sprintf( __( 'Follow %s', 'extrachill-events' ), $term->name ) ); ?></strong>
+			<span>
+				<?php
+				echo esc_html(
+					$email_sharing_available
+						? __( 'Get new event alerts or share your account email with this venue\'s verified team.', 'extrachill-events' )
+						: __( 'Get alerts when new events are added.', 'extrachill-events' )
+				);
+				?>
+			</span>
+		</div>
+		<div class="events-market-context__actions">
+			<button class="button-3 button-small" type="button" disabled aria-live="polite" aria-pressed="false" data-venue-update-subscription data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-slug="<?php echo esc_attr( $term->slug ); ?>"><?php esc_html_e( 'Loading alerts...', 'extrachill-events' ); ?></button>
+			<?php extrachill_events_render_venue_email_sharing_control(); ?>
+		</div>
+	</aside>
 	<?php
 }
 

--- a/tests/Unit/VenueUpdateSubscriptionsTest.php
+++ b/tests/Unit/VenueUpdateSubscriptionsTest.php
@@ -7,6 +7,9 @@
 
 // phpcs:disable -- This isolated fixture shares WordPress test doubles with the festival notification tests.
 
+use ExtraChillEvents\Core\VenueAuthorization;
+use ExtraChillEvents\Core\VenueMembershipRepository;
+
 require_once dirname( __DIR__ ) . '/Support/venue-update-subscription-stubs.php';
 require_once dirname( __DIR__, 2 ) . '/inc/core/venue-update-subscriptions.php';
 require_once dirname( __DIR__, 2 ) . '/inc/core/venue-email-sharing.php';
@@ -88,7 +91,7 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		$this->assertFalse( extrachill_events_authorize_venue_email_sharing_producer( false, EXTRACHILL_EVENTS_VENUE_EMAIL_SHARING_PRODUCER, array( 'entity_type' => 'venue', 'taxonomy' => 'venue' ), 'email' ) );
 	}
 
-	/** Anonymous archives offer one compact sign-in action without mutation controls. */
+	/** Anonymous archives offer a clear follow notice without mutation controls. */
 	public function test_anonymous_archive_renders_sign_in_without_mutation_control(): void {
 		$this->venue_archive();
 		wp_set_current_user( 0 );
@@ -97,9 +100,10 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		extrachill_events_render_venue_update_control();
 		$html = ob_get_clean();
 
-		$this->assertStringContainsString( 'ec-action-row', $html );
+		$this->assertStringContainsString( 'events-market-context', $html );
+		$this->assertStringContainsString( 'Follow The Royal American', $html );
 		$this->assertStringContainsString( 'Sign in for venue alerts', $html );
-		$this->assertStringNotContainsString( '<aside', $html );
+		$this->assertSame( 1, substr_count( $html, '<aside' ) );
 		$this->assertStringNotContainsString( 'data-venue-update-subscription', $html );
 		$this->assertStringNotContainsString( 'data-venue-email-sharing', $html );
 	}
@@ -119,8 +123,8 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'data-slug="the-royal-american"', $html );
 	}
 
-	/** Archive preferences compose two compact actions without a standalone card. */
-	public function test_archive_composes_independent_controls_in_one_action_row(): void {
+	/** Unmanaged venue archives keep event alerts without offering email consent. */
+	public function test_unmanaged_archive_does_not_offer_email_sharing(): void {
 		$this->venue_archive();
 		wp_set_current_user( self::factory()->user->create() );
 
@@ -128,12 +132,36 @@ final class VenueUpdateSubscriptionsTest extends WP_UnitTestCase {
 		extrachill_events_render_venue_update_control();
 		$html = ob_get_clean();
 
-		$this->assertSame( 0, substr_count( $html, '<aside' ) );
-		$this->assertStringContainsString( 'ec-action-row', $html );
+		$this->assertSame( 1, substr_count( $html, '<aside' ) );
+		$this->assertStringContainsString( 'events-market-context', $html );
 		$this->assertStringContainsString( 'data-venue-preferences', $html );
 		$this->assertStringContainsString( 'data-venue-update-subscription', $html );
+		$this->assertStringNotContainsString( 'data-venue-email-sharing', $html );
+	}
+
+	/** Managed venues offer explicit email consent independently of booking state. */
+	public function test_managed_archive_offers_email_sharing_without_booking_gate(): void {
+		$term     = $this->venue_archive();
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$created  = ( new VenueMembershipRepository() )->create(
+			array(
+				'venue_term_id'      => (int) $term->term_id,
+				'user_id'            => $owner_id,
+				'is_owner'           => true,
+				'status'             => VenueAuthorization::STATUS_ACTIVE,
+				'created_by_user_id' => $owner_id,
+			)
+		);
+		$this->assertIsArray( $created );
+		wp_set_current_user( self::factory()->user->create() );
+
+		ob_start();
+		extrachill_events_render_venue_update_control();
+		$html = ob_get_clean();
+
 		$this->assertStringContainsString( 'data-venue-email-sharing', $html );
-		$this->assertStringContainsString( 'Loading email sharing...', $html );
+		$this->assertStringContainsString( 'Loading email preference...', $html );
+		$this->assertStringContainsString( 'verified team', $html );
 	}
 
 	/** First publication deduplicates subscribers across all assigned venues. */


### PR DESCRIPTION
## Summary
- restore venue preferences to the existing Events notice surface after the venue map
- keep event alerts available on every canonical venue archive
- keep email consent independent of booking enablement while showing it only when an active verified owner can resolve it
- replace ambiguous `Share email` copy with `Share my email with this venue`
- add no new local styles or preference substrate

## Verification
- JavaScript tests: 16 suites, 95 tests passed
- full JavaScript lint passed
- WordPress PHPCS passed for changed PHP files
- PHP syntax checks passed
- managed and unmanaged venue integration coverage added for email consent eligibility
- local WordPress PHPUnit remains unavailable because the repository bootstrap does not provide `WP_UnitTestCase`; disposable WordPress CI owns that gate
- `git diff --check`

Closes #586