### PR TITLE
refactor: extract venue booking providers

### DIFF
--- a/extrachill-events.php
+++ b/extrachill-events.php
@@ -33,6 +33,8 @@ require_once __DIR__ . '/inc/Providers/CliProvider.php';
 require_once __DIR__ . '/inc/Providers/IngestionProvider.php';
 require_once __DIR__ . '/inc/Providers/PublicExperienceProvider.php';
 require_once __DIR__ . '/inc/Providers/DataMachineEventsProvider.php';
+require_once __DIR__ . '/inc/Providers/ArtistUrlImportProvider.php';
+require_once __DIR__ . '/inc/Providers/VenueBookingProvider.php';
 
 \ExtraChillEvents\Providers\CliProvider::register();
 \ExtraChillEvents\Providers\IngestionProvider::register();
@@ -128,71 +130,10 @@ class ExtraChillEvents {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueExpansionRunner.php';
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/EventSourceRampEvaluator.php';
 
-		// Artist URL Import subsystem (migrated from data-machine-events in #200).
-		// Moderation-queue table + REST controller/routes. The abilities load in
-		// init_abilities(); the admin screen instantiates in init_admin().
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ArtistUrlSubmissionsTable.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingSchema.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportSchema.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestSchema.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipRepository.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueAuthorization.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportAuthorization.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestAuthorization.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueInvitationToken.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueOnboardingRepository.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueOnboardingService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueInvitationDeliveryWorker.php';
-		\ExtraChillEvents\Core\VenueInvitationDeliveryWorker::register();
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingRepository.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportRepository.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportWorkspace.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestRepository.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestNotificationService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingNotificationService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportNotificationAdapter.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportNotificationService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingCommunicationService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingCorrespondenceAutomationService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingHoldRepository.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingMutationService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingEventSyncService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingEventConversionService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingMarketingService.php';
-		\ExtraChillEvents\Core\BookingMarketingService::register();
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingLifecycle.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingPrivateFileProvider.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalBookingPrivateFileProvider.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingPrivateFileProviders.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingAttachmentPolicy.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingAttachmentRepository.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingAttachmentDeliveryRepository.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingAttachmentService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingInquiryAdmissionService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingConfig.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingEmbed.php';
-		\ExtraChillEvents\Core\VenueBookingEmbed::register();
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/TicketReconciliationService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/TicketSettlementService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ShowSettlementService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingReportingService.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingPrivacyService.php';
-		\ExtraChillEvents\Core\BookingPrivacyService::register();
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueProfile.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/CanonicalEventPublicationGuard.php';
-		\ExtraChillEvents\Core\BookingHoldRepository::register();
-		\ExtraChillEvents\Core\BookingCommunicationService::register();
-		\ExtraChillEvents\Core\BookingCorrespondenceAutomationService::register();
-		\ExtraChillEvents\Core\BookingNotificationService::register();
-		\ExtraChillEvents\Core\LocalSupportNotificationService::register();
-		\ExtraChillEvents\Core\VendorRequestNotificationService::register();
-		new \ExtraChillEvents\Core\CanonicalEventPublicationGuard();
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/ArtistUrlImport.php';
-		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/ArtistUrlImportRoutes.php';
+		// Artist URL Import table/REST and venue booking dependencies retain their
+		// established order ahead of the public experience.
+		\ExtraChillEvents\Providers\ArtistUrlImportProvider::register();
+		\ExtraChillEvents\Providers\VenueBookingProvider::register();
 
 		\ExtraChillEvents\Providers\PublicExperienceProvider::register();
 	}

--- a/inc/Providers/ArtistUrlImportProvider.php
+++ b/inc/Providers/ArtistUrlImportProvider.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Artist URL Import dependency registration.
+ *
+ * @package ExtraChillEvents\Providers
+ */
+
+namespace ExtraChillEvents\Providers;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Loads the Artist URL Import table and REST surface once. */
+final class ArtistUrlImportProvider {
+
+	/**
+	 * Whether dependencies have loaded.
+	 *
+	 * @var bool
+	 */
+	private static $registered = false;
+
+	/**
+	 * Register the Artist URL Import dependencies.
+	 *
+	 * @return bool Whether the provider is registered.
+	 */
+	public static function register(): bool {
+		if ( self::$registered ) {
+			return true;
+		}
+
+		if ( ! function_exists( 'add_action' ) ) {
+			return false;
+		}
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ArtistUrlSubmissionsTable.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/ArtistUrlImport.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Api/ArtistUrlImportRoutes.php';
+
+		self::$registered = true;
+		return true;
+	}
+}

--- a/inc/Providers/VenueBookingProvider.php
+++ b/inc/Providers/VenueBookingProvider.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Venue and booking dependency registration.
+ *
+ * @package ExtraChillEvents\Providers
+ */
+
+namespace ExtraChillEvents\Providers;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Loads the ordered venue and booking feature group once. */
+final class VenueBookingProvider {
+
+	/**
+	 * Whether dependencies have loaded.
+	 *
+	 * @var bool
+	 */
+	private static $registered = false;
+
+	/**
+	 * Register venue and booking schemas, services, and hooks.
+	 *
+	 * Optional integrations are guarded by their owning services and are not
+	 * prerequisites for loading the domain.
+	 *
+	 * @return bool Whether the provider is registered.
+	 */
+	public static function register(): bool {
+		if ( self::$registered ) {
+			return true;
+		}
+
+		if ( ! function_exists( 'add_action' ) || ! function_exists( 'add_filter' ) ) {
+			return false;
+		}
+
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingSchema.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportSchema.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestSchema.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueAuthorization.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportAuthorization.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestAuthorization.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueMembershipService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueInvitationToken.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueOnboardingRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueOnboardingService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueInvitationDeliveryWorker.php';
+		\ExtraChillEvents\Core\VenueInvitationDeliveryWorker::register();
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportWorkspace.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VendorRequestNotificationService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingActivityRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingNotificationService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportNotificationAdapter.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalSupportNotificationService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingCommunicationService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingCorrespondenceAutomationService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingHoldRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingMutationService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingEventSyncService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingEventConversionService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingMarketingService.php';
+		\ExtraChillEvents\Core\BookingMarketingService::register();
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingLifecycle.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingPrivateFileProvider.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/LocalBookingPrivateFileProvider.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingPrivateFileProviders.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingAttachmentPolicy.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingAttachmentRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingAttachmentDeliveryRepository.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingAttachmentService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingInquiryAdmissionService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingConfig.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueBookingEmbed.php';
+		\ExtraChillEvents\Core\VenueBookingEmbed::register();
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/TicketReconciliationService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/TicketSettlementService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/ShowSettlementService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingReportingService.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/BookingPrivacyService.php';
+		\ExtraChillEvents\Core\BookingPrivacyService::register();
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/VenueProfile.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/CanonicalEventPublicationGuard.php';
+		\ExtraChillEvents\Core\BookingHoldRepository::register();
+		\ExtraChillEvents\Core\BookingCommunicationService::register();
+		\ExtraChillEvents\Core\BookingCorrespondenceAutomationService::register();
+		\ExtraChillEvents\Core\BookingNotificationService::register();
+		\ExtraChillEvents\Core\LocalSupportNotificationService::register();
+		\ExtraChillEvents\Core\VendorRequestNotificationService::register();
+		new \ExtraChillEvents\Core\CanonicalEventPublicationGuard();
+
+		self::$registered = true;
+		return true;
+	}
+}

--- a/tests/Unit/Core/FeatureProviderBootstrapTest.php
+++ b/tests/Unit/Core/FeatureProviderBootstrapTest.php
@@ -19,6 +19,8 @@ final class FeatureProviderBootstrapTest extends TestCase {
 		$this->assertTrue( $result['owner_site'] );
 		$this->assertTrue( $result['public_registered'] );
 		$this->assertTrue( $result['ingestion_hooked'] );
+		$this->assertTrue( $result['artist_url_registered'] );
+		$this->assertTrue( $result['booking_registered'] );
 	}
 
 	/** Unrelated subsites load safe hooks while owner-only callbacks remain guarded. */
@@ -28,6 +30,8 @@ final class FeatureProviderBootstrapTest extends TestCase {
 		$this->assertFalse( $result['owner_site'] );
 		$this->assertTrue( $result['public_registered'] );
 		$this->assertTrue( $result['ingestion_hooked'] );
+		$this->assertTrue( $result['artist_url_registered'] );
+		$this->assertTrue( $result['booking_registered'] );
 	}
 
 	/** CLI registration remains available and provider calls are idempotent. */
@@ -62,7 +66,11 @@ final class FeatureProviderBootstrapTest extends TestCase {
 		$result = $this->run_fixture( 'optional-absent' );
 
 		$this->assertFalse( $result['optional_dependency_seen'] );
+		$this->assertFalse( $result['optional_scheduler_seen'] );
+		$this->assertFalse( $result['optional_users_seen'] );
 		$this->assertTrue( $result['optional_loader_present'] );
+		$this->assertTrue( $result['artist_url_registered'] );
+		$this->assertTrue( $result['booking_registered'] );
 		$this->assertTrue( $result['public_registered'] );
 		$this->assertTrue( $result['ingestion_hooked'] );
 	}
@@ -74,15 +82,21 @@ final class FeatureProviderBootstrapTest extends TestCase {
 		$this->assertIsString( $bootstrap );
 		$cli       = strpos( $bootstrap, 'CliProvider::register()' );
 		$ingestion = strpos( $bootstrap, 'IngestionProvider::register()' );
+		$artist    = strpos( $bootstrap, 'ArtistUrlImportProvider::register()' );
+		$booking   = strpos( $bootstrap, 'VenueBookingProvider::register()' );
 		$public    = strpos( $bootstrap, 'PublicExperienceProvider::register()' );
 		$optional  = strpos( $bootstrap, 'DataMachineEventsProvider::register()' );
 
 		$this->assertIsInt( $cli );
 		$this->assertIsInt( $ingestion );
+		$this->assertIsInt( $artist );
+		$this->assertIsInt( $booking );
 		$this->assertIsInt( $public );
 		$this->assertIsInt( $optional );
 		$this->assertLessThan( $ingestion, $cli );
 		$this->assertLessThan( $public, $ingestion );
+		$this->assertLessThan( $booking, $artist );
+		$this->assertLessThan( $public, $booking );
 		$this->assertLessThan( $optional, $public );
 	}
 

--- a/tests/fixtures/bootstrap-matrix.php
+++ b/tests/fixtures/bootstrap-matrix.php
@@ -69,6 +69,8 @@ namespace {
 	$hooks_before_repeat = count( $GLOBALS['bootstrap_matrix_hooks'] );
 	\ExtraChillEvents\Providers\CliProvider::register();
 	\ExtraChillEvents\Providers\IngestionProvider::register();
+	\ExtraChillEvents\Providers\ArtistUrlImportProvider::register();
+	\ExtraChillEvents\Providers\VenueBookingProvider::register();
 	\ExtraChillEvents\Providers\PublicExperienceProvider::register();
 	\ExtraChillEvents\Providers\DataMachineEventsProvider::register();
 
@@ -79,6 +81,10 @@ namespace {
 			'optional_loader_present'  => function_exists( 'extrachill_events_init_data_machine_integration' ),
 			'optional_dependency_seen' => defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ),
 			'ingestion_hooked'         => in_array( 'datamachine_tasks', array_column( $GLOBALS['bootstrap_matrix_hooks'], 0 ), true ),
+			'artist_url_registered'    => function_exists( 'ExtraChillEvents\\Api\\register_artist_url_routes' ),
+			'booking_registered'       => class_exists( 'ExtraChillEvents\\Core\\BookingRepository', false ),
+			'optional_scheduler_seen'  => function_exists( 'as_schedule_single_action' ),
+			'optional_users_seen'      => function_exists( 'ec_users_notify_with_receipts' ),
 			'cli_commands'             => class_exists( 'WP_CLI', false ) ? count( WP_CLI::$commands ) : 0,
 			'cli_command_names'        => class_exists( 'WP_CLI', false ) ? array_keys( WP_CLI::$commands ) : array(),
 			'hooks_before_repeat'      => $hooks_before_repeat,


### PR DESCRIPTION
## Summary
- extract Artist URL Import table/REST dependencies into an idempotent domain-local provider
- extract the ordered venue and booking schemas, repositories, authorization, onboarding, notification, lifecycle, settlement, reporting, and privacy stack into an idempotent provider
- extend the bootstrap matrix across owner site, unrelated subsite, CLI, repeat registration, optional dependencies absent, and provider ordering

## Behavior
The providers keep the existing include and registration order. Their only bootstrap prerequisites are the WordPress hook primitives they use; Action Scheduler, Extra Chill Users notification APIs, Data Machine Events, and approval APIs remain optional runtime integrations. The matrix proves those optional APIs can be absent while booking, public, and ingestion surfaces still register.

`init_abilities()` is intentionally untouched because #606 owns the concurrent ability path.

## Remaining #607 seams
- qualification core composition still loaded directly in `load_dependencies()`
- abilities and transport adapters still composed in `init_abilities()`
- schema lifecycle remains in activation and rolling `maybe_install_schema()` methods
- administration remains split across network settings, priority venue/event screens, and Artist URL moderation
- optional Analytics-backed market reporting and Roadie-facing booking correspondence boundaries still require prerequisite mapping

## Verification
- `./vendor/bin/phpunit tests/Unit/Core/FeatureProviderBootstrapTest.php` (5 tests, 41 assertions)
- `./vendor/bin/phpunit -c phpunit-booking.xml.dist` (463 tests, 4,828 assertions)
- `./vendor/bin/phpunit -c phpunit-onboarding.xml.dist` (52 tests, 369 assertions)
- `./vendor/bin/phpunit -c phpunit-membership.xml.dist` (49 tests, 356 assertions)
- relevant standalone venue/booking tests (46 tests, 443 assertions)
- `npm run test:js` (16 suites, 95 tests)
- `npm run lint:js`
- `npm run build`
- scoped PHPCS for new providers and matrix coverage
- PHP syntax checks, `composer validate --no-check-publish`, and `git diff --check`

PHPStan is not installed or declared. The unscoped PHPUnit collector still hits the documented missing `WP_UnitTestCase` bootstrap, so the configured domain suites above were used. `homeboy review audit` was attempted with explicit local placement but produced no output before its five-minute timeout.

Refs #607