### PR TITLE
fix: clear booking release lint

### DIFF
--- a/blocks/venue-settings/src/booking-links.test.js
+++ b/blocks/venue-settings/src/booking-links.test.js
@@ -1,5 +1,8 @@
 /* global describe, expect, it */
 
+/**
+ * Internal dependencies
+ */
 import {
 	linkCollectionValue,
 	logicalIntakeRows,

--- a/inc/Core/VenueBookingConfig.php
+++ b/inc/Core/VenueBookingConfig.php
@@ -100,7 +100,7 @@ class VenueBookingConfig {
 			return $venue;
 		}
 
-		$stored = get_term_meta( $venue_term_id, self::META_KEY, true );
+		$stored          = get_term_meta( $venue_term_id, self::META_KEY, true );
 		$public_versions = array(
 			self::PUBLIC_INTAKE_VERSION,
 			self::RETIRED_GUIDE_CONFIG_VERSION,


### PR DESCRIPTION
## Summary
- align the public booking projection assignment for WordPress coding standards
- add the required dependency-group marker to the booking links unit test
- clear the actionable source findings blocking the v0.59.1 release

## Verification
- scoped Homeboy lint passed with no findings
- PHP syntax passed
- `git diff --check`

Closes #609