### PR TITLE
fix: authorize trusted priority boost fulfillment

### DIFF
--- a/inc/Abilities/PriorityEventAbilities.php
+++ b/inc/Abilities/PriorityEventAbilities.php
@@ -228,13 +228,15 @@ class PriorityEventAbilities {
 	}
 
 	/**
-	 * Require an authenticated administrator for paid priority grants.
+	 * Require an administrator or a trusted commerce fulfillment context.
 	 *
 	 * @param array $input Validated ability input.
 	 * @return true|\WP_Error
 	 */
 	public function can_grant_priority_boost( array $input ) {
-		unset( $input );
+		if ( $this->priority_boost_is_trusted_commerce_request( $input ) ) {
+			return true;
+		}
 
 		$actor_id = $this->get_priority_boost_actor_id();
 		if ( $actor_id < 1 ) {
@@ -279,6 +281,10 @@ class PriorityEventAbilities {
 
 		if ( is_array( $receipt ) ) {
 			return $this->replay_priority_boost( $option_name, $receipt, $request_hash, $post );
+		}
+
+		if ( ! $this->priority_boost_event_is_eligible( (int) $post->ID ) ) {
+			return new \WP_Error( 'priority_boost_event_ineligible', __( 'Priority boosts are available only for upcoming events.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
 
 		$existing_priority = $this->is_priority_boosted_event( (int) $post->ID );
@@ -404,6 +410,40 @@ class PriorityEventAbilities {
 	 */
 	protected function priority_boost_actor_can_manage( int $actor_id ): bool {
 		return user_can( $actor_id, 'manage_options' );
+	}
+
+	/**
+	 * Allow the commerce owner to authorize a verified fulfillment call.
+	 *
+	 * The default is deliberately false. The integration must scope its filter
+	 * to the payment-completion call and remove it immediately afterward.
+	 *
+	 * @param array $input Validated ability input.
+	 * @return bool
+	 */
+	protected function priority_boost_is_trusted_commerce_request( array $input ): bool {
+		/**
+		 * Filters whether this execution is trusted commerce fulfillment.
+		 *
+		 * @param bool  $trusted Whether the caller verified the fulfillment. Default false.
+		 * @param array $input   Validated priority boost input.
+		 */
+		return (bool) apply_filters( 'extrachill_events_priority_boost_trusted_commerce', false, $input );
+	}
+
+	/**
+	 * Check that a new grant targets an event that has not passed.
+	 *
+	 * @param int $post_id Event post ID.
+	 * @return bool
+	 */
+	protected function priority_boost_event_is_eligible( int $post_id ): bool {
+		$event_date = trim( (string) get_post_meta( $post_id, '_event_date', true ) );
+		$date       = \DateTimeImmutable::createFromFormat( '!Y-m-d', $event_date );
+
+		return false !== $date
+			&& $date->format( 'Y-m-d' ) === $event_date
+			&& $event_date >= current_time( 'Y-m-d' );
 	}
 
 	/**

--- a/tests/Support/PriorityBoostAbilityDouble.php
+++ b/tests/Support/PriorityBoostAbilityDouble.php
@@ -60,6 +60,20 @@ final class PriorityBoostAbilityDouble extends PriorityEventAbilities {
 	public $can_manage = true;
 
 	/**
+	 * Event dates by event ID.
+	 *
+	 * @var array<int,string>
+	 */
+	public $event_dates = array();
+
+	/**
+	 * Current site date fixture.
+	 *
+	 * @var string
+	 */
+	public $today = '2026-08-06';
+
+	/**
 	 * Resolve an event fixture.
 	 *
 	 * @param string $event_reference Event ID or slug.
@@ -83,6 +97,16 @@ final class PriorityBoostAbilityDouble extends PriorityEventAbilities {
 	protected function priority_boost_actor_can_manage( int $actor_id ): bool {
 		unset( $actor_id );
 		return $this->can_manage;
+	}
+
+	/**
+	 * Return fixture event eligibility.
+	 *
+	 * @param int $post_id Event post ID.
+	 * @return bool
+	 */
+	protected function priority_boost_event_is_eligible( int $post_id ): bool {
+		return isset( $this->event_dates[ $post_id ] ) && $this->event_dates[ $post_id ] >= $this->today;
 	}
 
 	/**

--- a/tests/Unit/Abilities/PriorityBoostAbilityTest.php
+++ b/tests/Unit/Abilities/PriorityBoostAbilityTest.php
@@ -22,14 +22,15 @@ final class PriorityBoostAbilityTest extends TestCase {
 
 	/** Prepare one canonical event. */
 	protected function setUp(): void {
-		$this->ability               = new PriorityBoostAbilityDouble();
-		$this->ability->events['42'] = (object) array(
+		$this->ability                  = new PriorityBoostAbilityDouble();
+		$this->ability->events['42']    = (object) array(
 			'ID'          => 42,
 			'post_type'   => 'data_machine_events',
 			'post_status' => 'publish',
 			'post_title'  => 'Test Event',
 			'post_name'   => 'test-event',
 		);
+		$this->ability->event_dates[42] = '2026-08-07';
 	}
 
 	/** A valid request grants priority and returns an opaque receipt. */
@@ -42,6 +43,9 @@ final class PriorityBoostAbilityTest extends TestCase {
 		$this->assertTrue( $this->ability->priority[42] );
 		$this->assertSame( 42, $result['event']['post_id'] );
 		$this->assertSame( 7, $result['receipt']['actor_id'] );
+		$this->assertArrayNotHasKey( 'external_reference', $result );
+		$this->assertArrayNotHasKey( 'idempotency_key', $result );
+		$this->assertArrayNotHasKey( 'external_reference', $result['receipt'] );
 	}
 
 	/** Exact retries return the original projection without another write. */
@@ -79,8 +83,40 @@ final class PriorityBoostAbilityTest extends TestCase {
 		$this->assertSame( 'priority_boost_event_not_found', $result->get_error_code() );
 	}
 
-	/** Non-administrator actors receive an explicit capability error. */
-	public function test_unauthorized_actor_returns_explicit_error(): void {
+	/** Trusted commerce fulfillment can execute without a WordPress actor. */
+	public function test_trusted_commerce_allows_user_zero(): void {
+		$this->ability->actor_id   = 0;
+		$this->ability->can_manage = false;
+		$input                     = $this->input();
+		$authorize                 = static function ( bool $trusted, array $received ) use ( $input ): bool {
+			return false === $trusted && $input === $received;
+		};
+		add_filter( 'extrachill_events_priority_boost_trusted_commerce', $authorize, 10, 2 );
+
+		try {
+			$this->assertTrue( $this->ability->can_grant_priority_boost( $input ) );
+			$result = $this->ability->grant_priority_boost( $input );
+			$this->assertTrue( $result['success'] );
+			$this->assertSame( 0, $result['receipt']['actor_id'] );
+		} finally {
+			remove_filter( 'extrachill_events_priority_boost_trusted_commerce', $authorize, 10 );
+		}
+	}
+
+	/** Untrusted user zero remains unauthenticated. */
+	public function test_untrusted_user_zero_requires_authentication(): void {
+		$this->ability->actor_id   = 0;
+		$this->ability->can_manage = false;
+
+		$result = $this->ability->can_grant_priority_boost( $this->input() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'priority_boost_authentication_required', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	/** Authenticated customers remain forbidden without trusted fulfillment. */
+	public function test_customer_returns_explicit_capability_error(): void {
 		$this->ability->can_manage = false;
 
 		$result = $this->ability->can_grant_priority_boost( $this->input() );
@@ -88,6 +124,38 @@ final class PriorityBoostAbilityTest extends TestCase {
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'priority_boost_forbidden', $result->get_error_code() );
 		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/** Administrators retain direct execution authority. */
+	public function test_administrator_remains_authorized(): void {
+		$this->assertTrue( $this->ability->can_grant_priority_boost( $this->input() ) );
+		$result = $this->ability->grant_priority_boost( $this->input() );
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 7, $result['receipt']['actor_id'] );
+	}
+
+	/** New grants reject past events before writing state. */
+	public function test_past_event_is_ineligible(): void {
+		$this->ability->event_dates[42] = '2026-08-05';
+
+		$result = $this->ability->grant_priority_boost( $this->input() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'priority_boost_event_ineligible', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
+		$this->assertSame( 0, $this->ability->priority_writes );
+	}
+
+	/** Exact retries retain their receipt after the event date passes. */
+	public function test_completed_grant_replays_after_event_passes(): void {
+		$first                          = $this->ability->grant_priority_boost( $this->input() );
+		$this->ability->event_dates[42] = '2026-08-05';
+
+		$replay = $this->ability->grant_priority_boost( $this->input() );
+
+		$this->assertTrue( $replay['replayed'] );
+		$this->assertSame( $first['receipt'], $replay['receipt'] );
+		$this->assertSame( 1, $this->ability->priority_writes );
 	}
 
 	/** Successful grants invalidate the established Events cache only. */


### PR DESCRIPTION
## Summary
- add an Events-owned, default-deny authorization filter for verified commerce fulfillment while preserving administrator access
- reject new boosts for missing, invalid, or past event dates without changing exact-replay and idempotency-conflict behavior
- cover trusted and untrusted user `0`, customer denial, administrator execution, opaque receipts, and post-event replay

## Authorization Model
The network cross-site helper was inspected before adding a contract. Its existing HMAC path only signs a positive current user ID, and target authentication rejects user `0`, so it cannot represent WooCommerce's normal fulfillment context without impersonating an administrator.

Events now exposes `extrachill_events_priority_boost_trusted_commerce`, which defaults to `false`. The commerce integration must add this filter only around a payment-completion call it has already verified and remove it immediately afterward. This keeps the trust decision in the owning integration while Events owns the authorization extension point and mutation.

## Threat Boundary
- anonymous user `0` remains denied unless trusted fulfillment is explicitly active
- authenticated customers remain denied by default
- administrators retain direct `manage_options` execution
- public request input cannot activate the trust path
- responses and receipts do not expose external references, idempotency keys, Stripe data, or order secrets

## Tests
- `./vendor/bin/phpunit tests/Unit/Abilities/PriorityBoostAbilityTest.php` (12 tests, 41 assertions)
- `npm run lint:js`
- `homeboy review --placement local --changed-since origin/main --summary`: audit and scoped PHPCS/ESLint/PHPStan lint passed with zero findings; test adapter could not start because `WP_CODEBOX_DB_HOST` is unavailable
- repository-wide PHPUnit remains blocked by the existing missing `WP_UnitTestCase` bootstrap

Closes #615