### PR TITLE
fix: clear CLI provider static analysis

### DIFF
--- a/inc/Providers/CliProvider.php
+++ b/inc/Providers/CliProvider.php
@@ -21,7 +21,7 @@ final class CliProvider {
 
 	/** Register commands when the WP-CLI runtime is available. */
 	public static function register(): void {
-		if ( self::$registered || ! defined( 'WP_CLI' ) || ! WP_CLI || ! file_exists( EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/AddCityCommand.php' ) ) { // @phpstan-ignore booleanAnd.rightAlwaysTrue
+		if ( self::$registered || ! defined( 'WP_CLI' ) || ! file_exists( EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/AddCityCommand.php' ) ) { // @phpstan-ignore booleanAnd.rightAlwaysTrue
 			return;
 		}
 


### PR DESCRIPTION
## Summary
- remove the redundant false-value check for the conventional `WP_CLI` runtime constant
- preserve idempotent CLI registration and command-file admission
- clear the PHPStan error introduced by #610 that blocks the v0.59.1 release

## Verification
- scoped Homeboy lint passed with no findings
- PHPCS and PHPStan passed

Refs #607