### PR TITLE
test: authenticate managed venue administrator

### DIFF
--- a/tests/Unit/Core/BookingConsoleTest.php
+++ b/tests/Unit/Core/BookingConsoleTest.php
@@ -97,12 +97,27 @@ final class BookingConsoleTest extends TestCase {
 
 	/** Ensure administrators receive one canonical venue workspace link. */
 	public function test_administrator_receives_one_manage_venue_header_action(): void {
-		$events_blog_id = (int) ec_get_blog_id( 'events' );
-		$switched       = ! ec_is_events_site() && function_exists( 'switch_to_blog' );
+		$previous_user_id = get_current_user_id();
+		$test_user_id     = 0;
+		$events_blog_id   = (int) ec_get_blog_id( 'events' );
+		$switched         = ! ec_is_events_site() && function_exists( 'switch_to_blog' );
 		if ( $switched ) {
 			switch_to_blog( $events_blog_id );
 		}
 		try {
+			if ( function_exists( 'wp_insert_user' ) && function_exists( 'wp_set_current_user' ) ) {
+				$test_user_id = wp_insert_user(
+					array(
+						'user_login' => 'booking-console-admin-' . wp_generate_uuid4(),
+						'user_pass'  => wp_generate_password( 24 ),
+						'role'       => 'administrator',
+					)
+				);
+				if ( is_wp_error( $test_user_id ) ) {
+					$this->fail( $test_user_id->get_error_message() );
+				}
+				wp_set_current_user( $test_user_id );
+			}
 			$this->assertSame(
 				array(
 					array(
@@ -114,6 +129,12 @@ final class BookingConsoleTest extends TestCase {
 				ec_events_add_venue_workspace_header_item( array() )
 			);
 		} finally {
+			if ( $test_user_id > 0 ) {
+				wp_set_current_user( $previous_user_id );
+				if ( function_exists( 'wp_delete_user' ) ) {
+					wp_delete_user( $test_user_id );
+				}
+			}
 			if ( $switched ) {
 				restore_current_blog();
 			}


### PR DESCRIPTION
## Summary

- Establishes an actual temporary administrator on the Events blog before asserting the role-gated venue header action.
- Restores the prior user and blog context after the assertion.
- Keeps the lightweight isolated test path unchanged when WordPress user APIs are unavailable.

## Context

The managed WordPress suite uses real `is_user_logged_in()` and `current_user_can()` functions. `BookingConsoleTest::test_administrator_receives_one_manage_venue_header_action` previously relied on isolated stubs, so managed CI ran as user `0` and the production guard correctly returned no header action.

PR #585 was merged before this final managed-runtime fix reached its branch. This focused follow-up contains only the remaining fixture correction.

## Verification

- `vendor/bin/phpunit --configuration phpunit-venue-unit.xml.dist` — 49 tests, 373 assertions
- `php -l tests/Unit/Core/BookingConsoleTest.php`
- `git diff --check origin/main...HEAD`