### PR TITLE
feat: expose public Events entity projections

### DIFF
--- a/inc/abilities/events-public-entity-projections.php
+++ b/inc/abilities/events-public-entity-projections.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Public Events entity projections ability.
+ *
+ * @package ExtraChillEvents
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_events_register_public_entity_projections_ability' );
+
+/** Register the canonical public presentation resolver. */
+function extrachill_events_register_public_entity_projections_ability(): void {
+	$item_input_schema  = array(
+		'type'                 => 'object',
+		'required'             => array( 'entity_type', 'slug' ),
+		'additionalProperties' => false,
+		'properties'           => array(
+			'entity_type' => array(
+				'type' => 'string',
+				'enum' => array( 'venue', 'location', 'local_scene_digest' ),
+			),
+			'slug'        => array(
+				'type'      => 'string',
+				'minLength' => 1,
+				'maxLength' => 200,
+				'pattern'   => '^[a-z0-9]+(?:-[a-z0-9]+)*$',
+			),
+		),
+	);
+	$item_output_schema = array(
+		'type'                 => 'object',
+		'required'             => array( 'entity_type', 'slug', 'status', 'name', 'url' ),
+		'additionalProperties' => false,
+		'properties'           => array(
+			'entity_type' => $item_input_schema['properties']['entity_type'],
+			'slug'        => $item_input_schema['properties']['slug'],
+			'status'      => array(
+				'type' => 'string',
+				'enum' => array( 'resolved', 'not_found' ),
+			),
+			'name'        => array( 'type' => 'string' ),
+			'url'         => array( 'type' => 'string' ),
+		),
+	);
+
+	wp_register_ability(
+		'extrachill/events-public-entity-projections',
+		array(
+			'label'               => __( 'Public Events Entity Projections', 'extrachill-events' ),
+			'description'         => __( 'Batch-resolves public names and canonical URLs for Events-owned subscription identities.', 'extrachill-events' ),
+			'category'            => 'extrachill-events',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'schema_version', 'items' ),
+				'additionalProperties' => false,
+				'properties'           => array(
+					'schema_version' => array(
+						'type' => 'string',
+						'enum' => array( '1' ),
+					),
+					'items'          => array(
+						'type'     => 'array',
+						'minItems' => 1,
+						'maxItems' => 100,
+						'items'    => $item_input_schema,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'                 => 'object',
+				'required'             => array( 'schema_version', 'items' ),
+				'additionalProperties' => false,
+				'properties'           => array(
+					'schema_version' => array(
+						'type' => 'string',
+						'enum' => array( '1' ),
+					),
+					'items'          => array(
+						'type'     => 'array',
+						'minItems' => 1,
+						'maxItems' => 100,
+						'items'    => $item_output_schema,
+					),
+				),
+			),
+			'execute_callback'    => 'extrachill_events_ability_public_entity_projections',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Resolve public Events-owned entity presentation in input order.
+ *
+ * @param array $input Validated ability input.
+ * @return array|WP_Error Projection response or owner infrastructure failure.
+ */
+function extrachill_events_ability_public_entity_projections( array $input ) {
+	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 0;
+	$events_blog_id = (int) apply_filters( 'extrachill_events_canonical_blog_id', $events_blog_id );
+
+	if ( $events_blog_id <= 0 || ( is_multisite() && ! get_site( $events_blog_id ) ) ) {
+		return new \WP_Error( 'events_site_unavailable', __( 'The canonical Events site is unavailable.', 'extrachill-events' ), array( 'status' => 500 ) );
+	}
+
+	$switched = get_current_blog_id() !== $events_blog_id;
+	if ( $switched ) {
+		switch_to_blog( $events_blog_id );
+	}
+
+	try {
+		$requested = array();
+		foreach ( $input['items'] as $item ) {
+			$taxonomy                                = 'venue' === $item['entity_type'] ? 'venue' : 'location';
+			$requested[ $taxonomy ][ $item['slug'] ] = true;
+		}
+
+		$terms_by_taxonomy = array();
+		foreach ( $requested as $taxonomy => $slugs ) {
+			if ( ! taxonomy_exists( $taxonomy ) ) {
+				return new \WP_Error(
+					'events_taxonomy_unavailable',
+					__( 'A canonical Events taxonomy is unavailable.', 'extrachill-events' ),
+					array(
+						'status'   => 500,
+						'taxonomy' => $taxonomy,
+					)
+				);
+			}
+
+			$terms = get_terms(
+				array(
+					'taxonomy'   => $taxonomy,
+					'hide_empty' => false,
+					'slug'       => array_keys( $slugs ),
+				)
+			);
+			if ( is_wp_error( $terms ) ) {
+				return new \WP_Error(
+					'events_entity_lookup_failed',
+					$terms->get_error_message(),
+					array(
+						'status'   => 500,
+						'taxonomy' => $taxonomy,
+					)
+				);
+			}
+
+			foreach ( $terms as $term ) {
+				$terms_by_taxonomy[ $taxonomy ][ $term->slug ] = $term;
+			}
+		}
+
+		$items = array();
+		foreach ( $input['items'] as $item ) {
+			$taxonomy = 'venue' === $item['entity_type'] ? 'venue' : 'location';
+			$term     = $terms_by_taxonomy[ $taxonomy ][ $item['slug'] ] ?? null;
+			$row      = array(
+				'entity_type' => $item['entity_type'],
+				'slug'        => $item['slug'],
+				'status'      => 'not_found',
+				'name'        => '',
+				'url'         => '',
+			);
+
+			if ( ! $term instanceof \WP_Term || ! is_term_publicly_viewable( $term ) ) {
+				$items[] = $row;
+				continue;
+			}
+
+			if ( 'location' === $taxonomy ) {
+				$location = extrachill_events_prepare_canonical_location( $term );
+				if ( null === $location ) {
+					$items[] = $row;
+					continue;
+				}
+				$url = $location['archive_url'];
+			} else {
+				$url = get_term_link( $term );
+			}
+
+			if ( is_wp_error( $url ) || '' === $url ) {
+				return new \WP_Error(
+					'events_entity_url_failed',
+					__( 'A canonical Events entity URL could not be generated.', 'extrachill-events' ),
+					array(
+						'status'   => 500,
+						'taxonomy' => $taxonomy,
+						'slug'     => $term->slug,
+					)
+				);
+			}
+
+			$row['status'] = 'resolved';
+			$row['name']   = $term->name;
+			$row['url']    = $url;
+			$items[]       = $row;
+		}
+
+		return array(
+			'schema_version' => '1',
+			'items'          => $items,
+		);
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
+}

--- a/inc/abilities/register.php
+++ b/inc/abilities/register.php
@@ -51,5 +51,6 @@ require_once __DIR__ . '/events-geocode.php';
 require_once __DIR__ . '/events-upcoming-counts.php';
 require_once __DIR__ . '/events-list-venues.php';
 require_once __DIR__ . '/events-get-venue.php';
+require_once __DIR__ . '/events-public-entity-projections.php';
 require_once __DIR__ . '/events-check-venue-duplicate.php';
 require_once __DIR__ . '/events-by-artist.php';

--- a/phpunit-artist-unit.xml.dist
+++ b/phpunit-artist-unit.xml.dist
@@ -4,6 +4,7 @@
 		<testsuite name="artist-unit">
 			<file>tests/Unit/Abilities/EventsByArtistAbilityTest.php</file>
 			<file>tests/Unit/Abilities/ArtistUrlImportConfigurationContractTest.php</file>
+			<file>tests/Unit/Core/FeatureProviderBootstrapTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/phpunit-managed.xml.dist
+++ b/phpunit-managed.xml.dist
@@ -12,6 +12,7 @@
 			<file>tests/Unit/Core/class-datamachineintegrationloadertest.php</file>
 			<exclude>tests/Unit/Core/LocalSceneDigestSystemTaskTest.php</exclude>
 			<exclude>tests/Unit/Core/LocalSceneDigestTest.php</exclude>
+			<exclude>tests/Unit/Core/FeatureProviderBootstrapTest.php</exclude>
 			<file>tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalLocationsAbilityTest.php</file>
 			<file>tests/Unit/Abilities/PublicEntityProjectionsAbilityTest.php</file>

--- a/phpunit-managed.xml.dist
+++ b/phpunit-managed.xml.dist
@@ -14,6 +14,7 @@
 			<exclude>tests/Unit/Core/LocalSceneDigestTest.php</exclude>
 			<file>tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalLocationsAbilityTest.php</file>
+			<file>tests/Unit/Abilities/PublicEntityProjectionsAbilityTest.php</file>
 			<file>tests/Unit/Abilities/EventsByTermTaxonomyContextTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalAdapterContractsTest.php</file>
 			<file>tests/Unit/Abilities/ManagedVenueVoicesRestTest.php</file>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,7 @@
 			<directory>tests/Unit/Core</directory>
 			<file>tests/Unit/Abilities/VenueQualificationTicketmasterPrecheckTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalLocationsAbilityTest.php</file>
+			<file>tests/Unit/Abilities/PublicEntityProjectionsAbilityTest.php</file>
 			<file>tests/Unit/Abilities/EventsByTermTaxonomyContextTest.php</file>
 			<file>tests/Unit/Abilities/EventsByArtistAbilityTest.php</file>
 			<file>tests/Unit/Abilities/CanonicalAdapterContractsTest.php</file>

--- a/tests/Unit/Abilities/PublicEntityProjectionsAbilityTest.php
+++ b/tests/Unit/Abilities/PublicEntityProjectionsAbilityTest.php
@@ -1,0 +1,347 @@
+<?php
+// phpcs:ignoreFile -- Managed WordPress fixture follows the repository test convention.
+/**
+ * Tests for the public Events entity projection owner contract.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+require_once dirname( __DIR__, 3 ) . '/inc/abilities/events-locations.php';
+require_once dirname( __DIR__, 3 ) . '/inc/abilities/events-public-entity-projections.php';
+
+/**
+ * Verify exact schemas, owner resolution, visibility, and failures.
+ */
+final class PublicEntityProjectionsAbilityTest extends WP_UnitTestCase {
+	/**
+	 * Canonical Events blog fixture.
+	 *
+	 * @var int
+	 */
+	private int $blog_id;
+
+	/**
+	 * Selectable location fixture.
+	 *
+	 * @var int
+	 */
+	private int $city;
+
+	/** Register canonical taxonomies and the ability. */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->blog_id = get_current_blog_id();
+		add_filter( 'extrachill_events_canonical_blog_id', array( $this, 'canonical_blog_id' ) );
+
+		foreach ( array( 'venue', 'location' ) as $taxonomy ) {
+			if ( taxonomy_exists( $taxonomy ) ) {
+				unregister_taxonomy( $taxonomy );
+			}
+		}
+		register_taxonomy(
+			'venue',
+			'post',
+			array(
+				'public'  => true,
+				'rewrite' => array( 'slug' => 'venue' ),
+			)
+		);
+		register_taxonomy(
+			'location',
+			'post',
+			array(
+				'public'       => true,
+				'hierarchical' => true,
+				'rewrite'      => array(
+					'slug'         => 'location',
+					'hierarchical' => true,
+				),
+			)
+		);
+
+		$usa        = self::factory()->term->create(
+			array(
+				'taxonomy' => 'location',
+				'name'     => 'USA',
+				'slug'     => 'usa',
+			)
+		);
+		$state      = self::factory()->term->create(
+			array(
+				'taxonomy' => 'location',
+				'name'     => 'South Carolina',
+				'slug'     => 'south-carolina',
+				'parent'   => $usa,
+			)
+		);
+		$this->city = self::factory()->term->create(
+			array(
+				'taxonomy' => 'location',
+				'name'     => 'Charleston',
+				'slug'     => 'charleston-sc',
+				'parent'   => $state,
+			)
+		);
+		self::factory()->term->create(
+			array(
+				'taxonomy' => 'venue',
+				'name'     => 'The Royal American',
+				'slug'     => 'the-royal-american',
+			)
+		);
+
+		if ( wp_has_ability( 'extrachill/events-public-entity-projections' ) ) {
+			wp_unregister_ability( 'extrachill/events-public-entity-projections' );
+		}
+		if ( ! wp_has_ability_category( 'extrachill-events' ) ) {
+			wp_register_ability_category( 'extrachill-events', array( 'label' => 'Extra Chill Events' ) );
+		}
+		extrachill_events_register_public_entity_projections_ability();
+	}
+
+	/** Restore filters and public taxonomy registrations. */
+	protected function tearDown(): void {
+		remove_filter( 'extrachill_events_canonical_blog_id', array( $this, 'canonical_blog_id' ) );
+		foreach ( array( 'venue', 'location' ) as $taxonomy ) {
+			if ( taxonomy_exists( $taxonomy ) ) {
+				unregister_taxonomy( $taxonomy );
+			}
+		}
+		register_taxonomy(
+			'venue',
+			'post',
+			array( 'public' => true )
+		);
+		register_taxonomy(
+			'location',
+			'post',
+			array(
+				'public'       => true,
+				'hierarchical' => true,
+			)
+		);
+		parent::tearDown();
+	}
+
+	/** Return the current test blog as the canonical Events site. */
+	public function canonical_blog_id(): int {
+		return $this->blog_id;
+	}
+
+	/** Resolve every supported type while preserving order and owner URLs. */
+	public function test_resolves_all_types_in_order_with_owner_urls(): void {
+		$input = array(
+			'schema_version' => '1',
+			'items'          => array(
+				array(
+					'entity_type' => 'local_scene_digest',
+					'slug'        => 'charleston-sc',
+				),
+				array(
+					'entity_type' => 'venue',
+					'slug'        => 'the-royal-american',
+				),
+				array(
+					'entity_type' => 'location',
+					'slug'        => 'charleston-sc',
+				),
+				array(
+					'entity_type' => 'venue',
+					'slug'        => 'missing-venue',
+				),
+			),
+		);
+
+		$result       = $this->ability()->execute( $input );
+		$location_url = get_term_link( get_term( $this->city, 'location' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( '1', $result['schema_version'] );
+		$this->assertSame( array( 'local_scene_digest', 'venue', 'location', 'venue' ), array_column( $result['items'], 'entity_type' ) );
+		$this->assertSame( array( 'resolved', 'resolved', 'resolved', 'not_found' ), array_column( $result['items'], 'status' ) );
+		$this->assertSame( $location_url, $result['items'][0]['url'] );
+		$this->assertSame( $location_url, $result['items'][2]['url'] );
+		$this->assertSame( 'The Royal American', $result['items'][1]['name'] );
+		$this->assertSame( '', $result['items'][3]['name'] );
+		$this->assertSame( '', $result['items'][3]['url'] );
+		foreach ( $result['items'] as $item ) {
+			$this->assertSame( array( 'entity_type', 'slug', 'status', 'name', 'url' ), array_keys( $item ) );
+		}
+	}
+
+	/** Hide stale, non-selectable, and non-public terms without partial data. */
+	public function test_deleted_nonselectable_and_private_terms_are_not_found(): void {
+		$deleted = self::factory()->term->create(
+			array(
+				'taxonomy' => 'venue',
+				'name'     => 'Gone',
+				'slug'     => 'gone',
+			)
+		);
+		wp_delete_term( $deleted, 'venue' );
+
+		$result = $this->ability()->execute(
+			array(
+				'schema_version' => '1',
+				'items'          => array(
+					array(
+						'entity_type' => 'venue',
+						'slug'        => 'gone',
+					),
+					array(
+						'entity_type' => 'location',
+						'slug'        => 'south-carolina',
+					),
+				),
+			)
+		);
+		$this->assertSame( array( 'not_found', 'not_found' ), array_column( $result['items'], 'status' ) );
+
+		unregister_taxonomy( 'venue' );
+		register_taxonomy( 'venue', 'post', array( 'public' => false ) );
+		self::factory()->term->create(
+			array(
+				'taxonomy' => 'venue',
+				'name'     => 'Private Room',
+				'slug'     => 'private-room',
+			)
+		);
+		$private = $this->ability()->execute(
+			array(
+				'schema_version' => '1',
+				'items'          => array(
+					array(
+						'entity_type' => 'venue',
+						'slug'        => 'private-room',
+					),
+				),
+			)
+		);
+		$this->assertSame( 'not_found', $private['items'][0]['status'] );
+	}
+
+	/** Enforce exact versioned schemas, canonical slugs, and batch bounds. */
+	public function test_schema_is_exact_and_rejects_malformed_inputs_and_bounds(): void {
+		$ability = $this->ability();
+		$schema  = $ability->get_input_schema();
+
+		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertFalse( $schema['properties']['items']['items']['additionalProperties'] );
+		$this->assertSame( 1, $schema['properties']['items']['minItems'] );
+		$this->assertSame( 100, $schema['properties']['items']['maxItems'] );
+		$this->assertFalse( $ability->get_output_schema()['additionalProperties'] );
+		$this->assertFalse( $ability->get_output_schema()['properties']['items']['items']['additionalProperties'] );
+		$this->assertSame( 1, $ability->get_output_schema()['properties']['items']['minItems'] );
+		$this->assertSame( array( 'schema_version', 'items' ), $schema['required'] );
+		$this->assertSame( array( 'entity_type', 'slug' ), $schema['properties']['items']['items']['required'] );
+		$this->assertSame( array( 'entity_type', 'slug', 'status', 'name', 'url' ), $ability->get_output_schema()['properties']['items']['items']['required'] );
+
+		$invalid = array(
+			array(
+				'schema_version' => '1',
+				'items'          => array(),
+				'extra'          => true,
+			),
+			array(
+				'schema_version' => '2',
+				'items'          => array(
+					array(
+						'entity_type' => 'venue',
+						'slug'        => 'valid',
+					),
+				),
+			),
+			array(
+				'schema_version' => '1',
+				'items'          => array(),
+			),
+			array(
+				'schema_version' => '1',
+				'items'          => array_fill(
+					0,
+					101,
+					array(
+						'entity_type' => 'venue',
+						'slug'        => 'valid',
+					)
+				),
+			),
+			array(
+				'schema_version' => '1',
+				'items'          => array(
+					array(
+						'entity_type' => 'venue',
+						'slug'        => 'Not-Canonical',
+					),
+				),
+			),
+			array(
+				'schema_version' => '1',
+				'items'          => array(
+					array(
+						'entity_type' => 'venue',
+						'slug'        => 'valid',
+						'extra'       => true,
+					),
+				),
+			),
+		);
+		foreach ( $invalid as $input ) {
+			$result = $ability->execute( $input );
+			$this->assertWPError( $result );
+			$this->assertSame( 'ability_invalid_input', $result->get_error_code() );
+		}
+
+		$bounded = $ability->execute(
+			array(
+				'schema_version' => '1',
+				'items'          => array_fill(
+					0,
+					100,
+					array(
+						'entity_type' => 'venue',
+						'slug'        => 'the-royal-american',
+					)
+				),
+			)
+		);
+		$this->assertIsArray( $bounded );
+		$this->assertCount( 100, $bounded['items'] );
+	}
+
+	/** Preserve unavailable owner infrastructure as WP_Error responses. */
+	public function test_owner_infrastructure_failures_remain_errors(): void {
+		add_filter( 'extrachill_events_canonical_blog_id', '__return_zero', 20 );
+		$unavailable = $this->ability()->execute( $this->valid_input() );
+		remove_filter( 'extrachill_events_canonical_blog_id', '__return_zero', 20 );
+
+		$this->assertWPError( $unavailable );
+		$this->assertSame( 'events_site_unavailable', $unavailable->get_error_code() );
+
+		unregister_taxonomy( 'venue' );
+		$taxonomy = $this->ability()->execute( $this->valid_input() );
+		$this->assertWPError( $taxonomy );
+		$this->assertSame( 'events_taxonomy_unavailable', $taxonomy->get_error_code() );
+	}
+
+	/** Return the registered owner ability. */
+	private function ability(): WP_Ability {
+		$ability = wp_get_ability( 'extrachill/events-public-entity-projections' );
+		$this->assertInstanceOf( WP_Ability::class, $ability );
+		return $ability;
+	}
+
+	/** Return one valid venue projection request. */
+	private function valid_input(): array {
+		return array(
+			'schema_version' => '1',
+			'items'          => array(
+				array(
+					'entity_type' => 'venue',
+					'slug'        => 'the-royal-american',
+				),
+			),
+		);
+	}
+}

--- a/tests/Unit/Abilities/PublicEntityProjectionsAbilityTest.php
+++ b/tests/Unit/Abilities/PublicEntityProjectionsAbilityTest.php
@@ -27,6 +27,13 @@ final class PublicEntityProjectionsAbilityTest extends WP_UnitTestCase {
 	 */
 	private int $city;
 
+	/**
+	 * Whether this fixture registered the Events ability category.
+	 *
+	 * @var bool
+	 */
+	private bool $registered_category = false;
+
 	/** Register canonical taxonomies and the ability. */
 	protected function setUp(): void {
 		parent::setUp();
@@ -95,14 +102,32 @@ final class PublicEntityProjectionsAbilityTest extends WP_UnitTestCase {
 			wp_unregister_ability( 'extrachill/events-public-entity-projections' );
 		}
 		if ( ! wp_has_ability_category( 'extrachill-events' ) ) {
-			wp_register_ability_category( 'extrachill-events', array( 'label' => 'Extra Chill Events' ) );
+			$this->registered_category = true;
+			$this->run_registration_lifecycle(
+				'wp_abilities_api_categories_init',
+				static function (): void {
+					wp_register_ability_category(
+						'extrachill-events',
+						array(
+							'label'       => 'Extra Chill Events',
+							'description' => 'Extra Chill Events abilities.',
+						)
+					);
+				}
+			);
 		}
-		extrachill_events_register_public_entity_projections_ability();
+		$this->run_registration_lifecycle( 'wp_abilities_api_init', 'extrachill_events_register_public_entity_projections_ability' );
 	}
 
 	/** Restore filters and public taxonomy registrations. */
 	protected function tearDown(): void {
 		remove_filter( 'extrachill_events_canonical_blog_id', array( $this, 'canonical_blog_id' ) );
+		if ( wp_has_ability( 'extrachill/events-public-entity-projections' ) ) {
+			wp_unregister_ability( 'extrachill/events-public-entity-projections' );
+		}
+		if ( $this->registered_category && wp_has_ability_category( 'extrachill-events' ) ) {
+			wp_unregister_ability_category( 'extrachill-events' );
+		}
 		foreach ( array( 'venue', 'location' ) as $taxonomy ) {
 			if ( taxonomy_exists( $taxonomy ) ) {
 				unregister_taxonomy( $taxonomy );
@@ -343,5 +368,26 @@ final class PublicEntityProjectionsAbilityTest extends WP_UnitTestCase {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Run one registration callback on its required lifecycle without firing unrelated hooks.
+	 *
+	 * @param string   $hook     Registration lifecycle hook.
+	 * @param callable $callback Registration callback.
+	 */
+	private function run_registration_lifecycle( string $hook, callable $callback ): void {
+		$previous = isset( $GLOBALS['wp_filter'][ $hook ] ) ? clone $GLOBALS['wp_filter'][ $hook ] : null;
+
+		remove_all_actions( $hook );
+		add_action( $hook, $callback );
+		do_action( $hook );
+		remove_all_actions( $hook );
+
+		if ( null === $previous ) {
+			unset( $GLOBALS['wp_filter'][ $hook ] );
+		} else {
+			$GLOBALS['wp_filter'][ $hook ] = $previous;
+		}
 	}
 }

--- a/tests/Unit/Core/FeatureProviderBootstrapTest.php
+++ b/tests/Unit/Core/FeatureProviderBootstrapTest.php
@@ -107,7 +107,7 @@ final class FeatureProviderBootstrapTest extends TestCase {
 	 * @return array<string, mixed>
 	 */
 	private function run_fixture( string $scenario ): array {
-		$command = escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( dirname( __DIR__, 2 ) . '/fixtures/bootstrap-matrix.php' ) . ' ' . escapeshellarg( $scenario ) . ' 2>&1';
+		$command = escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( dirname( __DIR__, 2 ) . '/fixtures/bootstrap-matrix.php' ) . ' ' . escapeshellarg( $scenario );
 		$output  = array();
 		$status  = 0;
 		exec( $command, $output, $status ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- Isolated bootstrap process is the behavior under test.

--- a/tests/Unit/Core/FeatureProviderBootstrapTest.php
+++ b/tests/Unit/Core/FeatureProviderBootstrapTest.php
@@ -107,7 +107,7 @@ final class FeatureProviderBootstrapTest extends TestCase {
 	 * @return array<string, mixed>
 	 */
 	private function run_fixture( string $scenario ): array {
-		$command = escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( dirname( __DIR__, 2 ) . '/fixtures/bootstrap-matrix.php' ) . ' ' . escapeshellarg( $scenario );
+		$command = escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( dirname( __DIR__, 2 ) . '/fixtures/bootstrap-matrix.php' ) . ' ' . escapeshellarg( $scenario ) . ' 2>&1';
 		$output  = array();
 		$status  = 0;
 		exec( $command, $output, $status ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- Isolated bootstrap process is the behavior under test.


### PR DESCRIPTION
## Summary
- add the public read-only `extrachill/events-public-entity-projections` owner ability for `venue`, `location`, and `local_scene_digest` identities
- resolve bounded canonical-slug batches on the Events site while preserving every input row and its order
- reuse Events taxonomy visibility, selectable-location hierarchy, and canonical term links without introducing routing or registry state

## Contract
- input and output use exact `additionalProperties: false` schemas with `schema_version: \"1\"`
- input accepts 1-100 ordered `{ entity_type, slug }` objects with canonical lowercase hyphenated slugs
- output returns exact `{ entity_type, slug, status, name, url }` rows; missing, deleted, non-selectable, or non-public terms return `not_found` with empty `name` and `url`
- unavailable Events site/taxonomies, taxonomy query failures, and canonical-link failures remain `WP_Error`

## URL Semantics
- venues return their Events-owned canonical venue term URL
- locations return their canonical selectable Events location archive URL
- Local Scene digests intentionally return that same Events-owned location archive URL, matching the existing digest notification destination so Community never constructs product URLs

## Tests
- managed WordPress coverage includes all entity types, input order and row preservation, stale/deleted/private/non-selectable terms, Local Scene URL behavior, exact schemas, malformed and extra fields, 1/100 bounds, and unavailable owner infrastructure
- `homeboy review lint --changed-only --placement local` (PHPCS, ESLint, PHPStan): pass
- isolated PHPUnit suites: 102 tests, 632 assertions, pass
- `npm run test:js`: 95 tests, pass
- `npm run lint:js`: pass
- `npm run build`: pass
- local managed PHPUnit selection reached the new test but WP Codebox could not provision its external MySQL runtime service; repository CI provides its dedicated MySQL service

Closes #619.
Unblocks Extra-Chill/extrachill-community#266.