### PR TITLE
fix: authorize priority boosts with service assertions

### DIFF
--- a/inc/Abilities/PriorityEventAbilities.php
+++ b/inc/Abilities/PriorityEventAbilities.php
@@ -413,22 +413,16 @@ class PriorityEventAbilities {
 	}
 
 	/**
-	 * Allow the commerce owner to authorize a verified fulfillment call.
-	 *
-	 * The default is deliberately false. The integration must scope its filter
-	 * to the payment-completion call and remove it immediately afterward.
+	 * Accept only exact target-runtime service authority verified by Network.
 	 *
 	 * @param array $input Validated ability input.
 	 * @return bool
 	 */
 	protected function priority_boost_is_trusted_commerce_request( array $input ): bool {
-		/**
-		 * Filters whether this execution is trusted commerce fulfillment.
-		 *
-		 * @param bool  $trusted Whether the caller verified the fulfillment. Default false.
-		 * @param array $input   Validated priority boost input.
-		 */
-		return (bool) apply_filters( 'extrachill_events_priority_boost_trusted_commerce', false, $input );
+		unset( $input );
+
+		return function_exists( 'extrachill_events_priority_boost_has_verified_service_authority' )
+			&& extrachill_events_priority_boost_has_verified_service_authority();
 	}
 
 	/**

--- a/inc/core/bootstrap.php
+++ b/inc/core/bootstrap.php
@@ -13,6 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/core/priority-boost-service-authority.php';
+
 function extrachill_events() {
 	return ExtraChillEvents::get_instance();
 }

--- a/inc/core/priority-boost-service-authority.php
+++ b/inc/core/priority-boost-service-authority.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Bounded service authority for paid event priority fulfillment.
+ *
+ * @package ExtraChillEvents
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ID    = 'extrachill.events.priority-boost';
+const EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_SCOPE = 'extrachill/events:priority-boost';
+const EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ROUTE = '/wp-abilities/v1/abilities/extrachill/grant-event-priority-boost/run';
+
+/**
+ * Build the exact target grant from Events-owned configuration.
+ *
+ * @param array<string,mixed> $config Product configuration.
+ * @return array<string,mixed>|null Network grant, or null when incomplete.
+ */
+function extrachill_events_priority_boost_build_target_grant( array $config ): ?array {
+	$required = array( 'source_site_id', 'target_site_id', 'target_host', 'keys' );
+	foreach ( $required as $field ) {
+		if ( ! isset( $config[ $field ] ) ) {
+			return null;
+		}
+	}
+
+	if ( (int) $config['source_site_id'] < 1 || (int) $config['target_site_id'] < 1 || '' === trim( (string) $config['target_host'] ) || ! is_array( $config['keys'] ) || empty( $config['keys'] ) ) {
+		return null;
+	}
+
+	return array(
+		'service_id'     => EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ID,
+		'scope'          => EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_SCOPE,
+		'source_site_id' => (int) $config['source_site_id'],
+		'target_site_id' => (int) $config['target_site_id'],
+		'target_host'    => strtolower( trim( (string) $config['target_host'] ) ),
+		'method'         => 'POST',
+		'route'          => EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ROUTE,
+		'keys'           => $config['keys'],
+	);
+}
+
+/**
+ * Resolve the target grant without embedding assertion secrets in source.
+ *
+ * Deployment configuration supplies key IDs and secrets through the constant
+ * below. The source integration independently registers the matching source
+ * grant and selects its active key through the Network contract.
+ *
+ * @return array<string,mixed>|null Target grant, or null when unavailable.
+ */
+function extrachill_events_priority_boost_target_grant(): ?array {
+	if ( ! function_exists( 'ec_get_blog_id' ) || ! function_exists( 'ec_get_site_url' ) ) {
+		return null;
+	}
+
+	$source_site_id = (int) ec_get_blog_id( 'shop' );
+	$target_site_id = (int) ec_get_blog_id( 'events' );
+	$target_url     = (string) ec_get_site_url( 'events' );
+	$target_host    = $target_url ? wp_parse_url( $target_url, PHP_URL_HOST ) : '';
+	$keys           = defined( 'EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ASSERTION_KEYS' )
+		? constant( 'EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ASSERTION_KEYS' )
+		: array();
+
+	/**
+	 * Filters deployment-provided priority boost assertion keys.
+	 *
+	 * @param array<string,string> $keys Key IDs mapped to assertion secrets.
+	 */
+	$keys = apply_filters( 'extrachill_events_priority_boost_service_assertion_keys', $keys );
+
+	return extrachill_events_priority_boost_build_target_grant(
+		array(
+			'source_site_id' => $source_site_id,
+			'target_site_id' => $target_site_id,
+			'target_host'    => is_string( $target_host ) ? $target_host : '',
+			'keys'           => is_array( $keys ) ? $keys : array(),
+		)
+	);
+}
+
+/**
+ * Register the Events-owned target grant with Network.
+ *
+ * @param array<int,array<string,mixed>> $grants Registered target grants.
+ * @return array<int,array<string,mixed>> Filtered target grants.
+ */
+function extrachill_events_register_priority_boost_target_grant( array $grants ): array {
+	$grant = extrachill_events_priority_boost_target_grant();
+	if ( null !== $grant ) {
+		$grants[] = $grant;
+	}
+
+	return $grants;
+}
+add_filter( 'ec_cross_site_service_assertion_target_grants', 'extrachill_events_register_priority_boost_target_grant' );
+
+/**
+ * Check verified claims against the exact Events-owned grant.
+ *
+ * Network has already verified the request method, route, query, body,
+ * signature, lifetime, key, target, and single-use nonce before exposing these
+ * claims. Events only applies its product authorization policy here.
+ *
+ * @param array<string,mixed> $claims Verified Network claims.
+ * @param array<string,mixed> $grant  Events target grant.
+ */
+function extrachill_events_priority_boost_service_claims_match( array $claims, array $grant ): bool {
+	foreach ( array( 'service_id', 'scope', 'source_site_id', 'target_site_id', 'target_host' ) as $field ) {
+		if ( ! array_key_exists( $field, $claims ) || (string) $claims[ $field ] !== (string) $grant[ $field ] ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Apply Events policy to one request carrying Network-verified claims.
+ *
+ * @param string              $method  HTTP method.
+ * @param string              $route   Exact REST route.
+ * @param array<string,mixed> $claims  Verified Network claims.
+ * @param array<string,mixed> $grant   Events target grant.
+ */
+function extrachill_events_priority_boost_service_request_is_authorized( string $method, string $route, array $claims, array $grant ): bool {
+	return 'POST' === $method
+		&& EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ROUTE === $route
+		&& extrachill_events_priority_boost_service_claims_match( $claims, $grant );
+}
+
+/**
+ * Store or read the exact REST request currently executing the ability.
+ *
+ * @param mixed $request Exact REST request, or null.
+ * @param bool  $replace Whether to replace the active request.
+ * @return mixed Active REST request, or null.
+ */
+function extrachill_events_priority_boost_active_rest_request( $request = null, bool $replace = false ) {
+	static $active_request = null;
+
+	if ( $replace ) {
+		$active_request = $request;
+	}
+
+	return $active_request;
+}
+
+/**
+ * Bind only the exact ability run request during its callback lifecycle.
+ *
+ * @param mixed $response Current REST response.
+ * @param array $handler  Matched route handler.
+ * @param mixed $request  Exact REST request.
+ * @return mixed Unchanged REST response.
+ */
+function extrachill_events_bind_priority_boost_rest_request( $response, array $handler, $request ) {
+	unset( $handler );
+
+	if ( ! is_wp_error( $response ) && 'POST' === $request->get_method() && EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ROUTE === $request->get_route() ) {
+		extrachill_events_priority_boost_active_rest_request( $request, true );
+	}
+
+	return $response;
+}
+add_filter( 'rest_request_before_callbacks', 'extrachill_events_bind_priority_boost_rest_request', 10, 3 );
+
+/**
+ * Clear the active request after REST has finished permission header checks.
+ *
+ * @param mixed $response Current REST response.
+ * @param mixed $server   REST server.
+ * @param mixed $request  Exact REST request.
+ * @return mixed Unchanged REST response.
+ */
+function extrachill_events_release_priority_boost_rest_request( $response, $server, $request ) {
+	unset( $server );
+
+	if ( extrachill_events_priority_boost_active_rest_request() === $request ) {
+		extrachill_events_priority_boost_active_rest_request( null, true );
+	}
+
+	return $response;
+}
+add_filter( 'rest_post_dispatch', 'extrachill_events_release_priority_boost_rest_request', 20, 3 );
+
+/** Check exact target-side Network claims for the active ability request. */
+function extrachill_events_priority_boost_has_verified_service_authority(): bool {
+	$request = extrachill_events_priority_boost_active_rest_request();
+	$grant   = extrachill_events_priority_boost_target_grant();
+
+	if ( null === $request || null === $grant || ! function_exists( 'ec_cross_site_verified_service_context' ) ) {
+		return false;
+	}
+
+	$claims = ec_cross_site_verified_service_context( $request );
+
+	return is_array( $claims )
+		&& extrachill_events_priority_boost_service_request_is_authorized( $request->get_method(), $request->get_route(), $claims, $grant );
+}

--- a/inc/core/priority-boost-service-authority.php
+++ b/inc/core/priority-boost-service-authority.php
@@ -77,7 +77,7 @@ function extrachill_events_priority_boost_target_grant(): ?array {
 			'source_site_id' => $source_site_id,
 			'target_site_id' => $target_site_id,
 			'target_host'    => is_string( $target_host ) ? $target_host : '',
-			'keys'           => is_array( $keys ) ? $keys : array(),
+			'keys'           => $keys,
 		)
 	);
 }

--- a/tests/Support/PriorityBoostAbilityDouble.php
+++ b/tests/Support/PriorityBoostAbilityDouble.php
@@ -59,6 +59,9 @@ final class PriorityBoostAbilityDouble extends PriorityEventAbilities {
 	 */
 	public $can_manage = true;
 
+	/** @var bool Whether the target runtime supplied exact verified service authority. */
+	public $verified_service_authority = false;
+
 	/**
 	 * Event dates by event ID.
 	 *
@@ -97,6 +100,16 @@ final class PriorityBoostAbilityDouble extends PriorityEventAbilities {
 	protected function priority_boost_actor_can_manage( int $actor_id ): bool {
 		unset( $actor_id );
 		return $this->can_manage;
+	}
+
+	/**
+	 * Return target-runtime service authority.
+	 *
+	 * @param array $input Validated ability input.
+	 */
+	protected function priority_boost_is_trusted_commerce_request( array $input ): bool {
+		unset( $input );
+		return $this->verified_service_authority;
 	}
 
 	/**

--- a/tests/Unit/Abilities/PriorityBoostAbilityTest.php
+++ b/tests/Unit/Abilities/PriorityBoostAbilityTest.php
@@ -8,6 +8,7 @@
 use PHPUnit\Framework\TestCase;
 
 require_once dirname( __DIR__, 3 ) . '/inc/Abilities/PriorityEventAbilities.php';
+require_once dirname( __DIR__, 3 ) . '/inc/core/priority-boost-service-authority.php';
 require_once dirname( __DIR__, 2 ) . '/Support/PriorityBoostAbilityDouble.php';
 
 /** Covers the paid event priority operation contract. */
@@ -83,24 +84,16 @@ final class PriorityBoostAbilityTest extends TestCase {
 		$this->assertSame( 'priority_boost_event_not_found', $result->get_error_code() );
 	}
 
-	/** Trusted commerce fulfillment can execute without a WordPress actor. */
-	public function test_trusted_commerce_allows_user_zero(): void {
-		$this->ability->actor_id   = 0;
-		$this->ability->can_manage = false;
-		$input                     = $this->input();
-		$authorize                 = static function ( bool $trusted, array $received ) use ( $input ): bool {
-			return false === $trusted && $input === $received;
-		};
-		add_filter( 'extrachill_events_priority_boost_trusted_commerce', $authorize, 10, 2 );
+	/** Exact target-runtime service authority can execute as user zero. */
+	public function test_verified_target_service_allows_user_zero(): void {
+		$this->ability->actor_id                   = 0;
+		$this->ability->can_manage                 = false;
+		$this->ability->verified_service_authority = true;
 
-		try {
-			$this->assertTrue( $this->ability->can_grant_priority_boost( $input ) );
-			$result = $this->ability->grant_priority_boost( $input );
-			$this->assertTrue( $result['success'] );
-			$this->assertSame( 0, $result['receipt']['actor_id'] );
-		} finally {
-			remove_filter( 'extrachill_events_priority_boost_trusted_commerce', $authorize, 10 );
-		}
+		$this->assertTrue( $this->ability->can_grant_priority_boost( $this->input() ) );
+		$result = $this->ability->grant_priority_boost( $this->input() );
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 0, $result['receipt']['actor_id'] );
 	}
 
 	/** Untrusted user zero remains unauthenticated. */
@@ -132,6 +125,99 @@ final class PriorityBoostAbilityTest extends TestCase {
 		$result = $this->ability->grant_priority_boost( $this->input() );
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( 7, $result['receipt']['actor_id'] );
+	}
+
+	/** Fresh transport assertions retain business duplicate semantics. */
+	public function test_fresh_assertions_replay_duplicate_business_callback(): void {
+		$this->ability->actor_id                   = 0;
+		$this->ability->can_manage                 = false;
+		$this->ability->verified_service_authority = true;
+
+		$this->assertTrue( $this->ability->can_grant_priority_boost( $this->input() ) );
+		$first = $this->ability->grant_priority_boost( $this->input() );
+
+		// A retry arrives with separately verified transport claims.
+		$this->ability->verified_service_authority = true;
+		$this->assertTrue( $this->ability->can_grant_priority_boost( $this->input() ) );
+		$second = $this->ability->grant_priority_boost( $this->input() );
+
+		$this->assertFalse( $first['replayed'] );
+		$this->assertTrue( $second['replayed'] );
+		$this->assertSame( $first['receipt'], $second['receipt'] );
+		$this->assertSame( 1, $this->ability->priority_writes );
+	}
+
+	/** Events registers one exact target operation with no embedded secret. */
+	public function test_builds_exact_target_grant_from_product_configuration(): void {
+		$grant = extrachill_events_priority_boost_build_target_grant(
+			array(
+				'source_site_id' => 3,
+				'target_site_id' => 7,
+				'target_host'    => 'EVENTS.EXTRACHILL.COM',
+				'keys'           => array( 'current' => str_repeat( 's', 32 ) ),
+			)
+		);
+
+		$this->assertSame( EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ID, $grant['service_id'] );
+		$this->assertSame( EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_SCOPE, $grant['scope'] );
+		$this->assertSame( 'POST', $grant['method'] );
+		$this->assertSame( EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ROUTE, $grant['route'] );
+		$this->assertSame( 'events.extrachill.com', $grant['target_host'] );
+		$this->assertArrayNotHasKey( 'active_key_id', $grant );
+	}
+
+	/** Missing key configuration keeps target service authority disabled. */
+	public function test_incomplete_target_grant_fails_closed(): void {
+		$this->assertNull(
+			extrachill_events_priority_boost_build_target_grant(
+				array(
+					'source_site_id' => 3,
+					'target_site_id' => 7,
+					'target_host'    => 'events.extrachill.com',
+					'keys'           => array(),
+				)
+			)
+		);
+	}
+
+	/** Only exact Network-verified product claims match the target grant. */
+	public function test_rejects_mismatched_or_missing_verified_claims(): void {
+		$grant  = $this->target_grant();
+		$claims = array_intersect_key( $grant, array_flip( array( 'service_id', 'scope', 'source_site_id', 'target_site_id', 'target_host' ) ) );
+
+		$this->assertTrue( extrachill_events_priority_boost_service_claims_match( $claims, $grant ) );
+
+		foreach ( array( 'service_id', 'scope', 'source_site_id', 'target_site_id', 'target_host' ) as $field ) {
+			$mismatched           = $claims;
+			$mismatched[ $field ] = 'wrong';
+			$this->assertFalse( extrachill_events_priority_boost_service_claims_match( $mismatched, $grant ), $field );
+		}
+
+		$this->assertFalse( extrachill_events_priority_boost_service_claims_match( array(), $grant ) );
+	}
+
+	/** Target policy binds verified claims to the exact ability request. */
+	public function test_target_policy_requires_exact_route_method_and_verified_context(): void {
+		$grant  = $this->target_grant();
+		$claims = array_intersect_key( $grant, array_flip( array( 'service_id', 'scope', 'source_site_id', 'target_site_id', 'target_host' ) ) );
+
+		$this->assertTrue( extrachill_events_priority_boost_service_request_is_authorized( 'POST', EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ROUTE, $claims, $grant ) );
+		$this->assertFalse( extrachill_events_priority_boost_service_request_is_authorized( 'GET', EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ROUTE, $claims, $grant ) );
+		$this->assertFalse( extrachill_events_priority_boost_service_request_is_authorized( 'POST', '/wp-abilities/v1/abilities/extrachill/other/run', $claims, $grant ) );
+		$this->assertFalse( extrachill_events_priority_boost_service_request_is_authorized( 'POST', EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ROUTE, array(), $grant ) );
+	}
+
+	/** Invalid transport assertions never become Events service authority. */
+	public function test_transport_rejections_remain_untrusted_at_integration_boundary(): void {
+		$this->ability->actor_id   = 0;
+		$this->ability->can_manage = false;
+
+		foreach ( array( 'forged', 'expired', 'replayed', 'wrong-route', 'wrong-method', 'wrong-body' ) as $transport_failure ) {
+			$this->ability->verified_service_authority = false;
+			$result                                    = $this->ability->can_grant_priority_boost( $this->input() );
+			$this->assertInstanceOf( WP_Error::class, $result, $transport_failure );
+			$this->assertSame( 'priority_boost_authentication_required', $result->get_error_code(), $transport_failure );
+		}
 	}
 
 	/** New grants reject past events before writing state. */
@@ -182,6 +268,18 @@ final class PriorityBoostAbilityTest extends TestCase {
 			'event'              => '42',
 			'external_reference' => 'order:100:item:5',
 			'idempotency_key'    => 'priority-boost:100:5',
+		);
+	}
+
+	/** Return one complete target grant fixture. */
+	private function target_grant(): array {
+		return extrachill_events_priority_boost_build_target_grant(
+			array(
+				'source_site_id' => 3,
+				'target_site_id' => 7,
+				'target_host'    => 'events.extrachill.com',
+				'keys'           => array( 'current' => str_repeat( 's', 32 ) ),
+			)
 		);
 	}
 }


### PR DESCRIPTION
## Summary

- register one Events-owned target service grant for the exact priority-boost ability execution route introduced by Network #159
- replace the in-process trusted fulfillment filter with target-runtime authorization from Network-verified request claims
- preserve administrator access, anonymous/customer denial, event eligibility, opaque receipts, exact replay, and idempotency-conflict behavior

## Bounded Scope

Events registers only this target operation through `ec_cross_site_service_assertion_target_grants`:

- service: `extrachill.events.priority-boost`
- scope: `extrachill/events:priority-boost`
- source site: the configured network `shop` site
- target site/host: the configured network `events` site
- method: `POST`
- route: `/wp-abilities/v1/abilities/extrachill/grant-event-priority-boost/run`

Assertion key IDs and secrets are supplied by deployment configuration through `EXTRACHILL_EVENTS_PRIORITY_BOOST_SERVICE_ASSERTION_KEYS` (or the product configuration filter); no secret is committed. Events registers the target keys only. The source integration independently registers the matching source grant and active key through Network's public contract.

## Claim Verification And Trust Boundary

Network #159 verifies localhost transport, complete assertion syntax, configured source/target grant, service, scope, site and host, method, exact route, canonical query/body, lifetime, key/signature, and atomic single-use nonce before REST permission callbacks. Events never parses assertion headers or copies transport cryptography.

During only the exact core ability run request, Events reads `ec_cross_site_verified_service_context( $request )` and requires service, scope, source site, target site, and target host to match its target grant. User `0` remains user `0`; no administrator or customer is impersonated. Missing Network APIs, missing key configuration, absent claims, and mismatched claims fail closed through the existing anonymous/customer denial paths.

Forged, expired, replayed, wrong-target, wrong-route, wrong-method, and wrong-body assertions never receive verified Network context and therefore cannot activate Events authority. Errors and ability projections expose no assertion secret, payment data, external reference, or idempotency key.

## Replay And Idempotency

Transport replay and business duplicate fulfillment remain separate:

- reuse of one assertion nonce is rejected by Network before Events permissions run;
- a legitimate retry uses a fresh assertion;
- Events then replays the existing receipt only when the same idempotency key identifies the same canonical event and external reference;
- conflicting key reuse retains the existing explicit `priority_boost_idempotency_conflict` response.

## Compatibility

- administrators retain direct `manage_options` execution
- anonymous callers and authenticated customers without exact verified service claims remain denied
- new grants still require an eligible upcoming event
- exact receipt replay and existing priority preservation are unchanged
- no generic Network code or service-assertion cryptography is duplicated

## Verification

Passing:

- `./vendor/bin/phpunit tests/Unit/Abilities/PriorityBoostAbilityTest.php` (18 tests, 77 assertions)
- focused WordPress PHPCS for `inc/core/priority-boost-service-authority.php`
- `npm run test:js` (16 suites, 95 tests)
- `npm run lint:js`
- `npm run build`
- `git diff --check`
- Homeboy managed audit: zero introduced findings
- Homeboy managed scoped lint: PHPCS, ESLint, and PHPStan level 7 passed with zero findings

Environment/baseline limitations:

- managed PHPUnit could not start because `WP_CODEBOX_DB_HOST` is unavailable; no test executed in that adapter
- repository `composer test` reaches the existing missing `WP_UnitTestCase` bootstrap
- repository `composer lint:php` scans existing source/vendor baselines; changed-scope Homeboy lint passes
- local PHPStan is not installed; managed scoped PHPStan passed

Depends on Extra-Chill/extrachill-network#159.
Closes #618.
Unblocks Extra-Chill/extrachill-shop#28.