### PR TITLE
fix: remove dead public booking requirements

### DIFF
--- a/blocks/venue-booking-inquiry/src/index.js
+++ b/blocks/venue-booking-inquiry/src/index.js
@@ -49,8 +49,7 @@ function Edit( { attributes, setAttributes } ) {
 				<strong>{ heading || 'Booking inquiries' }</strong>
 				<p>
 					The public form resolves the canonical venue profile,
-					booking requirements, spaces, consent, and intake fields at
-					render time.
+					spaces, consent, and intake fields at render time.
 				</p>
 				<p>
 					<small>

--- a/blocks/venue-settings/src/intake-public.js
+++ b/blocks/venue-settings/src/intake-public.js
@@ -21,28 +21,8 @@ export default function PublicBookingDetails( {
 		<Panel>
 			<PanelHeader
 				title="Public booking details"
-				description="Requirements and consent shown on this venue's public inquiry form."
+				description="Field labels and consent shown on this venue's public inquiry form."
 			/>
-			<FieldGroup
-				label="Public requirements"
-				htmlFor={ `${ idPrefix }venue-public-requirements` }
-				help="One plain-text requirement per line. Internal deal and contact details do not belong here."
-			>
-				<textarea
-					id={ `${ idPrefix }venue-public-requirements` }
-					rows="5"
-					value={ config.public_requirements.join( '\n' ) }
-					onChange={ ( event ) =>
-						setConfig( {
-							...config,
-							public_requirements: event.target.value
-								.split( '\n' )
-								.map( ( item ) => item.trim() )
-								.filter( Boolean ),
-						} )
-					}
-				/>
-			</FieldGroup>
 			<FieldGroup
 				label="Built-in field presentation"
 				htmlFor={ `${ idPrefix }venue-booking-presentation` }

--- a/blocks/venue-settings/src/state.js
+++ b/blocks/venue-settings/src/state.js
@@ -48,9 +48,6 @@ export const validateConfig = ( config ) => {
 	if ( config.embed?.allowed_parent_origins?.length > 20 ) {
 		errors.push( 'Use no more than 20 embed parent origins.' );
 	}
-	if ( config.public_requirements.length > 20 ) {
-		errors.push( 'Use no more than 20 public requirements.' );
-	}
 	if (
 		! config.appearance ||
 		! [ 'default', 'custom' ].includes( config.appearance.mode ) ||

--- a/blocks/venue-settings/src/state.test.js
+++ b/blocks/venue-settings/src/state.test.js
@@ -11,10 +11,9 @@ import {
 } from './state';
 
 const validConfig = () => ( {
-	version: 7,
+	version: 8,
 	enabled: true,
 	intake: { version: 1, fields: [] },
-	public_requirements: [],
 	consent: {
 		id: 'booking-privacy',
 		version: 1,

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -116,7 +116,7 @@ const profile = ( id ) => ( {
 	revision: String( id ).padStart( 64, '0' ),
 } );
 const config = ( id ) => ( {
-	version: 7,
+	version: 8,
 	revision: id,
 	updated_by_user_id: null,
 	updated_at: null,
@@ -133,7 +133,6 @@ const config = ( id ) => ( {
 			message_help: 'Share routing, timing, or context.',
 		},
 	},
-	public_requirements: [],
 	consent: {
 		id: 'booking-privacy',
 		version: 1,

--- a/inc/Abilities/VenueBookingConfigAbilities.php
+++ b/inc/Abilities/VenueBookingConfigAbilities.php
@@ -307,15 +307,6 @@ class VenueBookingConfigAbilities {
 				'required'             => array( 'version', 'fields', 'presentation' ),
 				'additionalProperties' => false,
 			),
-			'public_requirements'       => array(
-				'type'     => 'array',
-				'maxItems' => 20,
-				'items'    => array(
-					'type'      => 'string',
-					'minLength' => 1,
-					'maxLength' => 500,
-				),
-			),
 			'appearance'                => $appearance_schema,
 			'consent'                   => array(
 				'type'                 => 'object',
@@ -431,7 +422,7 @@ class VenueBookingConfigAbilities {
 			),
 			'correspondence'            => $this->correspondence_schema(),
 		);
-		$required            = array( 'version', 'enabled', 'intake', 'public_requirements', 'consent', 'appearance', 'embed', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
+		$required            = array( 'version', 'enabled', 'intake', 'consent', 'appearance', 'embed', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
 		if ( $include_metadata ) {
 			$properties['revision']           = array(
 				'type'    => 'integer',
@@ -456,7 +447,23 @@ class VenueBookingConfigAbilities {
 		if ( ! $accept_legacy ) {
 			return $schema;
 		}
-		$operational                                  = $schema;
+		$retired_requirements = $schema;
+
+		$retired_requirements['properties']['version']['enum'] = array( VenueBookingConfig::RETIRED_REQUIREMENTS_VERSION );
+
+		$retired_requirements['properties']['public_requirements'] = array(
+			'type'     => 'array',
+			'maxItems' => 20,
+			'items'    => array(
+				'type'      => 'string',
+				'minLength' => 1,
+				'maxLength' => 500,
+			),
+		);
+		$retired_requirements['required'][]                        = 'public_requirements';
+
+		$operational = $retired_requirements;
+
 		$operational['properties']['version']['enum'] = array( VenueBookingConfig::OPERATIONAL_CONFIG_VERSION );
 		$operational['required']                      = array_values( array_diff( $operational['required'], array( 'appearance' ) ) );
 		unset( $operational['properties']['appearance'] );
@@ -481,7 +488,7 @@ class VenueBookingConfigAbilities {
 		$legacy['properties']['version']['enum'] = array( VenueBookingConfig::LEGACY_VERSION );
 		$legacy['required']                      = array_values( array_diff( $legacy['required'], array( 'correspondence' ) ) );
 		unset( $legacy['properties']['correspondence'] );
-		return array( 'oneOf' => array( $legacy, $previous, $public_intake, $legacy_guide, $embedded_guide, $operational, $schema ) );
+		return array( 'oneOf' => array( $legacy, $previous, $public_intake, $legacy_guide, $embedded_guide, $operational, $retired_requirements, $schema ) );
 	}
 
 	/** Return the strict correspondence configuration schema. */

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -16,7 +16,8 @@ class VenueBookingConfig {
 
 	public const META_KEY                     = '_extrachill_booking_config';
 	public const HISTORY_META_KEY             = '_extrachill_booking_config_history';
-	public const VERSION                      = 7;
+	public const VERSION                      = 8;
+	public const RETIRED_REQUIREMENTS_VERSION = 7;
 	public const OPERATIONAL_CONFIG_VERSION   = 6;
 	public const RETIRED_GUIDE_CONFIG_VERSION = 4;
 	public const EMBED_CONFIG_VERSION         = 5;
@@ -99,7 +100,7 @@ class VenueBookingConfig {
 		}
 
 		$stored = get_term_meta( $venue_term_id, self::META_KEY, true );
-		if ( ! is_array( $stored ) || ! in_array( $stored['version'] ?? null, array( self::PUBLIC_INTAKE_VERSION, self::RETIRED_GUIDE_CONFIG_VERSION, self::EMBED_CONFIG_VERSION, self::OPERATIONAL_CONFIG_VERSION, self::VERSION ), true ) ) {
+		if ( ! is_array( $stored ) || ! in_array( $stored['version'] ?? null, array( self::PUBLIC_INTAKE_VERSION, self::RETIRED_GUIDE_CONFIG_VERSION, self::EMBED_CONFIG_VERSION, self::OPERATIONAL_CONFIG_VERSION, self::RETIRED_REQUIREMENTS_VERSION, self::VERSION ), true ) ) {
 			return new \WP_Error( 'invalid_booking_public_config', __( 'The public venue booking configuration is unavailable.', 'extrachill-events' ) );
 		}
 
@@ -114,24 +115,22 @@ class VenueBookingConfig {
 		$fields       = $this->normalize_intake_fields( $stored['intake']['fields'] ?? null );
 		$presentation = $this->normalize_intake_presentation( $stored['intake']['presentation'] ?? array() );
 		$appearance   = $this->normalize_appearance( $stored['appearance'] ?? array() );
-		$requirements = $this->normalize_public_requirements( $stored['public_requirements'] ?? null );
 		$consent      = $this->normalize_consent( $stored['consent'] ?? null );
 		$spaces       = $this->normalize_spaces( $stored['spaces'] ?? null );
-		foreach ( array( $fields, $presentation, $appearance, $requirements, $consent, $spaces ) as $section ) {
+		foreach ( array( $fields, $presentation, $appearance, $consent, $spaces ) as $section ) {
 			if ( is_wp_error( $section ) ) {
 				return $section;
 			}
 		}
 
 		return array(
-			'enabled'             => ! empty( $stored['enabled'] ),
-			'revision'            => $revision,
-			'fields'              => $fields,
-			'presentation'        => $presentation,
-			'appearance'          => $appearance,
-			'public_requirements' => $requirements,
-			'consent'             => $consent,
-			'spaces'              => $spaces,
+			'enabled'      => ! empty( $stored['enabled'] ),
+			'revision'     => $revision,
+			'fields'       => $fields,
+			'presentation' => $presentation,
+			'appearance'   => $appearance,
+			'consent'      => $consent,
+			'spaces'       => $spaces,
 		);
 	}
 
@@ -283,7 +282,7 @@ class VenueBookingConfig {
 	/** Normalize and validate the complete versioned contract. */
 	public function normalize( array $config ) {
 		$version = $config['version'] ?? self::LEGACY_VERSION;
-		if ( ! is_int( $version ) || ! in_array( $version, array( self::LEGACY_VERSION, self::PREVIOUS_VERSION, self::PUBLIC_INTAKE_VERSION, self::RETIRED_GUIDE_CONFIG_VERSION, self::EMBED_CONFIG_VERSION, self::OPERATIONAL_CONFIG_VERSION, self::VERSION ), true ) ) {
+		if ( ! is_int( $version ) || ! in_array( $version, array( self::LEGACY_VERSION, self::PREVIOUS_VERSION, self::PUBLIC_INTAKE_VERSION, self::RETIRED_GUIDE_CONFIG_VERSION, self::EMBED_CONFIG_VERSION, self::OPERATIONAL_CONFIG_VERSION, self::RETIRED_REQUIREMENTS_VERSION, self::VERSION ), true ) ) {
 			return new \WP_Error( 'booking_config_version_unsupported', __( 'The venue booking configuration version is unsupported.', 'extrachill-events' ), array( 'version' => $version ) );
 		}
 		$version_three_fields = array( 'public_requirements', 'consent', 'marketing_triggers' );
@@ -293,11 +292,14 @@ class VenueBookingConfig {
 		if ( $version >= self::PUBLIC_INTAKE_VERSION && ! array_key_exists( 'marketing_triggers', $config ) ) {
 			return new \WP_Error( 'booking_config_version_field_invalid', __( 'Venue booking configuration version 3 requires marketing triggers.', 'extrachill-events' ), array( 'version' => $version ) );
 		}
+		if ( self::VERSION === $version && array_key_exists( 'public_requirements', $config ) ) {
+			return new \WP_Error( 'booking_config_version_field_invalid', __( 'The current venue booking configuration does not support retired public requirements.', 'extrachill-events' ), array( 'version' => $version ) );
+		}
 		if ( $version < self::RETIRED_GUIDE_CONFIG_VERSION && array_key_exists( 'booking_guide', $config ) ) {
 			return new \WP_Error( 'booking_config_version_field_invalid', __( 'Booking guide settings require venue booking configuration version 4.', 'extrachill-events' ), array( 'version' => $version ) );
 		}
 		if ( self::VERSION === $version && array_key_exists( 'booking_guide', $config ) ) {
-			return new \WP_Error( 'booking_config_version_field_invalid', __( 'Venue booking configuration version 6 does not support retired booking guide settings.', 'extrachill-events' ), array( 'version' => $version ) );
+			return new \WP_Error( 'booking_config_version_field_invalid', __( 'The current venue booking configuration does not support retired booking guide settings.', 'extrachill-events' ), array( 'version' => $version ) );
 		}
 		if ( $version < self::EMBED_CONFIG_VERSION && array_key_exists( 'embed', $config ) ) {
 			return new \WP_Error( 'booking_config_version_field_invalid', __( 'Embed settings require venue booking configuration version 5.', 'extrachill-events' ), array( 'version' => $version ) );
@@ -339,9 +341,11 @@ class VenueBookingConfig {
 		if ( is_wp_error( $fields ) ) {
 			return $fields;
 		}
-		$requirements = $this->normalize_public_requirements( $config['public_requirements'] ?? array() );
-		if ( is_wp_error( $requirements ) ) {
-			return $requirements;
+		if ( $version >= self::PUBLIC_INTAKE_VERSION && $version <= self::RETIRED_REQUIREMENTS_VERSION ) {
+			$requirements = $this->normalize_public_requirements( $config['public_requirements'] ?? array() );
+			if ( is_wp_error( $requirements ) ) {
+				return $requirements;
+			}
 		}
 		$consent = $this->normalize_consent( $config['consent'] ?? array() );
 		if ( is_wp_error( $consent ) ) {
@@ -396,7 +400,6 @@ class VenueBookingConfig {
 				'fields'       => $fields,
 				'presentation' => $this->normalize_intake_presentation( $config['intake']['presentation'] ?? array() ),
 			),
-			'public_requirements'       => $requirements,
 			'consent'                   => $consent,
 			'appearance'                => $appearance,
 			'embed'                     => $embed,
@@ -430,7 +433,6 @@ class VenueBookingConfig {
 				'fields'       => array(),
 				'presentation' => $this->normalize_intake_presentation( array() ),
 			),
-			'public_requirements'       => array(),
 			'consent'                   => array(
 				'id'       => 'booking-privacy',
 				'version'  => self::CONSENT_VERSION,
@@ -1097,7 +1099,7 @@ class VenueBookingConfig {
 
 	/** Return top-level settings changed by the replacement document. */
 	private function changed_fields( array $current, array $next ): array {
-		$fields  = array( 'enabled', 'intake', 'public_requirements', 'consent', 'embed', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
+		$fields  = array( 'enabled', 'intake', 'consent', 'embed', 'spaces', 'default_deal', 'ticket_provider_reference', 'marketing_channels', 'marketing_triggers', 'hold_ttl_minutes', 'correspondence' );
 		$changed = array();
 		foreach ( $fields as $field ) {
 			if ( $current[ $field ] !== $next[ $field ] ) {

--- a/tests/BookingFoundationTest.php
+++ b/tests/BookingFoundationTest.php
@@ -628,7 +628,7 @@ final class BookingFoundationTest extends BookingTestCase {
 		$migrated = $service->normalize( array( 'version' => 1, 'enabled' => true ) );
 		$this->assertSame( VenueBookingConfig::VERSION, $migrated['version'] );
 		$this->assertArrayHasKey( 'correspondence', $migrated );
-		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => 8 ) )->get_error_code() );
+		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => 9 ) )->get_error_code() );
 		$this->assertSame( 'booking_config_version_unsupported', $service->normalize( array( 'version' => '1junk' ) )->get_error_code() );
 		$this->assertSame( 'booking_config_section_version_unsupported', $service->normalize( array( 'intake' => array( 'version' => 2 ) ) )->get_error_code() );
 		$this->assertSame( 'booking_config_section_version_unsupported', $service->normalize( array( 'correspondence' => array( 'version' => 2 ) ) )->get_error_code() );
@@ -694,6 +694,22 @@ final class BookingFoundationTest extends BookingTestCase {
 		$this->assertSame( '#121212', $migrated['appearance']['background_color'] );
 		$this->assertSame( 8, $migrated['appearance']['button_radius'] );
 		$this->assertTrue( $migrated['appearance']['show_logo'] );
+	}
+
+	public function test_config_migrates_version_seven_without_retired_public_requirements(): void {
+		$service                                = new VenueBookingConfig();
+		$version_seven                          = $service->defaults();
+		$version_seven['version']               = VenueBookingConfig::RETIRED_REQUIREMENTS_VERSION;
+		$version_seven['public_requirements']   = array( 'Send a stage plot.' );
+
+		$migrated = $service->normalize( $version_seven );
+
+		$this->assertSame( VenueBookingConfig::VERSION, $migrated['version'] );
+		$this->assertArrayNotHasKey( 'public_requirements', $migrated );
+		$this->assertArrayNotHasKey( 'public_requirements', $service->defaults() );
+		$current                                = $service->defaults();
+		$current['public_requirements']         = array( 'Dead configuration.' );
+		$this->assertSame( 'booking_config_version_field_invalid', $service->normalize( $current )->get_error_code() );
 	}
 
 	public function test_config_rejects_unbounded_appearance_values_and_scopes_output(): void {

--- a/tests/BookingMarketingTest.php
+++ b/tests/BookingMarketingTest.php
@@ -1295,7 +1295,7 @@ final class BookingMarketingTest extends BookingTestCase {
 	public function test_version_two_configs_migrate_without_implicit_marketing_triggers(): void {
 		$config            = ( new VenueBookingConfig() )->defaults();
 		$config['version'] = VenueBookingConfig::PREVIOUS_VERSION;
-		unset( $config['public_requirements'], $config['consent'], $config['marketing_triggers'], $config['embed'] );
+		unset( $config['consent'], $config['marketing_triggers'], $config['embed'] );
 		$normalized = ( new VenueBookingConfig() )->normalize( $config );
 		$this->assertSame( VenueBookingConfig::VERSION, $normalized['version'] );
 		$this->assertSame( array(), $normalized['marketing_triggers'] );

--- a/tests/NetworkE2E/booking/assert.php
+++ b/tests/NetworkE2E/booking/assert.php
@@ -639,7 +639,6 @@ if ( ! is_array( $config_before ) ) {
 }
 $config_input = $config_before;
 unset( $config_input['revision'], $config_input['updated_by_user_id'], $config_input['updated_at'] );
-$config_input['public_requirements'] = array( 'E2E-updated requirement.' );
 $config_after                        = booking_network_e2e_execute(
 	'extrachill/update-venue-booking-config',
 	array(

--- a/tests/NetworkE2E/booking/assert.php
+++ b/tests/NetworkE2E/booking/assert.php
@@ -639,6 +639,7 @@ if ( ! is_array( $config_before ) ) {
 }
 $config_input = $config_before;
 unset( $config_input['revision'], $config_input['updated_by_user_id'], $config_input['updated_at'] );
+$config_input['intake']['presentation']['message_help'] = 'E2E-updated public message help.';
 $config_after                        = booking_network_e2e_execute(
 	'extrachill/update-venue-booking-config',
 	array(

--- a/tests/Unit/VenueBookingInquiryRenderTest.php
+++ b/tests/Unit/VenueBookingInquiryRenderTest.php
@@ -36,7 +36,6 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 		$config                                      = ( new VenueBookingConfig() )->defaults();
 		$config['enabled']                           = true;
 		$config['revision']                          = 4;
-		$config['public_requirements']               = array( 'Include recent draw and routing.' );
 		$config['spaces']                            = array(
 			array(
 				'key'        => 'main-room',

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -1788,7 +1788,7 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertSame( 'venue_action_forbidden', call_user_func( $get['permission_callback'], array( 'venue_term_id' => 56 ) )->get_error_code() );
 		$config_input  = $update['input_schema']['properties']['config'];
 		$config_output = $get['output_schema'];
-		$this->assertCount( 7, $config_input['oneOf'] );
+		$this->assertCount( 8, $config_input['oneOf'] );
 		$this->assertSame( array( 1 ), $config_input['oneOf'][0]['properties']['version']['enum'] );
 		$this->assertNotContains( 'correspondence', $config_input['oneOf'][0]['required'] );
 		$this->assertNotContains( 'public_requirements', $config_input['oneOf'][0]['required'] );
@@ -1815,7 +1815,12 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertNotContains( 'appearance', $config_input['oneOf'][5]['required'] );
 		$this->assertSame( array( 7 ), $config_input['oneOf'][6]['properties']['version']['enum'] );
 		$this->assertContains( 'appearance', $config_input['oneOf'][6]['required'] );
-		$this->assertSame( array( 7 ), $config_output['properties']['version']['enum'] );
+		$this->assertContains( 'public_requirements', $config_input['oneOf'][6]['required'] );
+		$this->assertSame( array( 8 ), $config_input['oneOf'][7]['properties']['version']['enum'] );
+		$this->assertContains( 'appearance', $config_input['oneOf'][7]['required'] );
+		$this->assertNotContains( 'public_requirements', $config_input['oneOf'][7]['required'] );
+		$this->assertArrayNotHasKey( 'public_requirements', $config_input['oneOf'][7]['properties'] );
+		$this->assertSame( array( 8 ), $config_output['properties']['version']['enum'] );
 		$correspondence_output = $config_output['properties']['correspondence'];
 		$this->assertSame( 6, $correspondence_output['properties']['variables']['maxItems'] );
 		$this->assertContains( 'cc_address', $correspondence_output['required'] );
@@ -1833,7 +1838,8 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertNotContains( 'presentation', $config_input['oneOf'][1]['properties']['intake']['required'] );
 		$this->assertContains( 'presentation', $config_input['oneOf'][2]['properties']['intake']['required'] );
 		$this->assertContains( 'correspondence', $config_output['required'] );
-		$this->assertContains( 'public_requirements', $config_output['required'] );
+		$this->assertNotContains( 'public_requirements', $config_output['required'] );
+		$this->assertArrayNotHasKey( 'public_requirements', $config_output['properties'] );
 		$this->assertContains( 'consent', $config_output['required'] );
 		$this->assertContains( 'appearance', $config_output['required'] );
 		$this->assertSame( '^#[0-9a-fA-F]{6}$', $config_output['properties']['appearance']['properties']['background_color']['pattern'] );
@@ -1845,7 +1851,7 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 
 		$legacy = ( new VenueBookingConfig() )->defaults();
 		$legacy['version'] = 1;
-		unset( $legacy['correspondence'], $legacy['public_requirements'], $legacy['consent'], $legacy['marketing_triggers'], $legacy['embed'] );
+		unset( $legacy['correspondence'], $legacy['consent'], $legacy['marketing_triggers'], $legacy['embed'] );
 		unset( $legacy['revision'], $legacy['updated_by_user_id'], $legacy['updated_at'] );
 		$GLOBALS['venue_membership_test']['term_meta'][55][ VenueBookingConfig::META_KEY ] = $legacy;
 		$current = call_user_func( $get['execute_callback'], array( 'venue_term_id' => 55 ) );


### PR DESCRIPTION
## Summary

- Removes the editor-only Public requirements control that never affected the production booking form.
- Advances the booking config contract to version 8 without `public_requirements` in current defaults, schemas, validation, audit fields, or public projection.
- Keeps version 7 accepted as migration input and drops its retired field during normalization.
- Updates editor copy and tests so current settings describe only visible frontend behavior.

Closes #593.

## Verification

- `npm run test:js -- --runInBand` — 16 suites, 91 tests
- `npm run lint:js`
- `npm run build`
- `vendor/bin/phpunit -c phpunit-booking.xml.dist` — 464 tests, 4,852 assertions
- `vendor/bin/phpunit -c phpunit-venue-unit.xml.dist` — 49 tests, 380 assertions
- Homeboy scoped PHPCS, ESLint, and clean PHPStan producer
- `git diff --check`