### PR TITLE
refactor: extract bootstrap feature providers

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -29,155 +29,18 @@ define( 'EXTRACHILL_EVENTS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'EXTRACHILL_EVENTS_PLUGIN_FILE', __FILE__ );
 define( 'EXTRACHILL_EVENTS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
-// WP-CLI commands.
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( __DIR__ . '/inc/Cli/AddCityCommand.php' ) ) { // @phpstan-ignore booleanAnd.rightAlwaysTrue
-	require_once __DIR__ . '/inc/Core/EventSourceRampEvaluator.php';
-	require_once __DIR__ . '/inc/Cli/EventSourceRampCommand.php';
-	\WP_CLI::add_command( 'extrachill events ramp', \ExtraChillEvents\Cli\EventSourceRampCommand::class );
+require_once __DIR__ . '/inc/Providers/CliProvider.php';
+require_once __DIR__ . '/inc/Providers/IngestionProvider.php';
+require_once __DIR__ . '/inc/Providers/PublicExperienceProvider.php';
+require_once __DIR__ . '/inc/Providers/DataMachineEventsProvider.php';
 
-	require_once __DIR__ . '/inc/Cli/AddCityCommand.php';
-	\WP_CLI::add_command( 'extrachill-events add-city', \ExtraChillEvents\Cli\AddCityCommand::class );
-	require_once __DIR__ . '/inc/Cli/ExpandVenuesCommand.php';
-	require_once __DIR__ . '/inc/Cli/VenueExpansionReportCommand.php';
-	\WP_CLI::add_command( 'extrachill-events expand', \ExtraChillEvents\Cli\ExpandVenuesCommand::class );
-	\WP_CLI::add_command( 'extrachill-events expand-report', \ExtraChillEvents\Cli\VenueExpansionReportCommand::class );
-
-	// Qualify v2 — verdict-log subcommands hung off the existing
-	// `wp extrachill venues` parent (registered by extrachill-cli).
-	// Core classes need to load before the CLI commands instantiate them.
-	require_once __DIR__ . '/inc/Core/QualifyVerdict.php';
-	require_once __DIR__ . '/inc/Core/QualifyVerdictsTable.php';
-	require_once __DIR__ . '/inc/Core/QualifyCohortDeriver.php';
-	require_once __DIR__ . '/inc/Core/QualifyVerdictResolver.php';
-	require_once __DIR__ . '/inc/Core/PlatformDetector.php';
-	require_once __DIR__ . '/inc/Core/QualifyFingerprinter.php';
-
-	require_once __DIR__ . '/inc/Cli/QualifyStatsCommand.php';
-	\WP_CLI::add_command( 'extrachill venues qualify-stats', \ExtraChillEvents\Cli\QualifyStatsCommand::class );
-
-	require_once __DIR__ . '/inc/Cli/RequalifyPendingCommand.php';
-	\WP_CLI::add_command( 'extrachill venues requalify-pending', \ExtraChillEvents\Cli\RequalifyPendingCommand::class );
-
-	require_once __DIR__ . '/inc/Cli/FlowOps.php';
-	require_once __DIR__ . '/inc/Cli/FlowHelpers.php';
-
-	require_once __DIR__ . '/inc/Cli/RequalifyFlowCommand.php';
-	\WP_CLI::add_command( 'extrachill venues requalify-flow', \ExtraChillEvents\Cli\RequalifyFlowCommand::class );
-
-	require_once __DIR__ . '/inc/Cli/UnqualifiableFlowsCommand.php';
-	\WP_CLI::add_command( 'extrachill venues unqualifiable-flows', \ExtraChillEvents\Cli\UnqualifiableFlowsCommand::class );
-
-	// Pipeline assignment audit (issue #99). Lives under
-	// `wp extrachill events flows` so it's grouped with the other
-	// events-domain operator tooling rather than the venues surface.
-	require_once __DIR__ . '/inc/Cli/AuditPipelinesCommand.php';
-	\WP_CLI::add_command( 'extrachill events flows audit-pipelines', \ExtraChillEvents\Cli\AuditPipelinesCommand::class );
-
-	// Location / flow_config hygiene (extrachill-events#98).
-	// Issue #98 — Both commands operate against the events subsite (blog 7).
-	// Always invoke with `--url=events.extrachill.com` so $wpdb->prefix is c8c_7_.
-	require_once __DIR__ . '/inc/Core/FlowLocationGuard.php';
-	require_once __DIR__ . '/inc/Cli/RepairFlowLocationsCommand.php';
-	\WP_CLI::add_command( 'extrachill events flows repair-locations', \ExtraChillEvents\Cli\RepairFlowLocationsCommand::class );
-
-	require_once __DIR__ . '/inc/Cli/PruneOrphanLocationsCommand.php';
-	\WP_CLI::add_command( 'extrachill events locations prune-orphans', \ExtraChillEvents\Cli\PruneOrphanLocationsCommand::class );
-
-	require_once __DIR__ . '/inc/Core/LocationIntegrityAuditor.php';
-	require_once __DIR__ . '/inc/Cli/AuditLocationIntegrityCommand.php';
-	\WP_CLI::add_command( 'extrachill events locations audit-integrity', \ExtraChillEvents\Cli\AuditLocationIntegrityCommand::class );
-
-	require_once __DIR__ . '/inc/Cli/BackfillVenueMetaCommand.php';
-	\WP_CLI::add_command( 'extrachill events venues backfill-meta', \ExtraChillEvents\Cli\BackfillVenueMetaCommand::class );
-
-	// Honest authorship backfill (issue #207 Phase 3). Reattributes historical
-	// automation authored under a human (uid 1) onto the network bot account.
-	// Dry-run by default; --apply (or --commit) to mutate. Operates across
-	// blogs 7 (data_machine_events) and 11 (festival_wire); never touches blog 1.
-	require_once __DIR__ . '/inc/Cli/BackfillAuthorshipCommand.php';
-	\WP_CLI::add_command( 'extrachill events backfill-authorship', \ExtraChillEvents\Cli\BackfillAuthorshipCommand::class );
-}
-
-// Recheck handler must be loaded outside the WP_CLI guard so the Action
-// Scheduler hook fires whether the action runs via web request, cron, or
-// CLI runner.
-require_once __DIR__ . '/inc/Core/QualifyVerdict.php';
-require_once __DIR__ . '/inc/Core/QualifyVerdictsTable.php';
-require_once __DIR__ . '/inc/Core/QualifyCohortDeriver.php';
-require_once __DIR__ . '/inc/Cli/FlowOps.php';
-require_once __DIR__ . '/inc/Core/QualifyRecheckHandler.php';
-\ExtraChillEvents\Core\QualifyRecheckHandler::register();
+\ExtraChillEvents\Providers\CliProvider::register();
+\ExtraChillEvents\Providers\IngestionProvider::register();
 
 require_once __DIR__ . '/inc/admin/network-settings.php';
 \ExtraChillEvents\Admin\NetworkSettings::register();
 
 require_once __DIR__ . '/inc/core/datamachine-settings.php';
-
-// Register filters during plugin load, before Data Machine builds its task registry.
-add_filter(
-	'datamachine_tasks',
-	function ( array $tasks ): array {
-		if ( ! class_exists( '\\DataMachine\\Engine\\AI\\System\\Tasks\\SystemTask' ) ) {
-			return $tasks;
-		}
-		require_once __DIR__ . '/inc/Steps/QualifyDigest/QualifyDigestSystemTask.php';
-		require_once __DIR__ . '/inc/Steps/LocalSceneDigest/LocalSceneDigestSystemTask.php';
-		require_once __DIR__ . '/inc/Core/VenueExpansionRunner.php';
-		require_once __DIR__ . '/inc/Steps/VenueExpansion/VenueExpansionSystemTask.php';
-		$tasks[ \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::TASK_TYPE ]       = \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::class;
-		$tasks[ \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask::TASK_TYPE ] = \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask::class;
-		$tasks[ \ExtraChillEvents\Steps\VenueExpansion\VenueExpansionSystemTask::TASK_TYPE ]     = \ExtraChillEvents\Steps\VenueExpansion\VenueExpansionSystemTask::class;
-		return $tasks;
-	}
-);
-
-add_filter(
-	'datamachine_recurring_schedules',
-	function ( array $schedules ): array {
-		require_once __DIR__ . '/inc/Steps/QualifyDigest/QualifyDigestSystemTask.php';
-		require_once __DIR__ . '/inc/Steps/LocalSceneDigest/LocalSceneDigestSystemTask.php';
-		$schedules['extrachill_local_scene_digest'] = apply_filters(
-			'extrachill_local_scene_digest_schedule',
-			array(
-				'task_type'          => \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask::TASK_TYPE,
-				'interval'           => 'weekly',
-				'enabled_setting'    => 'extrachill_local_scene_digest_enabled',
-				'default_enabled'    => false,
-				'label'              => 'Weekly Local Scene Digest — Thursdays 15:00 UTC',
-				'first_run_callback' => 'strtotime',
-				'first_run_arg'      => 'next thursday 15:00 UTC',
-				'task_params'        => array(
-					'days'    => 7,
-					'limit'   => 8,
-					'dry_run' => false,
-				),
-			)
-		);
-		/**
-		 * Filter the qualify digest schedule definition. Allows
-		 * operators to flip interval, change the first-run anchor,
-		 * etc. without forking the plugin.
-		 */
-		$schedules['extrachill_qualify_digest'] = apply_filters(
-			'dme_qualify_digest_schedule',
-			array(
-				'task_type'          => \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::TASK_TYPE,
-				'interval'           => 'weekly',
-				'enabled_setting'    => 'dme_qualify_digest_enabled',
-				'default_enabled'    => true,
-				'label'              => 'Weekly — Mondays 09:00 UTC',
-				'first_run_callback' => 'strtotime',
-				'first_run_arg'      => 'next monday 09:00 UTC',
-				'task_params'        => array(
-					'since'   => '1 week ago',
-					'format'  => 'html',
-					'dry_run' => false,
-				),
-			)
-		);
-		return $schedules;
-	}
-);
 
 /**
  * ExtraChillEvents
@@ -217,7 +80,6 @@ class ExtraChillEvents {
 	private function init_hooks() {
 		add_filter( 'ec_feature_ceilings', array( $this, 'register_feature_ceilings' ) );
 		add_action( 'init', array( $this, 'load_textdomain' ) );
-		add_action( 'init', array( $this, 'init_data_machine_handlers' ), 20 );
 		add_action( 'plugins_loaded', array( $this, 'init_abilities' ), 25 );
 		add_action( 'plugins_loaded', array( $this, 'maybe_install_schema' ), 20 );
 
@@ -332,70 +194,7 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/ArtistUrlImport.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/ArtistUrlImportRoutes.php';
 
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/data-machine-events/init.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/events-by-term-taxonomy-context.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/cache-groups.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/page-cache.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/nav.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/priority-venue-ordering.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/priority-event-ordering.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-meta.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/archive-map.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-map.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/venue-map.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/artist-map.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-seo.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/account-market.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/local-scene-digest.php';
-		extrachill_events_init_local_scene_digest();
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/near-me.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/discovery-pages.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/router-pages.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/local-support-workspace.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/vendor-request-workspace.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/booking-console.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-normalizer.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/calendar-stats.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/admin/priority-venues.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/admin/priority-events.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/single-event/breadcrumbs.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/single-event/related-events.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/single-event/network-bridge.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/single-event/share-button.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/home/actions.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/concert-tracking-integration.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows-scope-token.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows-calendar-filter.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows-map-filter.php';
-	}
-
-	public function init_data_machine_handlers() {
-		if ( ! class_exists( 'DataMachine\Core\Steps\Fetch\Handlers\FetchHandler' ) ) {
-			return;
-		}
-
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/handlers/event-roundup/EventRoundupSettings.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/handlers/event-roundup/EventRoundupHandler.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/handlers/event-roundup/RoundupPublishSettings.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/handlers/event-roundup/RoundupPublishHandler.php';
-
-		new \ExtraChillEvents\Handlers\EventRoundup\EventRoundupHandler();
-		new \ExtraChillEvents\Handlers\EventRoundup\RoundupPublishHandler();
-
-		// Register the event roundup template with Data Machine's image
-		// template registry. The actual GD work lives in the template class;
-		// the handler/abilities just call datamachine/render-image-template.
-		if ( file_exists( EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Templates/EventRoundupTemplate.php' ) ) {
-			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Templates/EventRoundupTemplate.php';
-			add_filter(
-				'datamachine/image_generation/templates',
-				function ( array $templates ): array {
-					$templates['event_roundup'] = \ExtraChillEvents\Templates\EventRoundupTemplate::class;
-					return $templates;
-				}
-			);
-		}
+		\ExtraChillEvents\Providers\PublicExperienceProvider::register();
 	}
 
 	public function init_abilities() {
@@ -527,9 +326,7 @@ class ExtraChillEvents {
 	 * check survives internal namespace changes in DM-events.
 	 */
 	private function init_integrations() {
-		if ( defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ) {
-			extrachill_events_init_data_machine_integration();
-		}
+		\ExtraChillEvents\Providers\DataMachineEventsProvider::register();
 	}
 
 	public function activate() {

--- a/inc/Providers/CliProvider.php
+++ b/inc/Providers/CliProvider.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Events operator CLI registration.
+ *
+ * @package ExtraChillEvents\Providers
+ */
+
+namespace ExtraChillEvents\Providers;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Loads and registers Events-owned WP-CLI commands. */
+final class CliProvider {
+
+	/**
+	 * Whether command registration has run.
+	 *
+	 * @var bool
+	 */
+	private static $registered = false;
+
+	/** Register commands when the WP-CLI runtime is available. */
+	public static function register(): void {
+		if ( self::$registered || ! defined( 'WP_CLI' ) || ! WP_CLI || ! file_exists( EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/AddCityCommand.php' ) ) { // @phpstan-ignore booleanAnd.rightAlwaysTrue
+			return;
+		}
+
+		self::$registered = true;
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/EventSourceRampEvaluator.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/EventSourceRampCommand.php';
+		\WP_CLI::add_command( 'extrachill events ramp', \ExtraChillEvents\Cli\EventSourceRampCommand::class );
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/AddCityCommand.php';
+		\WP_CLI::add_command( 'extrachill-events add-city', \ExtraChillEvents\Cli\AddCityCommand::class );
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/ExpandVenuesCommand.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/VenueExpansionReportCommand.php';
+		\WP_CLI::add_command( 'extrachill-events expand', \ExtraChillEvents\Cli\ExpandVenuesCommand::class );
+		\WP_CLI::add_command( 'extrachill-events expand-report', \ExtraChillEvents\Cli\VenueExpansionReportCommand::class );
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdict.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdictsTable.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyCohortDeriver.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdictResolver.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/PlatformDetector.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyFingerprinter.php';
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/QualifyStatsCommand.php';
+		\WP_CLI::add_command( 'extrachill venues qualify-stats', \ExtraChillEvents\Cli\QualifyStatsCommand::class );
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/RequalifyPendingCommand.php';
+		\WP_CLI::add_command( 'extrachill venues requalify-pending', \ExtraChillEvents\Cli\RequalifyPendingCommand::class );
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/FlowOps.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/FlowHelpers.php';
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/RequalifyFlowCommand.php';
+		\WP_CLI::add_command( 'extrachill venues requalify-flow', \ExtraChillEvents\Cli\RequalifyFlowCommand::class );
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/UnqualifiableFlowsCommand.php';
+		\WP_CLI::add_command( 'extrachill venues unqualifiable-flows', \ExtraChillEvents\Cli\UnqualifiableFlowsCommand::class );
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/AuditPipelinesCommand.php';
+		\WP_CLI::add_command( 'extrachill events flows audit-pipelines', \ExtraChillEvents\Cli\AuditPipelinesCommand::class );
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/FlowLocationGuard.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/RepairFlowLocationsCommand.php';
+		\WP_CLI::add_command( 'extrachill events flows repair-locations', \ExtraChillEvents\Cli\RepairFlowLocationsCommand::class );
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/PruneOrphanLocationsCommand.php';
+		\WP_CLI::add_command( 'extrachill events locations prune-orphans', \ExtraChillEvents\Cli\PruneOrphanLocationsCommand::class );
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocationIntegrityAuditor.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/AuditLocationIntegrityCommand.php';
+		\WP_CLI::add_command( 'extrachill events locations audit-integrity', \ExtraChillEvents\Cli\AuditLocationIntegrityCommand::class );
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/BackfillVenueMetaCommand.php';
+		\WP_CLI::add_command( 'extrachill events venues backfill-meta', \ExtraChillEvents\Cli\BackfillVenueMetaCommand::class );
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/BackfillAuthorshipCommand.php';
+		\WP_CLI::add_command( 'extrachill events backfill-authorship', \ExtraChillEvents\Cli\BackfillAuthorshipCommand::class );
+	}
+}

--- a/inc/Providers/DataMachineEventsProvider.php
+++ b/inc/Providers/DataMachineEventsProvider.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Optional Data Machine Events integration.
+ *
+ * @package ExtraChillEvents\Providers
+ */
+
+namespace ExtraChillEvents\Providers;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Registers the sibling plugin adapter only when its public API is present. */
+final class DataMachineEventsProvider {
+
+	/**
+	 * Whether the optional adapter has initialized.
+	 *
+	 * @var bool
+	 */
+	private static $registered = false;
+
+	/** Register the optional integration without gating unrelated features. */
+	public static function register(): void {
+		if ( self::$registered ) {
+			return;
+		}
+
+		self::$registered = true;
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/data-machine-events/init.php';
+		if ( defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ) {
+			extrachill_events_init_data_machine_integration();
+		}
+	}
+}

--- a/inc/Providers/IngestionProvider.php
+++ b/inc/Providers/IngestionProvider.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Event ingestion and qualification orchestration.
+ *
+ * @package ExtraChillEvents\Providers
+ */
+
+namespace ExtraChillEvents\Providers;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Registers ingestion hooks and optional Data Machine adapters. */
+final class IngestionProvider {
+
+	/**
+	 * Whether runtime hooks have been registered.
+	 *
+	 * @var bool
+	 */
+	private static $registered = false;
+
+	/** Register the ingestion feature group once. */
+	public static function register(): void {
+		if ( self::$registered ) {
+			return;
+		}
+
+		self::$registered = true;
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdict.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyVerdictsTable.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyCohortDeriver.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/FlowOps.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifyRecheckHandler.php';
+		\ExtraChillEvents\Core\QualifyRecheckHandler::register();
+
+		add_action( 'init', array( self::class, 'register_data_machine_handlers' ), 20 );
+		add_filter( 'datamachine_tasks', array( self::class, 'register_tasks' ) );
+		add_filter( 'datamachine_recurring_schedules', array( self::class, 'register_recurring_schedules' ) );
+	}
+
+	/**
+	 * Add Events system tasks when Data Machine's task base class is available.
+	 *
+	 * @param array $tasks Registered task classes.
+	 * @return array
+	 */
+	public static function register_tasks( array $tasks ): array {
+		if ( ! class_exists( '\\DataMachine\\Engine\\AI\\System\\Tasks\\SystemTask' ) ) {
+			return $tasks;
+		}
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Steps/QualifyDigest/QualifyDigestSystemTask.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Steps/LocalSceneDigest/LocalSceneDigestSystemTask.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueExpansionRunner.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Steps/VenueExpansion/VenueExpansionSystemTask.php';
+		$tasks[ \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::TASK_TYPE ]       = \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::class;
+		$tasks[ \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask::TASK_TYPE ] = \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask::class;
+		$tasks[ \ExtraChillEvents\Steps\VenueExpansion\VenueExpansionSystemTask::TASK_TYPE ]     = \ExtraChillEvents\Steps\VenueExpansion\VenueExpansionSystemTask::class;
+		return $tasks;
+	}
+
+	/**
+	 * Add the existing weekly Events schedules.
+	 *
+	 * @param array $schedules Registered recurring schedules.
+	 * @return array
+	 */
+	public static function register_recurring_schedules( array $schedules ): array {
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Steps/QualifyDigest/QualifyDigestSystemTask.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Steps/LocalSceneDigest/LocalSceneDigestSystemTask.php';
+		$schedules['extrachill_local_scene_digest'] = apply_filters(
+			'extrachill_local_scene_digest_schedule',
+			array(
+				'task_type'          => \ExtraChillEvents\Steps\LocalSceneDigest\LocalSceneDigestSystemTask::TASK_TYPE,
+				'interval'           => 'weekly',
+				'enabled_setting'    => 'extrachill_local_scene_digest_enabled',
+				'default_enabled'    => false,
+				'label'              => 'Weekly Local Scene Digest — Thursdays 15:00 UTC',
+				'first_run_callback' => 'strtotime',
+				'first_run_arg'      => 'next thursday 15:00 UTC',
+				'task_params'        => array(
+					'days'    => 7,
+					'limit'   => 8,
+					'dry_run' => false,
+				),
+			)
+		);
+		$schedules['extrachill_qualify_digest']     = apply_filters(
+			'dme_qualify_digest_schedule',
+			array(
+				'task_type'          => \ExtraChillEvents\Steps\QualifyDigest\QualifyDigestSystemTask::TASK_TYPE,
+				'interval'           => 'weekly',
+				'enabled_setting'    => 'dme_qualify_digest_enabled',
+				'default_enabled'    => true,
+				'label'              => 'Weekly — Mondays 09:00 UTC',
+				'first_run_callback' => 'strtotime',
+				'first_run_arg'      => 'next monday 09:00 UTC',
+				'task_params'        => array(
+					'since'   => '1 week ago',
+					'format'  => 'html',
+					'dry_run' => false,
+				),
+			)
+		);
+		return $schedules;
+	}
+
+	/** Initialize legacy handler adapters only when their Data Machine base exists. */
+	public static function register_data_machine_handlers(): void {
+		if ( ! class_exists( 'DataMachine\Core\Steps\Fetch\Handlers\FetchHandler' ) ) {
+			return;
+		}
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/handlers/event-roundup/EventRoundupSettings.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/handlers/event-roundup/EventRoundupHandler.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/handlers/event-roundup/RoundupPublishSettings.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/handlers/event-roundup/RoundupPublishHandler.php';
+
+		new \ExtraChillEvents\Handlers\EventRoundup\EventRoundupHandler();
+		new \ExtraChillEvents\Handlers\EventRoundup\RoundupPublishHandler();
+
+		if ( file_exists( EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Templates/EventRoundupTemplate.php' ) ) {
+			require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Templates/EventRoundupTemplate.php';
+			add_filter( 'datamachine/image_generation/templates', array( self::class, 'register_image_template' ) );
+		}
+	}
+
+	/**
+	 * Add the event roundup image template.
+	 *
+	 * @param array $templates Registered image templates.
+	 * @return array
+	 */
+	public static function register_image_template( array $templates ): array {
+		$templates['event_roundup'] = \ExtraChillEvents\Templates\EventRoundupTemplate::class;
+		return $templates;
+	}
+}

--- a/inc/Providers/PublicExperienceProvider.php
+++ b/inc/Providers/PublicExperienceProvider.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Public event and calendar experience registration.
+ *
+ * @package ExtraChillEvents\Providers
+ */
+
+namespace ExtraChillEvents\Providers;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Loads the established public Events feature modules once. */
+final class PublicExperienceProvider {
+
+	/**
+	 * Whether public modules have loaded.
+	 *
+	 * @var bool
+	 */
+	private static $registered = false;
+
+	/** Register public UI, routing, discovery, and concert tracking features. */
+	public static function register(): void {
+		if ( self::$registered ) {
+			return;
+		}
+
+		self::$registered = true;
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/events-by-term-taxonomy-context.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/cache-groups.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/page-cache.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/nav.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/priority-venue-ordering.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/priority-event-ordering.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-meta.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/archive-map.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-map.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/venue-map.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/artist-map.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-seo.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/account-market.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/local-scene-digest.php';
+		extrachill_events_init_local_scene_digest();
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/near-me.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/discovery-pages.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/router-pages.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/local-support-workspace.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/vendor-request-workspace.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/booking-console.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/location-normalizer.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/calendar-stats.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/admin/priority-venues.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/admin/priority-events.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/single-event/breadcrumbs.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/single-event/related-events.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/single-event/network-bridge.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/single-event/share-button.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/home/actions.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/concert-tracking-integration.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows-scope-token.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows-calendar-filter.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/my-shows-map-filter.php';
+	}
+}

--- a/tests/Unit/Core/FeatureProviderBootstrapTest.php
+++ b/tests/Unit/Core/FeatureProviderBootstrapTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Feature-provider bootstrap matrix coverage.
+ *
+ * @package ExtraChillEvents\Tests\Unit\Core
+ */
+
+namespace ExtraChillEvents\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+
+/** Verifies site, CLI, idempotence, and optional dependency boundaries. */
+final class FeatureProviderBootstrapTest extends TestCase {
+
+	/** Owner-site requests retain the complete public and ingestion surfaces. */
+	public function test_owner_site_boots_public_and_ingestion_features(): void {
+		$result = $this->run_fixture( 'owner' );
+
+		$this->assertTrue( $result['owner_site'] );
+		$this->assertTrue( $result['public_registered'] );
+		$this->assertTrue( $result['ingestion_hooked'] );
+	}
+
+	/** Unrelated subsites load safe hooks while owner-only callbacks remain guarded. */
+	public function test_unrelated_subsite_retains_registration_without_claiming_ownership(): void {
+		$result = $this->run_fixture( 'unrelated' );
+
+		$this->assertFalse( $result['owner_site'] );
+		$this->assertTrue( $result['public_registered'] );
+		$this->assertTrue( $result['ingestion_hooked'] );
+	}
+
+	/** CLI registration remains available and provider calls are idempotent. */
+	public function test_cli_boot_registers_commands_once(): void {
+		$result = $this->run_fixture( 'cli' );
+
+		$this->assertSame( 14, $result['cli_commands'] );
+		$this->assertSame(
+			array(
+				'extrachill events ramp',
+				'extrachill-events add-city',
+				'extrachill-events expand',
+				'extrachill-events expand-report',
+				'extrachill venues qualify-stats',
+				'extrachill venues requalify-pending',
+				'extrachill venues requalify-flow',
+				'extrachill venues unqualifiable-flows',
+				'extrachill events flows audit-pipelines',
+				'extrachill events flows repair-locations',
+				'extrachill events locations prune-orphans',
+				'extrachill events locations audit-integrity',
+				'extrachill events venues backfill-meta',
+				'extrachill events backfill-authorship',
+			),
+			$result['cli_command_names']
+		);
+		$this->assertSame( $result['hooks_before_repeat'], $result['hooks_after_repeat'] );
+	}
+
+	/** A missing optional sibling does not suppress unrelated providers. */
+	public function test_optional_dependency_absence_does_not_suppress_other_features(): void {
+		$result = $this->run_fixture( 'optional-absent' );
+
+		$this->assertFalse( $result['optional_dependency_seen'] );
+		$this->assertTrue( $result['optional_loader_present'] );
+		$this->assertTrue( $result['public_registered'] );
+		$this->assertTrue( $result['ingestion_hooked'] );
+	}
+
+	/** Provider composition keeps unconditional features ahead of the optional adapter. */
+	public function test_provider_order_is_explicit(): void {
+		$bootstrap = file_get_contents( dirname( __DIR__, 3 ) . '/extrachill-events.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source contract.
+
+		$this->assertIsString( $bootstrap );
+		$cli       = strpos( $bootstrap, 'CliProvider::register()' );
+		$ingestion = strpos( $bootstrap, 'IngestionProvider::register()' );
+		$public    = strpos( $bootstrap, 'PublicExperienceProvider::register()' );
+		$optional  = strpos( $bootstrap, 'DataMachineEventsProvider::register()' );
+
+		$this->assertIsInt( $cli );
+		$this->assertIsInt( $ingestion );
+		$this->assertIsInt( $public );
+		$this->assertIsInt( $optional );
+		$this->assertLessThan( $ingestion, $cli );
+		$this->assertLessThan( $public, $ingestion );
+		$this->assertLessThan( $optional, $public );
+	}
+
+	/**
+	 * Execute one isolated bootstrap scenario.
+	 *
+	 * @param string $scenario Fixture scenario name.
+	 * @return array<string, mixed>
+	 */
+	private function run_fixture( string $scenario ): array {
+		$command = escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( dirname( __DIR__, 2 ) . '/fixtures/bootstrap-matrix.php' ) . ' ' . escapeshellarg( $scenario );
+		$output  = array();
+		$status  = 0;
+		exec( $command, $output, $status ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- Isolated bootstrap process is the behavior under test.
+
+		$this->assertSame( 0, $status, implode( "\n", $output ) );
+		$result = json_decode( implode( "\n", $output ), true );
+		$this->assertIsArray( $result );
+
+		return $result;
+	}
+}

--- a/tests/Unit/Core/LocalSceneDigestSystemTaskTest.php
+++ b/tests/Unit/Core/LocalSceneDigestSystemTaskTest.php
@@ -117,7 +117,7 @@ class LocalSceneDigestSystemTaskTest extends TestCase {
 	}
 
 	public function test_recurring_schedule_is_default_disabled_and_explicitly_delivers(): void {
-		$bootstrap = file_get_contents( dirname( __DIR__, 3 ) . '/extrachill-events.php' );
+		$bootstrap = file_get_contents( dirname( __DIR__, 3 ) . '/inc/Providers/IngestionProvider.php' );
 		$this->assertIsString( $bootstrap );
 		$this->assertMatchesRegularExpression( "/'enabled_setting'\\s*=>\\s*'extrachill_local_scene_digest_enabled'/", $bootstrap );
 		$this->assertMatchesRegularExpression( "/'default_enabled'\\s*=>\\s*false/", $bootstrap );

--- a/tests/fixtures/bootstrap-matrix.php
+++ b/tests/fixtures/bootstrap-matrix.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Isolated runtime fixture for the feature-provider bootstrap matrix.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+// phpcs:disable -- Purpose-built WordPress runtime stubs must share one isolated fixture.
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+	define( 'HOUR_IN_SECONDS', 3600 );
+	define( 'MINUTE_IN_SECONDS', 60 );
+	$GLOBALS['bootstrap_matrix_hooks'] = array();
+	$GLOBALS['bootstrap_matrix_blog']  = 'unrelated' === ( $argv[1] ?? '' ) ? 2 : 7;
+
+	function plugin_dir_path( $file ) {
+		return trailingslashit( dirname( $file ) );
+	}
+
+	function plugin_dir_url( $file ) {
+		return 'https://example.org/wp-content/plugins/' . basename( dirname( $file ) ) . '/';
+	}
+
+	function plugin_basename( $file ) {
+		return basename( dirname( $file ) ) . '/' . basename( $file );
+	}
+
+	function trailingslashit( $value ) {
+		return rtrim( $value, '/\\' ) . '/';
+	}
+
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['bootstrap_matrix_hooks'][] = array( $hook, $callback, $priority, $accepted_args );
+		return true;
+	}
+
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		return add_filter( $hook, $callback, $priority, $accepted_args );
+	}
+
+	function register_activation_hook() {}
+	function register_deactivation_hook() {}
+	function is_admin() {
+		return false;
+	}
+
+	function get_current_blog_id() {
+		return $GLOBALS['bootstrap_matrix_blog'];
+	}
+
+	function ec_get_blog_id( $site ) {
+		return 'events' === $site ? 7 : null;
+	}
+
+	if ( 'cli' === ( $argv[1] ?? '' ) ) {
+		define( 'WP_CLI', true );
+		class WP_CLI {
+			public static $commands = array();
+
+			public static function add_command( $name, $class ) {
+				self::$commands[ $name ] = $class;
+			}
+		}
+	}
+
+	require dirname( __DIR__, 2 ) . '/extrachill-events.php';
+
+	$hooks_before_repeat = count( $GLOBALS['bootstrap_matrix_hooks'] );
+	\ExtraChillEvents\Providers\CliProvider::register();
+	\ExtraChillEvents\Providers\IngestionProvider::register();
+	\ExtraChillEvents\Providers\PublicExperienceProvider::register();
+	\ExtraChillEvents\Providers\DataMachineEventsProvider::register();
+
+	echo json_encode(
+		array(
+			'owner_site'               => ec_is_events_site(),
+			'public_registered'        => function_exists( 'ec_events_render_homepage' ),
+			'optional_loader_present'  => function_exists( 'extrachill_events_init_data_machine_integration' ),
+			'optional_dependency_seen' => defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ),
+			'ingestion_hooked'         => in_array( 'datamachine_tasks', array_column( $GLOBALS['bootstrap_matrix_hooks'], 0 ), true ),
+			'cli_commands'             => class_exists( 'WP_CLI', false ) ? count( WP_CLI::$commands ) : 0,
+			'cli_command_names'        => class_exists( 'WP_CLI', false ) ? array_keys( WP_CLI::$commands ) : array(),
+			'hooks_before_repeat'      => $hooks_before_repeat,
+			'hooks_after_repeat'       => count( $GLOBALS['bootstrap_matrix_hooks'] ),
+		)
+	);
+}


### PR DESCRIPTION
## Summary
- extract existing CLI, ingestion/Data Machine, public experience, and optional Data Machine Events bootstrap groups into concrete idempotent providers
- reduce the plugin entrypoint from 607 to 404 lines without changing hooks, command names, schedules, slugs, or public feature modules
- add an isolated bootstrap matrix for the owner site, unrelated subsites, CLI, repeated registration, provider order, and absent optional dependencies

## Scope
This is an independently valuable first slice of #607, not a complete closure.

Remaining exact provider seams:
- venue and booking operations: schemas, repositories, authorization, onboarding, notifications, lifecycle services, settlement/reporting/privacy, and Artist URL Import REST loading currently in `load_dependencies()`
- abilities and transport adapters: procedural event abilities plus booking, ingestion, qualification, reporting, and Artist URL Import ability registration currently in `init_abilities()`
- schema lifecycle: activation, rolling `maybe_install_schema()`, and deactivation behavior
- administration: network settings, priority venue/event screens, and Artist URL moderation UI
- remaining optional consumers: Google Analytics-backed market reporting and Roadie-facing booking correspondence boundaries after their actual runtime prerequisites are mapped

No generic provider interface, registry, or framework was introduced.

## Verification
- `./vendor/bin/phpunit tests/Unit/Core/FeatureProviderBootstrapTest.php` (5 tests, 29 assertions)
- `./vendor/bin/phpunit tests/Unit/Core/LocalSceneDigestSystemTaskTest.php` (6 tests, 31 assertions)
- `./vendor/bin/phpunit tests/AbilityRegistrationLifecycleTest.php` (1 test, 16 assertions)
- `npm run test:js` (16 suites, 94 tests)
- `npm run lint:js`
- `npm run build`
- scoped PHPCS on all new provider and matrix files, excluding the repository's established PascalCase class-file naming convention
- PHP syntax checks and `composer validate --no-check-publish`

PHPStan is not installed or declared in this repository, so no PHPStan executable was available. The broader `tests/Unit/Core` directory ran 259/261 tests successfully; its two errors are an existing order-dependent test-stub collision where `AccountMarketTest` defines a three-argument `add_query_arg()` before `BookingConsoleTest` exercises WordPress's two-argument form.

Refs #607