### PR TITLE
fix: defer translated booking service errors

### DIFF
--- a/inc/Abilities/BookingAttachmentAbilities.php
+++ b/inc/Abilities/BookingAttachmentAbilities.php
@@ -32,7 +32,7 @@ class BookingAttachmentAbilities {
 	private $bookings;
 	/** Attachment service.
 	 *
-	 * @var BookingAttachmentService
+	 * @var BookingAttachmentService|null
 	 */
 	private $service;
 	/** Venue authorization policy.
@@ -53,7 +53,8 @@ class BookingAttachmentAbilities {
 		$this->attachments   = $attachments ? $attachments : new BookingAttachmentRepository();
 		$this->bookings      = $bookings ? $bookings : new BookingRepository();
 		$this->authorization = $authorization ? $authorization : new VenueAuthorization();
-		$this->service       = $service ? $service : new BookingAttachmentService( $this->attachments, $this->bookings, null, null, null, $this->authorization );
+		$this->service       = $service;
+		// @phpstan-ignore arguments.count
 		add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
 	}
 
@@ -124,7 +125,7 @@ class BookingAttachmentAbilities {
 		$input['uploader_type']    = 'user';
 		$input['uploader_user_id'] = get_current_user_id();
 		unset( $input['uploader_reference'] );
-		$result = $this->service->attach( $input );
+		$result = $this->service()->attach( $input );
 		return is_array( $result ) ? $this->present( $result ) : $result;
 	}
 
@@ -137,7 +138,7 @@ class BookingAttachmentAbilities {
 		$input['uploader_type']    = 'user';
 		$input['uploader_user_id'] = get_current_user_id();
 		unset( $input['uploader_reference'] );
-		$result = $this->service->replace( $input );
+		$result = $this->service()->replace( $input );
 		return is_array( $result ) ? $this->present( $result ) : $result;
 	}
 
@@ -147,7 +148,7 @@ class BookingAttachmentAbilities {
 	 * @param array $input Ability input.
 	 */
 	public function delete( array $input ) {
-		$result = $this->service->delete( (int) $input['booking_id'], (int) $input['attachment_id'], get_current_user_id() );
+		$result = $this->service()->delete( (int) $input['booking_id'], (int) $input['attachment_id'], get_current_user_id() );
 		return is_array( $result ) ? $this->present( $result ) : $result;
 	}
 
@@ -157,7 +158,7 @@ class BookingAttachmentAbilities {
 	 * @param array $input Ability input.
 	 */
 	public function download( array $input ) {
-		return $this->service->download_descriptor( (int) $input['booking_id'], (int) $input['attachment_id'], get_current_user_id() );
+		return $this->service()->download_descriptor( (int) $input['booking_id'], (int) $input['attachment_id'], get_current_user_id() );
 	}
 
 	/**
@@ -166,7 +167,7 @@ class BookingAttachmentAbilities {
 	 * @param array $input Ability input.
 	 */
 	public function record_delivery( array $input ) {
-		return $this->service->record_delivery_outcome(
+		return $this->service()->record_delivery_outcome(
 			(int) $input['booking_id'],
 			(int) $input['attachment_id'],
 			(string) $input['correlation_id'],
@@ -182,7 +183,16 @@ class BookingAttachmentAbilities {
 	 * @param array $input Ability input.
 	 */
 	public function inspect_deliveries( array $input ) {
-		return $this->service->delivery_diagnostics( (int) $input['booking_id'], get_current_user_id(), 100 );
+		return $this->service()->delivery_diagnostics( (int) $input['booking_id'], get_current_user_id(), 100 );
+	}
+
+	/** Resolve private storage only when an attachment operation executes. */
+	private function service(): BookingAttachmentService {
+		if ( null === $this->service ) {
+			$this->service = new BookingAttachmentService( $this->attachments, $this->bookings, null, null, null, $this->authorization );
+		}
+
+		return $this->service;
 	}
 
 	/**

--- a/inc/Abilities/BookingReportingAbilities.php
+++ b/inc/Abilities/BookingReportingAbilities.php
@@ -19,11 +19,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Registers stable read-only reports over canonical booking records. */
 class BookingReportingAbilities {
 	private static bool $registered = false;
-	/** @var BookingReportingService */
+	/** @var BookingReportingService|null */
 	private $service;
 
 	public function __construct( ?BookingReportingService $service = null ) {
-		$this->service = $service ? $service : new BookingReportingService();
+		$this->service = $service;
 		if ( ! self::$registered ) {
 			// @phpstan-ignore arguments.count
 			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
@@ -61,21 +61,29 @@ class BookingReportingAbilities {
 	}
 
 	public function operations( array $input ) {
-		return $this->service->operations( $input, get_current_user_id() );
+		return $this->service()->operations( $input, get_current_user_id() );
 	}
 
 	public function finance( array $input ) {
-		return $this->service->finance( $input, get_current_user_id() );
+		return $this->service()->finance( $input, get_current_user_id() );
 	}
 
 	public function can_read_operations( array $input ) {
-		$result = $this->service->authorize_operations( $input, get_current_user_id() );
+		$result = $this->service()->authorize_operations( $input, get_current_user_id() );
 		return $result instanceof \WP_Error ? $result : true;
 	}
 
 	public function can_read_finance( array $input ) {
-		$result = $this->service->authorize_finance( $input, get_current_user_id() );
+		$result = $this->service()->authorize_finance( $input, get_current_user_id() );
 		return $result instanceof \WP_Error ? $result : true;
+	}
+
+	private function service(): BookingReportingService {
+		if ( null === $this->service ) {
+			$this->service = new BookingReportingService();
+		}
+
+		return $this->service;
 	}
 
 	private function input_schema( bool $finance ): array {

--- a/inc/Abilities/ShowSettlementAbilities.php
+++ b/inc/Abilities/ShowSettlementAbilities.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Registers bounded private finance operations over immutable show revisions. */
 class ShowSettlementAbilities {
 	private static bool $registered = false;
-	/** @var ShowSettlementService */
+	/** @var ShowSettlementService|null */
 	private $service;
 	/** @var BookingRepository */
 	private $bookings;
@@ -35,8 +35,9 @@ class ShowSettlementAbilities {
 		$this->bookings             = $bookings ? $bookings : new BookingRepository();
 		$this->authorization        = $authorization ? $authorization : new VenueAuthorization();
 		$this->artist_authorization = $artist_authorization ? $artist_authorization : new LocalSupportAuthorization( $this->authorization );
-		$this->service              = $service ? $service : new ShowSettlementService( $this->bookings, null, $this->authorization, null, null, null, $this->artist_authorization );
+		$this->service              = $service;
 		if ( ! self::$registered ) {
+			// @phpstan-ignore arguments.count
 			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
 			self::$registered = true;
 		}
@@ -79,39 +80,47 @@ class ShowSettlementAbilities {
 	}
 
 	public function draft( array $input ) {
-		return $this->service->draft( $input, get_current_user_id() );
+		return $this->service()->draft( $input, get_current_user_id() );
 	}
 
 	public function read( array $input ) {
-		return $this->service->get( (int) $input['booking_id'], get_current_user_id(), isset( $input['revision'] ) ? (int) $input['revision'] : null );
+		return $this->service()->get( (int) $input['booking_id'], get_current_user_id(), isset( $input['revision'] ) ? (int) $input['revision'] : null );
 	}
 
 	public function revise( array $input ) {
-		return $this->service->revise( $input, get_current_user_id() );
+		return $this->service()->revise( $input, get_current_user_id() );
 	}
 
 	public function finalize( array $input ) {
-		return $this->service->finalize( $input, get_current_user_id() );
+		return $this->service()->finalize( $input, get_current_user_id() );
 	}
 
 	public function acknowledge( array $input ) {
-		return $this->service->acknowledge( $input, get_current_user_id() );
+		return $this->service()->acknowledge( $input, get_current_user_id() );
 	}
 
 	public function dispute( array $input ) {
-		return $this->service->dispute( $input, get_current_user_id() );
+		return $this->service()->dispute( $input, get_current_user_id() );
 	}
 
 	public function correct( array $input ) {
-		return $this->service->correct( $input, get_current_user_id() );
+		return $this->service()->correct( $input, get_current_user_id() );
 	}
 
 	public function mark_paid( array $input ) {
-		return $this->service->mark_paid( $input, get_current_user_id() );
+		return $this->service()->mark_paid( $input, get_current_user_id() );
 	}
 
 	public function void_settlement( array $input ) {
-		return $this->service->void( $input, get_current_user_id() );
+		return $this->service()->void( $input, get_current_user_id() );
+	}
+
+	private function service(): ShowSettlementService {
+		if ( null === $this->service ) {
+			$this->service = new ShowSettlementService( $this->bookings, null, $this->authorization, null, null, null, $this->artist_authorization );
+		}
+
+		return $this->service;
 	}
 
 	public function can_manage( array $input ) {

--- a/inc/Abilities/TicketSettlementAbilities.php
+++ b/inc/Abilities/TicketSettlementAbilities.php
@@ -22,21 +22,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Registers stable finance contracts over the ticket settlement service. */
 class TicketSettlementAbilities {
 	private static bool $registered = false;
-	/** @var TicketSettlementService */
+	/** @var TicketSettlementService|null */
 	private $service;
 	/** @var BookingRepository */
 	private $bookings;
 	/** @var VenueAuthorization */
 	private $authorization;
-	/** @var TicketReconciliationService */
+	/** @var TicketReconciliationService|null */
 	private $reconciliation;
 
 	public function __construct( ?TicketSettlementService $service = null, ?BookingRepository $bookings = null, ?VenueAuthorization $authorization = null, ?TicketReconciliationService $reconciliation = null ) {
 		$this->bookings       = $bookings ? $bookings : new BookingRepository();
 		$this->authorization  = $authorization ? $authorization : new VenueAuthorization();
-		$this->reconciliation = $reconciliation ? $reconciliation : new TicketReconciliationService( $this->bookings, null, $this->authorization );
-		$this->service        = $service ? $service : new TicketSettlementService( $this->bookings, null, $this->authorization, null, $this->reconciliation );
+		$this->reconciliation = $reconciliation;
+		$this->service        = $service;
 		if ( ! self::$registered ) {
+			// @phpstan-ignore arguments.count
 			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
 			self::$registered = true;
 		}
@@ -120,48 +121,64 @@ class TicketSettlementAbilities {
 	}
 
 	public function record_sales( array $input ) {
-		return $this->service->record_sales( $input, get_current_user_id() );
+		return $this->service()->record_sales( $input, get_current_user_id() );
 	}
 
 	public function register_source( array $input ) {
-		return $this->reconciliation->register_source( $input, get_current_user_id() );
+		return $this->reconciliation()->register_source( $input, get_current_user_id() );
 	}
 
 	public function list_sources( array $input ) {
-		$result = $this->reconciliation->list_sources( (int) $input['booking_id'], get_current_user_id() );
+		$result = $this->reconciliation()->list_sources( (int) $input['booking_id'], get_current_user_id() );
 		return is_array( $result ) ? array_values( $result ) : $result;
 	}
 
 	public function import_csv( array $input ) {
-		return $this->service->import_csv( $input, get_current_user_id() );
+		return $this->service()->import_csv( $input, get_current_user_id() );
 	}
 
 	public function diagnostics( array $input ) {
-		return $this->reconciliation->diagnostics( (int) $input['booking_id'], get_current_user_id() );
+		return $this->reconciliation()->diagnostics( (int) $input['booking_id'], get_current_user_id() );
 	}
 
 	public function resolve( array $input ) {
-		return $this->reconciliation->resolve( $input, get_current_user_id() );
+		return $this->reconciliation()->resolve( $input, get_current_user_id() );
 	}
 
 	public function list_sales( array $input ) {
-		return $this->service->list_sales( (int) $input['booking_id'], get_current_user_id(), (int) ( $input['limit'] ?? 100 ), (int) ( $input['offset'] ?? 0 ) );
+		return $this->service()->list_sales( (int) $input['booking_id'], get_current_user_id(), (int) ( $input['limit'] ?? 100 ), (int) ( $input['offset'] ?? 0 ) );
 	}
 
 	public function calculate( array $input ) {
-		return $this->service->calculate( $input, get_current_user_id() );
+		return $this->service()->calculate( $input, get_current_user_id() );
 	}
 
 	public function finalize( array $input ) {
-		return $this->service->finalize( $input, get_current_user_id() );
+		return $this->service()->finalize( $input, get_current_user_id() );
 	}
 
 	public function mark_paid( array $input ) {
-		return $this->service->mark_paid( $input, get_current_user_id() );
+		return $this->service()->mark_paid( $input, get_current_user_id() );
 	}
 
 	public function void_settlement( array $input ) {
-		return $this->service->void( $input, get_current_user_id() );
+		return $this->service()->void( $input, get_current_user_id() );
+	}
+
+	private function reconciliation(): TicketReconciliationService {
+		if ( null === $this->reconciliation ) {
+			$this->reconciliation = new TicketReconciliationService( $this->bookings, null, $this->authorization );
+		}
+
+		return $this->reconciliation;
+	}
+
+	private function service(): TicketSettlementService {
+		if ( null === $this->service ) {
+			$this->service = new TicketSettlementService( $this->bookings, null, $this->authorization, null, $this->reconciliation() );
+		}
+
+		return $this->service;
 	}
 
 	public function can_access_booking( array $input ) {

--- a/tests/Unit/Core/FeatureProviderBootstrapTest.php
+++ b/tests/Unit/Core/FeatureProviderBootstrapTest.php
@@ -63,6 +63,13 @@ final class FeatureProviderBootstrapTest extends TestCase {
 		$this->assertSame( $result['hooks_before_repeat'], $result['hooks_after_repeat'] );
 	}
 
+	/** Plugin bootstrap must not evaluate translated strings before init. */
+	public function test_cli_boot_does_not_trigger_early_translations(): void {
+		$result = $this->run_fixture( 'cli' );
+
+		$this->assertSame( array(), $result['translation_calls'] );
+	}
+
 	/** A missing optional sibling does not suppress unrelated providers. */
 	public function test_optional_dependency_absence_does_not_suppress_other_features(): void {
 		$result = $this->run_fixture( 'optional-absent' );

--- a/tests/fixtures/bootstrap-matrix.php
+++ b/tests/fixtures/bootstrap-matrix.php
@@ -15,6 +15,29 @@ namespace {
 	$GLOBALS['bootstrap_matrix_blog']  = 'unrelated' === ( $argv[1] ?? '' ) ? 2 : 7;
 	$GLOBALS['bootstrap_matrix_fail']  = 'provider-throwing' === ( $argv[1] ?? '' );
 	$GLOBALS['bootstrap_matrix_provider_failures'] = array();
+	$GLOBALS['bootstrap_matrix_translation_calls'] = array();
+
+	function __( $text, $domain = 'default' ) {
+		if ( 'extrachill-events' === $domain ) {
+			$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 2 );
+			$GLOBALS['bootstrap_matrix_translation_calls'][] = array(
+				'file' => $trace[1]['file'] ?? '',
+				'line' => $trace[1]['line'] ?? 0,
+			);
+		}
+		return $text;
+	}
+
+	function wp_register_ability() {}
+
+	function get_option( $option, $default = false ) {
+		$values = array(
+			'extrachill_events_booking_schema_version'        => '16',
+			'extrachill_events_local_support_schema_version'  => '1',
+			'extrachill_events_vendor_request_schema_version' => '1',
+		);
+		return $values[ $option ] ?? $default;
+	}
 
 	function plugin_dir_path( $file ) {
 		return trailingslashit( dirname( $file ) );
@@ -43,6 +66,10 @@ namespace {
 
 	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
 		return add_filter( $hook, $callback, $priority, $accepted_args );
+	}
+
+	function apply_filters( $hook, $value ) {
+		return $value;
 	}
 
 	function do_action( $hook, ...$args ) {
@@ -78,6 +105,12 @@ namespace {
 
 	require dirname( __DIR__, 2 ) . '/extrachill-events.php';
 
+	foreach ( $GLOBALS['bootstrap_matrix_hooks'] as $registered_hook ) {
+		if ( 'plugins_loaded' === $registered_hook[0] && array( \ExtraChillEvents\Providers\AbilitiesProvider::class, 'initialize' ) === $registered_hook[1] ) {
+			call_user_func( $registered_hook[1] );
+		}
+	}
+
 	$hooks_before_repeat = count( $GLOBALS['bootstrap_matrix_hooks'] );
 	\ExtraChillEvents\Providers\CliProvider::register();
 	\ExtraChillEvents\Providers\IngestionProvider::register();
@@ -104,6 +137,7 @@ namespace {
 			'cli_commands'             => class_exists( 'WP_CLI', false ) ? count( WP_CLI::$commands ) : 0,
 			'cli_command_names'        => class_exists( 'WP_CLI', false ) ? array_keys( WP_CLI::$commands ) : array(),
 			'provider_failures'        => $GLOBALS['bootstrap_matrix_provider_failures'],
+			'translation_calls'        => $GLOBALS['bootstrap_matrix_translation_calls'],
 			'ability_lifecycle_hooked' => in_array( array( 'plugins_loaded', array( \ExtraChillEvents\Providers\AbilitiesProvider::class, 'initialize' ), 25, 1 ), $GLOBALS['bootstrap_matrix_hooks'], true ),
 			'public_contract_hooks'    => array_values(
 				array_intersect(


### PR DESCRIPTION
## Summary
- defer attachment, ticket settlement, show settlement, and booking reporting service construction until an ability operation actually executes
- preserve `plugins_loaded:25` ability-owner registration so Events abilities still attach before the first valid registry resolution
- add a CLI bootstrap regression that records any `extrachill-events` translation evaluated before `init`

## Triggering call path
`extrachill-events.php` initializes `ExtraChillEvents`, which registers `AbilitiesProvider::initialize()` at `plugins_loaded:25`. That callback instantiated booking ability owners. Their constructors eagerly built `BookingAttachmentService` directly or through `TicketReconciliationService`, `TicketSettlementService`, `ShowSettlementService`, and `BookingReportingService`. `BookingPrivateFileProviders::resolve()` then constructed `LocalBookingPrivateFileProvider`; its fail-closed root validation evaluated an `extrachill-events` translated `WP_Error` while WordPress was still in `plugins_loaded`, triggering `_load_textdomain_just_in_time()` before the permitted localization lifecycle.

## Lifecycle root cause
The ability owners must exist before WordPress lazily resolves the one-shot ability registry after `init`, which is why PR #469 moved owner construction to `plugins_loaded:25`. The owners themselves are safe at that point, but their default service graphs were not: private-storage validation translated operational errors during construction even though no ability was executing.

## Minimal fix
The four affected ability owners now retain injected services unchanged but lazily create their default service graph on first execution or permission evaluation. Ability metadata, hooks, schemas, REST exposure, CLI registration, and service error behavior remain unchanged. No textdomain-loading infrastructure or storage-provider contract changed.

## Contexts checked
- reproduced the current warning with an ordinary Events-blog WP-CLI bootstrap on `https://events.extrachill.com`
- exercised isolated owner-site, unrelated-subsite, and WP-CLI bootstrap scenarios
- preserved early ability lifecycle coverage and representative attachment, settlement, reporting, REST/ability behavior
- no production files, content, schemas, or configuration were modified

## Tests
- `./vendor/bin/phpunit tests/Unit/Core/FeatureProviderBootstrapTest.php` (9 tests, 70 assertions)
- `./vendor/bin/phpunit tests/AbilityRegistrationLifecycleTest.php` (1 test, 16 assertions)
- `./vendor/bin/phpunit tests/BookingAttachmentTest.php` (36 tests, 194 assertions)
- `./vendor/bin/phpunit tests/TicketSettlementTest.php` (11 tests, 1,844 assertions)
- `./vendor/bin/phpunit tests/ShowSettlementTest.php` (9 tests, 95 assertions)
- `./vendor/bin/phpunit tests/BookingReportingTest.php` (5 tests, 48 assertions)
- `homeboy review lint --changed-since origin/main --placement local`: underlying PHPCS and PHPStan checks passed; the wrapper exits nonzero because registered validation dependency checkouts are stale
- `homeboy review test --changed-since origin/main`: unavailable before execution because the Codebox adapter lacks `WP_CODEBOX_DB_HOST`; focused local PHPUnit coverage above passed

## Production verification
After deployment, run:

```bash
wp --url=https://events.extrachill.com --path=/var/www/extrachill.com --allow-root eval 'print \"bootstrap-ok\\n\";'
```

Expected: `bootstrap-ok` with no `_load_textdomain_just_in_time` notice for `extrachill-events`. Also verify a representative Events ability remains registered through the normal CLI/ability listing.

Closes #509