### PR TITLE
refactor: simplify My Venues selection

### DIFF
--- a/blocks/venue-booking-inquiry/render.php
+++ b/blocks/venue-booking-inquiry/render.php
@@ -11,9 +11,9 @@ defined( 'ABSPATH' ) || exit;
 
 $events_blog_id = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'events' ) ) : 0;
 $venue_id       = absint( $attributes['venueId'] ?? 0 );
-if ( $venue_id < 1 && (int) get_current_blog_id() === $events_blog_id && function_exists( 'extrachill_events_get_venue_archive_term' ) ) {
-	$archive_venue = extrachill_events_get_venue_archive_term();
-	$venue_id      = $archive_venue ? (int) $archive_venue->term_id : 0;
+if ( $venue_id < 1 && (int) get_current_blog_id() === $events_blog_id && is_tax( 'venue' ) ) {
+	$archive_venue = get_queried_object();
+	$venue_id      = $archive_venue instanceof WP_Term && 'venue' === $archive_venue->taxonomy ? (int) $archive_venue->term_id : 0;
 }
 if ( $events_blog_id < 1 || $venue_id < 1 || ! class_exists( VenueBookingConfig::class ) ) {
 	return;

--- a/blocks/venue-settings/src/venue-workspace-header.js
+++ b/blocks/venue-settings/src/venue-workspace-header.js
@@ -5,7 +5,6 @@ import {
 	ActionRow,
 	Badge,
 	BlockShellHeader,
-	FieldGroup,
 	Panel,
 } from '@extrachill/components';
 
@@ -14,59 +13,72 @@ const STATUS_TONES = {
 	active: 'success',
 };
 
-export function VenueWorkspaceHeader( { venues, selected, onSwitchVenue } ) {
-	const statusTone = STATUS_TONES[ selected?.status ] || 'warning';
-	const statusLabel = selected?.status
-		? selected.status.charAt( 0 ).toUpperCase() + selected.status.slice( 1 )
+function VenueIdentityCard( { venue, onOpen } ) {
+	const statusTone = STATUS_TONES[ venue.status ] || 'warning';
+	const statusLabel = venue.status
+		? venue.status.charAt( 0 ).toUpperCase() + venue.status.slice( 1 )
 		: '';
+
+	return (
+		<Panel compact depth={ 2 }>
+			<ActionRow align="between">
+				<a
+					href={ venue.archive_url }
+					className={ `taxonomy-badge venue-badge venue-${ venue.slug }` }
+				>
+					{ venue.name }
+				</a>
+				<span>
+					<Badge tone={ statusTone } variant="solid">
+						{ statusLabel }
+					</Badge>{ ' ' }
+					{ venue.is_owner && (
+						<Badge tone="success" variant="solid">
+							Owner
+						</Badge>
+					) }{ ' ' }
+					{ onOpen && (
+						<button
+							type="button"
+							className="button-2"
+							onClick={ onOpen }
+						>
+							Open { venue.name }
+						</button>
+					) }
+				</span>
+			</ActionRow>
+		</Panel>
+	);
+}
+
+export function VenueWorkspaceHeader( { venues, selected, onSwitchVenue } ) {
+	const visibleVenues = selected ? [ selected ] : venues;
 
 	return (
 		<>
 			<BlockShellHeader
 				title="Manage venues"
-				description="Manage every venue together or filter the workspace to one venue."
-			/>
-			{ venues.length > 0 && (
-				<FieldGroup label="Venue workspace" htmlFor="venue-workspace">
-					<select
-						id="venue-workspace"
-						value={ selected?.id || 0 }
-						onChange={ onSwitchVenue }
-					>
-						<option value="0">My Venues</option>
-						{ venues.map( ( venue ) => (
-							<option key={ venue.id } value={ venue.id }>
-								{ venue.name }
-								{ venue.status !== 'active'
-									? ` (${ venue.status })`
-									: '' }
-							</option>
-						) ) }
-					</select>
-				</FieldGroup>
-			) }
-			{ selected && (
-				<Panel compact depth={ 2 }>
-					<ActionRow align="between">
-						<a
-							href={ selected.archive_url }
-							className={ `taxonomy-badge venue-badge venue-${ selected.slug }` }
+				description="Manage every venue together or open one venue."
+				actions={
+					selected ? (
+						<button
+							type="button"
+							className="button-2"
+							onClick={ () => onSwitchVenue( 0 ) }
 						>
-							{ selected.name }
-						</a>
-						<span>
-							<Badge tone={ statusTone } variant="solid">
-								{ statusLabel }
-							</Badge>{ ' ' }
-							{ selected.is_owner && (
-								<Badge tone="success" variant="solid">
-									Owner
-								</Badge>
-							) }
-						</span>
-					</ActionRow>
-				</Panel>
-			) }
+							My Venues
+						</button>
+					) : null
+				}
+			/>
+			{ visibleVenues.map( ( venue ) => (
+				<VenueIdentityCard
+					key={ venue.id }
+					venue={ venue }
+					onOpen={ selected ? null : () => onSwitchVenue( venue.id ) }
+				/>
+			) ) }
 		</>
 	);
 }

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -206,7 +206,7 @@ export function VenueSettingsApp( { context } ) {
 		return () => window.removeEventListener( 'beforeunload', warn );
 	}, [ dirty ] );
 
-	const switchVenue = ( event ) => {
+	const switchVenue = ( venueId ) => {
 		if (
 			dirty &&
 			// eslint-disable-next-line no-alert -- Native navigation guard is keyboard and screen-reader accessible.
@@ -214,7 +214,6 @@ export function VenueSettingsApp( { context } ) {
 		) {
 			return;
 		}
-		const venueId = Number( event.target.value );
 		const url = new URL( context.route_url );
 		if ( venueId ) {
 			url.searchParams.set( 'venue_id', venueId );

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -16,6 +16,7 @@ import { act } from 'react';
  * Internal dependencies
  */
 import { VenueSettingsApp } from './view';
+import { VenueWorkspaceHeader } from './venue-workspace-header';
 
 jest.mock( '@wordpress/api-fetch', () => ( {
 	__esModule: true,
@@ -37,8 +38,13 @@ jest.mock( '@extrachill/components', () => {
 				children
 			),
 		BlockShell: Wrapper,
-		BlockShellHeader: ( { title } ) =>
-			React.createElement( 'h1', null, title ),
+		BlockShellHeader: ( { title, actions } ) =>
+			React.createElement(
+				'div',
+				null,
+				React.createElement( 'h1', null, title ),
+				actions
+			),
 		BlockShellInner: Wrapper,
 		FieldGroup: ( { label, help, children } ) =>
 			React.createElement(
@@ -85,10 +91,16 @@ jest.mock( '@extrachill/components', () => {
 					)
 				)
 			),
-		ResponsiveTabs: ( { tabs, active, onChange, renderPanel } ) =>
+		ResponsiveTabs: ( {
+			tabs,
+			active,
+			onChange,
+			renderPanel,
+			contextSurface,
+		} ) =>
 			React.createElement(
 				'div',
-				null,
+				{ 'data-context-surface': contextSurface },
 				tabs.map( ( tab ) =>
 					React.createElement(
 						'button',
@@ -325,6 +337,49 @@ const setControl = async ( control, value ) => {
 };
 
 describe( 'venue settings authorization-facing states', () => {
+	it( 'routes venue card actions through the shared switch callback', async () => {
+		const venue = {
+			id: 44,
+			name: 'Venue 44',
+			slug: 'venue-44',
+			archive_url: 'https://events.example/venue/venue-44/',
+			status: 'active',
+			is_owner: true,
+		};
+		const onSwitchVenue = jest.fn();
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const root = createRoot( container );
+
+		await act( async () => {
+			root.render(
+				<VenueWorkspaceHeader
+					venues={ [ venue ] }
+					selected={ null }
+					onSwitchVenue={ onSwitchVenue }
+				/>
+			);
+		} );
+		await act( async () =>
+			buttonByText( container, 'Open Venue 44' ).click()
+		);
+		expect( onSwitchVenue ).toHaveBeenLastCalledWith( 44 );
+
+		await act( async () => {
+			root.render(
+				<VenueWorkspaceHeader
+					venues={ [ venue ] }
+					selected={ venue }
+					onSwitchVenue={ onSwitchVenue }
+				/>
+			);
+		} );
+		await act( async () => buttonByText( container, 'My Venues' ).click() );
+		expect( onSwitchVenue ).toHaveBeenLastCalledWith( 0 );
+
+		await act( async () => root.unmount() );
+	} );
+
 	beforeAll( () => {
 		global.IS_REACT_ACT_ENVIRONMENT = true;
 	} );
@@ -383,6 +438,8 @@ describe( 'venue settings authorization-facing states', () => {
 			{
 				id: 44,
 				name: 'Venue 44',
+				slug: 'venue-44',
+				archive_url: 'https://events.example/venue/venue-44/',
 				status: 'active',
 				is_owner: true,
 				can_access: true,
@@ -391,6 +448,8 @@ describe( 'venue settings authorization-facing states', () => {
 			{
 				id: 45,
 				name: 'Venue 45',
+				slug: 'venue-45',
+				archive_url: 'https://events.example/venue/venue-45/',
 				status: 'active',
 				is_owner: false,
 				can_access: true,
@@ -405,15 +464,19 @@ describe( 'venue settings authorization-facing states', () => {
 			} )
 		);
 
-		const selector = container.querySelector( '#venue-workspace' );
-		expect( selector.value ).toBe( '0' );
-		expect( selector.options[ 0 ].textContent ).toBe( 'My Venues' );
-		expect( container.textContent ).toContain( 'Venue 44' );
-		expect( container.textContent ).toContain( 'Venue 45' );
+		expect( container.querySelector( '#venue-workspace' ) ).toBeNull();
 		expect(
-			[ ...container.querySelectorAll( 'button' ) ]
-				.slice( 0, 5 )
-				.map( ( button ) => button.textContent )
+			container.querySelectorAll( 'a.taxonomy-badge.venue-badge' )
+		).toHaveLength( 2 );
+		expect( buttonByText( container, 'Open Venue 44' ) ).toBeDefined();
+		expect( buttonByText( container, 'Open Venue 45' ) ).toBeDefined();
+		expect( container.textContent ).toContain( 'Owner' );
+		expect(
+			[
+				...container.querySelectorAll(
+					'[data-context-surface="venue-settings"] > button'
+				),
+			].map( ( button ) => button.textContent )
 		).toEqual( [
 			'Calendar',
 			'Venue',
@@ -589,9 +652,11 @@ describe( 'venue settings authorization-facing states', () => {
 		const { container, root } = await renderApp( context() );
 		expect( container.textContent ).not.toContain( 'Team' );
 		expect(
-			[ ...container.querySelectorAll( 'button' ) ]
-				.slice( 0, 4 )
-				.map( ( button ) => button.textContent )
+			[
+				...container.querySelectorAll(
+					'[data-context-surface="venue-settings"] > button'
+				),
+			].map( ( button ) => button.textContent )
 		).toEqual( [ 'Calendar', 'Venue', 'Booking Form', 'Settings' ] );
 		for ( const retired of [
 			'Bookings',
@@ -620,9 +685,11 @@ describe( 'venue settings authorization-facing states', () => {
 			} )
 		);
 		expect(
-			[ ...container.querySelectorAll( 'button' ) ]
-				.slice( 0, 5 )
-				.map( ( button ) => button.textContent )
+			[
+				...container.querySelectorAll(
+					'[data-context-surface="venue-settings"] > button'
+				),
+			].map( ( button ) => button.textContent )
 		).toEqual( [
 			'Calendar',
 			'Venue',
@@ -666,6 +733,7 @@ describe( 'venue settings authorization-facing states', () => {
 		expect( administrator.classList.contains( 'ec-badge--solid' ) ).toBe(
 			true
 		);
+		expect( buttonByText( container, 'My Venues' ) ).toBeDefined();
 		const viewTabs = [
 			...container.querySelectorAll( '[role="tab"]' ),
 		].filter( ( tab ) =>


### PR DESCRIPTION
## Summary
- replace the redundant venue dropdown/selected-card split with one shared venue identity card
- list every managed venue visibly in My Venues with its taxonomy badge, membership status, and owner badge
- provide one clear Open action per venue and a My Venues return action from selected workspaces
- preserve the existing managed-venue scope and dirty-state navigation guard without adding custom CSS
- restore automatic booking-form resolution on venue archives using WordPress core queried-term APIs after the retired follow helper was removed

## Verification
- `npm run test:js -- --runInBand` (95 tests)
- `npm run lint:js`
- `npm run build`
- PHP syntax check
- `git diff --check`

Closes #603
Closes #608