### PR TITLE
fix: clear booking form release lint

### DIFF
--- a/blocks/venue-booking-inquiry/render.php
+++ b/blocks/venue-booking-inquiry/render.php
@@ -82,18 +82,15 @@ if ( ! is_array( $canonical ) ) {
 	return;
 }
 
-$booking_config       = $canonical['booking_config'];
-$instance             = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'ec-booking-' ) : 'ec-booking-' . $venue_id;
-$logged_in            = is_user_logged_in();
-$form_enabled         = ! empty( $booking_config['enabled'] );
+$booking_config = $canonical['booking_config'];
+$instance       = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'ec-booking-' ) : 'ec-booking-' . $venue_id;
+$logged_in      = is_user_logged_in();
 if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 	define( 'DONOTCACHEPAGE', true );
 }
 nocache_headers();
-if ( $form_enabled ) {
-	if ( function_exists( 'ec_enqueue_turnstile_script' ) ) {
-		ec_enqueue_turnstile_script();
-	}
+if ( function_exists( 'ec_enqueue_turnstile_script' ) ) {
+	ec_enqueue_turnstile_script();
 }
 
 $public_config = array(
@@ -111,8 +108,8 @@ $public_config = array(
 	'consent'              => $booking_config['consent'],
 );
 
-$json = $form_enabled ? wp_json_encode( $public_config, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ) : '';
-if ( $form_enabled && false === $json ) {
+$json = wp_json_encode( $public_config, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+if ( false === $json ) {
 	return;
 }
 $wrapper_extra = array(
@@ -125,17 +122,15 @@ if ( (int) get_current_blog_id() === $events_blog_id && is_tax( 'venue' ) ) {
 $wrapper_attributes = get_block_wrapper_attributes( $wrapper_extra );
 ?>
 <section <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Core escapes block wrapper attributes. ?>>
-	<?php if ( $form_enabled ) : ?>
-		<div data-booking-app></div>
-		<script type="application/json"><?php echo $json; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON_HEX flags make the script payload inert. ?></script>
-		<div data-booking-turnstile>
-			<?php
-			if ( function_exists( 'ec_render_turnstile_widget' ) ) {
-				echo wp_kses_post( ec_render_turnstile_widget( array( 'data-appearance' => 'always' ) ) );
-			} else {
-				esc_html_e( 'Security challenge unavailable. Please contact the venue directly.', 'extrachill-events' );
-			}
-			?>
-		</div>
-	<?php endif; ?>
+	<div data-booking-app></div>
+	<script type="application/json"><?php echo $json; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON_HEX flags make the script payload inert. ?></script>
+	<div data-booking-turnstile>
+		<?php
+		if ( function_exists( 'ec_render_turnstile_widget' ) ) {
+			echo wp_kses_post( ec_render_turnstile_widget( array( 'data-appearance' => 'always' ) ) );
+		} else {
+			esc_html_e( 'Security challenge unavailable. Please contact the venue directly.', 'extrachill-events' );
+		}
+		?>
+	</div>
 </section>

--- a/inc/Abilities/VenueBookingConfigAbilities.php
+++ b/inc/Abilities/VenueBookingConfigAbilities.php
@@ -243,7 +243,7 @@ class VenueBookingConfigAbilities {
 			'required'             => array( 'artist_name_label', 'contact_name_label', 'contact_email_label', 'contact_phone_label', 'message_label', 'message_help' ),
 			'additionalProperties' => false,
 		);
-		$appearance_schema = array(
+		$appearance_schema   = array(
 			'type'                 => 'object',
 			'properties'           => array(
 				'mode'              => array(

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -693,7 +693,7 @@ class VenueBookingConfig {
 	 * @return array|\WP_Error
 	 */
 	private function normalize_appearance( $appearance ) {
-		$defaults = array(
+		$defaults   = array(
 			'mode'              => 'default',
 			'background_color'  => '#121212',
 			'surface_color'     => '#1f1f1f',

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -707,6 +707,9 @@ final class BookingFoundationTest extends BookingTestCase {
 		$config['appearance']['mode']                 = 'custom';
 		$config['appearance']['button_radius']        = 33;
 		$this->assertSame( 'invalid_booking_appearance_radius', $service->normalize( $config )->get_error_code() );
+		$config['appearance']['button_radius']        = 8;
+		$config['appearance']['background_color']     = '#AABBCC';
+		$this->assertSame( '#aabbcc', $service->normalize( $config )['appearance']['background_color'] );
 		$this->assertStringContainsString( '--ec-booking-background:#121212', VenueBookingConfig::appearance_style( $service->defaults()['appearance'] ) );
 		$this->assertStringNotContainsString( ':root', VenueBookingConfig::appearance_style( $service->defaults()['appearance'] ) );
 	}

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -1836,6 +1836,7 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertContains( 'public_requirements', $config_output['required'] );
 		$this->assertContains( 'consent', $config_output['required'] );
 		$this->assertContains( 'appearance', $config_output['required'] );
+		$this->assertSame( '^#[0-9a-fA-F]{6}$', $config_output['properties']['appearance']['properties']['background_color']['pattern'] );
 		$this->assertContains( 'marketing_triggers', $config_output['required'] );
 		$this->assertNotContains( 'booking_guide', $config_output['required'] );
 		$this->assertArrayNotHasKey( 'booking_guide', $config_output['properties'] );


### PR DESCRIPTION
## Summary

- Removes redundant enabled-form branches after the public projection has already failed closed on disabled configs.
- Aligns changed PHP assignments with repository formatting rules.
- Clears the release-blocking PHPCS and PHPStan findings without skipping release gates.

## Verification

- `npm run build`
- `vendor/bin/phpunit --configuration phpunit-network-block.xml.dist` — 3 tests, 22 assertions
- `vendor/bin/phpunit --configuration phpunit-venue-unit.xml.dist` — 49 tests, 373 assertions
- `vendor/bin/phpunit -c phpunit-booking.xml.dist` — 464 tests, 4,848 assertions
- Changed PHP syntax checks
- `git diff --check`