### PR TITLE
fix: remove duplicate booking form address

### DIFF
--- a/blocks/venue-booking-inquiry/render.php
+++ b/blocks/venue-booking-inquiry/render.php
@@ -46,18 +46,6 @@ $canonical = ( static function () use ( $events_blog_id, $venue_id ) {
 			}
 		}
 
-		if ( function_exists( 'data_machine_events_get_venue_data' ) && function_exists( 'data_machine_events_get_venue_address' ) ) {
-			$venue_data = data_machine_events_get_venue_data( $venue_id );
-			$address    = data_machine_events_get_venue_address( $venue_id, $venue_data );
-		} else {
-			$street     = (string) get_term_meta( $venue_id, '_venue_address', true );
-			$city       = (string) get_term_meta( $venue_id, '_venue_city', true );
-			$state      = (string) get_term_meta( $venue_id, '_venue_state', true );
-			$zip        = (string) get_term_meta( $venue_id, '_venue_zip', true );
-			$city_state = implode( ', ', array_filter( array( $city, $state ) ) );
-			$address    = implode( ', ', array_filter( array( $street, $city_state, $zip ) ) );
-		}
-
 		$profile  = function_exists( 'data_machine_events_get_venue_profile' ) ? data_machine_events_get_venue_profile( $venue_id ) : array();
 		$logo_url = is_array( $profile ) ? (string) ( $profile['logo_url'] ?? '' ) : '';
 		$logo_url = filter_var( $logo_url, FILTER_VALIDATE_URL ) ? $logo_url : '';
@@ -68,7 +56,6 @@ $canonical = ( static function () use ( $events_blog_id, $venue_id ) {
 				'id'          => $venue_id,
 				'name'        => $venue->name,
 				'description' => wp_strip_all_tags( $venue->description ),
-				'address'     => $address,
 				'logoUrl'     => $logo_url,
 			),
 		);

--- a/blocks/venue-booking-inquiry/src/view.js
+++ b/blocks/venue-booking-inquiry/src/view.js
@@ -352,10 +352,7 @@ export function BookingInquiry( { config, wrapper, preview = false } ) {
 					alt=""
 				/>
 			) }
-			<BlockShellHeader
-				title={ `Booking at ${ config.venue.name }` }
-				description={ config.venue.address }
-			/>
+			<BlockShellHeader title={ `Booking at ${ config.venue.name }` } />
 			<BlockShellInner className="ec-panel ec-booking-inquiry__panel">
 				<form
 					className="ec-booking-inquiry__form"

--- a/blocks/venue-settings/src/booking-form-tab.js
+++ b/blocks/venue-settings/src/booking-form-tab.js
@@ -34,14 +34,6 @@ const previewConfig = ( config, venueName, profile, idPrefix ) => ( {
 	venue: {
 		id: profile?.term_id || 0,
 		name: venueName,
-		address: [
-			profile?.address,
-			profile?.city,
-			profile?.state,
-			profile?.zip,
-		]
-			.filter( Boolean )
-			.join( ', ' ),
 		logoUrl: profile?.logo_url || '',
 	},
 	spaces: config.spaces,

--- a/tests/Unit/VenueBookingInquiryRenderTest.php
+++ b/tests/Unit/VenueBookingInquiryRenderTest.php
@@ -76,7 +76,8 @@ final class VenueBookingInquiryRenderTest extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'ec-venue-booking-inquiry', $output );
 		$this->assertStringContainsString( 'Test Room', $output );
-		$this->assertStringContainsString( '42 Test Street, Charleston, SC, 29403', $output );
+		$this->assertStringNotContainsString( '42 Test Street', $output );
+		$this->assertStringNotContainsString( 'Charleston, SC, 29403', $output );
 		$this->assertStringNotContainsString( 'Include recent draw and routing.', $output );
 		$this->assertStringNotContainsString( 'Booking guide', $output );
 		$this->assertStringContainsString( '"revision":4', $output );


### PR DESCRIPTION
## Summary
- stop repeating the venue address beneath the booking form title on venue archives
- remove the now-unused address lookup and public payload field
- keep the settings preview consistent with production rendering
- assert that canonical address metadata does not leak into booking form markup

## Verification
- JavaScript unit suite: 94 tests passed
- PHP syntax checks passed
- `git diff --check origin/main...HEAD`

Closes #601