### PR TITLE
fix: clear release lint blockers

### DIFF
--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -55,9 +55,6 @@ namespace ExtraChillEvents\Abilities;
 use DataMachine\Core\Selection\SelectionMode;
 use DataMachine\Abilities\HandlerAbilities;
 use ExtraChillEvents\Core\ArtistUrlSubmissionsTable;
-use function add_action;
-use function is_wp_error;
-use function wp_remote_retrieve_body;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -55,6 +55,9 @@ namespace ExtraChillEvents\Abilities;
 use DataMachine\Core\Selection\SelectionMode;
 use DataMachine\Abilities\HandlerAbilities;
 use ExtraChillEvents\Core\ArtistUrlSubmissionsTable;
+use function add_action;
+use function is_wp_error;
+use function wp_remote_retrieve_body;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -319,14 +322,16 @@ class ArtistUrlImportAbilities {
 	// ────────────────────────────────────────────────────────────────────
 
 	public function permissionLoggedIn(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		$is_cli = defined( 'WP_CLI' ) ? wp_validate_boolean( constant( 'WP_CLI' ) ) : false;
+		if ( $is_cli ) {
 			return true;
 		}
 		return is_user_logged_in();
 	}
 
 	public function permissionAdmin(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		$is_cli = defined( 'WP_CLI' ) ? wp_validate_boolean( constant( 'WP_CLI' ) ) : false;
+		if ( $is_cli ) {
 			return true;
 		}
 		return current_user_can( 'manage_options' );
@@ -336,7 +341,11 @@ class ArtistUrlImportAbilities {
 	// preview-artist-url
 	// ────────────────────────────────────────────────────────────────────
 
-	public function executePreview( array $input ): array|\WP_Error {
+	/**
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public function executePreview( array $input ) {
 		$raw_url = isset( $input['url'] ) ? (string) $input['url'] : '';
 		$url     = esc_url_raw( $raw_url );
 
@@ -407,7 +416,11 @@ class ArtistUrlImportAbilities {
 	// submit-artist-url
 	// ────────────────────────────────────────────────────────────────────
 
-	public function executeSubmit( array $input ): array|\WP_Error {
+	/**
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public function executeSubmit( array $input ) {
 		$raw_url = isset( $input['url'] ) ? (string) $input['url'] : '';
 		$url     = esc_url_raw( $raw_url );
 		if ( '' === $url ) {
@@ -559,7 +572,11 @@ class ArtistUrlImportAbilities {
 	// approve-artist-url-submission
 	// ────────────────────────────────────────────────────────────────────
 
-	public function executeApprove( array $input ): array|\WP_Error {
+	/**
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public function executeApprove( array $input ) {
 		$submission_id = (int) ( $input['submission_id'] ?? 0 );
 		if ( $submission_id <= 0 ) {
 			return new \WP_Error( 'invalid_submission_id', __( 'submission_id is required.', 'extrachill-events' ), array( 'status' => 400 ) );
@@ -715,7 +732,7 @@ class ArtistUrlImportAbilities {
 			$events_found_count
 		);
 		$artist_archive_link = get_term_link( $artist_term_id, 'artist' );
-		if ( is_wp_error( $artist_archive_link ) || ! is_string( $artist_archive_link ) || '' === $artist_archive_link ) {
+		if ( is_wp_error( $artist_archive_link ) || '' === $artist_archive_link ) {
 			$artist_archive_link = home_url();
 		}
 
@@ -755,7 +772,11 @@ class ArtistUrlImportAbilities {
 	// reject-artist-url-submission
 	// ────────────────────────────────────────────────────────────────────
 
-	public function executeReject( array $input ): array|\WP_Error {
+	/**
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public function executeReject( array $input ) {
 		$submission_id = (int) ( $input['submission_id'] ?? 0 );
 		if ( $submission_id <= 0 ) {
 			return new \WP_Error( 'invalid_submission_id', __( 'submission_id is required.', 'extrachill-events' ), array( 'status' => 400 ) );
@@ -954,10 +975,9 @@ class ArtistUrlImportAbilities {
 
 		// Fill in any handler defaults the same way test-handler does, so
 		// the probe matches a real flow run's config surface.
-		if ( method_exists( $abilities, 'applyDefaults' ) ) {
-			$config = $abilities->applyDefaults( self::SCRAPER_HANDLER_SLUG, $config );
-		}
+		$config = $abilities->applyDefaults( self::SCRAPER_HANDLER_SLUG, $config );
 
+		/** @var \DataMachine\Core\Steps\Fetch\Handlers\FetchHandler $handler */
 		$handler = new $handler_class();
 
 		try {
@@ -966,7 +986,7 @@ class ArtistUrlImportAbilities {
 			return new \WP_Error( 'scraper_failed', $e->getMessage(), array( 'status' => 502 ) );
 		}
 
-		return is_array( $results ) ? $results : array();
+		return $results;
 	}
 
 	/**
@@ -1160,13 +1180,13 @@ class ArtistUrlImportAbilities {
 
 		// Try an exact match first (cheap path, common case).
 		$exact = get_term_by( 'name', $name, 'artist' );
-		if ( $exact && ! is_wp_error( $exact ) ) {
+		if ( $exact instanceof \WP_Term ) {
 			return (int) $exact->term_id;
 		}
 
 		// Fall back to slug match — handles minor casing/punctuation drift.
 		$by_slug = get_term_by( 'slug', sanitize_title( $name ), 'artist' );
-		if ( $by_slug && ! is_wp_error( $by_slug ) ) {
+		if ( $by_slug instanceof \WP_Term ) {
 			return (int) $by_slug->term_id;
 		}
 
@@ -1223,7 +1243,7 @@ class ArtistUrlImportAbilities {
 
 		if ( $explicit_id > 0 ) {
 			$term = get_term( $explicit_id, 'artist' );
-			if ( $term && ! is_wp_error( $term ) ) {
+			if ( $term instanceof \WP_Term ) {
 				return (int) $term->term_id;
 			}
 		}
@@ -1231,7 +1251,7 @@ class ArtistUrlImportAbilities {
 		$explicit_name = trim( $explicit_name );
 		if ( '' !== $explicit_name ) {
 			$existing = get_term_by( 'name', $explicit_name, 'artist' );
-			if ( $existing && ! is_wp_error( $existing ) ) {
+			if ( $existing instanceof \WP_Term ) {
 				return (int) $existing->term_id;
 			}
 
@@ -1239,7 +1259,7 @@ class ArtistUrlImportAbilities {
 			if ( is_wp_error( $inserted ) ) {
 				// Slug collision — try slug lookup as a recovery.
 				$by_slug = get_term_by( 'slug', sanitize_title( $explicit_name ), 'artist' );
-				if ( $by_slug && ! is_wp_error( $by_slug ) ) {
+				if ( $by_slug instanceof \WP_Term ) {
 					return (int) $by_slug->term_id;
 				}
 				return new \WP_Error( 'artist_create_failed', $inserted->get_error_message(), array( 'status' => 500 ) );
@@ -1249,7 +1269,7 @@ class ArtistUrlImportAbilities {
 
 		if ( $suggested_id > 0 ) {
 			$term = get_term( $suggested_id, 'artist' );
-			if ( $term && ! is_wp_error( $term ) ) {
+			if ( $term instanceof \WP_Term ) {
 				return (int) $term->term_id;
 			}
 		}

--- a/inc/core/priority-boost-service-authority.php
+++ b/inc/core/priority-boost-service-authority.php
@@ -198,6 +198,5 @@ function extrachill_events_priority_boost_has_verified_service_authority(): bool
 
 	$claims = ec_cross_site_verified_service_context( $request );
 
-	return is_array( $claims )
-		&& extrachill_events_priority_boost_service_request_is_authorized( $request->get_method(), $request->get_route(), $claims, $grant );
+	return extrachill_events_priority_boost_service_request_is_authorized( $request->get_method(), $request->get_route(), $claims, $grant );
 }

--- a/tests/Integration/Stubs/persisted-qualification-stubs.php
+++ b/tests/Integration/Stubs/persisted-qualification-stubs.php
@@ -11,8 +11,11 @@ function wp_get_ability( string $name ) {
 	return $GLOBALS['ec_persisted_qualification_abilities'][ $name ] ?? null;
 }
 
-function is_wp_error(): bool {
-	return false;
+/**
+ * @phpstan-assert-if-true \WP_Error $thing
+ */
+function is_wp_error( $thing ): bool {
+	return $thing instanceof \WP_Error;
 }
 
 function wp_remote_get(): array {
@@ -42,10 +45,15 @@ class QualifyVerdictsTable {
 
 namespace ExtraChillEvents\Abilities;
 
-function add_action(): void {}
+function add_action( $hook_name, $callback, $priority = 10, $accepted_args = 1 ): bool {
+	return true;
+}
 
-function is_wp_error(): bool {
-	return false;
+/**
+ * @phpstan-assert-if-true \WP_Error $thing
+ */
+function is_wp_error( $thing ): bool {
+	return $thing instanceof \WP_Error;
 }
 
 function wp_remote_get(): array {
@@ -107,8 +115,11 @@ class EventIdentifierGenerator {
 
 namespace ExtraChillEvents\Cli;
 
-function is_wp_error(): bool {
-	return false;
+/**
+ * @phpstan-assert-if-true \WP_Error $thing
+ */
+function is_wp_error( $thing ): bool {
+	return $thing instanceof \WP_Error;
 }
 
 class FlowOps {


### PR DESCRIPTION
## Summary
- correct persisted-qualification WordPress test doubles at the owning test substrate so their call signatures and `WP_Error` behavior match production contracts
- keep artist URL import callbacks compatible with the plugin's PHP 7.4 floor and use concrete WordPress/Data Machine contracts for result narrowing
- remove the redundant priority-boost claims guard after Network's verified-context contract has already established the array shape

## Root Causes
- `tests/Integration/Stubs/persisted-qualification-stubs.php` declared zero-argument namespaced `add_action()` and `is_wp_error()` doubles; PHPStan resolved unqualified production calls against those inaccurate test signatures, producing argument-count errors and cascading union/type errors
- the stubbed `is_wp_error()` implementations always returned false, weakening test behavior and preventing static narrowing; they now recognize real `WP_Error` instances and expose the corresponding PHPStan assertion contract
- native union return declarations in `ArtistUrlImportAbilities` conflicted with the component's PHP 7.4 compatibility target
- defensive checks around contractually typed WordPress, Data Machine, and Network returns were reported as impossible or always true by the current release analyzer

## Review Repair
- removed the production `use function add_action`, `use function is_wp_error`, and `use function wp_remote_retrieve_body` aliases
- corrected the owning `Core`, `Abilities`, and `Cli` namespaced WordPress doubles instead
- preserved the legitimate PHP 7.4 callback declarations and dependency-contract narrowing
- added follow-up commit `c5aaf07 test: correct persisted qualification WordPress stubs` without rewriting branch history

## Verification
- `homeboy review lint extrachill-events --path /var/lib/datamachine/workspace/extrachill-events@fix-566-release-lint --changed-since v0.59.1 --placement local` (passes, zero findings; run `d9ee406e-a03e-472e-bee1-289363d1f7a7`)
- `vendor/bin/phpunit tests/AbilityRegistrationLifecycleTest.php` (1 test, 16 assertions)
- `vendor/bin/phpunit tests/Unit/Abilities/ArtistUrlImportConfigurationContractTest.php` (8 tests, 26 assertions)
- `vendor/bin/phpunit tests/Unit/Abilities/ArtistUrlImportNotificationTest.php` (2 tests, 10 assertions)
- `vendor/bin/phpunit tests/Unit/Abilities/PriorityBoostAbilityTest.php` (18 tests, 77 assertions)
- direct corrected-stub smoke covering all three namespaced `is_wp_error()` doubles and the real `add_action()` call shape (passes)
- `git diff --check` (passes)

## Residual Risk
- low: production aliases are removed; the analyzer now relies on accurate owning test doubles, and production behavior remains unchanged apart from PHP 7.4-compatible declarations and contract-equivalent narrowing
- the managed Homeboy relevant-test adapter cannot bootstrap in this shell because `WP_CODEBOX_DB_HOST` and the remaining external database-service secrets are unavailable; repository-wide local PHPUnit likewise requires the managed WordPress `WP_UnitTestCase` bootstrap. Focused affected suites pass with 29 tests and 129 assertions.

Fixes #566