### PR TITLE
feat: qualify generic event source intake

### DIFF
--- a/blocks/event-submission/render.php
+++ b/blocks/event-submission/render.php
@@ -18,16 +18,14 @@ $defaults   = array(
 );
 $attributes = wp_parse_args( $attributes, $defaults );
 
-$headline        = $attributes['headline'] ?? '';
-$description     = $attributes['description'] ?? '';
-$success_message = $attributes['successMessage'] ?? '';
-$button_label    = $attributes['buttonLabel'] ? $attributes['buttonLabel'] : __( 'Send Submission', 'extrachill-events' );
-$system_prompt   = $attributes['systemPrompt'] ?? '';
-$endpoint        = esc_url( rest_url( 'extrachill/v1/event-submissions' ) );
-// Artist URL import endpoints moved from the data-machine-events substrate to
-// this plugin's own extrachill/v1 namespace in extrachill-events#200.
-$preview_endpoint = esc_url( rest_url( 'extrachill/v1/artist-url/preview' ) );
-$submit_endpoint  = esc_url( rest_url( 'extrachill/v1/artist-url/submit' ) );
+$headline         = $attributes['headline'] ?? '';
+$description      = $attributes['description'] ?? '';
+$success_message  = $attributes['successMessage'] ?? '';
+$button_label     = $attributes['buttonLabel'] ? $attributes['buttonLabel'] : __( 'Send Submission', 'extrachill-events' );
+$system_prompt    = $attributes['systemPrompt'] ?? '';
+$endpoint         = esc_url( rest_url( 'extrachill/v1/event-submissions' ) );
+$preview_endpoint = esc_url( rest_url( 'extrachill/v1/event-source/preview' ) );
+$submit_endpoint  = esc_url( rest_url( 'extrachill/v1/event-source/submit' ) );
 $rest_nonce       = wp_create_nonce( 'wp_rest' );
 $form_id          = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'ec-event-form-' ) : 'ec-event-form-' . uniqid();
 
@@ -41,8 +39,8 @@ $success_attr = $success_message ? wp_strip_all_tags( $success_message ) : __( '
 <div
 	class="ec-event-submission"
 	data-endpoint="<?php echo esc_url( $endpoint ); ?>"
-	data-artist-url-preview="<?php echo esc_url( $preview_endpoint ); ?>"
-	data-artist-url-submit="<?php echo esc_url( $submit_endpoint ); ?>"
+	data-event-source-preview="<?php echo esc_url( $preview_endpoint ); ?>"
+	data-event-source-submit="<?php echo esc_url( $submit_endpoint ); ?>"
 	data-rest-nonce="<?php echo esc_attr( $rest_nonce ); ?>"
 	data-success-message="<?php echo esc_attr( $success_attr ); ?>"
 	data-system-prompt="<?php echo esc_attr( $system_prompt ); ?>"
@@ -59,16 +57,16 @@ $success_attr = $success_message ? wp_strip_all_tags( $success_message ) : __( '
 		<?php if ( is_user_logged_in() ) : ?>
 		<div class="ec-event-submission__url-import" data-state="idle">
 			<div class="ec-event-submission__url-import-intro">
-				<label for="<?php echo esc_attr( $form_id ); ?>-artist-url">
-					<strong><?php esc_html_e( 'Have an artist tour page?', 'extrachill-events' ); ?></strong>
+				<label for="<?php echo esc_attr( $form_id ); ?>-event-source-url">
+					<strong><?php esc_html_e( 'Have a reliable event source?', 'extrachill-events' ); ?></strong>
 				</label>
 				<p class="ec-event-submission__url-import-hint">
-					<?php esc_html_e( "Paste the URL and we'll import all their events automatically. Leave blank to submit a single event manually below.", 'extrachill-events' ); ?>
+					<?php esc_html_e( 'Try an artist tour page, venue calendar, or festival schedule. We will test it and review reliable recurring sources; use the manual form below for one event.', 'extrachill-events' ); ?>
 				</p>
 				<div class="ec-event-submission__url-import-row">
 					<input
 						type="url"
-						id="<?php echo esc_attr( $form_id ); ?>-artist-url"
+						id="<?php echo esc_attr( $form_id ); ?>-event-source-url"
 						class="ec-event-submission__url-import-input"
 						placeholder="https://"
 						autocomplete="off"

--- a/blocks/event-submission/view.js
+++ b/blocks/event-submission/view.js
@@ -124,7 +124,9 @@
 	// byte-identically when no URL is provided.
 	// ────────────────────────────────────────────────────────────────────
 
-	const urlImportTimeoutMs = 8000;
+	// Qualification may test a discovered calendar plus several bounded
+	// candidates. Keep the request finite without racing the server's work.
+	const urlImportTimeoutMs = 60000;
 
 	const fetchJson = async ( url, body, nonce ) => {
 		const controller = new AbortController();
@@ -284,6 +286,16 @@
 				if ( payload?.existing_coverage?.covered ) {
 					setUrlStatus(
 						'This source is already covered by an existing import.',
+						true
+					);
+					setState( 'error' );
+					showManualForm( container );
+					return;
+				}
+				if ( ! payload?.recurring_eligible ) {
+					setUrlStatus(
+						payload?.warnings?.[ 0 ] ||
+							'This page is not eligible for a recurring import. Use the manual form below.',
 						true
 					);
 					setState( 'error' );

--- a/blocks/event-submission/view.js
+++ b/blocks/event-submission/view.js
@@ -115,10 +115,10 @@
 	};
 
 	// ────────────────────────────────────────────────────────────────────
-	// Artist URL import (extrachill-events#320)
+	// Qualified event-source import (extrachill-events#628)
 	//
 	// Sits on top of the manual form. When the user types a URL into the
-	// import field, we probe it via `extrachill/v1/artist-url/preview`
+	// import field, we probe it via `extrachill/v1/event-source/preview`
 	// and, on success, swap the manual form for a confirmation panel
 	// (events found + Submit for review). The manual form keeps working
 	// byte-identically when no URL is provided.
@@ -217,8 +217,8 @@
 			'.ec-event-submission__url-import-cancel'
 		);
 
-		const previewUrl = container.dataset.artistUrlPreview;
-		const submitUrl = container.dataset.artistUrlSubmit;
+		const previewUrl = container.dataset.eventSourcePreview;
+		const submitUrl = container.dataset.eventSourceSubmit;
 		const nonce = container.dataset.restNonce;
 
 		const setState = ( state ) => {
@@ -281,12 +281,26 @@
 					showManualForm( container );
 					return;
 				}
+				if ( payload?.existing_coverage?.covered ) {
+					setUrlStatus(
+						'This source is already covered by an existing import.',
+						true
+					);
+					setState( 'error' );
+					showManualForm( container );
+					return;
+				}
 
 				const count = Number( payload?.events_found || 0 );
-				const artist = payload?.suggested_artist_name || 'this artist';
+				const binding = payload?.recommended_binding || {};
+				const sourceLabel =
+					binding.name ||
+					( payload?.source_kind === 'unknown'
+						? 'an unclassified source'
+						: `this ${ payload?.source_kind || 'source' }` );
 				summaryEl.textContent = `Found ${ count } event${
 					count === 1 ? '' : 's'
-				} from ${ artist }. Submit for review?`;
+				} from ${ sourceLabel }. Submit for review?`;
 				renderConfirmationEvents(
 					eventsListEl,
 					payload?.events_preview || []

--- a/blocks/event-submission/view.test.js
+++ b/blocks/event-submission/view.test.js
@@ -1,0 +1,84 @@
+const markup = `
+	<div class="ec-event-submission"
+		data-event-source-preview="/event-source/preview"
+		data-event-source-submit="/event-source/submit"
+		data-rest-nonce="nonce">
+		<div class="ec-event-submission__url-import" data-state="idle">
+			<input class="ec-event-submission__url-import-input" value="https://venue.test/events" />
+			<button class="ec-event-submission__url-import-try" type="button">Try</button>
+			<div class="ec-event-submission__url-import-status"></div>
+			<div class="ec-event-submission__url-import-confirm" hidden>
+				<p class="ec-event-submission__url-import-summary"></p>
+				<ul class="ec-event-submission__url-import-events"></ul>
+				<button class="ec-event-submission__url-import-submit" type="button">Submit</button>
+				<button class="ec-event-submission__url-import-cancel" type="button">Cancel</button>
+			</div>
+		</div>
+		<form class="ec-event-submission__form"><div class="ec-event-submission__status"></div></form>
+	</div>`;
+
+const initialize = () => {
+	document.body.innerHTML = markup;
+	jest.isolateModules( () => require( './view.js' ) );
+	document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+	return {
+		button: document.querySelector(
+			'.ec-event-submission__url-import-try'
+		),
+		status: document.querySelector(
+			'.ec-event-submission__url-import-status'
+		),
+		confirm: document.querySelector(
+			'.ec-event-submission__url-import-confirm'
+		),
+	};
+};
+
+describe( 'qualified event-source preview', () => {
+	afterEach( () => {
+		jest.useRealTimers();
+		jest.restoreAllMocks();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'allows the bounded 60-second qualification window before aborting', async () => {
+		jest.useFakeTimers();
+		global.fetch = jest.fn(
+			( url, options ) =>
+				new Promise( ( resolve, reject ) => {
+					options.signal.addEventListener( 'abort', () => {
+						const error = new Error( 'aborted' );
+						error.name = 'AbortError';
+						reject( error );
+					} );
+				} )
+		);
+		const ui = initialize();
+		ui.button.click();
+
+		jest.advanceTimersByTime( 59999 );
+		expect( ui.status.textContent ).toBe( 'Checking that URL…' );
+		jest.advanceTimersByTime( 1 );
+		await Promise.resolve();
+		await Promise.resolve();
+		expect( ui.status.textContent ).toContain( 'took too long' );
+	} );
+
+	it( 'does not offer submission for an ineligible preview', async () => {
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: true,
+			status: 200,
+			json: async () => ( {
+				success: true,
+				recurring_eligible: false,
+				warnings: [ 'Unbounded aggregator source.' ],
+			} ),
+		} );
+		const ui = initialize();
+		ui.button.click();
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( ui.status.textContent ).toBe( 'Unbounded aggregator source.' );
+		expect( ui.confirm.hidden ).toBe( true );
+	} );
+} );

--- a/blocks/event-submission/view.test.jsx
+++ b/blocks/event-submission/view.test.jsx
@@ -1,3 +1,5 @@
+/* global describe, afterEach, it, jest, expect */
+
 const markup = `
 	<div class="ec-event-submission"
 		data-event-source-preview="/event-source/preview"

--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -95,6 +95,17 @@ class ArtistUrlImportAbilities {
 	 */
 	private const ARTIST_FUZZY_MATCH_THRESHOLD = 85;
 
+	/** Host-owned platform/aggregator pages are not bounded recurring entities. */
+	private const UNSUPPORTED_SOURCE_HOSTS = array(
+		'axs.com'         => 'platform',
+		'bandsintown.com' => 'aggregator',
+		'dice.fm'         => 'platform',
+		'eventbrite.com'  => 'platform',
+		'jambase.com'     => 'aggregator',
+		'songkick.com'    => 'aggregator',
+		'allevents.in'    => 'aggregator',
+	);
+
 	/**
 	 * Default author for events published by an approved pipeline.
 	 */
@@ -197,7 +208,7 @@ class ArtistUrlImportAbilities {
 				'description'         => __( 'Discover and test a canonical recurring event source, classify its bounded domain identity, and recommend moderation routing.', 'extrachill-events' ),
 				'category'            => 'extrachill-events',
 				'input_schema'        => $qualify_schema,
-				'output_schema'       => array( 'type' => 'object' ),
+				'output_schema'       => $this->qualificationOutputSchema(),
 				'execute_callback'    => array( $this, 'executeQualifyEventSource' ),
 				'permission_callback' => array( $this, 'permissionLoggedIn' ),
 				'meta'                => array( 'show_in_rest' => true ),
@@ -211,7 +222,7 @@ class ArtistUrlImportAbilities {
 				'description'         => __( 'Compatibility-shaped preview of qualified event-source intake.', 'extrachill-events' ),
 				'category'            => 'extrachill-events',
 				'input_schema'        => $qualify_schema,
-				'output_schema'       => array( 'type' => 'object' ),
+				'output_schema'       => $this->qualificationOutputSchema(),
 				'execute_callback'    => array( $this, 'executePreview' ),
 				'permission_callback' => array( $this, 'permissionLoggedIn' ),
 				'meta'                => array( 'show_in_rest' => true ),
@@ -236,7 +247,21 @@ class ArtistUrlImportAbilities {
 						'contact_name'  => array( 'type' => 'string' ),
 					),
 				),
-				'output_schema'       => array( 'type' => 'object' ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'required'   => array( 'success', 'submission_id', 'status', 'message', 'events_found', 'source_kind' ),
+					'properties' => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'submission_id' => array( 'type' => 'integer' ),
+						'status'        => array( 'type' => 'string' ),
+						'message'       => array( 'type' => 'string' ),
+						'events_found'  => array( 'type' => 'integer' ),
+						'source_kind'   => array(
+							'type' => 'string',
+							'enum' => array( 'artist', 'venue' ),
+						),
+					),
+				),
 				'execute_callback'    => array( $this, 'executeSubmit' ),
 				'permission_callback' => array( $this, 'permissionLoggedIn' ),
 				'meta'                => array( 'show_in_rest' => true ),
@@ -269,7 +294,39 @@ class ArtistUrlImportAbilities {
 					'required'   => array( 'submission_id' ),
 					'properties' => $approval_properties,
 				),
-				'output_schema'       => array( 'type' => 'object' ),
+				'output_schema'       => array(
+					'oneOf' => array(
+						array(
+							'type'       => 'object',
+							'required'   => array( 'success', 'pipeline_id', 'flow_id', 'source_kind', 'artist_term_id' ),
+							'properties' => array(
+								'success'        => array( 'type' => 'boolean' ),
+								'pipeline_id'    => array( 'type' => 'integer' ),
+								'flow_id'        => array( 'type' => 'integer' ),
+								'source_kind'    => array(
+									'type' => 'string',
+									'enum' => array( 'artist' ),
+								),
+								'artist_term_id' => array( 'type' => 'integer' ),
+								'events_imported_immediately' => array( 'type' => array( 'integer', 'null' ) ),
+							),
+						),
+						array(
+							'type'       => 'object',
+							'required'   => array( 'success', 'pipeline_id', 'flow_id', 'source_kind', 'venue_term_id' ),
+							'properties' => array(
+								'success'       => array( 'type' => 'boolean' ),
+								'pipeline_id'   => array( 'type' => 'integer' ),
+								'flow_id'       => array( 'type' => 'integer' ),
+								'source_kind'   => array(
+									'type' => 'string',
+									'enum' => array( 'venue' ),
+								),
+								'venue_term_id' => array( 'type' => 'integer' ),
+							),
+						),
+					),
+				),
 				'execute_callback'    => array( $this, 'executeApprove' ),
 				'permission_callback' => array( $this, 'permissionAdmin' ),
 				'meta'                => array( 'show_in_rest' => true ),
@@ -290,11 +347,102 @@ class ArtistUrlImportAbilities {
 						'reason'        => array( 'type' => 'string' ),
 					),
 				),
-				'output_schema'       => array( 'type' => 'object' ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'required'   => array( 'success' ),
+					'properties' => array( 'success' => array( 'type' => 'boolean' ) ),
+				),
 				'execute_callback'    => array( $this, 'executeReject' ),
 				'permission_callback' => array( $this, 'permissionAdmin' ),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
+		);
+	}
+
+	/** JSON Schema for qualification and generic preview responses. */
+	private function qualificationOutputSchema(): array {
+		$binding = array(
+			'type'       => 'object',
+			'properties' => array(
+				'taxonomy' => array( 'type' => 'string' ),
+				'term_id'  => array( 'type' => array( 'integer', 'null' ) ),
+				'name'     => array( 'type' => 'string' ),
+			),
+		);
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'success', 'qualified', 'canonical_events_url', 'verdict', 'events_found', 'events_preview', 'extraction_method', 'source_kind', 'classification_confidence', 'entity_candidates', 'existing_coverage', 'warnings', 'recommended_route', 'recommended_binding', 'recurring_eligible' ),
+			'properties' => array(
+				'success'                   => array( 'type' => 'boolean' ),
+				'qualified'                 => array( 'type' => 'boolean' ),
+				'canonical_events_url'      => array(
+					'type'   => 'string',
+					'format' => 'uri',
+				),
+				'verdict'                   => array( 'type' => 'string' ),
+				'events_found'              => array( 'type' => 'integer' ),
+				'events_preview'            => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'title'     => array( 'type' => 'string' ),
+							'startDate' => array( 'type' => 'string' ),
+							'startTime' => array( 'type' => 'string' ),
+							'venue'     => array( 'type' => 'string' ),
+							'ticketUrl' => array( 'type' => 'string' ),
+						),
+					),
+				),
+				'extraction_method'         => array( 'type' => 'string' ),
+				'source_kind'               => array(
+					'type' => 'string',
+					'enum' => array( 'artist', 'venue', 'unknown' ),
+				),
+				'classification_confidence' => array(
+					'type' => 'string',
+					'enum' => array( 'low', 'medium', 'high' ),
+				),
+				'entity_candidates'         => array(
+					'type'  => 'array',
+					'items' => $binding,
+				),
+				'existing_coverage'         => array(
+					'type'       => 'object',
+					'required'   => array( 'covered', 'type' ),
+					'properties' => array(
+						'covered'   => array( 'type' => 'boolean' ),
+						'type'      => array( 'type' => 'string' ),
+						'flow_id'   => array( 'type' => 'integer' ),
+						'flow_name' => array( 'type' => 'string' ),
+					),
+				),
+				'warnings'                  => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'string' ),
+				),
+				'recommended_route'         => array(
+					'type' => 'string',
+					'enum' => array( 'moderation', 'reject_duplicate', 'explicit_review' ),
+				),
+				'recommended_binding'       => $binding,
+				'recurring_eligible'        => array( 'type' => 'boolean' ),
+				'scope_evidence'            => array(
+					'type'       => 'object',
+					'required'   => array( 'bounded', 'type', 'host' ),
+					'properties' => array(
+						'bounded'          => array( 'type' => 'boolean' ),
+						'type'             => array( 'type' => 'string' ),
+						'host'             => array( 'type' => 'string' ),
+						'official_host'    => array( 'type' => 'string' ),
+						'event_page_shape' => array( 'type' => 'string' ),
+					),
+				),
+				'detected_format'           => array( 'type' => 'string' ),
+				'source_metadata'           => array( 'type' => 'object' ),
+				'suggested_artist_name'     => array( 'type' => 'string' ),
+				'suggested_artist_term_id'  => array( 'type' => array( 'integer', 'null' ) ),
+			),
 		);
 	}
 
@@ -475,8 +623,19 @@ class ArtistUrlImportAbilities {
 
 	/** Artist approval compatibility alias. */
 	public function executeArtistApprove( array $input ) {
-		$input['source_kind'] = 'artist';
+		$input['source_kind']   = 'artist';
+		$input['compat_artist'] = true;
 		return $this->executeApprove( $input );
+	}
+
+	/** Testable admission seam; mutations must always call this fresh. */
+	protected function qualifyForAdmission( string $url, bool $compat_artist = false ) {
+		return $this->executeQualifyEventSource(
+			array(
+				'url'           => $url,
+				'compat_artist' => $compat_artist,
+			)
+		);
 	}
 
 	/**
@@ -531,7 +690,14 @@ class ArtistUrlImportAbilities {
 			}
 		}
 
-		$classification = $this->classifySource( $canonical_url, $probe, ! empty( $input['compat_artist'] ) );
+		$host_scope = $this->unsupportedHostScope( $canonical_url );
+		if ( $host_scope && empty( $coverage['covered'] ) ) {
+			$coverage = array(
+				'covered' => false,
+				'type'    => 'unsupported_' . $host_scope,
+			);
+		}
+		$classification = $this->classifySource( $canonical_url, $probe, $qualification, ! empty( $input['compat_artist'] ) );
 		$warnings       = array_values( array_unique( array_merge( (array) ( $qualification['warnings'] ?? array() ), $classification['warnings'] ) ) );
 		if ( ! empty( $coverage['covered'] ) ) {
 			$warnings[] = __( 'This source is already covered and should not create another recurring flow.', 'extrachill-events' );
@@ -555,6 +721,7 @@ class ArtistUrlImportAbilities {
 			'extraction_method'         => $extraction_method,
 			'source_kind'               => $classification['source_kind'],
 			'classification_confidence' => $classification['confidence'],
+			'scope_evidence'            => $classification['scope_evidence'],
 			'entity_candidates'         => $classification['candidates'],
 			'existing_coverage'         => $coverage,
 			'warnings'                  => array_values( array_unique( $warnings ) ),
@@ -585,7 +752,7 @@ class ArtistUrlImportAbilities {
 	}
 
 	/** Classify bounded artist/venue identity from repeated extracted events. */
-	private function classifySource( string $url, array $probe, bool $force_artist = false ): array {
+	protected function classifySource( string $url, array $probe, array $qualification = array(), bool $force_artist = false ): array {
 		$venues     = array();
 		$performers = array();
 		foreach ( (array) ( $probe['raw_events'] ?? array() ) as $event ) {
@@ -626,52 +793,115 @@ class ArtistUrlImportAbilities {
 			);
 		}
 
-		$kind       = 'unknown';
-		$confidence = 'low';
-		$warnings   = array();
-		$binding    = array(
+		$kind              = 'unknown';
+		$confidence        = 'low';
+		$warnings          = array();
+		$scope_evidence    = array(
+			'bounded'          => false,
+			'type'             => 'none',
+			'host'             => strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) ),
+			'event_page_shape' => (string) ( $qualification['fingerprint']['structured_data']['event_page_shape'] ?? '' ),
+		);
+		$binding           = array(
 			'taxonomy' => '',
 			'term_id'  => null,
 			'name'     => '',
 		);
-		if ( $force_artist ) {
-			$kind       = 'artist';
-			$confidence = null !== $artist['term_id'] ? 'high' : 'medium';
-			$binding    = array(
-				'taxonomy' => 'artist',
-				'term_id'  => $artist['term_id'],
-				'name'     => $artist['name'],
+		$unsupported_scope = $this->unsupportedHostScope( $url );
+		if ( $unsupported_scope ) {
+			$warnings[] = sprintf(
+				/* translators: %s: unsupported source scope. */
+				__( 'This %s host is not a bounded artist or venue source.', 'extrachill-events' ),
+				$unsupported_scope
 			);
 		} elseif ( (int) $probe['events_found'] < 2 ) {
 			$warnings[] = __( 'A one-off event page is not enough evidence for a recurring source.', 'extrachill-events' );
 		} elseif ( 1 === count( $venues ) && count( $performers ) > 1 ) {
-			$kind       = 'venue';
-			$confidence = null !== $venue_term_id ? 'high' : 'medium';
-			$binding    = array(
-				'taxonomy' => 'venue',
-				'term_id'  => $venue_term_id,
-				'name'     => $venue_name,
-			);
+			$ownership = $this->venueOwnershipEvidence( $venue_term_id, $url );
+			if ( $ownership['bounded'] ) {
+				$kind           = 'venue';
+				$confidence     = 'high';
+				$scope_evidence = $ownership;
+				$binding        = array(
+					'taxonomy' => 'venue',
+					'term_id'  => $venue_term_id,
+					'name'     => $venue_name,
+				);
+			} else {
+				$warnings[] = __( 'Repeated venue data does not prove that this host is the venue’s official source.', 'extrachill-events' );
+			}
 		} elseif ( 1 === count( $performers ) && count( $venues ) > 1 ) {
 			$performer_name = (string) reset( $performers );
 			$performer_id   = $this->matchTerm( $performer_name, 'artist' );
 			$kind           = 'artist';
 			$confidence     = null !== $performer_id ? 'high' : 'medium';
+			$scope_evidence = array(
+				'bounded' => true,
+				'type'    => 'single_performer_multiple_venues',
+				'host'    => strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) ),
+			);
 			$binding        = array(
 				'taxonomy' => 'artist',
 				'term_id'  => $performer_id,
 				'name'     => $performer_name,
+			);
+		} elseif ( $force_artist && count( $venues ) > 1 && null !== $artist['term_id'] ) {
+			$kind           = 'artist';
+			$confidence     = 'high';
+			$scope_evidence = array(
+				'bounded' => true,
+				'type'    => 'legacy_artist_identity_multiple_venues',
+				'host'    => strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) ),
+			);
+			$binding        = array(
+				'taxonomy' => 'artist',
+				'term_id'  => $artist['term_id'],
+				'name'     => $artist['name'],
 			);
 		} else {
 			$warnings[] = __( 'The extracted events do not establish one bounded artist or venue identity.', 'extrachill-events' );
 		}
 
 		return array(
-			'source_kind' => $kind,
-			'confidence'  => $confidence,
-			'candidates'  => $candidates,
-			'warnings'    => $warnings,
-			'binding'     => $binding,
+			'source_kind'    => $kind,
+			'confidence'     => $confidence,
+			'candidates'     => $candidates,
+			'warnings'       => $warnings,
+			'binding'        => $binding,
+			'scope_evidence' => $scope_evidence,
+		);
+	}
+
+	/** Return the unsupported scope for a known platform/aggregator host. */
+	private function unsupportedHostScope( string $url ): string {
+		$host = strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) );
+		$host = preg_replace( '/^www\./', '', $host );
+		foreach ( self::UNSUPPORTED_SOURCE_HOSTS as $domain => $scope ) {
+			if ( $host === $domain || str_ends_with( $host, '.' . $domain ) ) {
+				return $scope;
+			}
+		}
+		return '';
+	}
+
+	/** Prove venue ownership by matching the source to its stored official website. */
+	private function venueOwnershipEvidence( ?int $venue_term_id, string $url ): array {
+		$source_host = strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) );
+		$website     = '';
+		if ( $venue_term_id && function_exists( 'data_machine_events_get_venue_data' ) ) {
+			$data    = data_machine_events_get_venue_data( $venue_term_id );
+			$website = is_array( $data ) ? (string) ( $data['website'] ?? '' ) : '';
+		} elseif ( $venue_term_id ) {
+			$website = (string) get_term_meta( $venue_term_id, '_venue_website', true );
+		}
+		$website_host = strtolower( (string) wp_parse_url( $website, PHP_URL_HOST ) );
+		$matches      = '' !== $source_host && '' !== $website_host
+			&& ( $source_host === $website_host || str_ends_with( $source_host, '.' . $website_host ) || str_ends_with( $website_host, '.' . $source_host ) );
+		return array(
+			'bounded'       => $matches,
+			'type'          => $matches ? 'official_venue_website' : 'unverified_venue_host',
+			'host'          => $source_host,
+			'official_host' => $website_host,
 		);
 	}
 
@@ -697,16 +927,8 @@ class ArtistUrlImportAbilities {
 			return $normalized;
 		}
 
-		$hash     = ArtistUrlSubmissionsTable::url_hash( $normalized );
-		$existing = ArtistUrlSubmissionsTable::find_by_hash( $hash );
-		if ( $existing && in_array(
-			$existing['status'],
-			array(
-				ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
-				ArtistUrlSubmissionsTable::STATUS_APPROVED,
-			),
-			true
-		) ) {
+		$existing = ArtistUrlSubmissionsTable::find_tracked_by_url( $normalized );
+		if ( $existing ) {
 			return new \WP_Error(
 				'url_already_tracked',
 				__( 'This URL is already being tracked.', 'extrachill-events' ),
@@ -718,18 +940,12 @@ class ArtistUrlImportAbilities {
 			);
 		}
 
-		$result = $this->executeQualifyEventSource(
-			array(
-				'url'           => $normalized,
-				'compat_artist' => ! empty( $input['compat_artist'] ),
-			)
-		);
+		$result = $this->qualifyForAdmission( $normalized, ! empty( $input['compat_artist'] ) );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
-		$canonical_hash = ArtistUrlSubmissionsTable::url_hash( (string) $result['canonical_events_url'] );
-		$canonical_row  = ArtistUrlSubmissionsTable::find_by_hash( $canonical_hash );
-		if ( $canonical_row && in_array( $canonical_row['status'], array( ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW, ArtistUrlSubmissionsTable::STATUS_APPROVED ), true ) ) {
+		$canonical_row = ArtistUrlSubmissionsTable::find_tracked_by_url( (string) $result['canonical_events_url'] );
+		if ( $canonical_row ) {
 			return new \WP_Error(
 				'url_already_tracked',
 				__( 'This event source is already being tracked.', 'extrachill-events' ),
@@ -766,16 +982,8 @@ class ArtistUrlImportAbilities {
 			return $normalized;
 		}
 
-		$hash     = ArtistUrlSubmissionsTable::url_hash( $normalized );
-		$existing = ArtistUrlSubmissionsTable::find_by_hash( $hash );
-		if ( $existing && in_array(
-			$existing['status'],
-			array(
-				ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
-				ArtistUrlSubmissionsTable::STATUS_APPROVED,
-			),
-			true
-		) ) {
+		$existing = ArtistUrlSubmissionsTable::find_tracked_by_url( $normalized );
+		if ( $existing ) {
 			return new \WP_Error(
 				'url_already_tracked',
 				__( 'This URL is already being tracked.', 'extrachill-events' ),
@@ -808,47 +1016,19 @@ class ArtistUrlImportAbilities {
 		}
 
 		// Re-qualify server-side regardless of what the preview saw.
-		$qualification = $this->executeQualifyEventSource(
-			array(
-				'url'           => $normalized,
-				'compat_artist' => ! empty( $input['compat_artist'] ),
-			)
-		);
+		$qualification = $this->qualifyForAdmission( $normalized, ! empty( $input['compat_artist'] ) );
 
-		if ( is_wp_error( $qualification ) || 0 === ( $qualification['events_found'] ?? 0 ) ) {
-			$submission_id = ArtistUrlSubmissionsTable::insert(
+		if ( is_wp_error( $qualification ) ) {
+			return $qualification;
+		}
+		if ( empty( $qualification['recurring_eligible'] ) ) {
+			return new \WP_Error(
+				'source_not_admissible',
+				__( 'This page is not eligible for a recurring event import. Submit individual events with the manual form.', 'extrachill-events' ),
 				array(
-					'user_id'            => $user_id,
-					'contact_email'      => $contact_email,
-					'contact_name'       => $contact_name,
-					'url'                => $normalized,
-					'url_hash'           => $hash,
-					'detected_format'    => '',
-					'events_found_count' => 0,
-					'status'             => ArtistUrlSubmissionsTable::STATUS_SCRAPING_FAILED,
+					'status'        => 422,
+					'qualification' => $qualification,
 				)
-			);
-
-			if ( null !== $submission_id ) {
-				$this->notifyAdminSubmission(
-					array(
-						'url'                   => $normalized,
-						'contact_name'          => $contact_name,
-						'contact_email'         => $contact_email,
-						'detected_format'       => '',
-						'events_found_count'    => 0,
-						'suggested_artist_name' => '',
-						'status'                => ArtistUrlSubmissionsTable::STATUS_SCRAPING_FAILED,
-					)
-				);
-			}
-
-			return array(
-				'success'       => false,
-				'submission_id' => (int) $submission_id,
-				'status'        => ArtistUrlSubmissionsTable::STATUS_SCRAPING_FAILED,
-				'message'       => __( "We couldn't extract events from that page. Try the manual form below.", 'extrachill-events' ),
-				'events_found'  => 0,
 			);
 		}
 
@@ -864,8 +1044,8 @@ class ArtistUrlImportAbilities {
 		}
 		$canonical_url  = (string) ( $qualification['canonical_events_url'] ?? $normalized );
 		$canonical_hash = ArtistUrlSubmissionsTable::url_hash( $canonical_url );
-		$canonical_row  = ArtistUrlSubmissionsTable::find_by_hash( $canonical_hash );
-		if ( $canonical_row && in_array( $canonical_row['status'], array( ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW, ArtistUrlSubmissionsTable::STATUS_APPROVED ), true ) ) {
+		$canonical_row  = ArtistUrlSubmissionsTable::find_tracked_by_url( $canonical_url );
+		if ( $canonical_row ) {
 			return new \WP_Error(
 				'url_already_tracked',
 				__( 'This event source is already being tracked.', 'extrachill-events' ),
@@ -971,20 +1151,96 @@ class ArtistUrlImportAbilities {
 			);
 		}
 
+		$compat_artist = ! empty( $input['compat_artist'] ) || ! empty( $submission['compatibility_legacy'] );
+		$fresh         = $this->qualifyForAdmission( (string) ( $submission['canonical_url'] ?? $submission['url'] ), $compat_artist );
+		if ( is_wp_error( $fresh ) ) {
+			return $fresh;
+		}
+		if ( empty( $fresh['recurring_eligible'] ) ) {
+			return new \WP_Error(
+				'source_no_longer_admissible',
+				__( 'Fresh qualification no longer admits this source for a recurring import.', 'extrachill-events' ),
+				array(
+					'status'        => 409,
+					'qualification' => $fresh,
+				)
+			);
+		}
+
 		$source_kind = $this->resolveApprovalKind( (string) ( $submission['source_kind'] ?? 'artist' ), $input['source_kind'] ?? null );
 		if ( is_wp_error( $source_kind ) ) {
 			return $source_kind;
 		}
+		if ( $source_kind !== (string) $fresh['source_kind'] ) {
+			return new \WP_Error(
+				'source_kind_changed',
+				__( 'Fresh qualification does not match the selected source kind.', 'extrachill-events' ),
+				array(
+					'status'        => 409,
+					'qualification' => $fresh,
+				)
+			);
+		}
+		$duplicate = ArtistUrlSubmissionsTable::find_tracked_by_url( (string) $fresh['canonical_events_url'], $submission_id );
+		if ( $duplicate ) {
+			return new \WP_Error(
+				'source_already_covered',
+				__( 'Another moderation record already tracks this canonical event source.', 'extrachill-events' ),
+				array(
+					'status'        => 409,
+					'submission_id' => (int) $duplicate['id'],
+				)
+			);
+		}
+
+		$fresh_binding = (array) ( $fresh['recommended_binding'] ?? array() );
+		ArtistUrlSubmissionsTable::update(
+			$submission_id,
+			array(
+				'canonical_url'         => (string) $fresh['canonical_events_url'],
+				'source_kind'           => $source_kind,
+				'entity_taxonomy'       => (string) ( $fresh_binding['taxonomy'] ?? '' ),
+				'entity_term_id'        => isset( $fresh_binding['term_id'] ) ? (int) $fresh_binding['term_id'] : null,
+				'entity_name'           => (string) ( $fresh_binding['name'] ?? '' ),
+				'qualification_verdict' => (string) $fresh['verdict'],
+				'qualification_data'    => wp_json_encode( $fresh ),
+				'detected_format'       => (string) $fresh['extraction_method'],
+				'events_found_count'    => (int) $fresh['events_found'],
+			)
+		);
+		$submission['canonical_url']  = (string) $fresh['canonical_events_url'];
+		$submission['entity_term_id'] = $fresh_binding['term_id'] ?? null;
+		$submission['entity_name']    = (string) ( $fresh_binding['name'] ?? '' );
 
 		if ( 'venue' === $source_kind ) {
+			$fresh_venue_id = (int) ( $fresh_binding['term_id'] ?? 0 );
+			$selected_id    = (int) ( $input['venue_term_id'] ?? $input['entity_term_id'] ?? $fresh_venue_id );
+			if ( $fresh_venue_id <= 0 || $selected_id !== $fresh_venue_id ) {
+				return new \WP_Error( 'venue_identity_changed', __( 'Venue approval must use the canonical venue proven by fresh qualification.', 'extrachill-events' ), array( 'status' => 409 ) );
+			}
+			$pipeline_check = ( new VenueAddAbilities() )->validateCityPipeline( (int) ( $input['pipeline_id'] ?? 0 ) );
+			if ( is_wp_error( $pipeline_check ) ) {
+				return $pipeline_check;
+			}
+			$input['venue_term_id'] = $fresh_venue_id;
+			$input['venue_name']    = (string) ( $fresh_binding['name'] ?? '' );
 			return $this->approveVenueSubmission( $submission_id, $submission, $input );
 		}
 
 		// Resolve artist term.
+		$fresh_artist_id = (int) ( $fresh_binding['term_id'] ?? 0 );
+		$explicit_id     = isset( $input['artist_term_id'] ) ? (int) $input['artist_term_id'] : (int) ( $input['entity_term_id'] ?? 0 );
+		$explicit_name   = isset( $input['artist_name'] ) ? (string) $input['artist_name'] : (string) ( $input['entity_name'] ?? '' );
+		if ( $fresh_artist_id > 0 && $explicit_id > 0 && $fresh_artist_id !== $explicit_id ) {
+			return new \WP_Error( 'artist_identity_changed', __( 'Artist approval must use the artist proven by fresh qualification.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		if ( '' !== trim( $explicit_name ) && '' !== (string) ( $fresh_binding['name'] ?? '' ) && 0 !== strcasecmp( trim( $explicit_name ), trim( (string) $fresh_binding['name'] ) ) ) {
+			return new \WP_Error( 'artist_identity_changed', __( 'Artist approval must use the artist proven by fresh qualification.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
 		$artist_term_id = $this->resolveArtistTerm(
-			isset( $input['artist_term_id'] ) ? (int) $input['artist_term_id'] : (int) ( $input['entity_term_id'] ?? 0 ),
-			isset( $input['artist_name'] ) ? (string) $input['artist_name'] : (string) ( $input['entity_name'] ?? '' ),
-			isset( $submission['suggested_artist_term_id'] ) ? (int) $submission['suggested_artist_term_id'] : (int) ( $submission['entity_term_id'] ?? 0 )
+			$explicit_id,
+			'' !== trim( $explicit_name ) ? $explicit_name : (string) ( $fresh_binding['name'] ?? '' ),
+			$fresh_artist_id
 		);
 
 		if ( is_wp_error( $artist_term_id ) ) {
@@ -1148,6 +1404,7 @@ class ArtistUrlImportAbilities {
 			'success'                     => true,
 			'pipeline_id'                 => $pipeline_id,
 			'flow_id'                     => $flow_id,
+			'source_kind'                 => 'artist',
 			'artist_term_id'              => $artist_term_id,
 			'events_imported_immediately' => $events_imported_immediately,
 		);

--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -55,6 +55,7 @@ namespace ExtraChillEvents\Abilities;
 use DataMachine\Core\Selection\SelectionMode;
 use DataMachine\Abilities\HandlerAbilities;
 use ExtraChillEvents\Core\ArtistUrlSubmissionsTable;
+use ExtraChillEvents\Core\VenueExpansionRunner;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -166,6 +167,7 @@ class ArtistUrlImportAbilities {
 	 */
 	private function registerAbilities(): void {
 		$register_callback = function () {
+			$this->registerGenericAbilities();
 			$this->registerPreviewAbility();
 			$this->registerSubmitAbility();
 			$this->registerApproveAbility();
@@ -173,6 +175,127 @@ class ArtistUrlImportAbilities {
 		};
 
 		add_action( 'wp_abilities_api_init', $register_callback );
+	}
+
+	/** Register the Phase 1 source-neutral contracts. */
+	private function registerGenericAbilities(): void {
+		$qualify_schema = array(
+			'type'       => 'object',
+			'required'   => array( 'url' ),
+			'properties' => array(
+				'url' => array(
+					'type'   => 'string',
+					'format' => 'uri',
+				),
+			),
+		);
+
+		wp_register_ability(
+			'extrachill/qualify-event-source',
+			array(
+				'label'               => __( 'Qualify Event Source', 'extrachill-events' ),
+				'description'         => __( 'Discover and test a canonical recurring event source, classify its bounded domain identity, and recommend moderation routing.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => $qualify_schema,
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => array( $this, 'executeQualifyEventSource' ),
+				'permission_callback' => array( $this, 'permissionLoggedIn' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		wp_register_ability(
+			'extrachill-events/preview-event-source',
+			array(
+				'label'               => __( 'Preview Event Source', 'extrachill-events' ),
+				'description'         => __( 'Compatibility-shaped preview of qualified event-source intake.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => $qualify_schema,
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => array( $this, 'executePreview' ),
+				'permission_callback' => array( $this, 'permissionLoggedIn' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		wp_register_ability(
+			'extrachill-events/submit-event-source',
+			array(
+				'label'               => __( 'Submit Event Source', 'extrachill-events' ),
+				'description'         => __( 'Server-side requalify and persist an event source for moderation.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'url' ),
+					'properties' => array(
+						'url'           => array(
+							'type'   => 'string',
+							'format' => 'uri',
+						),
+						'contact_email' => array( 'type' => 'string' ),
+						'contact_name'  => array( 'type' => 'string' ),
+					),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => array( $this, 'executeSubmit' ),
+				'permission_callback' => array( $this, 'permissionLoggedIn' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		$approval_properties = array(
+			'submission_id'     => array( 'type' => 'integer' ),
+			'source_kind'       => array(
+				'type' => 'string',
+				'enum' => array( 'artist', 'venue', 'unknown' ),
+			),
+			'entity_term_id'    => array( 'type' => 'integer' ),
+			'entity_name'       => array( 'type' => 'string' ),
+			'artist_term_id'    => array( 'type' => 'integer' ),
+			'artist_name'       => array( 'type' => 'string' ),
+			'venue_term_id'     => array( 'type' => 'integer' ),
+			'venue_name'        => array( 'type' => 'string' ),
+			'pipeline_id'       => array( 'type' => 'integer' ),
+			'schedule_interval' => array( 'type' => 'string' ),
+		);
+		wp_register_ability(
+			'extrachill-events/approve-event-source-submission',
+			array(
+				'label'               => __( 'Approve Event Source Submission', 'extrachill-events' ),
+				'description'         => __( 'Approve a moderated artist or venue source through its existing owner flow primitive.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'submission_id' ),
+					'properties' => $approval_properties,
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => array( $this, 'executeApprove' ),
+				'permission_callback' => array( $this, 'permissionAdmin' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		wp_register_ability(
+			'extrachill-events/reject-event-source-submission',
+			array(
+				'label'               => __( 'Reject Event Source Submission', 'extrachill-events' ),
+				'description'         => __( 'Reject a moderated event source.', 'extrachill-events' ),
+				'category'            => 'extrachill-events',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'submission_id' ),
+					'properties' => array(
+						'submission_id' => array( 'type' => 'integer' ),
+						'reason'        => array( 'type' => 'string' ),
+					),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => array( $this, 'executeReject' ),
+				'permission_callback' => array( $this, 'permissionAdmin' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
 	}
 
 	// ────────────────────────────────────────────────────────────────────
@@ -209,7 +332,7 @@ class ArtistUrlImportAbilities {
 						'source_metadata'          => array( 'type' => 'object' ),
 					),
 				),
-				'execute_callback'    => array( $this, 'executePreview' ),
+				'execute_callback'    => array( $this, 'executeArtistPreview' ),
 				'permission_callback' => array( $this, 'permissionLoggedIn' ),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
@@ -245,7 +368,7 @@ class ArtistUrlImportAbilities {
 						'events_found'  => array( 'type' => 'integer' ),
 					),
 				),
-				'execute_callback'    => array( $this, 'executeSubmit' ),
+				'execute_callback'    => array( $this, 'executeArtistSubmit' ),
 				'permission_callback' => array( $this, 'permissionLoggedIn' ),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
@@ -279,7 +402,7 @@ class ArtistUrlImportAbilities {
 						'events_imported_immediately' => array( 'type' => array( 'integer', 'null' ) ),
 					),
 				),
-				'execute_callback'    => array( $this, 'executeApprove' ),
+				'execute_callback'    => array( $this, 'executeArtistApprove' ),
 				'permission_callback' => array( $this, 'permissionAdmin' ),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
@@ -338,28 +461,240 @@ class ArtistUrlImportAbilities {
 	// preview-artist-url
 	// ────────────────────────────────────────────────────────────────────
 
+	/** Artist ability compatibility alias. */
+	public function executeArtistPreview( array $input ) {
+		$input['compat_artist'] = true;
+		return $this->executePreview( $input );
+	}
+
+	/** Artist submission compatibility alias. */
+	public function executeArtistSubmit( array $input ) {
+		$input['compat_artist'] = true;
+		return $this->executeSubmit( $input );
+	}
+
+	/** Artist approval compatibility alias. */
+	public function executeArtistApprove( array $input ) {
+		$input['source_kind'] = 'artist';
+		return $this->executeApprove( $input );
+	}
+
+	/**
+	 * Source-neutral qualification facade over the existing venue qualifier
+	 * and Data Machine Events scraper handler.
+	 */
+	public function executeQualifyEventSource( array $input ) {
+		$url = $this->normalizeInputUrl( (string) ( $input['url'] ?? '' ) );
+		if ( is_wp_error( $url ) ) {
+			return $url;
+		}
+
+		$qualification = ( new VenueQualificationAbilities() )->executeQualifyVenue(
+			array(
+				'url'             => $url,
+				'persist_verdict' => true,
+			)
+		);
+		if ( is_wp_error( $qualification ) ) {
+			return $qualification;
+		}
+
+		$canonical_url = ArtistUrlSubmissionsTable::normalize_url( (string) ( $qualification['events_url'] ?? $url ) );
+		if ( '' === $canonical_url ) {
+			$canonical_url = $url;
+		}
+		$probe = $this->probeUrl( $canonical_url );
+		if ( is_wp_error( $probe ) ) {
+			return $probe;
+		}
+
+		$coverage = array(
+			'covered' => false,
+			'type'    => 'none',
+		);
+		$flow     = ( new VenueExpansionRunner() )->lookupExistingFlow( $canonical_url );
+		if ( $flow ) {
+			$coverage = array(
+				'covered'   => true,
+				'type'      => 'universal_scraper_flow',
+				'flow_id'   => (int) ( $flow['flow_id'] ?? 0 ),
+				'flow_name' => (string) ( $flow['flow_name'] ?? '' ),
+			);
+		}
+		foreach ( (array) ( $qualification['warnings'] ?? array() ) as $warning ) {
+			if ( false !== stripos( (string) $warning, 'already covered' ) ) {
+				$coverage = array(
+					'covered' => true,
+					'type'    => 'platform_pipeline',
+				);
+				break;
+			}
+		}
+
+		$classification = $this->classifySource( $canonical_url, $probe, ! empty( $input['compat_artist'] ) );
+		$warnings       = array_values( array_unique( array_merge( (array) ( $qualification['warnings'] ?? array() ), $classification['warnings'] ) ) );
+		if ( ! empty( $coverage['covered'] ) ) {
+			$warnings[] = __( 'This source is already covered and should not create another recurring flow.', 'extrachill-events' );
+		}
+
+		$recurring_eligible = ! empty( $qualification['qualified'] )
+			&& (int) $probe['events_found'] >= 2
+			&& in_array( $classification['source_kind'], array( 'artist', 'venue' ), true )
+			&& empty( $coverage['covered'] );
+		$extraction_method  = '' !== (string) $probe['detected_format']
+			? (string) $probe['detected_format']
+			: (string) ( $qualification['method'] ?? '' );
+
+		return array(
+			'success'                   => (int) $probe['events_found'] > 0,
+			'qualified'                 => ! empty( $qualification['qualified'] ),
+			'canonical_events_url'      => $canonical_url,
+			'verdict'                   => (string) ( $qualification['verdict'] ?? '' ),
+			'events_found'              => (int) $probe['events_found'],
+			'events_preview'            => $probe['events_preview'],
+			'extraction_method'         => $extraction_method,
+			'source_kind'               => $classification['source_kind'],
+			'classification_confidence' => $classification['confidence'],
+			'entity_candidates'         => $classification['candidates'],
+			'existing_coverage'         => $coverage,
+			'warnings'                  => array_values( array_unique( $warnings ) ),
+			'recommended_route'         => $recurring_eligible ? 'moderation' : ( ! empty( $coverage['covered'] ) ? 'reject_duplicate' : 'explicit_review' ),
+			'recommended_binding'       => $classification['binding'],
+			'recurring_eligible'        => $recurring_eligible,
+			'detected_format'           => (string) $probe['detected_format'],
+			'source_metadata'           => $probe['source_metadata'],
+			'suggested_artist_name'     => 'artist' === $classification['source_kind'] ? (string) ( $classification['binding']['name'] ?? '' ) : '',
+			'suggested_artist_term_id'  => 'artist' === $classification['source_kind'] ? ( $classification['binding']['term_id'] ?? null ) : null,
+		);
+	}
+
+	/** Validate and normalize an http(s) source URL. */
+	private function normalizeInputUrl( string $raw_url ) {
+		$url = esc_url_raw( $raw_url );
+		if ( '' === $url ) {
+			return new \WP_Error( 'invalid_url', __( 'URL is required.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
+		if ( ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
+			return new \WP_Error( 'invalid_protocol', __( 'Only http and https URLs are supported.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		$normalized = ArtistUrlSubmissionsTable::normalize_url( $url );
+		return '' === $normalized
+			? new \WP_Error( 'invalid_url', __( 'URL could not be parsed.', 'extrachill-events' ), array( 'status' => 400 ) )
+			: $normalized;
+	}
+
+	/** Classify bounded artist/venue identity from repeated extracted events. */
+	private function classifySource( string $url, array $probe, bool $force_artist = false ): array {
+		$venues     = array();
+		$performers = array();
+		foreach ( (array) ( $probe['raw_events'] ?? array() ) as $event ) {
+			$venue = $event['venue'] ?? '';
+			if ( is_array( $venue ) ) {
+				$venue = $venue['name'] ?? '';
+			}
+			$performer = $event['performer'] ?? $event['artist'] ?? '';
+			if ( is_array( $performer ) ) {
+				$performer = $performer['name'] ?? '';
+			}
+			if ( is_string( $venue ) && '' !== trim( $venue ) ) {
+				$venues[ strtolower( trim( $venue ) ) ] = trim( $venue );
+			}
+			if ( is_string( $performer ) && '' !== trim( $performer ) ) {
+				$performers[ strtolower( trim( $performer ) ) ] = trim( $performer );
+			}
+		}
+
+		$artist     = $this->suggestArtist( $url, $probe );
+		$venue_name = 1 === count( $venues ) ? (string) reset( $venues ) : '';
+		$candidates = array();
+		if ( '' !== $artist['name'] ) {
+			$candidates[] = array(
+				'source_kind' => 'artist',
+				'taxonomy'    => 'artist',
+				'term_id'     => $artist['term_id'],
+				'name'        => $artist['name'],
+			);
+		}
+		$venue_term_id = $this->matchTerm( $venue_name, 'venue' );
+		if ( '' !== $venue_name ) {
+			$candidates[] = array(
+				'source_kind' => 'venue',
+				'taxonomy'    => 'venue',
+				'term_id'     => $venue_term_id,
+				'name'        => $venue_name,
+			);
+		}
+
+		$kind       = 'unknown';
+		$confidence = 'low';
+		$warnings   = array();
+		$binding    = array(
+			'taxonomy' => '',
+			'term_id'  => null,
+			'name'     => '',
+		);
+		if ( $force_artist ) {
+			$kind       = 'artist';
+			$confidence = null !== $artist['term_id'] ? 'high' : 'medium';
+			$binding    = array(
+				'taxonomy' => 'artist',
+				'term_id'  => $artist['term_id'],
+				'name'     => $artist['name'],
+			);
+		} elseif ( (int) $probe['events_found'] < 2 ) {
+			$warnings[] = __( 'A one-off event page is not enough evidence for a recurring source.', 'extrachill-events' );
+		} elseif ( 1 === count( $venues ) && count( $performers ) > 1 ) {
+			$kind       = 'venue';
+			$confidence = null !== $venue_term_id ? 'high' : 'medium';
+			$binding    = array(
+				'taxonomy' => 'venue',
+				'term_id'  => $venue_term_id,
+				'name'     => $venue_name,
+			);
+		} elseif ( 1 === count( $performers ) && count( $venues ) > 1 ) {
+			$performer_name = (string) reset( $performers );
+			$performer_id   = $this->matchTerm( $performer_name, 'artist' );
+			$kind           = 'artist';
+			$confidence     = null !== $performer_id ? 'high' : 'medium';
+			$binding        = array(
+				'taxonomy' => 'artist',
+				'term_id'  => $performer_id,
+				'name'     => $performer_name,
+			);
+		} else {
+			$warnings[] = __( 'The extracted events do not establish one bounded artist or venue identity.', 'extrachill-events' );
+		}
+
+		return array(
+			'source_kind' => $kind,
+			'confidence'  => $confidence,
+			'candidates'  => $candidates,
+			'warnings'    => $warnings,
+			'binding'     => $binding,
+		);
+	}
+
+	/** Exact taxonomy candidate lookup without creating terms during preview. */
+	private function matchTerm( string $name, string $taxonomy ): ?int {
+		if ( '' === $name || ! taxonomy_exists( $taxonomy ) ) {
+			return null;
+		}
+		$term = get_term_by( 'name', $name, $taxonomy );
+		if ( ! $term instanceof \WP_Term ) {
+			$term = get_term_by( 'slug', sanitize_title( $name ), $taxonomy );
+		}
+		return $term instanceof \WP_Term ? (int) $term->term_id : null;
+	}
+
 	/**
 	 * @param array $input Ability input.
 	 * @return array|\WP_Error
 	 */
 	public function executePreview( array $input ) {
-		$raw_url = isset( $input['url'] ) ? (string) $input['url'] : '';
-		$url     = esc_url_raw( $raw_url );
-
-		if ( '' === $url ) {
-			return new \WP_Error( 'invalid_url', __( 'URL is required.', 'extrachill-events' ), array( 'status' => 400 ) );
-		}
-
-		// Protocol whitelist — http/https only. esc_url_raw() already enforces
-		// this against the default allowed protocols, but be explicit.
-		$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
-		if ( ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
-			return new \WP_Error( 'invalid_protocol', __( 'Only http and https URLs are supported.', 'extrachill-events' ), array( 'status' => 400 ) );
-		}
-
-		$normalized = ArtistUrlSubmissionsTable::normalize_url( $url );
-		if ( '' === $normalized ) {
-			return new \WP_Error( 'invalid_url', __( 'URL could not be parsed.', 'extrachill-events' ), array( 'status' => 400 ) );
+		$normalized = $this->normalizeInputUrl( (string) ( $input['url'] ?? '' ) );
+		if ( is_wp_error( $normalized ) ) {
+			return $normalized;
 		}
 
 		$hash     = ArtistUrlSubmissionsTable::url_hash( $normalized );
@@ -383,12 +718,30 @@ class ArtistUrlImportAbilities {
 			);
 		}
 
-		$probe = $this->probeUrl( $normalized );
-		if ( is_wp_error( $probe ) ) {
-			return $probe;
+		$result = $this->executeQualifyEventSource(
+			array(
+				'url'           => $normalized,
+				'compat_artist' => ! empty( $input['compat_artist'] ),
+			)
+		);
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		$canonical_hash = ArtistUrlSubmissionsTable::url_hash( (string) $result['canonical_events_url'] );
+		$canonical_row  = ArtistUrlSubmissionsTable::find_by_hash( $canonical_hash );
+		if ( $canonical_row && in_array( $canonical_row['status'], array( ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW, ArtistUrlSubmissionsTable::STATUS_APPROVED ), true ) ) {
+			return new \WP_Error(
+				'url_already_tracked',
+				__( 'This event source is already being tracked.', 'extrachill-events' ),
+				array(
+					'status'          => 409,
+					'existing_status' => $canonical_row['status'],
+					'submission_id'   => (int) $canonical_row['id'],
+				)
+			);
 		}
 
-		if ( 0 === $probe['events_found'] ) {
+		if ( 0 === $result['events_found'] ) {
 			return new \WP_Error(
 				'no_events_found',
 				__( "We couldn't extract events from that page. Try the manual form below.", 'extrachill-events' ),
@@ -396,17 +749,7 @@ class ArtistUrlImportAbilities {
 			);
 		}
 
-		$suggestion = $this->suggestArtist( $normalized, $probe );
-
-		return array(
-			'success'                  => true,
-			'detected_format'          => (string) $probe['detected_format'],
-			'events_found'             => (int) $probe['events_found'],
-			'events_preview'           => $probe['events_preview'],
-			'suggested_artist_name'    => (string) $suggestion['name'],
-			'suggested_artist_term_id' => $suggestion['term_id'],
-			'source_metadata'          => $probe['source_metadata'],
-		);
+		return $result;
 	}
 
 	// ────────────────────────────────────────────────────────────────────
@@ -418,20 +761,9 @@ class ArtistUrlImportAbilities {
 	 * @return array|\WP_Error
 	 */
 	public function executeSubmit( array $input ) {
-		$raw_url = isset( $input['url'] ) ? (string) $input['url'] : '';
-		$url     = esc_url_raw( $raw_url );
-		if ( '' === $url ) {
-			return new \WP_Error( 'invalid_url', __( 'URL is required.', 'extrachill-events' ), array( 'status' => 400 ) );
-		}
-
-		$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
-		if ( ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
-			return new \WP_Error( 'invalid_protocol', __( 'Only http and https URLs are supported.', 'extrachill-events' ), array( 'status' => 400 ) );
-		}
-
-		$normalized = ArtistUrlSubmissionsTable::normalize_url( $url );
-		if ( '' === $normalized ) {
-			return new \WP_Error( 'invalid_url', __( 'URL could not be parsed.', 'extrachill-events' ), array( 'status' => 400 ) );
+		$normalized = $this->normalizeInputUrl( (string) ( $input['url'] ?? '' ) );
+		if ( is_wp_error( $normalized ) ) {
+			return $normalized;
 		}
 
 		$hash     = ArtistUrlSubmissionsTable::url_hash( $normalized );
@@ -470,15 +802,20 @@ class ArtistUrlImportAbilities {
 			// anonymous to match that contract.
 			return new \WP_Error(
 				'login_required',
-				__( 'You must be logged in to submit a tour URL.', 'extrachill-events' ),
+				__( 'You must be logged in to submit an event source.', 'extrachill-events' ),
 				array( 'status' => 401 )
 			);
 		}
 
-		// Re-probe server-side regardless of what the preview saw.
-		$probe = $this->probeUrl( $normalized );
+		// Re-qualify server-side regardless of what the preview saw.
+		$qualification = $this->executeQualifyEventSource(
+			array(
+				'url'           => $normalized,
+				'compat_artist' => ! empty( $input['compat_artist'] ),
+			)
+		);
 
-		if ( is_wp_error( $probe ) || 0 === ( $probe['events_found'] ?? 0 ) ) {
+		if ( is_wp_error( $qualification ) || 0 === ( $qualification['events_found'] ?? 0 ) ) {
 			$submission_id = ArtistUrlSubmissionsTable::insert(
 				array(
 					'user_id'            => $user_id,
@@ -515,7 +852,37 @@ class ArtistUrlImportAbilities {
 			);
 		}
 
-		$suggestion = $this->suggestArtist( $normalized, $probe );
+		if ( ! empty( $qualification['existing_coverage']['covered'] ) ) {
+			return new \WP_Error(
+				'source_already_covered',
+				__( 'This event source is already covered by an existing import.', 'extrachill-events' ),
+				array(
+					'status'            => 409,
+					'existing_coverage' => $qualification['existing_coverage'],
+				)
+			);
+		}
+		$canonical_url  = (string) ( $qualification['canonical_events_url'] ?? $normalized );
+		$canonical_hash = ArtistUrlSubmissionsTable::url_hash( $canonical_url );
+		$canonical_row  = ArtistUrlSubmissionsTable::find_by_hash( $canonical_hash );
+		if ( $canonical_row && in_array( $canonical_row['status'], array( ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW, ArtistUrlSubmissionsTable::STATUS_APPROVED ), true ) ) {
+			return new \WP_Error(
+				'url_already_tracked',
+				__( 'This event source is already being tracked.', 'extrachill-events' ),
+				array(
+					'status'          => 409,
+					'existing_status' => $canonical_row['status'],
+					'submission_id'   => (int) $canonical_row['id'],
+				)
+			);
+		}
+
+		$binding     = (array) ( $qualification['recommended_binding'] ?? array() );
+		$source_kind = (string) ( $qualification['source_kind'] ?? 'unknown' );
+		$suggestion  = array(
+			'name'    => 'artist' === $source_kind ? (string) ( $binding['name'] ?? '' ) : '',
+			'term_id' => 'artist' === $source_kind ? ( $binding['term_id'] ?? null ) : null,
+		);
 
 		$submission_id = ArtistUrlSubmissionsTable::insert(
 			array(
@@ -523,11 +890,18 @@ class ArtistUrlImportAbilities {
 				'contact_email'            => $contact_email,
 				'contact_name'             => $contact_name,
 				'url'                      => $normalized,
-				'url_hash'                 => $hash,
+				'url_hash'                 => $canonical_hash,
+				'canonical_url'            => $canonical_url,
+				'source_kind'              => $source_kind,
+				'entity_taxonomy'          => (string) ( $binding['taxonomy'] ?? '' ),
+				'entity_term_id'           => isset( $binding['term_id'] ) ? (int) $binding['term_id'] : null,
+				'entity_name'              => (string) ( $binding['name'] ?? '' ),
+				'qualification_verdict'    => (string) ( $qualification['verdict'] ?? '' ),
+				'qualification_data'       => wp_json_encode( $qualification ),
 				'suggested_artist_name'    => $suggestion['name'],
 				'suggested_artist_term_id' => $suggestion['term_id'],
-				'detected_format'          => $probe['detected_format'],
-				'events_found_count'       => (int) $probe['events_found'],
+				'detected_format'          => $qualification['extraction_method'],
+				'events_found_count'       => (int) $qualification['events_found'],
 				'status'                   => ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
 			)
 		);
@@ -541,8 +915,8 @@ class ArtistUrlImportAbilities {
 				'url'                   => $normalized,
 				'contact_name'          => $contact_name,
 				'contact_email'         => $contact_email,
-				'detected_format'       => $probe['detected_format'],
-				'events_found_count'    => (int) $probe['events_found'],
+				'detected_format'       => $qualification['extraction_method'],
+				'events_found_count'    => (int) $qualification['events_found'],
 				'suggested_artist_name' => $suggestion['name'],
 				'status'                => ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
 			)
@@ -561,7 +935,8 @@ class ArtistUrlImportAbilities {
 			'submission_id' => (int) $submission_id,
 			'status'        => ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
 			'message'       => __( "Submitted for review. We'll set up automatic imports if approved.", 'extrachill-events' ),
-			'events_found'  => (int) $probe['events_found'],
+			'events_found'  => (int) $qualification['events_found'],
+			'source_kind'   => $source_kind,
 		);
 	}
 
@@ -596,11 +971,20 @@ class ArtistUrlImportAbilities {
 			);
 		}
 
+		$source_kind = $this->resolveApprovalKind( (string) ( $submission['source_kind'] ?? 'artist' ), $input['source_kind'] ?? null );
+		if ( is_wp_error( $source_kind ) ) {
+			return $source_kind;
+		}
+
+		if ( 'venue' === $source_kind ) {
+			return $this->approveVenueSubmission( $submission_id, $submission, $input );
+		}
+
 		// Resolve artist term.
 		$artist_term_id = $this->resolveArtistTerm(
-			isset( $input['artist_term_id'] ) ? (int) $input['artist_term_id'] : 0,
-			isset( $input['artist_name'] ) ? (string) $input['artist_name'] : '',
-			isset( $submission['suggested_artist_term_id'] ) ? (int) $submission['suggested_artist_term_id'] : 0
+			isset( $input['artist_term_id'] ) ? (int) $input['artist_term_id'] : (int) ( $input['entity_term_id'] ?? 0 ),
+			isset( $input['artist_name'] ) ? (string) $input['artist_name'] : (string) ( $input['entity_name'] ?? '' ),
+			isset( $submission['suggested_artist_term_id'] ) ? (int) $submission['suggested_artist_term_id'] : (int) ( $submission['entity_term_id'] ?? 0 )
 		);
 
 		if ( is_wp_error( $artist_term_id ) ) {
@@ -646,7 +1030,7 @@ class ArtistUrlImportAbilities {
 		);
 
 		$import_handler_config = array(
-			'source_url'       => $submission['url'],
+			'source_url'       => (string) ( $submission['canonical_url'] ?? $submission['url'] ),
 			'search'           => '',
 			'exclude_keywords' => '',
 		);
@@ -707,12 +1091,16 @@ class ArtistUrlImportAbilities {
 		ArtistUrlSubmissionsTable::update(
 			$submission_id,
 			array(
-				'status'         => ArtistUrlSubmissionsTable::STATUS_APPROVED,
-				'pipeline_id'    => $pipeline_id,
-				'flow_id'        => $flow_id,
-				'artist_term_id' => $artist_term_id,
-				'reviewed_at'    => current_time( 'mysql', true ),
-				'reviewed_by'    => get_current_user_id(),
+				'status'          => ArtistUrlSubmissionsTable::STATUS_APPROVED,
+				'pipeline_id'     => $pipeline_id,
+				'flow_id'         => $flow_id,
+				'artist_term_id'  => $artist_term_id,
+				'source_kind'     => 'artist',
+				'entity_taxonomy' => 'artist',
+				'entity_term_id'  => $artist_term_id,
+				'entity_name'     => $artist_name,
+				'reviewed_at'     => current_time( 'mysql', true ),
+				'reviewed_by'     => get_current_user_id(),
 			)
 		);
 
@@ -765,6 +1153,99 @@ class ArtistUrlImportAbilities {
 		);
 	}
 
+	/** Resolve approval dispatch without silently coercing unknown sources. */
+	private function resolveApprovalKind( string $stored_kind, $explicit_kind = null ) {
+		$kind = null !== $explicit_kind ? sanitize_key( (string) $explicit_kind ) : sanitize_key( $stored_kind );
+		if ( in_array( $kind, array( 'artist', 'venue' ), true ) ) {
+			return $kind;
+		}
+		return new \WP_Error(
+			'explicit_source_kind_required',
+			__( 'Select artist or venue and a concrete entity before approving this ambiguous source.', 'extrachill-events' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	/** Approve a venue source through the existing city/venue flow owner. */
+	private function approveVenueSubmission( int $submission_id, array $submission, array $input ) {
+		$pipeline_id = (int) ( $input['pipeline_id'] ?? 0 );
+		if ( $pipeline_id <= 0 ) {
+			return new \WP_Error( 'venue_pipeline_required', __( 'A city pipeline_id is required for venue approval.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+
+		$venue_term_id = (int) ( $input['venue_term_id'] ?? $input['entity_term_id'] ?? $submission['entity_term_id'] ?? 0 );
+		$venue_name    = sanitize_text_field( (string) ( $input['venue_name'] ?? $input['entity_name'] ?? $submission['entity_name'] ?? '' ) );
+		if ( $venue_term_id > 0 ) {
+			$term = get_term( $venue_term_id, 'venue' );
+			if ( $term instanceof \WP_Term ) {
+				$venue_name = (string) $term->name;
+			}
+		}
+		if ( '' === $venue_name ) {
+			return new \WP_Error( 'venue_required', __( 'Select a venue term or provide a venue name.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+
+		$interval = isset( $input['schedule_interval'] ) ? sanitize_key( (string) $input['schedule_interval'] ) : 'daily';
+		$ability  = wp_get_ability( 'extrachill/add-venue' );
+		if ( ! $ability ) {
+			return new \WP_Error( 'missing_ability', __( 'extrachill/add-venue ability is not available.', 'extrachill-events' ), array( 'status' => 500 ) );
+		}
+		$result = $ability->execute(
+			array(
+				'pipeline_id'   => $pipeline_id,
+				'name'          => $venue_name,
+				'venue_term_id' => $venue_term_id,
+				'url'           => (string) ( $submission['canonical_url'] ?? $submission['url'] ),
+				'website'       => (string) $submission['url'],
+				'interval'      => $interval,
+			)
+		);
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$flow_id       = (int) ( $result['flow_id'] ?? 0 );
+		$venue_term_id = (int) ( $result['venue_term_id'] ?? $venue_term_id );
+		ArtistUrlSubmissionsTable::update(
+			$submission_id,
+			array(
+				'status'          => ArtistUrlSubmissionsTable::STATUS_APPROVED,
+				'pipeline_id'     => $pipeline_id,
+				'flow_id'         => $flow_id,
+				'source_kind'     => 'venue',
+				'entity_taxonomy' => 'venue',
+				'entity_term_id'  => $venue_term_id,
+				'entity_name'     => $venue_name,
+				'reviewed_at'     => current_time( 'mysql', true ),
+				'reviewed_by'     => get_current_user_id(),
+			)
+		);
+
+		delete_transient( 'user_points_' . (int) $submission['user_id'] );
+		$link = get_term_link( $venue_term_id, 'venue' );
+		$this->notifySubmitter(
+			$submission,
+			'event_source_approved',
+			/* translators: %s: venue name. */
+			sprintf( __( 'Your event source for %s was approved', 'extrachill-events' ), $venue_name ),
+			is_wp_error( $link ) ? home_url() : $link,
+			$venue_term_id
+		);
+
+		$run_ability = wp_get_ability( 'datamachine/run-flow' );
+		if ( $run_ability && $flow_id > 0 ) {
+			$run_ability->execute( array( 'flow_id' => $flow_id ) );
+		}
+
+		return array(
+			'success'       => true,
+			'pipeline_id'   => $pipeline_id,
+			'flow_id'       => $flow_id,
+			'source_kind'   => 'venue',
+			'venue_term_id' => $venue_term_id,
+		);
+	}
+
 	// ────────────────────────────────────────────────────────────────────
 	// reject-artist-url-submission
 	// ────────────────────────────────────────────────────────────────────
@@ -797,11 +1278,11 @@ class ArtistUrlImportAbilities {
 		);
 
 		// Notify the submitter that the import was rejected.
-		$reject_title = __( 'Your tour import submission was not approved', 'extrachill-events' );
+		$reject_title = __( 'Your event source submission was not approved', 'extrachill-events' );
 		if ( '' !== $reason ) {
 			$reject_title = sprintf(
 				/* translators: %s: rejection reason */
-				__( 'Your tour import submission was not approved: %s', 'extrachill-events' ),
+				__( 'Your event source submission was not approved: %s', 'extrachill-events' ),
 				$reason
 			);
 		}
@@ -858,6 +1339,7 @@ class ArtistUrlImportAbilities {
 				'events_preview'  => array(),
 				'source_metadata' => array(),
 				'raw_first_event' => array(),
+				'raw_events'      => array(),
 				'page_html'       => '',
 			);
 		}
@@ -879,6 +1361,7 @@ class ArtistUrlImportAbilities {
 
 		$events_preview  = array();
 		$raw_first_event = array();
+		$raw_events      = array();
 		$count           = 0;
 		foreach ( $packet_entries as $entry ) {
 			$body    = (string) ( $entry['data']['body'] ?? '' );
@@ -891,6 +1374,7 @@ class ArtistUrlImportAbilities {
 				continue;
 			}
 			++$count;
+			$raw_events[] = $event;
 			if ( empty( $raw_first_event ) ) {
 				$raw_first_event = $event;
 			}
@@ -911,6 +1395,7 @@ class ArtistUrlImportAbilities {
 			'events_preview'  => $events_preview,
 			'source_metadata' => $first_meta,
 			'raw_first_event' => $raw_first_event,
+			'raw_events'      => $raw_events,
 			'page_html'       => $this->fetchPageHtml( $url ),
 		);
 	}
@@ -1562,18 +2047,18 @@ class ArtistUrlImportAbilities {
 
 		$subject = sprintf(
 			/* translators: 1: site name, 2: status label. */
-			__( '[%1$s] New Artist URL Submission: %2$s', 'extrachill-events' ),
+			__( '[%1$s] New Event Source Submission: %2$s', 'extrachill-events' ),
 			$site_name,
 			$status_label
 		);
 
 		$preheader = sprintf(
 			/* translators: %s: submitter name. */
-			__( 'Artist URL submission from %s.', 'extrachill-events' ),
+			__( 'Event source submission from %s.', 'extrachill-events' ),
 			(string) ( $data['contact_name'] ?? '' )
 		);
 
-		$body_html  = '<p>' . esc_html__( 'A new artist URL submission has been received:', 'extrachill-events' ) . '</p>';
+		$body_html  = '<p>' . esc_html__( 'A new event source submission has been received:', 'extrachill-events' ) . '</p>';
 		$body_html .= '<ul>';
 		$body_html .= '<li>' . sprintf(
 			/* translators: %s: submitted URL. */
@@ -1615,7 +2100,7 @@ class ArtistUrlImportAbilities {
 
 		$queue_url = $this->moderationQueueUrl();
 
-		$body_html .= '<p><a href="' . esc_url( $queue_url ) . '">' . esc_html__( 'Review artist URL submissions', 'extrachill-events' ) . '</a></p>';
+		$body_html .= '<p><a href="' . esc_url( $queue_url ) . '">' . esc_html__( 'Review event source submissions', 'extrachill-events' ) . '</a></p>';
 
 		$context = array(
 			'subject_html' => esc_html( $subject ),
@@ -1632,7 +2117,7 @@ class ArtistUrlImportAbilities {
 					$context,
 					array(
 						'cta_url'   => $queue_url,
-						'cta_label' => __( 'Review artist URL submissions', 'extrachill-events' ),
+						'cta_label' => __( 'Review event source submissions', 'extrachill-events' ),
 					)
 				),
 			),
@@ -1661,18 +2146,18 @@ class ArtistUrlImportAbilities {
 
 		$subject = sprintf(
 			/* translators: 1: site name, 2: submitted URL. */
-			__( '[%1$s] Artist URL Submission Received: %2$s', 'extrachill-events' ),
+			__( '[%1$s] Event Source Submission Received: %2$s', 'extrachill-events' ),
 			$site_name,
 			$url
 		);
 
 		$preheader = sprintf(
 			/* translators: %s: submitted URL. */
-			__( 'We received your tour URL submission for %s.', 'extrachill-events' ),
+			__( 'We received your event source submission for %s.', 'extrachill-events' ),
 			$url
 		);
 
-		$body_html  = '<p>' . esc_html__( 'Thanks for submitting an artist tour URL!', 'extrachill-events' ) . '</p>';
+		$body_html  = '<p>' . esc_html__( 'Thanks for submitting a recurring event source!', 'extrachill-events' ) . '</p>';
 		$body_html .= '<p>' . sprintf(
 			/* translators: %s: submitted URL. */
 			esc_html__( 'We received your submission for: %s', 'extrachill-events' ),

--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -1237,9 +1237,13 @@ class ArtistUrlImportAbilities {
 		if ( '' !== trim( $explicit_name ) && '' !== (string) ( $fresh_binding['name'] ?? '' ) && 0 !== strcasecmp( trim( $explicit_name ), trim( (string) $fresh_binding['name'] ) ) ) {
 			return new \WP_Error( 'artist_identity_changed', __( 'Artist approval must use the artist proven by fresh qualification.', 'extrachill-events' ), array( 'status' => 409 ) );
 		}
+		$resolved_artist_name = trim( $explicit_name );
+		if ( '' === $resolved_artist_name ) {
+			$resolved_artist_name = (string) ( $fresh_binding['name'] ?? '' );
+		}
 		$artist_term_id = $this->resolveArtistTerm(
 			$explicit_id,
-			'' !== trim( $explicit_name ) ? $explicit_name : (string) ( $fresh_binding['name'] ?? '' ),
+			$resolved_artist_name,
 			$fresh_artist_id
 		);
 

--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -55,6 +55,7 @@ namespace ExtraChillEvents\Abilities;
 use DataMachine\Core\Selection\SelectionMode;
 use DataMachine\Abilities\HandlerAbilities;
 use ExtraChillEvents\Core\ArtistUrlSubmissionsTable;
+use ExtraChillEvents\Core\QualifyVerdict;
 use ExtraChillEvents\Core\VenueExpansionRunner;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -371,11 +372,15 @@ class ArtistUrlImportAbilities {
 		);
 		return array(
 			'type'       => 'object',
-			'required'   => array( 'success', 'qualified', 'canonical_events_url', 'verdict', 'events_found', 'events_preview', 'extraction_method', 'source_kind', 'classification_confidence', 'entity_candidates', 'existing_coverage', 'warnings', 'recommended_route', 'recommended_binding', 'recurring_eligible' ),
+			'required'   => array( 'success', 'qualified', 'canonical_events_url', 'source_identity_url', 'verdict', 'events_found', 'events_preview', 'extraction_method', 'source_kind', 'classification_confidence', 'entity_candidates', 'existing_coverage', 'warnings', 'recommended_route', 'recommended_binding', 'recurring_eligible' ),
 			'properties' => array(
 				'success'                   => array( 'type' => 'boolean' ),
 				'qualified'                 => array( 'type' => 'boolean' ),
 				'canonical_events_url'      => array(
+					'type'   => 'string',
+					'format' => 'uri',
+				),
+				'source_identity_url'       => array(
 					'type'   => 'string',
 					'format' => 'uri',
 				),
@@ -658,11 +663,12 @@ class ArtistUrlImportAbilities {
 			return $qualification;
 		}
 
-		$canonical_url = ArtistUrlSubmissionsTable::normalize_url( (string) ( $qualification['events_url'] ?? $url ) );
-		if ( '' === $canonical_url ) {
-			$canonical_url = $url;
+		$events_url = $this->normalizeInputUrl( (string) ( $qualification['events_url'] ?? $url ) );
+		if ( is_wp_error( $events_url ) ) {
+			$events_url = $url;
 		}
-		$probe = $this->probeUrl( $canonical_url );
+		$identity_url = ArtistUrlSubmissionsTable::normalize_url( $events_url );
+		$probe        = $this->probeUrl( $events_url );
 		if ( is_wp_error( $probe ) ) {
 			return $probe;
 		}
@@ -671,7 +677,7 @@ class ArtistUrlImportAbilities {
 			'covered' => false,
 			'type'    => 'none',
 		);
-		$flow     = ( new VenueExpansionRunner() )->lookupExistingFlow( $canonical_url );
+		$flow     = ( new VenueExpansionRunner() )->lookupExistingFlow( $events_url );
 		if ( $flow ) {
 			$coverage = array(
 				'covered'   => true,
@@ -690,14 +696,14 @@ class ArtistUrlImportAbilities {
 			}
 		}
 
-		$host_scope = $this->unsupportedHostScope( $canonical_url );
+		$host_scope = $this->unsupportedHostScope( $events_url );
 		if ( $host_scope && empty( $coverage['covered'] ) ) {
 			$coverage = array(
 				'covered' => false,
 				'type'    => 'unsupported_' . $host_scope,
 			);
 		}
-		$classification = $this->classifySource( $canonical_url, $probe, $qualification, ! empty( $input['compat_artist'] ) );
+		$classification = $this->classifySource( $events_url, $probe, $qualification, ! empty( $input['compat_artist'] ) );
 		$warnings       = array_values( array_unique( array_merge( (array) ( $qualification['warnings'] ?? array() ), $classification['warnings'] ) ) );
 		if ( ! empty( $coverage['covered'] ) ) {
 			$warnings[] = __( 'This source is already covered and should not create another recurring flow.', 'extrachill-events' );
@@ -714,7 +720,8 @@ class ArtistUrlImportAbilities {
 		return array(
 			'success'                   => (int) $probe['events_found'] > 0,
 			'qualified'                 => ! empty( $qualification['qualified'] ),
-			'canonical_events_url'      => $canonical_url,
+			'canonical_events_url'      => $events_url,
+			'source_identity_url'       => $identity_url,
 			'verdict'                   => (string) ( $qualification['verdict'] ?? '' ),
 			'events_found'              => (int) $probe['events_found'],
 			'events_preview'            => $probe['events_preview'],
@@ -735,7 +742,7 @@ class ArtistUrlImportAbilities {
 		);
 	}
 
-	/** Validate and normalize an http(s) source URL. */
+	/** Validate an operational http(s) source URL without changing its query. */
 	private function normalizeInputUrl( string $raw_url ) {
 		$url = esc_url_raw( $raw_url );
 		if ( '' === $url ) {
@@ -745,10 +752,11 @@ class ArtistUrlImportAbilities {
 		if ( ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
 			return new \WP_Error( 'invalid_protocol', __( 'Only http and https URLs are supported.', 'extrachill-events' ), array( 'status' => 400 ) );
 		}
-		$normalized = ArtistUrlSubmissionsTable::normalize_url( $url );
-		return '' === $normalized
-			? new \WP_Error( 'invalid_url', __( 'URL could not be parsed.', 'extrachill-events' ), array( 'status' => 400 ) )
-			: $normalized;
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) || empty( $parts['host'] ) ) {
+			return new \WP_Error( 'invalid_url', __( 'URL could not be parsed.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		return preg_replace( '/#.*$/', '', $url );
 	}
 
 	/** Classify bounded artist/venue identity from repeated extracted events. */
@@ -1151,27 +1159,29 @@ class ArtistUrlImportAbilities {
 			);
 		}
 
-		$compat_artist = ! empty( $input['compat_artist'] ) || ! empty( $submission['compatibility_legacy'] );
+		$is_legacy     = ! empty( $submission['compatibility_legacy'] );
+		$compat_artist = ! empty( $input['compat_artist'] ) || $is_legacy;
 		$fresh         = $this->qualifyForAdmission( (string) ( $submission['canonical_url'] ?? $submission['url'] ), $compat_artist );
 		if ( is_wp_error( $fresh ) ) {
 			return $fresh;
 		}
+		$legacy_admission = false;
 		if ( empty( $fresh['recurring_eligible'] ) ) {
-			return new \WP_Error(
-				'source_no_longer_admissible',
-				__( 'Fresh qualification no longer admits this source for a recurring import.', 'extrachill-events' ),
-				array(
-					'status'        => 409,
-					'qualification' => $fresh,
-				)
-			);
+			$legacy_check = $this->validateLegacyArtistAdmission( $submission, $fresh, $input );
+			if ( is_wp_error( $legacy_check ) ) {
+				return $legacy_check;
+			}
+			$legacy_admission = true;
 		}
 
 		$source_kind = $this->resolveApprovalKind( (string) ( $submission['source_kind'] ?? 'artist' ), $input['source_kind'] ?? null );
 		if ( is_wp_error( $source_kind ) ) {
 			return $source_kind;
 		}
-		if ( $source_kind !== (string) $fresh['source_kind'] ) {
+		if ( $legacy_admission && 'artist' !== $source_kind ) {
+			return new \WP_Error( 'legacy_artist_only', __( 'Legacy artist submissions can only be approved as artists.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		if ( ! $legacy_admission && $source_kind !== (string) $fresh['source_kind'] ) {
 			return new \WP_Error(
 				'source_kind_changed',
 				__( 'Fresh qualification does not match the selected source kind.', 'extrachill-events' ),
@@ -1193,24 +1203,9 @@ class ArtistUrlImportAbilities {
 			);
 		}
 
-		$fresh_binding = (array) ( $fresh['recommended_binding'] ?? array() );
-		ArtistUrlSubmissionsTable::update(
-			$submission_id,
-			array(
-				'canonical_url'         => (string) $fresh['canonical_events_url'],
-				'source_kind'           => $source_kind,
-				'entity_taxonomy'       => (string) ( $fresh_binding['taxonomy'] ?? '' ),
-				'entity_term_id'        => isset( $fresh_binding['term_id'] ) ? (int) $fresh_binding['term_id'] : null,
-				'entity_name'           => (string) ( $fresh_binding['name'] ?? '' ),
-				'qualification_verdict' => (string) $fresh['verdict'],
-				'qualification_data'    => wp_json_encode( $fresh ),
-				'detected_format'       => (string) $fresh['extraction_method'],
-				'events_found_count'    => (int) $fresh['events_found'],
-			)
-		);
-		$submission['canonical_url']  = (string) $fresh['canonical_events_url'];
-		$submission['entity_term_id'] = $fresh_binding['term_id'] ?? null;
-		$submission['entity_name']    = (string) ( $fresh_binding['name'] ?? '' );
+		$fresh_binding                     = (array) ( $fresh['recommended_binding'] ?? array() );
+		$submission['canonical_url']       = (string) $fresh['canonical_events_url'];
+		$submission['fresh_qualification'] = $fresh;
 
 		if ( 'venue' === $source_kind ) {
 			$fresh_venue_id = (int) ( $fresh_binding['term_id'] ?? 0 );
@@ -1227,24 +1222,22 @@ class ArtistUrlImportAbilities {
 			return $this->approveVenueSubmission( $submission_id, $submission, $input );
 		}
 
-		// Resolve artist term.
-		$fresh_artist_id = (int) ( $fresh_binding['term_id'] ?? 0 );
-		$explicit_id     = isset( $input['artist_term_id'] ) ? (int) $input['artist_term_id'] : (int) ( $input['entity_term_id'] ?? 0 );
-		$explicit_name   = isset( $input['artist_name'] ) ? (string) $input['artist_name'] : (string) ( $input['entity_name'] ?? '' );
-		if ( $fresh_artist_id > 0 && $explicit_id > 0 && $fresh_artist_id !== $explicit_id ) {
-			return new \WP_Error( 'artist_identity_changed', __( 'Artist approval must use the artist proven by fresh qualification.', 'extrachill-events' ), array( 'status' => 409 ) );
+		$expected_artist_id   = $legacy_admission ? (int) ( $submission['entity_term_id'] ?? $submission['suggested_artist_term_id'] ?? 0 ) : (int) ( $fresh_binding['term_id'] ?? 0 );
+		$expected_artist_name = $legacy_admission ? (string) ( $submission['entity_name'] ?? $submission['suggested_artist_name'] ?? '' ) : (string) ( $fresh_binding['name'] ?? '' );
+		$artist_identity      = $this->validateArtistApprovalIdentity( $expected_artist_id, $expected_artist_name, $input, $is_legacy );
+		if ( is_wp_error( $artist_identity ) ) {
+			return $artist_identity;
 		}
-		if ( '' !== trim( $explicit_name ) && '' !== (string) ( $fresh_binding['name'] ?? '' ) && 0 !== strcasecmp( trim( $explicit_name ), trim( (string) $fresh_binding['name'] ) ) ) {
-			return new \WP_Error( 'artist_identity_changed', __( 'Artist approval must use the artist proven by fresh qualification.', 'extrachill-events' ), array( 'status' => 409 ) );
+		$flow_ability = wp_get_ability( 'datamachine/create-flow' );
+		if ( ! $flow_ability ) {
+			return new \WP_Error( 'missing_ability', __( 'datamachine/create-flow ability is not available.', 'extrachill-events' ), array( 'status' => 500 ) );
 		}
-		$resolved_artist_name = trim( $explicit_name );
-		if ( '' === $resolved_artist_name ) {
-			$resolved_artist_name = (string) ( $fresh_binding['name'] ?? '' );
-		}
+
+		// Resolve or create only the identity that passed every admission gate.
 		$artist_term_id = $this->resolveArtistTerm(
-			$explicit_id,
-			$resolved_artist_name,
-			$fresh_artist_id
+			$artist_identity['term_id'],
+			$artist_identity['name'],
+			$expected_artist_id
 		);
 
 		if ( is_wp_error( $artist_term_id ) ) {
@@ -1271,11 +1264,6 @@ class ArtistUrlImportAbilities {
 
 		// 2. Create the flow with universal_web_scraper handler and the
 		// SelectionMode-driven taxonomy bindings on the shared pipeline.
-		$flow_ability = wp_get_ability( 'datamachine/create-flow' );
-		if ( ! $flow_ability ) {
-			return new \WP_Error( 'missing_ability', __( 'datamachine/create-flow ability is not available.', 'extrachill-events' ), array( 'status' => 500 ) );
-		}
-
 		$upsert_handler_config = array(
 			'post_status'                 => 'publish',
 			'include_images'              => false,
@@ -1350,17 +1338,20 @@ class ArtistUrlImportAbilities {
 		// 3. Update the submission row: approved + linked shared pipeline/flow.
 		ArtistUrlSubmissionsTable::update(
 			$submission_id,
-			array(
-				'status'          => ArtistUrlSubmissionsTable::STATUS_APPROVED,
-				'pipeline_id'     => $pipeline_id,
-				'flow_id'         => $flow_id,
-				'artist_term_id'  => $artist_term_id,
-				'source_kind'     => 'artist',
-				'entity_taxonomy' => 'artist',
-				'entity_term_id'  => $artist_term_id,
-				'entity_name'     => $artist_name,
-				'reviewed_at'     => current_time( 'mysql', true ),
-				'reviewed_by'     => get_current_user_id(),
+			array_merge(
+				$this->freshQualificationPersistence( $submission ),
+				array(
+					'status'          => ArtistUrlSubmissionsTable::STATUS_APPROVED,
+					'pipeline_id'     => $pipeline_id,
+					'flow_id'         => $flow_id,
+					'artist_term_id'  => $artist_term_id,
+					'source_kind'     => 'artist',
+					'entity_taxonomy' => 'artist',
+					'entity_term_id'  => $artist_term_id,
+					'entity_name'     => $artist_name,
+					'reviewed_at'     => current_time( 'mysql', true ),
+					'reviewed_by'     => get_current_user_id(),
+				)
 			)
 		);
 
@@ -1427,6 +1418,124 @@ class ArtistUrlImportAbilities {
 		);
 	}
 
+	/** Admit only previously accepted artist rows through the legacy exception. */
+	private function validateLegacyArtistAdmission( array $submission, array $fresh, array $input ) {
+		if ( empty( $submission['compatibility_legacy'] ) ) {
+			return new \WP_Error(
+				'source_no_longer_admissible',
+				__( 'Fresh qualification no longer admits this source for a recurring import.', 'extrachill-events' ),
+				array(
+					'status'        => 409,
+					'qualification' => $fresh,
+				)
+			);
+		}
+		$explicit_id   = (int) ( $input['artist_term_id'] ?? $input['entity_term_id'] ?? 0 );
+		$explicit_name = trim( (string) ( $input['artist_name'] ?? $input['entity_name'] ?? '' ) );
+		$stored_name   = trim( (string) ( $submission['entity_name'] ?? $submission['suggested_artist_name'] ?? '' ) );
+		$coverage_type = (string) ( $fresh['existing_coverage']['type'] ?? 'none' );
+		$verdict       = (string) ( $fresh['verdict'] ?? '' );
+		$unsafe        = array(
+			QualifyVerdict::QUALIFIED_FOR_FLYER,
+			QualifyVerdict::UNSUPPORTED_SOURCE,
+			QualifyVerdict::RESERVATION_ONLY,
+			QualifyVerdict::BOT_BLOCKED,
+			QualifyVerdict::UNREACHABLE,
+			QualifyVerdict::COVERED_ELSEWHERE,
+		);
+
+		if ( (int) ( $submission['events_found_count'] ?? 0 ) < 1 || '' === (string) ( $submission['detected_format'] ?? '' ) || '' === $stored_name ) {
+			return new \WP_Error( 'legacy_evidence_missing', __( 'This legacy row does not contain the accepted artist-source evidence required for approval.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		if ( $explicit_id <= 0 && '' === $explicit_name ) {
+			return new \WP_Error( 'legacy_artist_required', __( 'Select an explicit artist identity to approve this legacy submission.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+		if ( empty( $fresh['success'] ) || (int) ( $fresh['events_found'] ?? 0 ) < 1 || ! empty( $fresh['existing_coverage']['covered'] ) || str_starts_with( $coverage_type, 'unsupported_' ) || in_array( $verdict, $unsafe, true ) || str_contains( strtolower( (string) ( $fresh['extraction_method'] ?? '' ) ), 'vision' ) ) {
+			return new \WP_Error(
+				'legacy_source_unsafe',
+				__( 'Fresh scraper safety checks do not admit this legacy artist source.', 'extrachill-events' ),
+				array(
+					'status'        => 409,
+					'qualification' => $fresh,
+				)
+			);
+		}
+		if ( 'venue' === (string) ( $fresh['source_kind'] ?? 'unknown' ) ) {
+			return new \WP_Error( 'legacy_source_kind_changed', __( 'Fresh qualification identifies this legacy source as a venue.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$fresh_name = 'artist' === (string) ( $fresh['source_kind'] ?? '' ) ? trim( (string) ( $fresh['recommended_binding']['name'] ?? '' ) ) : '';
+		if ( '' !== $fresh_name && ! $this->artistNamesMatch( $stored_name, $fresh_name ) ) {
+			return new \WP_Error( 'artist_identity_changed', __( 'Fresh qualification identifies a different artist than the legacy submission.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return true;
+	}
+
+	/** Validate moderator identity against the artist proven by admission. */
+	private function validateArtistApprovalIdentity( int $expected_id, string $expected_name, array $input, bool $require_explicit ) {
+		$explicit_id   = (int) ( $input['artist_term_id'] ?? $input['entity_term_id'] ?? 0 );
+		$explicit_name = trim( (string) ( $input['artist_name'] ?? $input['entity_name'] ?? '' ) );
+		$expected_name = trim( $expected_name );
+		$expected_term = $expected_id > 0 ? get_term( $expected_id, 'artist' ) : null;
+		if ( $expected_term instanceof \WP_Term && '' === $expected_name ) {
+			$expected_name = (string) $expected_term->name;
+		}
+		if ( $require_explicit && $explicit_id <= 0 && '' === $explicit_name ) {
+			return new \WP_Error( 'legacy_artist_required', __( 'Select an explicit artist identity to approve this legacy submission.', 'extrachill-events' ), array( 'status' => 400 ) );
+		}
+
+		$explicit_term = null;
+		if ( $explicit_id > 0 ) {
+			$explicit_term = get_term( $explicit_id, 'artist' );
+			if ( ! $explicit_term instanceof \WP_Term ) {
+				return new \WP_Error( 'artist_not_found', __( 'The selected artist term does not exist.', 'extrachill-events' ), array( 'status' => 404 ) );
+			}
+		}
+		if ( $expected_id > 0 && $explicit_id > 0 && $expected_id !== $explicit_id ) {
+			return new \WP_Error( 'artist_identity_changed', __( 'Artist approval must use the artist proven by fresh qualification.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		if ( '' !== $expected_name && $explicit_term instanceof \WP_Term && ! $this->artistNamesMatch( $expected_name, (string) $explicit_term->name ) ) {
+			return new \WP_Error( 'artist_identity_changed', __( 'The selected artist term does not match the artist proven by qualification.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		if ( '' !== $expected_name && '' !== $explicit_name && ! $this->artistNamesMatch( $expected_name, $explicit_name ) ) {
+			return new \WP_Error( 'artist_identity_changed', __( 'The supplied artist name does not match the artist proven by qualification.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		if ( $explicit_term instanceof \WP_Term && '' !== $explicit_name && ! $this->artistNamesMatch( (string) $explicit_term->name, $explicit_name ) ) {
+			return new \WP_Error( 'artist_identity_changed', __( 'The supplied artist name does not match the selected artist term.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		$resolved_name = '' !== $expected_name ? $expected_name : $explicit_name;
+		if ( '' === $resolved_name && $explicit_term instanceof \WP_Term ) {
+			$resolved_name = (string) $explicit_term->name;
+		}
+		if ( $expected_id <= 0 && $explicit_id <= 0 && '' === $resolved_name ) {
+			return new \WP_Error( 'artist_required', __( 'Qualification did not prove a concrete artist identity.', 'extrachill-events' ), array( 'status' => 409 ) );
+		}
+		return array(
+			'term_id' => $explicit_id > 0 ? $explicit_id : $expected_id,
+			'name'    => $resolved_name,
+		);
+	}
+
+	/** Compare artist labels without allowing unrelated term substitution. */
+	private function artistNamesMatch( string $left, string $right ): bool {
+		return '' !== trim( $left ) && sanitize_title( $left ) === sanitize_title( $right );
+	}
+
+	/** Persist fresh qualification evidence only with a successful approval. */
+	private function freshQualificationPersistence( array $submission ): array {
+		$fresh   = (array) ( $submission['fresh_qualification'] ?? array() );
+		$binding = (array) ( $fresh['recommended_binding'] ?? array() );
+		return array(
+			'canonical_url'         => (string) ( $fresh['canonical_events_url'] ?? $submission['canonical_url'] ?? $submission['url'] ?? '' ),
+			'qualification_verdict' => (string) ( $fresh['verdict'] ?? '' ),
+			'qualification_data'    => wp_json_encode( $fresh ),
+			'detected_format'       => (string) ( $fresh['extraction_method'] ?? '' ),
+			'events_found_count'    => (int) ( $fresh['events_found'] ?? 0 ),
+			'entity_taxonomy'       => (string) ( $binding['taxonomy'] ?? '' ),
+			'entity_term_id'        => isset( $binding['term_id'] ) ? (int) $binding['term_id'] : null,
+			'entity_name'           => (string) ( $binding['name'] ?? '' ),
+		);
+	}
+
 	/** Approve a venue source through the existing city/venue flow owner. */
 	private function approveVenueSubmission( int $submission_id, array $submission, array $input ) {
 		$pipeline_id = (int) ( $input['pipeline_id'] ?? 0 );
@@ -1469,16 +1578,19 @@ class ArtistUrlImportAbilities {
 		$venue_term_id = (int) ( $result['venue_term_id'] ?? $venue_term_id );
 		ArtistUrlSubmissionsTable::update(
 			$submission_id,
-			array(
-				'status'          => ArtistUrlSubmissionsTable::STATUS_APPROVED,
-				'pipeline_id'     => $pipeline_id,
-				'flow_id'         => $flow_id,
-				'source_kind'     => 'venue',
-				'entity_taxonomy' => 'venue',
-				'entity_term_id'  => $venue_term_id,
-				'entity_name'     => $venue_name,
-				'reviewed_at'     => current_time( 'mysql', true ),
-				'reviewed_by'     => get_current_user_id(),
+			array_merge(
+				$this->freshQualificationPersistence( $submission ),
+				array(
+					'status'          => ArtistUrlSubmissionsTable::STATUS_APPROVED,
+					'pipeline_id'     => $pipeline_id,
+					'flow_id'         => $flow_id,
+					'source_kind'     => 'venue',
+					'entity_taxonomy' => 'venue',
+					'entity_term_id'  => $venue_term_id,
+					'entity_name'     => $venue_name,
+					'reviewed_at'     => current_time( 'mysql', true ),
+					'reviewed_by'     => get_current_user_id(),
+				)
 			)
 		);
 

--- a/inc/Abilities/VenueAddAbilities.php
+++ b/inc/Abilities/VenueAddAbilities.php
@@ -373,6 +373,7 @@ class VenueAddAbilities {
 						'post_status'                 => 'publish',
 						'include_images'              => false,
 						'post_author'                 => self::DEFAULT_POST_AUTHOR,
+						'taxonomy_venue_selection'    => (string) $venue_term_id,
 						'taxonomy_category_selection' => 'skip',
 						'taxonomy_post_tag_selection' => 'skip',
 						'taxonomy_location_selection' => $location_term,

--- a/inc/Abilities/VenueAddAbilities.php
+++ b/inc/Abilities/VenueAddAbilities.php
@@ -162,21 +162,20 @@ class VenueAddAbilities {
 			}
 		}
 
-		// Validate pipeline exists.
-		$pipeline = $this->getPipeline( $pipeline_id );
-		if ( ! $pipeline ) {
-			return new \WP_Error( 'pipeline_not_found', sprintf( 'Pipeline %d not found.', $pipeline_id ), array( 'status' => 404 ) );
+		$pipeline_context = $this->validateCityPipeline( $pipeline_id );
+		if ( is_wp_error( $pipeline_context ) ) {
+			return $pipeline_context;
 		}
+		$pipeline = $pipeline_context['pipeline'];
 
 		$pipeline_name = $pipeline['pipeline_name'] ?? '';
+		$location_term = (string) $pipeline_context['location_term_id'];
+		$location      = $pipeline_context['location'];
 
-		// Derive city from pipeline name if not provided (e.g. "Nashville Events" → "Nashville").
+		// The canonical location binding owns city identity; pipeline names are display only.
 		if ( empty( $city ) ) {
-			$city = str_ireplace( ' Events', '', $pipeline_name );
+			$city = (string) $location->name;
 		}
-
-		// Derive location term from pipeline name.
-		$location_term = str_ireplace( ' Events', '', $pipeline_name );
 
 		// Check for idempotency — does a flow with this venue already exist in this pipeline?
 		$existing_flow = $this->findExistingVenueFlow( $pipeline_id, $name );
@@ -270,6 +269,68 @@ class VenueAddAbilities {
 		return $wpdb->get_row(
 			$wpdb->prepare( "SELECT * FROM {$table} WHERE pipeline_id = %d", $pipeline_id ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a trusted internal identifier built from $wpdb->prefix.
 			ARRAY_A
+		);
+	}
+
+	/**
+	 * Validate that a pipeline is an event-import city pipeline with one
+	 * concrete canonical location binding.
+	 */
+	public function validateCityPipeline( int $pipeline_id ) {
+		$pipeline = $this->getPipeline( $pipeline_id );
+		if ( ! $pipeline ) {
+			return new \WP_Error( 'pipeline_not_found', sprintf( 'Pipeline %d not found.', $pipeline_id ), array( 'status' => 404 ) );
+		}
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_flows';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Trusted internal table name.
+				"SELECT flow_config FROM {$table} WHERE pipeline_id = %d",
+				$pipeline_id
+			),
+			ARRAY_A
+		);
+
+		$location_ids     = array();
+		$has_event_import = false;
+		$has_event_upsert = false;
+		foreach ( (array) $rows as $row ) {
+			$config = json_decode( (string) ( $row['flow_config'] ?? '' ), true );
+			foreach ( (array) $config as $step ) {
+				if ( 'event_import' === ( $step['step_type'] ?? '' ) ) {
+					$has_event_import = true;
+				}
+				if ( 'upsert' !== ( $step['step_type'] ?? '' ) ) {
+					continue;
+				}
+				$upsert = $step['handler_config'] ?? $step['handler_configs']['upsert_event'] ?? array();
+				if ( ! is_array( $upsert ) ) {
+					continue;
+				}
+				$has_event_upsert = true;
+				$value            = (string) ( $upsert['taxonomy_location_selection'] ?? '' );
+				if ( ctype_digit( $value ) && (int) $value > 0 ) {
+					$location_ids[ (int) $value ] = true;
+				}
+			}
+		}
+
+		if ( ! $has_event_import || ! $has_event_upsert || 1 !== count( $location_ids ) ) {
+			return new \WP_Error( 'invalid_city_pipeline', 'The selected pipeline is not an event city pipeline with one canonical location.', array( 'status' => 400 ) );
+		}
+		$location_id = (int) array_key_first( $location_ids );
+		$location    = get_term( $location_id, 'location' );
+		if ( ! $location instanceof \WP_Term ) {
+			return new \WP_Error( 'invalid_pipeline_location', 'The selected pipeline location is not a canonical location term.', array( 'status' => 400 ) );
+		}
+
+		return array(
+			'pipeline'         => $pipeline,
+			'location'         => $location,
+			'location_term_id' => $location_id,
 		);
 	}
 

--- a/inc/Abilities/VenueAddAbilities.php
+++ b/inc/Abilities/VenueAddAbilities.php
@@ -294,11 +294,14 @@ class VenueAddAbilities {
 			ARRAY_A
 		);
 
-		$location_ids     = array();
-		$has_event_import = false;
-		$has_event_upsert = false;
+		$location_ids      = array();
+		$coherent_flows    = 0;
+		$invalid_structure = false;
 		foreach ( (array) $rows as $row ) {
-			$config = json_decode( (string) ( $row['flow_config'] ?? '' ), true );
+			$config           = json_decode( (string) ( $row['flow_config'] ?? '' ), true );
+			$has_event_import = false;
+			$has_event_upsert = false;
+			$flow_locations   = array();
 			foreach ( (array) $config as $step ) {
 				if ( 'event_import' === ( $step['step_type'] ?? '' ) ) {
 					$has_event_import = true;
@@ -313,12 +316,26 @@ class VenueAddAbilities {
 				$has_event_upsert = true;
 				$value            = (string) ( $upsert['taxonomy_location_selection'] ?? '' );
 				if ( ctype_digit( $value ) && (int) $value > 0 ) {
-					$location_ids[ (int) $value ] = true;
+					$flow_locations[ (int) $value ] = true;
+				} else {
+					$invalid_structure = true;
 				}
+			}
+			if ( $has_event_import !== $has_event_upsert ) {
+				$invalid_structure = true;
+				continue;
+			}
+			if ( $has_event_import && $has_event_upsert ) {
+				if ( 1 !== count( $flow_locations ) ) {
+					$invalid_structure = true;
+					continue;
+				}
+				++$coherent_flows;
+				$location_ids[ (int) array_key_first( $flow_locations ) ] = true;
 			}
 		}
 
-		if ( ! $has_event_import || ! $has_event_upsert || 1 !== count( $location_ids ) ) {
+		if ( $invalid_structure || $coherent_flows < 1 || 1 !== count( $location_ids ) ) {
 			return new \WP_Error( 'invalid_city_pipeline', 'The selected pipeline is not an event city pipeline with one canonical location.', array( 'status' => 400 ) );
 		}
 		$location_id = (int) array_key_first( $location_ids );

--- a/inc/Abilities/VenueQualificationAbilities.php
+++ b/inc/Abilities/VenueQualificationAbilities.php
@@ -204,7 +204,6 @@ class VenueQualificationAbilities {
 			return new \WP_Error( 'missing_url', 'URL is required.', array( 'status' => 400 ) );
 		}
 
-		$url = rtrim( $url, '/' );
 		if ( ! preg_match( '#^https?://#', $url ) ) {
 			$url = 'https://' . $url;
 		}

--- a/inc/Api/ArtistUrlImportRoutes.php
+++ b/inc/Api/ArtistUrlImportRoutes.php
@@ -2,9 +2,10 @@
 /**
  * Artist URL Import REST Routes
  *
- * Registers the four artist-URL-import REST routes under this plugin's own
- * `extrachill/v1` namespace (matching `extrachill/v1/event-submissions`).
- * Migrated out of data-machine-events in extrachill-events#200.
+ * Registers generic event-source routes under this plugin's own
+ * `extrachill/v1` namespace. The four shipped `artist-url` routes remain
+ * Phase 1 compatibility aliases and delegate through the artist ability
+ * aliases to the same generic intake implementation.
  *
  * The one-release `datamachine/v1/artist-url/*` compatibility aliases that
  * shipped with the #200 migration were retired in extrachill-events#256: the
@@ -126,15 +127,133 @@ function register_artist_url_routes_for( string $route_namespace ): void {
 	);
 }
 
+/** Register the source-neutral Phase 1 routes. */
+function register_event_source_routes_for( string $route_namespace ): void {
+	$controller = new ArtistUrlImport();
+	register_rest_route(
+		$route_namespace,
+		'/event-source/preview',
+		array(
+			'methods'             => 'POST',
+			'callback'            => array( $controller, 'preview_event_source' ),
+			'permission_callback' => array( ArtistUrlImport::class, 'permission_logged_in' ),
+			'args'                => array(
+				'url' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'esc_url_raw',
+				),
+			),
+		)
+	);
+	register_rest_route(
+		$route_namespace,
+		'/event-source/submit',
+		array(
+			'methods'             => 'POST',
+			'callback'            => array( $controller, 'submit_event_source' ),
+			'permission_callback' => array( ArtistUrlImport::class, 'permission_logged_in' ),
+			'args'                => array(
+				'url'           => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'esc_url_raw',
+				),
+				'contact_email' => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_email',
+				),
+				'contact_name'  => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+			),
+		)
+	);
+	register_rest_route(
+		$route_namespace,
+		'/event-source/(?P<id>\d+)/approve',
+		array(
+			'methods'             => 'POST',
+			'callback'            => array( $controller, 'approve_event_source' ),
+			'permission_callback' => array( ArtistUrlImport::class, 'permission_admin' ),
+			'args'                => array(
+				'id'                => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'source_kind'       => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_key',
+				),
+				'entity_term_id'    => array(
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'entity_name'       => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'venue_term_id'     => array(
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'venue_name'        => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'artist_term_id'    => array(
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'artist_name'       => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'pipeline_id'       => array(
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'schedule_interval' => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_key',
+				),
+			),
+		)
+	);
+	register_rest_route(
+		$route_namespace,
+		'/event-source/(?P<id>\d+)/reject',
+		array(
+			'methods'             => 'POST',
+			'callback'            => array( $controller, 'reject_event_source' ),
+			'permission_callback' => array( ArtistUrlImport::class, 'permission_admin' ),
+			'args'                => array(
+				'id'     => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'reason' => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_textarea_field',
+				),
+			),
+		)
+	);
+}
+
 /**
  * Register all artist-url routes on rest_api_init.
  *
- * Only the canonical `extrachill/v1` namespace is registered; the
- * `datamachine/v1` one-release aliases were retired in extrachill-events#256.
+ * Both generic event-source routes and shipped artist compatibility routes
+ * are registered in the canonical `extrachill/v1` namespace.
  *
  * @return void
  */
 function register_artist_url_routes(): void {
+	register_event_source_routes_for( ARTIST_URL_NAMESPACE );
 	register_artist_url_routes_for( ARTIST_URL_NAMESPACE );
 }
 

--- a/inc/Api/Controllers/ArtistUrlImport.php
+++ b/inc/Api/Controllers/ArtistUrlImport.php
@@ -155,6 +155,48 @@ class ArtistUrlImport {
 		);
 	}
 
+	public function preview_event_source( \WP_REST_Request $request ) {
+		if ( ! self::looks_like_xhr( $request ) ) {
+			return self::direct_nav_404();
+		}
+		return self::run_ability( 'extrachill-events/preview-event-source', array( 'url' => (string) $request->get_param( 'url' ) ) );
+	}
+
+	public function submit_event_source( \WP_REST_Request $request ) {
+		if ( ! self::looks_like_xhr( $request ) ) {
+			return self::direct_nav_404();
+		}
+		return self::run_ability(
+			'extrachill-events/submit-event-source',
+			array(
+				'url'           => (string) $request->get_param( 'url' ),
+				'contact_email' => (string) $request->get_param( 'contact_email' ),
+				'contact_name'  => (string) $request->get_param( 'contact_name' ),
+			)
+		);
+	}
+
+	public function approve_event_source( \WP_REST_Request $request ) {
+		$input = array( 'submission_id' => (int) $request->get_param( 'id' ) );
+		foreach ( array( 'source_kind', 'entity_term_id', 'entity_name', 'venue_term_id', 'venue_name', 'artist_term_id', 'artist_name', 'pipeline_id', 'schedule_interval' ) as $key ) {
+			$value = $request->get_param( $key );
+			if ( null !== $value ) {
+				$input[ $key ] = $value;
+			}
+		}
+		return self::run_ability( 'extrachill-events/approve-event-source-submission', $input );
+	}
+
+	public function reject_event_source( \WP_REST_Request $request ) {
+		return self::run_ability(
+			'extrachill-events/reject-event-source-submission',
+			array(
+				'submission_id' => (int) $request->get_param( 'id' ),
+				'reason'        => (string) $request->get_param( 'reason' ),
+			)
+		);
+	}
+
 	// ────────────────────────────────────────────────────────────────────
 	// Permission callbacks
 	// ────────────────────────────────────────────────────────────────────

--- a/inc/Core/ArtistUrlSubmissionsTable.php
+++ b/inc/Core/ArtistUrlSubmissionsTable.php
@@ -152,45 +152,7 @@ class ArtistUrlSubmissionsTable {
 	 * @return string Normalized URL, or empty string if the input is not parseable.
 	 */
 	public static function normalize_url( string $url ): string {
-		$url = trim( $url );
-		if ( '' === $url ) {
-			return '';
-		}
-
-		$parts = wp_parse_url( $url );
-		if ( ! is_array( $parts ) || empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
-			return '';
-		}
-
-		$scheme = strtolower( $parts['scheme'] );
-		$host   = strtolower( $parts['host'] );
-		$port   = $parts['port'] ?? '';
-		$path   = $parts['path'] ?? '/';
-		$query  = $parts['query'] ?? '';
-
-		// Strip default ports.
-		if ( ( 'http' === $scheme && 80 === (int) $port ) || ( 'https' === $scheme && 443 === (int) $port ) ) {
-			$port = '';
-		}
-
-		// Trim trailing slash on non-root paths.
-		if ( strlen( $path ) > 1 && '/' === substr( $path, -1 ) ) {
-			$path = rtrim( $path, '/' );
-		}
-		if ( '' === $path ) {
-			$path = '/';
-		}
-
-		$normalized = $scheme . '://' . $host;
-		if ( '' !== (string) $port ) {
-			$normalized .= ':' . $port;
-		}
-		$normalized .= $path;
-		if ( '' !== $query ) {
-			$normalized .= '?' . $query;
-		}
-
-		return $normalized;
+		return QualifyVerdict::canonicalize_url( $url );
 	}
 
 	/**
@@ -220,6 +182,47 @@ class ArtistUrlSubmissionsTable {
 		);
 
 		return $row ? self::with_compatibility_defaults( $row ) : null;
+	}
+
+	/**
+	 * Find a pending or approved source by canonical URL identity.
+	 *
+	 * The hash fast path covers Phase 1 rows. The legacy scan keeps old
+	 * artist records readable when their stored hash includes tracking/query or
+	 * trailing-slash variants from the pre-canonical schema.
+	 */
+	public static function find_tracked_by_url( string $url, int $exclude_id = 0 ): ?array {
+		$canonical = self::normalize_url( $url );
+		if ( '' === $canonical ) {
+			return null;
+		}
+		$hashed = self::find_by_hash( self::url_hash( $canonical ) );
+		if ( $hashed && (int) $hashed['id'] !== $exclude_id && in_array( $hashed['status'], array( self::STATUS_PENDING_REVIEW, self::STATUS_APPROVED ), true ) ) {
+			return $hashed;
+		}
+
+		global $wpdb;
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Trusted internal table name.
+				"SELECT * FROM {$table} WHERE status IN (%s, %s) ORDER BY id DESC",
+				self::STATUS_PENDING_REVIEW,
+				self::STATUS_APPROVED
+			),
+			ARRAY_A
+		);
+		foreach ( (array) $rows as $row ) {
+			if ( (int) $row['id'] === $exclude_id ) {
+				continue;
+			}
+			$candidate = (string) ( $row['canonical_url'] ?? $row['url'] ?? '' );
+			if ( self::normalize_url( $candidate ) === $canonical ) {
+				return self::with_compatibility_defaults( $row );
+			}
+		}
+		return null;
 	}
 
 	/**
@@ -382,7 +385,10 @@ class ArtistUrlSubmissionsTable {
 	 */
 	public static function with_compatibility_defaults( array $row ): array {
 		if ( empty( $row['source_kind'] ) ) {
-			$row['source_kind'] = 'artist';
+			$row['source_kind']          = 'artist';
+			$row['compatibility_legacy'] = true;
+		} else {
+			$row['compatibility_legacy'] = false;
 		}
 		if ( empty( $row['canonical_url'] ) ) {
 			$row['canonical_url'] = (string) ( $row['url'] ?? '' );

--- a/inc/Core/ArtistUrlSubmissionsTable.php
+++ b/inc/Core/ArtistUrlSubmissionsTable.php
@@ -2,13 +2,10 @@
 /**
  * Artist URL Submissions Table
  *
- * Stores the moderation queue for URL-based artist tour imports submitted
- * via the event-submission block (extrachill-events#320). A row is
- * inserted when a logged-in user submits an artist tour URL; an admin
- * reviews the row and either approves it — at which point a Data Machine
- * pipeline + flow are created via `datamachine/create-flow` — or rejects
- * it. Failed scrapes are recorded with `status = 'scraping_failed'` so
- * admins can review URLs that need handler-format expansion.
+ * Stores the moderation queue for qualified recurring event sources. The
+ * original table name and artist columns remain compatibility contracts;
+ * generic source identity, canonical URL, and qualification fields extend
+ * those rows without moving or rewriting deployed data.
  *
  * Ownership note (extrachill-events#200): this subsystem was migrated out
  * of the generic `data-machine-events` substrate, which must not carry
@@ -42,7 +39,7 @@ class ArtistUrlSubmissionsTable {
 	/**
 	 * Schema version. Bump when CREATE TABLE definition changes.
 	 */
-	const SCHEMA_VERSION = '1';
+	const SCHEMA_VERSION = '2';
 
 	/**
 	 * Site option key that stores the installed schema version.
@@ -88,6 +85,13 @@ class ArtistUrlSubmissionsTable {
 			contact_name varchar(255) NULL,
 			url varchar(2048) NOT NULL,
 			url_hash char(64) NOT NULL,
+			canonical_url varchar(2048) NULL,
+			source_kind varchar(32) NULL,
+			entity_taxonomy varchar(32) NULL,
+			entity_term_id bigint(20) unsigned NULL,
+			entity_name varchar(255) NULL,
+			qualification_verdict varchar(64) NULL,
+			qualification_data longtext NULL,
 			suggested_artist_name varchar(255) NULL,
 			suggested_artist_term_id bigint(20) unsigned NULL,
 			detected_format varchar(64) NULL,
@@ -215,7 +219,7 @@ class ArtistUrlSubmissionsTable {
 			ARRAY_A
 		);
 
-		return $row ? $row : null;
+		return $row ? self::with_compatibility_defaults( $row ) : null;
 	}
 
 	/**
@@ -234,7 +238,7 @@ class ArtistUrlSubmissionsTable {
 			ARRAY_A
 		);
 
-		return $row ? $row : null;
+		return $row ? self::with_compatibility_defaults( $row ) : null;
 	}
 
 	/**
@@ -253,6 +257,13 @@ class ArtistUrlSubmissionsTable {
 			'contact_name'             => null,
 			'url'                      => '',
 			'url_hash'                 => '',
+			'canonical_url'            => null,
+			'source_kind'              => null,
+			'entity_taxonomy'          => null,
+			'entity_term_id'           => null,
+			'entity_name'              => null,
+			'qualification_verdict'    => null,
+			'qualification_data'       => null,
 			'suggested_artist_name'    => null,
 			'suggested_artist_term_id' => null,
 			'detected_format'          => null,
@@ -294,6 +305,13 @@ class ArtistUrlSubmissionsTable {
 			'pipeline_id',
 			'flow_id',
 			'artist_term_id',
+			'canonical_url',
+			'source_kind',
+			'entity_taxonomy',
+			'entity_term_id',
+			'entity_name',
+			'qualification_verdict',
+			'qualification_data',
 			'suggested_artist_name',
 			'suggested_artist_term_id',
 			'detected_format',
@@ -352,7 +370,33 @@ class ArtistUrlSubmissionsTable {
 			);
 		}
 
-		return $rows ? $rows : array();
+		return $rows ? array_map( array( self::class, 'with_compatibility_defaults' ), $rows ) : array();
+	}
+
+	/**
+	 * Read legacy artist rows through the generic event-source model.
+	 *
+	 * Existing records predate the source columns, so an empty source kind is
+	 * concrete evidence of the shipped artist-tour contract rather than an
+	 * unknown classification.
+	 */
+	public static function with_compatibility_defaults( array $row ): array {
+		if ( empty( $row['source_kind'] ) ) {
+			$row['source_kind'] = 'artist';
+		}
+		if ( empty( $row['canonical_url'] ) ) {
+			$row['canonical_url'] = (string) ( $row['url'] ?? '' );
+		}
+		if ( empty( $row['entity_taxonomy'] ) && 'artist' === $row['source_kind'] ) {
+			$row['entity_taxonomy'] = 'artist';
+		}
+		if ( empty( $row['entity_term_id'] ) && ! empty( $row['suggested_artist_term_id'] ) ) {
+			$row['entity_term_id'] = (int) $row['suggested_artist_term_id'];
+		}
+		if ( empty( $row['entity_name'] ) && ! empty( $row['suggested_artist_name'] ) ) {
+			$row['entity_name'] = (string) $row['suggested_artist_name'];
+		}
+		return $row;
 	}
 
 	/**

--- a/inc/Core/ArtistUrlSubmissionsTable.php
+++ b/inc/Core/ArtistUrlSubmissionsTable.php
@@ -156,13 +156,13 @@ class ArtistUrlSubmissionsTable {
 	}
 
 	/**
-	 * Compute the dedupe hash for a normalized URL.
+	 * Compute the dedupe hash for a URL's canonical identity.
 	 *
-	 * @param string $normalized_url URL already passed through normalize_url().
+	 * @param string $url Operational or canonical URL.
 	 * @return string sha256 hex.
 	 */
-	public static function url_hash( string $normalized_url ): string {
-		return hash( 'sha256', $normalized_url );
+	public static function url_hash( string $url ): string {
+		return hash( 'sha256', self::normalize_url( $url ) );
 	}
 
 	/**

--- a/inc/Core/QualifyVerdict.php
+++ b/inc/Core/QualifyVerdict.php
@@ -354,6 +354,7 @@ final class QualifyVerdict {
 
 		$scheme = strtolower( $parts['scheme'] ?? 'https' );
 		$host   = strtolower( $parts['host'] );
+		$port   = isset( $parts['port'] ) ? (int) $parts['port'] : 0;
 		$path   = $parts['path'] ?? '';
 		$query  = $parts['query'] ?? '';
 
@@ -383,7 +384,11 @@ final class QualifyVerdict {
 			}
 		}
 
-		$canonical = $scheme . '://' . $host . $path;
+		$canonical = $scheme . '://' . $host;
+		if ( $port > 0 && ! ( 'http' === $scheme && 80 === $port ) && ! ( 'https' === $scheme && 443 === $port ) ) {
+			$canonical .= ':' . $port;
+		}
+		$canonical .= $path;
 		if ( '' !== $kept_query ) {
 			$canonical .= '?' . $kept_query;
 		}

--- a/inc/Core/VenueExpansionRunner.php
+++ b/inc/Core/VenueExpansionRunner.php
@@ -337,6 +337,11 @@ class VenueExpansionRunner {
 		return ( $this->flow_for_url )( $url );
 	}
 
+	/** Return an existing universal-scraper flow for a canonical source URL. */
+	public function lookupExistingFlow( string $url ): ?array {
+		return $this->findExistingFlow( $url );
+	}
+
 	/** Remember a newly created flow before the next candidate is processed. */
 	private function rememberFlow( string $url, array $row ): void {
 		$canonical = QualifyVerdict::canonicalize_url( $url );

--- a/inc/admin/ArtistUrlSubmissionsAdmin.php
+++ b/inc/admin/ArtistUrlSubmissionsAdmin.php
@@ -72,8 +72,8 @@ class ArtistUrlSubmissionsAdmin {
 	public function register_submenu(): void {
 		add_submenu_page(
 			'edit.php?post_type=' . self::events_post_type(),
-			__( 'Artist URL Submissions', 'extrachill-events' ),
-			__( 'Artist URL Imports', 'extrachill-events' ),
+			__( 'Event Source Submissions', 'extrachill-events' ),
+			__( 'Event Source Imports', 'extrachill-events' ),
 			'manage_options',
 			self::PAGE_SLUG,
 			array( $this, 'render_page' )
@@ -106,8 +106,8 @@ class ArtistUrlSubmissionsAdmin {
 		$flash = isset( $_GET['flash'] ) ? sanitize_key( wp_unslash( (string) $_GET['flash'] ) ) : '';
 
 		echo '<div class="wrap">';
-		echo '<h1>' . esc_html__( 'Artist URL Imports', 'extrachill-events' ) . '</h1>';
-		echo '<p>' . esc_html__( 'Moderation queue for URL-based artist tour imports submitted via the event-submission form. Approving a row creates a Data Machine pipeline scoped to the chosen artist; rejecting closes it without creating one.', 'extrachill-events' ) . '</p>';
+		echo '<h1>' . esc_html__( 'Event Source Imports', 'extrachill-events' ) . '</h1>';
+		echo '<p>' . esc_html__( 'Moderation queue for recurring artist tour pages and venue calendars. Ambiguous sources require an explicit source kind and entity before approval.', 'extrachill-events' ) . '</p>';
 
 		if ( 'approved' === $flash ) {
 			echo '<div class="notice notice-success"><p>' . esc_html__( 'Submission approved and pipeline created.', 'extrachill-events' ) . '</p></div>';
@@ -153,7 +153,7 @@ class ArtistUrlSubmissionsAdmin {
 		echo '<th>' . esc_html__( 'ID', 'extrachill-events' ) . '</th>';
 		echo '<th>' . esc_html__( 'URL', 'extrachill-events' ) . '</th>';
 		echo '<th>' . esc_html__( 'Submitter', 'extrachill-events' ) . '</th>';
-		echo '<th>' . esc_html__( 'Suggested artist', 'extrachill-events' ) . '</th>';
+		echo '<th>' . esc_html__( 'Source / entity', 'extrachill-events' ) . '</th>';
 		echo '<th>' . esc_html__( 'Events found', 'extrachill-events' ) . '</th>';
 		echo '<th>' . esc_html__( 'Detected format', 'extrachill-events' ) . '</th>';
 		echo '<th>' . esc_html__( 'Submitted', 'extrachill-events' ) . '</th>';
@@ -178,13 +178,15 @@ class ArtistUrlSubmissionsAdmin {
 			}
 		}
 
-		$suggested = (string) ( $row['suggested_artist_name'] ?? '' );
-		if ( ! empty( $row['suggested_artist_term_id'] ) ) {
-			$term = get_term( (int) $row['suggested_artist_term_id'], 'artist' );
+		$source_kind = (string) ( $row['source_kind'] ?? 'artist' );
+		$suggested   = (string) ( $row['entity_name'] ?? $row['suggested_artist_name'] ?? '' );
+		if ( ! empty( $row['entity_term_id'] ) ) {
+			$term = get_term( (int) $row['entity_term_id'], (string) ( $row['entity_taxonomy'] ?? $source_kind ) );
 			if ( $term && ! is_wp_error( $term ) ) {
 				$suggested .= sprintf( ' (term #%d: %s)', $term->term_id, $term->name );
 			}
 		}
+		$suggested = $source_kind . ( $suggested ? ': ' . $suggested : '' );
 
 		echo '<tr>';
 		echo '<td>' . esc_html( (string) $row['id'] ) . '</td>';
@@ -224,19 +226,34 @@ class ArtistUrlSubmissionsAdmin {
 		$action_url        = admin_url( 'admin-post.php' );
 		$suggested_term_id = (int) ( $row['suggested_artist_term_id'] ?? 0 );
 		$suggested_name    = (string) ( $row['suggested_artist_name'] ?? '' );
+		$source_kind       = (string) ( $row['source_kind'] ?? 'artist' );
+		$entity_term_id    = (int) ( $row['entity_term_id'] ?? $suggested_term_id );
+		$entity_name       = (string) ( $row['entity_name'] ?? $suggested_name );
 		?>
 		<form method="post" action="<?php echo esc_url( $action_url ); ?>" style="display: block; margin-bottom: 6px;">
 			<?php wp_nonce_field( self::NONCE_APPROVE . '_' . $submission_id ); ?>
 			<input type="hidden" name="action" value="<?php echo esc_attr( self::NONCE_APPROVE ); ?>" />
 			<input type="hidden" name="submission_id" value="<?php echo esc_attr( (string) $submission_id ); ?>" />
+			<label style="display: block; margin: 2px 0;">
+				<?php esc_html_e( 'Source kind:', 'extrachill-events' ); ?>
+				<select name="source_kind">
+					<option value="unknown" <?php selected( $source_kind, 'unknown' ); ?>><?php esc_html_e( 'Unknown (cannot approve)', 'extrachill-events' ); ?></option>
+					<option value="artist" <?php selected( $source_kind, 'artist' ); ?>><?php esc_html_e( 'Artist', 'extrachill-events' ); ?></option>
+					<option value="venue" <?php selected( $source_kind, 'venue' ); ?>><?php esc_html_e( 'Venue', 'extrachill-events' ); ?></option>
+				</select>
+			</label>
 
 			<label style="display: block; margin: 2px 0;">
-				<?php esc_html_e( 'Existing artist term ID:', 'extrachill-events' ); ?>
-				<input type="number" name="artist_term_id" min="0" value="<?php echo esc_attr( $suggested_term_id ? $suggested_term_id : '' ); ?>" style="width: 100px;" />
+				<?php esc_html_e( 'Entity term ID:', 'extrachill-events' ); ?>
+				<input type="number" name="entity_term_id" min="0" value="<?php echo esc_attr( $entity_term_id ? $entity_term_id : '' ); ?>" style="width: 100px;" />
 			</label>
 			<label style="display: block; margin: 2px 0;">
-				<?php esc_html_e( 'OR new artist name:', 'extrachill-events' ); ?>
-				<input type="text" name="artist_name" value="<?php echo esc_attr( $suggested_term_id ? '' : $suggested_name ); ?>" style="width: 200px;" />
+				<?php esc_html_e( 'Entity name:', 'extrachill-events' ); ?>
+				<input type="text" name="entity_name" value="<?php echo esc_attr( $entity_name ); ?>" style="width: 200px;" />
+			</label>
+			<label style="display: block; margin: 2px 0;">
+				<?php esc_html_e( 'City pipeline ID (venue only):', 'extrachill-events' ); ?>
+				<input type="number" name="pipeline_id" min="0" style="width: 100px;" />
 			</label>
 			<label style="display: block; margin: 2px 0;">
 				<?php esc_html_e( 'Schedule:', 'extrachill-events' ); ?>
@@ -279,7 +296,7 @@ class ArtistUrlSubmissionsAdmin {
 		$submission_id = isset( $_POST['submission_id'] ) ? (int) $_POST['submission_id'] : 0;
 		check_admin_referer( self::NONCE_APPROVE . '_' . $submission_id );
 
-		$ability = wp_get_ability( 'extrachill-events/approve-artist-url-submission' );
+		$ability = wp_get_ability( 'extrachill-events/approve-event-source-submission' );
 		if ( ! $ability ) {
 			$this->redirect_with_flash( 'pending_review', 'error', __( 'Ability not registered.', 'extrachill-events' ) );
 		}
@@ -287,8 +304,10 @@ class ArtistUrlSubmissionsAdmin {
 		$result = $ability->execute(
 			array(
 				'submission_id'     => $submission_id,
-				'artist_term_id'    => isset( $_POST['artist_term_id'] ) ? (int) $_POST['artist_term_id'] : 0,
-				'artist_name'       => isset( $_POST['artist_name'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['artist_name'] ) ) : '',
+				'source_kind'       => isset( $_POST['source_kind'] ) ? sanitize_key( wp_unslash( (string) $_POST['source_kind'] ) ) : 'unknown',
+				'entity_term_id'    => isset( $_POST['entity_term_id'] ) ? (int) $_POST['entity_term_id'] : 0,
+				'entity_name'       => isset( $_POST['entity_name'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['entity_name'] ) ) : '',
+				'pipeline_id'       => isset( $_POST['pipeline_id'] ) ? (int) $_POST['pipeline_id'] : 0,
 				'schedule_interval' => isset( $_POST['schedule_interval'] ) ? sanitize_key( wp_unslash( (string) $_POST['schedule_interval'] ) ) : 'weekly',
 			)
 		);
@@ -308,7 +327,7 @@ class ArtistUrlSubmissionsAdmin {
 		$submission_id = isset( $_POST['submission_id'] ) ? (int) $_POST['submission_id'] : 0;
 		check_admin_referer( self::NONCE_REJECT . '_' . $submission_id );
 
-		$ability = wp_get_ability( 'extrachill-events/reject-artist-url-submission' );
+		$ability = wp_get_ability( 'extrachill-events/reject-event-source-submission' );
 		if ( ! $ability ) {
 			$this->redirect_with_flash( 'pending_review', 'error', __( 'Ability not registered.', 'extrachill-events' ) );
 		}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,7 @@
 			<file>tests/Unit/Abilities/CanonicalAdapterContractsTest.php</file>
 			<file>tests/Unit/Abilities/ArtistUrlImportNotificationTest.php</file>
 			<file>tests/Unit/Abilities/ArtistUrlImportConfigurationContractTest.php</file>
+			<file>tests/Unit/Abilities/EventSourceIntakeTest.php</file>
 			<file>tests/Unit/Abilities/PriorityBoostAbilityTest.php</file>
 			<file>tests/Unit/Core/VenueExpansionPlanTest.php</file>
 			<file>tests/Unit/Core/VenueExpansionRunnerTest.php</file>

--- a/tests/Unit/Abilities/EventSourceIntakeTest.php
+++ b/tests/Unit/Abilities/EventSourceIntakeTest.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Focused tests for qualified event-source intake.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+// phpcs:disable -- Isolated pure-unit fixtures intentionally declare WordPress doubles.
+
+require_once dirname( __DIR__, 3 ) . '/inc/Core/ArtistUrlSubmissionsTable.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Core/VenueExpansionRunner.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Abilities/ArtistUrlImportAbilities.php';
+
+use ExtraChillEvents\Abilities\ArtistUrlImportAbilities;
+use ExtraChillEvents\Abilities\VenueQualificationAbilities;
+use ExtraChillEvents\Core\ArtistUrlSubmissionsTable;
+use ExtraChillEvents\Core\VenueExpansionRunner;
+
+if ( ! class_exists( 'WP_Term' ) ) {
+	class WP_Term {
+		public int $term_id;
+		public string $name;
+
+		public function __construct( int $term_id, string $name ) {
+			$this->term_id = $term_id;
+			$this->name    = $name;
+		}
+	}
+}
+
+if ( ! function_exists( 'taxonomy_exists' ) ) {
+	function taxonomy_exists( $taxonomy ) {
+		return in_array( $taxonomy, array( 'artist', 'venue' ), true );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		return strtolower( trim( preg_replace( '/[^a-z0-9]+/i', '-', $title ), '-' ) );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+	}
+}
+
+if ( ! function_exists( 'get_term_by' ) ) {
+	function get_term_by( $field, $value, $taxonomy ) {
+		$key = $taxonomy . ':' . strtolower( (string) $value );
+		return $GLOBALS['event_source_terms'][ $key ] ?? false;
+	}
+}
+
+if ( ! function_exists( 'get_terms' ) ) {
+	function get_terms() {
+		return array( 72 => 'The Band' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( $text );
+	}
+}
+
+final class EventSourceIntakeTest extends BookingTestCase {
+	private ArtistUrlImportAbilities $intake;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['event_source_terms'] = array(
+			'venue:the room' => new WP_Term( 41, 'The Room' ),
+			'artist:the band' => new WP_Term( 72, 'The Band' ),
+		);
+		$this->intake = ( new ReflectionClass( ArtistUrlImportAbilities::class ) )->newInstanceWithoutConstructor();
+	}
+
+	private function classify( array $events, bool $compatibility_artist = false ): array {
+		$method = new ReflectionMethod( ArtistUrlImportAbilities::class, 'classifySource' );
+		$method->setAccessible( true );
+		return $method->invoke(
+			$this->intake,
+			'https://example.test/events',
+			array(
+				'events_found'    => count( $events ),
+				'raw_events'      => $events,
+				'raw_first_event' => $events[0] ?? array(),
+				'page_html'       => '',
+			),
+			$compatibility_artist
+		);
+	}
+
+	private function approval_kind( string $stored, ?string $explicit = null ) {
+		$method = new ReflectionMethod( ArtistUrlImportAbilities::class, 'resolveApprovalKind' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->intake, $stored, $explicit );
+	}
+
+	public function test_repeated_venue_with_varied_performers_classifies_as_venue(): void {
+		$result = $this->classify(
+			array(
+				array( 'venue' => 'The Room', 'performer' => 'Artist A' ),
+				array( 'venue' => 'The Room', 'performer' => 'Artist B' ),
+			)
+		);
+
+		$this->assertSame( 'venue', $result['source_kind'] );
+		$this->assertSame( 'high', $result['confidence'] );
+		$this->assertSame( 41, $result['binding']['term_id'] );
+	}
+
+	public function test_repeated_performer_across_venues_classifies_as_artist(): void {
+		$result = $this->classify(
+			array(
+				array( 'venue' => 'Room A', 'performer' => 'The Band' ),
+				array( 'venue' => 'Room B', 'performer' => 'The Band' ),
+			)
+		);
+
+		$this->assertSame( 'artist', $result['source_kind'] );
+		$this->assertSame( 72, $result['binding']['term_id'] );
+	}
+
+	public function test_one_off_and_ambiguous_sources_remain_unknown(): void {
+		$result = $this->classify( array( array( 'venue' => 'The Room', 'performer' => 'The Band' ) ) );
+
+		$this->assertSame( 'unknown', $result['source_kind'] );
+		$this->assertSame( 'low', $result['confidence'] );
+		$this->assertNotEmpty( $result['warnings'] );
+	}
+
+	public function test_artist_compatibility_alias_preserves_artist_classification(): void {
+		$result = $this->classify( array( array( 'venue' => 'The Room' ) ), true );
+
+		$this->assertSame( 'artist', $result['source_kind'] );
+	}
+
+	public function test_approval_dispatch_preserves_artist_and_venue(): void {
+		$this->assertSame( 'artist', $this->approval_kind( 'artist' ) );
+		$this->assertSame( 'venue', $this->approval_kind( 'venue' ) );
+	}
+
+	public function test_unknown_approval_requires_explicit_supported_kind(): void {
+		$blocked = $this->approval_kind( 'unknown' );
+
+		$this->assertInstanceOf( WP_Error::class, $blocked );
+		$this->assertSame( 'explicit_source_kind_required', $blocked->get_error_code() );
+		$this->assertSame( 'venue', $this->approval_kind( 'unknown', 'venue' ) );
+	}
+
+	public function test_legacy_rows_read_as_artist_sources(): void {
+		$row = ArtistUrlSubmissionsTable::with_compatibility_defaults(
+			array(
+				'url'                      => 'https://artist.test/tour',
+				'suggested_artist_name'    => 'The Band',
+				'suggested_artist_term_id' => 72,
+			)
+		);
+
+		$this->assertSame( 'artist', $row['source_kind'] );
+		$this->assertSame( 'artist', $row['entity_taxonomy'] );
+		$this->assertSame( 72, $row['entity_term_id'] );
+	}
+
+	public function test_venue_qualifier_discovers_canonical_navigation_candidate(): void {
+		$qualifier = ( new ReflectionClass( VenueQualificationAbilities::class ) )->newInstanceWithoutConstructor();
+		$method    = new ReflectionMethod( VenueQualificationAbilities::class, 'buildCandidateUrls' );
+		$method->setAccessible( true );
+		$candidates = $method->invoke(
+			$qualifier,
+			'https://venue.test',
+			'https://venue.test',
+			'<nav><a href="/calendar">Upcoming shows</a></nav>'
+		);
+
+		$this->assertContains( 'https://venue.test/calendar', array_column( $candidates, 'url' ) );
+	}
+
+	public function test_existing_coverage_uses_venue_expansion_flow_lookup(): void {
+		$runner = new VenueExpansionRunner( null, null, static fn() => array( 'flow_id' => 99, 'flow_name' => 'Existing' ) );
+
+		$this->assertSame( 99, $runner->lookupExistingFlow( 'https://venue.test/calendar' )['flow_id'] );
+	}
+
+	public function test_generic_and_compatibility_contracts_are_both_checked_in(): void {
+		$abilities = file_get_contents( dirname( __DIR__, 3 ) . '/inc/Abilities/ArtistUrlImportAbilities.php' );
+		$routes    = file_get_contents( dirname( __DIR__, 3 ) . '/inc/Api/ArtistUrlImportRoutes.php' );
+
+		$this->assertStringContainsString( 'extrachill/qualify-event-source', $abilities );
+		$this->assertStringContainsString( 'extrachill-events/preview-event-source', $abilities );
+		$this->assertStringContainsString( 'extrachill-events/preview-artist-url', $abilities );
+		$this->assertStringContainsString( '/event-source/preview', $routes );
+		$this->assertStringContainsString( '/artist-url/preview', $routes );
+	}
+
+	public function test_venue_owner_preselects_venue_and_location_taxonomies(): void {
+		$source = file_get_contents( dirname( __DIR__, 3 ) . '/inc/Abilities/VenueAddAbilities.php' );
+
+		$this->assertStringContainsString( "'taxonomy_venue_selection'", $source );
+		$this->assertStringContainsString( "'taxonomy_location_selection'", $source );
+	}
+}

--- a/tests/Unit/Abilities/EventSourceIntakeTest.php
+++ b/tests/Unit/Abilities/EventSourceIntakeTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Focused tests for qualified event-source intake.
+ * Behavioral tests for qualified event-source intake.
  *
  * @package ExtraChillEvents\Tests
  */
@@ -9,28 +9,80 @@
 
 require_once dirname( __DIR__, 3 ) . '/inc/Core/ArtistUrlSubmissionsTable.php';
 require_once dirname( __DIR__, 3 ) . '/inc/Core/VenueExpansionRunner.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Core/FlowLocationGuard.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Abilities/VenueAddAbilities.php';
 require_once dirname( __DIR__, 3 ) . '/inc/Abilities/ArtistUrlImportAbilities.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Api/Controllers/ArtistUrlImport.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Api/ArtistUrlImportRoutes.php';
 
 use ExtraChillEvents\Abilities\ArtistUrlImportAbilities;
+use ExtraChillEvents\Abilities\VenueAddAbilities;
 use ExtraChillEvents\Abilities\VenueQualificationAbilities;
+use ExtraChillEvents\Api\Controllers\ArtistUrlImport;
 use ExtraChillEvents\Core\ArtistUrlSubmissionsTable;
 use ExtraChillEvents\Core\VenueExpansionRunner;
+
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
 
 if ( ! class_exists( 'WP_Term' ) ) {
 	class WP_Term {
 		public int $term_id;
 		public string $name;
+		public int $parent = 0;
 
-		public function __construct( int $term_id, string $name ) {
+		public function __construct( int $term_id, string $name, int $parent = 0 ) {
 			$this->term_id = $term_id;
 			$this->name    = $name;
+			$this->parent  = $parent;
+		}
+	}
+}
+
+if ( ! class_exists( 'DataMachine\Core\Selection\SelectionMode' ) ) {
+	class EventSourceSelectionMode {
+		public const AI_DECIDES = 'ai_decides';
+		public const SKIP = 'skip';
+	}
+	class_alias( EventSourceSelectionMode::class, 'DataMachine\Core\Selection\SelectionMode' );
+}
+
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request {
+		private array $params;
+		private array $headers;
+
+		public function __construct( array $params = array(), array $headers = array( 'accept' => 'application/json' ) ) {
+			$this->params  = $params;
+			$this->headers = $headers;
+		}
+
+		public function get_param( string $key ) {
+			return $this->params[ $key ] ?? null;
+		}
+
+		public function get_header( string $key ): string {
+			return (string) ( $this->headers[ $key ] ?? '' );
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_REST_Response' ) ) {
+	class WP_REST_Response {
+		public $data;
+		public int $status;
+
+		public function __construct( $data, int $status = 200 ) {
+			$this->data   = $data;
+			$this->status = $status;
 		}
 	}
 }
 
 if ( ! function_exists( 'taxonomy_exists' ) ) {
 	function taxonomy_exists( $taxonomy ) {
-		return in_array( $taxonomy, array( 'artist', 'venue' ), true );
+		return in_array( $taxonomy, array( 'artist', 'venue', 'location' ), true );
 	}
 }
 
@@ -46,6 +98,12 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_email' ) ) {
+	function sanitize_email( $email ) {
+		return (string) $email;
+	}
+}
+
 if ( ! function_exists( 'get_term_by' ) ) {
 	function get_term_by( $field, $value, $taxonomy ) {
 		$key = $taxonomy . ':' . strtolower( (string) $value );
@@ -53,9 +111,30 @@ if ( ! function_exists( 'get_term_by' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_term' ) ) {
+	function get_term( $term_id, $taxonomy = '' ) {
+		return $GLOBALS['event_source_term_ids'][ $taxonomy . ':' . (int) $term_id ] ?? null;
+	}
+}
+
 if ( ! function_exists( 'get_terms' ) ) {
-	function get_terms() {
+	function get_terms( $args = array() ) {
+		if ( 'location' === ( $args['taxonomy'] ?? '' ) ) {
+			return array_values( array_filter( $GLOBALS['event_source_term_ids'], static fn( $term, $key ) => str_starts_with( $key, 'location:' ), ARRAY_FILTER_USE_BOTH ) );
+		}
 		return array( 72 => 'The Band' );
+	}
+}
+
+if ( ! function_exists( 'get_term_meta' ) ) {
+	function get_term_meta( $term_id, $key ) {
+		return $GLOBALS['event_source_term_meta'][ (int) $term_id ][ $key ] ?? '';
+	}
+}
+
+if ( ! function_exists( 'data_machine_events_get_venue_data' ) ) {
+	function data_machine_events_get_venue_data( int $term_id ): ?array {
+		return $GLOBALS['event_source_venue_data'][ $term_id ] ?? null;
 	}
 }
 
@@ -65,141 +144,420 @@ if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return 7;
+	}
+}
+
+if ( ! function_exists( 'wp_get_current_user' ) ) {
+	function wp_get_current_user() {
+		return (object) array( 'user_email' => 'person@example.test', 'display_name' => 'Person', 'user_login' => 'person' );
+	}
+}
+
+if ( ! function_exists( 'delete_transient' ) ) {
+	function delete_transient() {}
+}
+
+if ( ! function_exists( 'get_term_link' ) ) {
+	function get_term_link( $term_id, $taxonomy ) {
+		return 'https://events.test/' . $taxonomy . '/' . $term_id;
+	}
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return 'https://events.test' . $path;
+	}
+}
+
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( $name, $definition ) {
+		$GLOBALS['event_source_registered_abilities'][ $name ] = $definition;
+	}
+}
+
+if ( ! function_exists( 'register_rest_route' ) ) {
+	function register_rest_route( $namespace, $route, $definition ) {
+		$GLOBALS['event_source_registered_routes'][ $namespace . $route ] = $definition;
+	}
+}
+
+final class EventSourceWpdb {
+	public string $base_prefix = 'wp_';
+	public string $prefix = 'wp_';
+	public array $submissions = array();
+	public array $pipelines = array();
+	public array $flows = array();
+	public array $updates = array();
+	public int $insert_id = 0;
+
+	public function prepare( $query, ...$args ) {
+		return array( 'query' => $query, 'args' => $args );
+	}
+
+	public function get_row( $prepared, $format = null ) {
+		$query = is_array( $prepared ) ? $prepared['query'] : $prepared;
+		$args  = is_array( $prepared ) ? $prepared['args'] : array();
+		if ( str_contains( $query, 'artist_url_submissions' ) ) {
+			if ( str_contains( $query, 'url_hash' ) ) {
+				foreach ( $this->submissions as $row ) {
+					if ( $row['url_hash'] === ( $args[0] ?? '' ) ) {
+						return $row;
+					}
+				}
+			} else {
+				return $this->submissions[ (int) ( $args[0] ?? 0 ) ] ?? null;
+			}
+		}
+		if ( str_contains( $query, 'datamachine_pipelines' ) ) {
+			return $this->pipelines[ (int) ( $args[0] ?? 0 ) ] ?? null;
+		}
+		return null;
+	}
+
+	public function get_results( $prepared, $format = null ): array {
+		$query = is_array( $prepared ) ? $prepared['query'] : $prepared;
+		$args  = is_array( $prepared ) ? $prepared['args'] : array();
+		if ( str_contains( $query, 'artist_url_submissions' ) ) {
+			return array_values( $this->submissions );
+		}
+		if ( str_contains( $query, 'datamachine_flows' ) ) {
+			$pipeline_id = (int) ( $args[0] ?? 0 );
+			return array_values( array_filter( $this->flows, static fn( $row ) => (int) $row['pipeline_id'] === $pipeline_id ) );
+		}
+		return array();
+	}
+
+	public function insert( $table, array $row ) {
+		$this->insert_id                = count( $this->submissions ) + 1;
+		$row['id']                      = $this->insert_id;
+		$this->submissions[ $this->insert_id ] = $row;
+		return 1;
+	}
+
+	public function update( $table, array $data, array $where ) {
+		$id = (int) $where['id'];
+		$this->updates[] = compact( 'table', 'data', 'where' );
+		$this->submissions[ $id ] = array_merge( $this->submissions[ $id ] ?? array( 'id' => $id ), $data );
+		return 1;
+	}
+}
+
+final class EventSourceAbilityDouble {
+	public array $calls = array();
+	private $result;
+
+	public function __construct( $result ) {
+		$this->result = $result;
+	}
+
+	public function execute( array $input ) {
+		$this->calls[] = $input;
+		return is_callable( $this->result ) ? ( $this->result )( $input ) : $this->result;
+	}
+}
+
+class TestableEventSourceIntake extends ArtistUrlImportAbilities {
+	public array $qualifications = array();
+
+	protected function qualifyForAdmission( string $url, bool $compat_artist = false ) {
+		$result = array_shift( $this->qualifications );
+		return is_callable( $result ) ? $result( $url, $compat_artist ) : $result;
+	}
+}
+
+class CompatibilityEventSourceIntake extends ArtistUrlImportAbilities {
+	public array $received = array();
+
+	public function executePreview( array $input ) {
+		$this->received['preview'] = $input;
+		return array( 'path' => 'preview' );
+	}
+
+	public function executeSubmit( array $input ) {
+		$this->received['submit'] = $input;
+		return array( 'path' => 'submit' );
+	}
+
+	public function executeApprove( array $input ) {
+		$this->received['approve'] = $input;
+		return array( 'path' => 'approve' );
+	}
+}
+
 final class EventSourceIntakeTest extends BookingTestCase {
 	private ArtistUrlImportAbilities $intake;
+	private EventSourceWpdb $wpdb;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$GLOBALS['event_source_terms'] = array(
-			'venue:the room' => new WP_Term( 41, 'The Room' ),
+			'venue:the room'  => new WP_Term( 41, 'The Room' ),
 			'artist:the band' => new WP_Term( 72, 'The Band' ),
 		);
+		$GLOBALS['event_source_term_ids'] = array(
+			'venue:41'   => $GLOBALS['event_source_terms']['venue:the room'],
+			'artist:72'  => $GLOBALS['event_source_terms']['artist:the band'],
+			'location:10'=> new WP_Term( 10, 'Charleston' ),
+		);
+		$GLOBALS['event_source_venue_data'] = array( 41 => array( 'website' => 'https://venue.test' ) );
+		$GLOBALS['event_source_registered_abilities'] = array();
+		$GLOBALS['event_source_registered_routes']    = array();
+		$GLOBALS['ec_artist_test']['registered']      = array();
+		$this->wpdb = new EventSourceWpdb();
+		$GLOBALS['wpdb'] = $this->wpdb;
 		$this->intake = ( new ReflectionClass( ArtistUrlImportAbilities::class ) )->newInstanceWithoutConstructor();
 	}
 
-	private function classify( array $events, bool $compatibility_artist = false ): array {
+	private function classification( array $events, string $url = 'https://venue.test/events', bool $compatibility_artist = false, string $html = '' ): array {
 		$method = new ReflectionMethod( ArtistUrlImportAbilities::class, 'classifySource' );
 		$method->setAccessible( true );
 		return $method->invoke(
 			$this->intake,
-			'https://example.test/events',
+			$url,
 			array(
 				'events_found'    => count( $events ),
 				'raw_events'      => $events,
 				'raw_first_event' => $events[0] ?? array(),
-				'page_html'       => '',
+				'page_html'       => $html,
 			),
+			array( 'fingerprint' => array( 'structured_data' => array( 'event_page_shape' => 'recurring' ) ) ),
 			$compatibility_artist
 		);
 	}
 
-	private function approval_kind( string $stored, ?string $explicit = null ) {
-		$method = new ReflectionMethod( ArtistUrlImportAbilities::class, 'resolveApprovalKind' );
-		$method->setAccessible( true );
-		return $method->invoke( $this->intake, $stored, $explicit );
-	}
-
-	public function test_repeated_venue_with_varied_performers_classifies_as_venue(): void {
-		$result = $this->classify(
-			array(
-				array( 'venue' => 'The Room', 'performer' => 'Artist A' ),
-				array( 'venue' => 'The Room', 'performer' => 'Artist B' ),
-			)
+	private function qualification( string $kind = 'artist', bool $eligible = true ): array {
+		$term_id = 'venue' === $kind ? 41 : 72;
+		$name    = 'venue' === $kind ? 'The Room' : 'The Band';
+		return array(
+			'success'              => true,
+			'qualified'            => true,
+			'canonical_events_url' => 'https://source.test/events',
+			'verdict'              => 'qualified_structured',
+			'events_found'         => 3,
+			'events_preview'       => array(),
+			'extraction_method'    => 'json_ld',
+			'source_kind'          => $kind,
+			'recommended_binding'  => array( 'taxonomy' => $kind, 'term_id' => $term_id, 'name' => $name ),
+			'existing_coverage'    => array( 'covered' => false, 'type' => 'none' ),
+			'warnings'             => array(),
+			'recurring_eligible'   => $eligible,
 		);
-
-		$this->assertSame( 'venue', $result['source_kind'] );
-		$this->assertSame( 'high', $result['confidence'] );
-		$this->assertSame( 41, $result['binding']['term_id'] );
 	}
 
-	public function test_repeated_performer_across_venues_classifies_as_artist(): void {
-		$result = $this->classify(
+	private function pending_submission( string $kind ): array {
+		return array(
+			'id'                       => 1,
+			'user_id'                  => 0,
+			'url'                      => 'https://source.test/events',
+			'url_hash'                 => ArtistUrlSubmissionsTable::url_hash( 'https://source.test/events' ),
+			'canonical_url'            => 'https://source.test/events',
+			'source_kind'              => $kind,
+			'entity_taxonomy'          => $kind,
+			'entity_term_id'           => 'venue' === $kind ? 41 : 72,
+			'entity_name'              => 'venue' === $kind ? 'The Room' : 'The Band',
+			'suggested_artist_term_id' => 'artist' === $kind ? 72 : null,
+			'status'                   => ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
+			'events_found_count'       => 3,
+		);
+	}
+
+	private function city_pipeline_fixture(): void {
+		$this->wpdb->pipelines[5] = array( 'pipeline_id' => 5, 'pipeline_name' => 'Display Name Is Not Identity' );
+		$this->wpdb->flows[]      = array(
+			'pipeline_id' => 5,
+			'flow_config' => wp_json_encode(
+				array(
+					'import' => array( 'step_type' => 'event_import' ),
+					'upsert' => array(
+						'step_type'       => 'upsert',
+						'handler_configs' => array( 'upsert_event' => array( 'taxonomy_location_selection' => '10' ) ),
+					),
+				)
+			),
+		);
+	}
+
+	public function test_venue_requires_official_host_ownership(): void {
+		$events = array(
+			array( 'venue' => 'The Room', 'performer' => 'Artist A' ),
+			array( 'venue' => 'The Room', 'performer' => 'Artist B' ),
+		);
+		$this->assertSame( 'venue', $this->classification( $events )['source_kind'] );
+		$this->assertSame( 'unknown', $this->classification( $events, 'https://promoter.test/calendar' )['source_kind'] );
+	}
+
+	public function test_platform_and_aggregator_hosts_remain_unknown(): void {
+		$events = array(
+			array( 'venue' => 'The Room', 'performer' => 'Artist A' ),
+			array( 'venue' => 'The Room', 'performer' => 'Artist B' ),
+		);
+		$result = $this->classification( $events, 'https://www.eventbrite.com/o/promoter/events' );
+		$this->assertSame( 'unknown', $result['source_kind'] );
+		$this->assertFalse( $result['scope_evidence']['bounded'] );
+	}
+
+	public function test_artist_requires_repeated_single_performer_scope(): void {
+		$result = $this->classification(
 			array(
 				array( 'venue' => 'Room A', 'performer' => 'The Band' ),
 				array( 'venue' => 'Room B', 'performer' => 'The Band' ),
-			)
+			),
+			'https://the-band.test/tour'
 		);
+		$this->assertSame( 'artist', $result['source_kind'] );
+		$this->assertTrue( $result['scope_evidence']['bounded'] );
+	}
+
+	public function test_submission_rejects_ineligible_source_without_queueing(): void {
+		$intake = ( new ReflectionClass( TestableEventSourceIntake::class ) )->newInstanceWithoutConstructor();
+		$intake->qualifications[] = $this->qualification( 'artist', false );
+		$result = $intake->executeSubmit( array( 'url' => 'https://source.test/events' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'source_not_admissible', $result->get_error_code() );
+		$this->assertSame( array(), $this->wpdb->submissions );
+	}
+
+	public function test_approval_requalifies_and_blocks_stale_admission(): void {
+		$this->wpdb->submissions[1] = $this->pending_submission( 'artist' );
+		$intake = ( new ReflectionClass( TestableEventSourceIntake::class ) )->newInstanceWithoutConstructor();
+		$fresh = $this->qualification( 'artist', false );
+		$fresh['existing_coverage'] = array( 'covered' => true, 'type' => 'universal_scraper_flow' );
+		$intake->qualifications[] = $fresh;
+		$result = $intake->executeApprove( array( 'submission_id' => 1 ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'source_no_longer_admissible', $result->get_error_code() );
+		$this->assertSame( array(), $this->wpdb->updates );
+	}
+
+	public function test_artist_approval_dispatches_only_after_fresh_admission(): void {
+		$this->wpdb->submissions[1] = $this->pending_submission( 'artist' );
+		$intake = ( new ReflectionClass( TestableEventSourceIntake::class ) )->newInstanceWithoutConstructor();
+		$intake->qualifications[] = $this->qualification( 'artist', true );
+		$create_flow = new EventSourceAbilityDouble( array( 'success' => true, 'flow_id' => 77 ) );
+		$abilities   = array(
+			'datamachine/get-pipeline-configuration' => new EventSourceAbilityDouble(
+				array(
+					'success'  => true,
+					'pipeline' => array( 'pipeline_id' => 42 ),
+					'flows'    => array( array( 'flow_id' => 77, 'revision' => 'sha256:' . str_repeat( 'a', 64 ) ) ),
+				)
+			),
+			'datamachine/create-flow' => $create_flow,
+			'datamachine/update-step-configuration' => new EventSourceAbilityDouble( array( 'success' => true, 'revision' => 'sha256:' . str_repeat( 'b', 64 ) ) ),
+			'datamachine/run-flow' => new EventSourceAbilityDouble( array( 'success' => true ) ),
+		);
+		$GLOBALS['ec_test_ability_resolver'] = static fn( $name ) => $abilities[ $name ] ?? null;
+
+		$result = $intake->executeApprove( array( 'submission_id' => 1 ) );
 
 		$this->assertSame( 'artist', $result['source_kind'] );
-		$this->assertSame( 72, $result['binding']['term_id'] );
+		$this->assertSame( '72', $create_flow->calls[0]['step_configs']['upsert']['handler_config']['taxonomy_artist_selection'] );
 	}
 
-	public function test_one_off_and_ambiguous_sources_remain_unknown(): void {
-		$result = $this->classify( array( array( 'venue' => 'The Room', 'performer' => 'The Band' ) ) );
+	public function test_venue_approval_validates_pipeline_and_dispatches_owner(): void {
+		$this->city_pipeline_fixture();
+		$this->wpdb->submissions[1] = $this->pending_submission( 'venue' );
+		$intake = ( new ReflectionClass( TestableEventSourceIntake::class ) )->newInstanceWithoutConstructor();
+		$intake->qualifications[] = $this->qualification( 'venue', true );
+		$add_venue = new EventSourceAbilityDouble( array( 'flow_id' => 88, 'pipeline_id' => 5, 'venue_term_id' => 41 ) );
+		$run_flow  = new EventSourceAbilityDouble( array( 'success' => true ) );
+		$GLOBALS['ec_test_ability_resolver'] = static fn( $name ) => array(
+			'extrachill/add-venue'     => $add_venue,
+			'datamachine/run-flow'     => $run_flow,
+		)[ $name ] ?? null;
 
-		$this->assertSame( 'unknown', $result['source_kind'] );
-		$this->assertSame( 'low', $result['confidence'] );
-		$this->assertNotEmpty( $result['warnings'] );
+		$result = $intake->executeApprove( array( 'submission_id' => 1, 'pipeline_id' => 5 ) );
+
+		$this->assertSame( 'venue', $result['source_kind'] );
+		$this->assertSame( 41, $add_venue->calls[0]['venue_term_id'] );
+		$this->assertSame( 5, $add_venue->calls[0]['pipeline_id'] );
 	}
 
-	public function test_artist_compatibility_alias_preserves_artist_classification(): void {
-		$result = $this->classify( array( array( 'venue' => 'The Room' ) ), true );
+	public function test_arbitrary_or_ambiguous_pipeline_is_rejected(): void {
+		$this->wpdb->pipelines[9] = array( 'pipeline_id' => 9, 'pipeline_name' => 'Artist Tour Import' );
+		$validator = ( new ReflectionClass( VenueAddAbilities::class ) )->newInstanceWithoutConstructor();
+		$result    = $validator->validateCityPipeline( 9 );
 
-		$this->assertSame( 'artist', $result['source_kind'] );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_city_pipeline', $result->get_error_code() );
 	}
 
-	public function test_approval_dispatch_preserves_artist_and_venue(): void {
-		$this->assertSame( 'artist', $this->approval_kind( 'artist' ) );
-		$this->assertSame( 'venue', $this->approval_kind( 'venue' ) );
+	public function test_city_pipeline_location_comes_from_bound_term_not_name(): void {
+		$this->city_pipeline_fixture();
+		$validator = ( new ReflectionClass( VenueAddAbilities::class ) )->newInstanceWithoutConstructor();
+		$result    = $validator->validateCityPipeline( 5 );
+
+		$this->assertSame( 10, $result['location_term_id'] );
+		$this->assertSame( 'Charleston', $result['location']->name );
 	}
 
-	public function test_unknown_approval_requires_explicit_supported_kind(): void {
-		$blocked = $this->approval_kind( 'unknown' );
-
-		$this->assertInstanceOf( WP_Error::class, $blocked );
-		$this->assertSame( 'explicit_source_kind_required', $blocked->get_error_code() );
-		$this->assertSame( 'venue', $this->approval_kind( 'unknown', 'venue' ) );
-	}
-
-	public function test_legacy_rows_read_as_artist_sources(): void {
-		$row = ArtistUrlSubmissionsTable::with_compatibility_defaults(
-			array(
-				'url'                      => 'https://artist.test/tour',
-				'suggested_artist_name'    => 'The Band',
-				'suggested_artist_term_id' => 72,
-			)
+	public function test_canonical_dedup_reads_legacy_tracking_variants(): void {
+		$this->wpdb->submissions[4] = array(
+			'id'        => 4,
+			'url'       => 'https://venue.test/events/?utm_source=email',
+			'url_hash'  => hash( 'sha256', 'legacy-value' ),
+			'status'    => ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
 		);
+		$found = ArtistUrlSubmissionsTable::find_tracked_by_url( 'https://venue.test/events#calendar' );
 
-		$this->assertSame( 'artist', $row['source_kind'] );
-		$this->assertSame( 'artist', $row['entity_taxonomy'] );
-		$this->assertSame( 72, $row['entity_term_id'] );
+		$this->assertSame( 4, $found['id'] );
+		$this->assertSame(
+			'https://venue.test/events',
+			ArtistUrlSubmissionsTable::normalize_url( 'https://venue.test:443/events/?utm_medium=social#calendar' )
+		);
+	}
+
+	public function test_ability_aliases_delegate_with_compatibility_flags(): void {
+		$intake = ( new ReflectionClass( CompatibilityEventSourceIntake::class ) )->newInstanceWithoutConstructor();
+		$this->assertSame( 'preview', $intake->executeArtistPreview( array( 'url' => 'https://artist.test' ) )['path'] );
+		$this->assertTrue( $intake->received['preview']['compat_artist'] );
+		$this->assertSame( 'submit', $intake->executeArtistSubmit( array( 'url' => 'https://artist.test' ) )['path'] );
+		$this->assertTrue( $intake->received['submit']['compat_artist'] );
+		$this->assertSame( 'approve', $intake->executeArtistApprove( array( 'submission_id' => 1 ) )['path'] );
+		$this->assertSame( 'artist', $intake->received['approve']['source_kind'] );
+		$this->assertTrue( $intake->received['approve']['compat_artist'] );
+	}
+
+	public function test_generic_ability_schemas_and_rest_routes_register_behaviorally(): void {
+		$method = new ReflectionMethod( ArtistUrlImportAbilities::class, 'registerGenericAbilities' );
+		$method->setAccessible( true );
+		$method->invoke( $this->intake );
+		$registered = array_merge( $GLOBALS['event_source_registered_abilities'], $GLOBALS['ec_artist_test']['registered'] );
+		$qualify    = $registered['extrachill/qualify-event-source'];
+		$approve    = $registered['extrachill-events/approve-event-source-submission'];
+		$this->assertArrayHasKey( 'recurring_eligible', $qualify['output_schema']['properties'] );
+		$this->assertCount( 2, $approve['output_schema']['oneOf'] );
+
+		\ExtraChillEvents\Api\register_event_source_routes_for( 'extrachill/v1' );
+		\ExtraChillEvents\Api\register_artist_url_routes_for( 'extrachill/v1' );
+		$this->assertArrayHasKey( 'extrachill/v1/event-source/preview', $GLOBALS['event_source_registered_routes'] );
+		$this->assertArrayHasKey( 'extrachill/v1/artist-url/preview', $GLOBALS['event_source_registered_routes'] );
+	}
+
+	public function test_rest_compatibility_callback_invokes_artist_alias(): void {
+		$ability = new EventSourceAbilityDouble( array( 'success' => true ) );
+		$GLOBALS['ec_test_ability_resolver'] = static fn( $name ) => 'extrachill-events/preview-artist-url' === $name ? $ability : null;
+		$response = ( new ArtistUrlImport() )->preview( new WP_REST_Request( array( 'url' => 'https://artist.test/tour' ) ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 'https://artist.test/tour', $ability->calls[0]['url'] );
 	}
 
 	public function test_venue_qualifier_discovers_canonical_navigation_candidate(): void {
 		$qualifier = ( new ReflectionClass( VenueQualificationAbilities::class ) )->newInstanceWithoutConstructor();
 		$method    = new ReflectionMethod( VenueQualificationAbilities::class, 'buildCandidateUrls' );
 		$method->setAccessible( true );
-		$candidates = $method->invoke(
-			$qualifier,
-			'https://venue.test',
-			'https://venue.test',
-			'<nav><a href="/calendar">Upcoming shows</a></nav>'
-		);
-
+		$candidates = $method->invoke( $qualifier, 'https://venue.test', 'https://venue.test', '<nav><a href="/calendar">Upcoming shows</a></nav>' );
 		$this->assertContains( 'https://venue.test/calendar', array_column( $candidates, 'url' ) );
 	}
 
 	public function test_existing_coverage_uses_venue_expansion_flow_lookup(): void {
 		$runner = new VenueExpansionRunner( null, null, static fn() => array( 'flow_id' => 99, 'flow_name' => 'Existing' ) );
-
 		$this->assertSame( 99, $runner->lookupExistingFlow( 'https://venue.test/calendar' )['flow_id'] );
-	}
-
-	public function test_generic_and_compatibility_contracts_are_both_checked_in(): void {
-		$abilities = file_get_contents( dirname( __DIR__, 3 ) . '/inc/Abilities/ArtistUrlImportAbilities.php' );
-		$routes    = file_get_contents( dirname( __DIR__, 3 ) . '/inc/Api/ArtistUrlImportRoutes.php' );
-
-		$this->assertStringContainsString( 'extrachill/qualify-event-source', $abilities );
-		$this->assertStringContainsString( 'extrachill-events/preview-event-source', $abilities );
-		$this->assertStringContainsString( 'extrachill-events/preview-artist-url', $abilities );
-		$this->assertStringContainsString( '/event-source/preview', $routes );
-		$this->assertStringContainsString( '/artist-url/preview', $routes );
-	}
-
-	public function test_venue_owner_preselects_venue_and_location_taxonomies(): void {
-		$source = file_get_contents( dirname( __DIR__, 3 ) . '/inc/Abilities/VenueAddAbilities.php' );
-
-		$this->assertStringContainsString( "'taxonomy_venue_selection'", $source );
-		$this->assertStringContainsString( "'taxonomy_location_selection'", $source );
 	}
 }

--- a/tests/Unit/Abilities/EventSourceIntakeTest.php
+++ b/tests/Unit/Abilities/EventSourceIntakeTest.php
@@ -152,7 +152,7 @@ if ( ! function_exists( 'get_current_user_id' ) ) {
 
 if ( ! function_exists( 'wp_get_current_user' ) ) {
 	function wp_get_current_user() {
-		return (object) array( 'user_email' => 'person@example.test', 'display_name' => 'Person', 'user_login' => 'person' );
+		return $GLOBALS['event_source_current_user'] ?? (object) array( 'user_email' => 'person@example.test', 'display_name' => 'Person', 'user_login' => 'person' );
 	}
 }
 
@@ -169,6 +169,30 @@ if ( ! function_exists( 'get_term_link' ) ) {
 if ( ! function_exists( 'home_url' ) ) {
 	function home_url( $path = '' ) {
 		return 'https://events.test' . $path;
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $name, $default = false ) {
+		return 'admin_email' === $name ? '' : $default;
+	}
+}
+
+if ( ! function_exists( 'is_email' ) ) {
+	function is_email( $email ) {
+		return false !== filter_var( $email, FILTER_VALIDATE_EMAIL ) ? $email : false;
+	}
+}
+
+if ( ! function_exists( 'wp_mail' ) ) {
+	function wp_mail() {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_bloginfo' ) ) {
+	function get_bloginfo() {
+		return 'Events Test';
 	}
 }
 
@@ -296,15 +320,18 @@ final class EventSourceIntakeTest extends BookingTestCase {
 		$GLOBALS['event_source_terms'] = array(
 			'venue:the room'  => new WP_Term( 41, 'The Room' ),
 			'artist:the band' => new WP_Term( 72, 'The Band' ),
+			'artist:other artist' => new WP_Term( 73, 'Other Artist' ),
 		);
 		$GLOBALS['event_source_term_ids'] = array(
 			'venue:41'   => $GLOBALS['event_source_terms']['venue:the room'],
 			'artist:72'  => $GLOBALS['event_source_terms']['artist:the band'],
+			'artist:73'  => $GLOBALS['event_source_terms']['artist:other artist'],
 			'location:10'=> new WP_Term( 10, 'Charleston' ),
 		);
 		$GLOBALS['event_source_venue_data'] = array( 41 => array( 'website' => 'https://venue.test' ) );
 		$GLOBALS['event_source_registered_abilities'] = array();
 		$GLOBALS['event_source_registered_routes']    = array();
+		$GLOBALS['event_source_current_user']         = (object) array( 'user_email' => 'person@example.test', 'display_name' => 'Person', 'user_login' => 'person' );
 		$GLOBALS['ec_artist_test']['registered']      = array();
 		$this->wpdb = new EventSourceWpdb();
 		$GLOBALS['wpdb'] = $this->wpdb;
@@ -328,13 +355,14 @@ final class EventSourceIntakeTest extends BookingTestCase {
 		);
 	}
 
-	private function qualification( string $kind = 'artist', bool $eligible = true ): array {
+	private function qualification( string $kind = 'artist', bool $eligible = true, string $url = 'https://source.test/events' ): array {
 		$term_id = 'venue' === $kind ? 41 : 72;
 		$name    = 'venue' === $kind ? 'The Room' : 'The Band';
 		return array(
 			'success'              => true,
 			'qualified'            => true,
-			'canonical_events_url' => 'https://source.test/events',
+			'canonical_events_url' => $url,
+			'source_identity_url'  => ArtistUrlSubmissionsTable::normalize_url( $url ),
 			'verdict'              => 'qualified_structured',
 			'events_found'         => 3,
 			'events_preview'       => array(),
@@ -361,6 +389,50 @@ final class EventSourceIntakeTest extends BookingTestCase {
 			'suggested_artist_term_id' => 'artist' === $kind ? 72 : null,
 			'status'                   => ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
 			'events_found_count'       => 3,
+		);
+	}
+
+	private function legacy_submission(): array {
+		return array(
+			'id'                       => 1,
+			'user_id'                  => 0,
+			'url'                      => 'https://source.test/events?view=calendar&utm_source=legacy',
+			'url_hash'                 => ArtistUrlSubmissionsTable::url_hash( 'https://source.test/events?view=calendar&utm_source=legacy' ),
+			'canonical_url'            => '',
+			'source_kind'              => '',
+			'entity_taxonomy'          => '',
+			'entity_term_id'           => null,
+			'entity_name'              => '',
+			'suggested_artist_name'    => 'The Band',
+			'suggested_artist_term_id' => null,
+			'detected_format'           => 'json_ld',
+			'events_found_count'       => 1,
+			'status'                   => ArtistUrlSubmissionsTable::STATUS_PENDING_REVIEW,
+		);
+	}
+
+	private function safe_legacy_qualification( int $events_found = 1 ): array {
+		$fresh                          = $this->qualification( 'unknown', false, 'https://source.test/events?view=calendar&utm_source=legacy' );
+		$fresh['success']               = true;
+		$fresh['events_found']          = $events_found;
+		$fresh['verdict']               = 'extraction_gap';
+		$fresh['extraction_method']     = 'json_ld';
+		$fresh['recommended_binding']   = array( 'taxonomy' => '', 'term_id' => null, 'name' => '' );
+		return $fresh;
+	}
+
+	private function artist_flow_abilities( EventSourceAbilityDouble $create_flow ): array {
+		return array(
+			'datamachine/get-pipeline-configuration' => new EventSourceAbilityDouble(
+				array(
+					'success'  => true,
+					'pipeline' => array( 'pipeline_id' => 42 ),
+					'flows'    => array( array( 'flow_id' => 77, 'revision' => 'sha256:' . str_repeat( 'a', 64 ) ) ),
+				)
+			),
+			'datamachine/create-flow' => $create_flow,
+			'datamachine/update-step-configuration' => new EventSourceAbilityDouble( array( 'success' => true, 'revision' => 'sha256:' . str_repeat( 'b', 64 ) ) ),
+			'datamachine/run-flow' => new EventSourceAbilityDouble( array( 'success' => true ) ),
 		);
 	}
 
@@ -421,6 +493,28 @@ final class EventSourceIntakeTest extends BookingTestCase {
 		$this->assertSame( array(), $this->wpdb->submissions );
 	}
 
+	public function test_operational_query_url_is_qualified_and_persisted_while_hash_uses_identity(): void {
+		$GLOBALS['event_source_current_user']->user_email = '';
+		$intake = ( new ReflectionClass( TestableEventSourceIntake::class ) )->newInstanceWithoutConstructor();
+		$seen   = '';
+		$operational_url = 'https://source.test/events?view=calendar&utm_source=email';
+		$intake->qualifications[] = function ( string $url ) use ( &$seen, $operational_url ) {
+			$seen = $url;
+			return $this->qualification( 'artist', true, $operational_url );
+		};
+
+		$result = $intake->executeSubmit( array( 'url' => $operational_url . '#schedule' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $operational_url, $seen );
+		$this->assertSame( $operational_url, $this->wpdb->submissions[1]['url'] );
+		$this->assertSame( $operational_url, $this->wpdb->submissions[1]['canonical_url'] );
+		$this->assertSame(
+			ArtistUrlSubmissionsTable::url_hash( 'https://source.test/events?view=calendar' ),
+			$this->wpdb->submissions[1]['url_hash']
+		);
+	}
+
 	public function test_approval_requalifies_and_blocks_stale_admission(): void {
 		$this->wpdb->submissions[1] = $this->pending_submission( 'artist' );
 		$intake = ( new ReflectionClass( TestableEventSourceIntake::class ) )->newInstanceWithoutConstructor();
@@ -437,26 +531,81 @@ final class EventSourceIntakeTest extends BookingTestCase {
 	public function test_artist_approval_dispatches_only_after_fresh_admission(): void {
 		$this->wpdb->submissions[1] = $this->pending_submission( 'artist' );
 		$intake = ( new ReflectionClass( TestableEventSourceIntake::class ) )->newInstanceWithoutConstructor();
-		$intake->qualifications[] = $this->qualification( 'artist', true );
+		$operational_url = 'https://source.test/events?view=calendar&utm_source=approval';
+		$intake->qualifications[] = $this->qualification( 'artist', true, $operational_url );
 		$create_flow = new EventSourceAbilityDouble( array( 'success' => true, 'flow_id' => 77 ) );
-		$abilities   = array(
-			'datamachine/get-pipeline-configuration' => new EventSourceAbilityDouble(
-				array(
-					'success'  => true,
-					'pipeline' => array( 'pipeline_id' => 42 ),
-					'flows'    => array( array( 'flow_id' => 77, 'revision' => 'sha256:' . str_repeat( 'a', 64 ) ) ),
-				)
-			),
-			'datamachine/create-flow' => $create_flow,
-			'datamachine/update-step-configuration' => new EventSourceAbilityDouble( array( 'success' => true, 'revision' => 'sha256:' . str_repeat( 'b', 64 ) ) ),
-			'datamachine/run-flow' => new EventSourceAbilityDouble( array( 'success' => true ) ),
-		);
+		$abilities   = $this->artist_flow_abilities( $create_flow );
 		$GLOBALS['ec_test_ability_resolver'] = static fn( $name ) => $abilities[ $name ] ?? null;
 
 		$result = $intake->executeApprove( array( 'submission_id' => 1 ) );
 
 		$this->assertSame( 'artist', $result['source_kind'] );
 		$this->assertSame( '72', $create_flow->calls[0]['step_configs']['upsert']['handler_config']['taxonomy_artist_selection'] );
+		$this->assertSame( $operational_url, $create_flow->calls[0]['step_configs']['event_import']['handler_config']['source_url'] );
+	}
+
+	public function test_unmatched_fresh_artist_rejects_unrelated_explicit_term_without_side_effects(): void {
+		$row                         = $this->pending_submission( 'artist' );
+		$row['entity_term_id']       = null;
+		$row['entity_name']          = 'New Artist';
+		$this->wpdb->submissions[1] = $row;
+		$fresh                       = $this->qualification( 'artist', true );
+		$fresh['recommended_binding'] = array( 'taxonomy' => 'artist', 'term_id' => null, 'name' => 'New Artist' );
+		$intake                       = ( new ReflectionClass( TestableEventSourceIntake::class ) )->newInstanceWithoutConstructor();
+		$intake->qualifications[]     = $fresh;
+
+		$result = $intake->executeApprove( array( 'submission_id' => 1, 'artist_term_id' => 72 ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'artist_identity_changed', $result->get_error_code() );
+		$this->assertSame( array(), $this->wpdb->updates );
+	}
+
+	public function test_legacy_one_event_submission_allows_matching_explicit_artist(): void {
+		$this->wpdb->submissions[1] = $this->legacy_submission();
+		$intake = ( new ReflectionClass( TestableEventSourceIntake::class ) )->newInstanceWithoutConstructor();
+		$intake->qualifications[] = $this->safe_legacy_qualification( 1 );
+		$create_flow = new EventSourceAbilityDouble( array( 'success' => true, 'flow_id' => 77 ) );
+		$abilities   = $this->artist_flow_abilities( $create_flow );
+		$GLOBALS['ec_test_ability_resolver'] = static fn( $name ) => $abilities[ $name ] ?? null;
+
+		$result = $intake->executeApprove( array( 'submission_id' => 1, 'artist_term_id' => 72 ) );
+
+		$this->assertSame( 'artist', $result['source_kind'] );
+		$this->assertSame( 72, $result['artist_term_id'] );
+	}
+
+	public function test_legacy_multiple_same_venue_evidence_remains_approvable(): void {
+		$row                             = $this->legacy_submission();
+		$row['events_found_count']       = 2;
+		$this->wpdb->submissions[1]     = $row;
+		$intake                          = ( new ReflectionClass( TestableEventSourceIntake::class ) )->newInstanceWithoutConstructor();
+		$intake->qualifications[]        = $this->safe_legacy_qualification( 2 );
+		$create_flow                     = new EventSourceAbilityDouble( array( 'success' => true, 'flow_id' => 77 ) );
+		$abilities                       = $this->artist_flow_abilities( $create_flow );
+		$GLOBALS['ec_test_ability_resolver'] = static fn( $name ) => $abilities[ $name ] ?? null;
+
+		$result = $intake->executeApprove( array( 'submission_id' => 1, 'artist_name' => 'The Band' ) );
+
+		$this->assertSame( 'artist', $result['source_kind'] );
+	}
+
+	public function test_failed_legacy_identity_can_retry_without_losing_compatibility(): void {
+		$this->wpdb->submissions[1] = $this->legacy_submission();
+		$intake = ( new ReflectionClass( TestableEventSourceIntake::class ) )->newInstanceWithoutConstructor();
+		$intake->qualifications[] = $this->safe_legacy_qualification( 1 );
+		$intake->qualifications[] = $this->safe_legacy_qualification( 1 );
+		$create_flow = new EventSourceAbilityDouble( array( 'success' => true, 'flow_id' => 77 ) );
+		$abilities   = $this->artist_flow_abilities( $create_flow );
+		$GLOBALS['ec_test_ability_resolver'] = static fn( $name ) => $abilities[ $name ] ?? null;
+
+		$failed = $intake->executeApprove( array( 'submission_id' => 1, 'artist_term_id' => 73 ) );
+		$this->assertInstanceOf( WP_Error::class, $failed );
+		$this->assertSame( array(), $this->wpdb->updates );
+		$this->assertSame( '', $this->wpdb->submissions[1]['source_kind'] );
+
+		$retried = $intake->executeApprove( array( 'submission_id' => 1, 'artist_term_id' => 72 ) );
+		$this->assertSame( 'artist', $retried['source_kind'] );
 	}
 
 	public function test_venue_approval_validates_pipeline_and_dispatches_owner(): void {
@@ -482,6 +631,31 @@ final class EventSourceIntakeTest extends BookingTestCase {
 		$this->wpdb->pipelines[9] = array( 'pipeline_id' => 9, 'pipeline_name' => 'Artist Tour Import' );
 		$validator = ( new ReflectionClass( VenueAddAbilities::class ) )->newInstanceWithoutConstructor();
 		$result    = $validator->validateCityPipeline( 9 );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_city_pipeline', $result->get_error_code() );
+	}
+
+	public function test_mixed_import_and_located_upsert_flows_do_not_form_a_city_pipeline(): void {
+		$this->wpdb->pipelines[11] = array( 'pipeline_id' => 11, 'pipeline_name' => 'Mixed Events' );
+		$this->wpdb->flows[] = array(
+			'pipeline_id' => 11,
+			'flow_config' => wp_json_encode( array( 'import' => array( 'step_type' => 'event_import' ) ) ),
+		);
+		$this->wpdb->flows[] = array(
+			'pipeline_id' => 11,
+			'flow_config' => wp_json_encode(
+				array(
+					'upsert' => array(
+						'step_type'       => 'upsert',
+						'handler_configs' => array( 'upsert_event' => array( 'taxonomy_location_selection' => '10' ) ),
+					),
+				)
+			),
+		);
+		$validator = ( new ReflectionClass( VenueAddAbilities::class ) )->newInstanceWithoutConstructor();
+
+		$result = $validator->validateCityPipeline( 11 );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'invalid_city_pipeline', $result->get_error_code() );


### PR DESCRIPTION
## Summary
- add source-neutral qualification and moderation for bounded recurring artist and venue sources
- enforce fresh admission before both submission persistence and approval side effects
- preserve executable source URLs separately from canonical dedup identities
- migrate the public client to generic REST routes while retaining shipped artist routes and abilities as compatibility aliases

## Qualification, scope, and admission
`extrachill/qualify-event-source` composes the existing `extrachill/qualify-venue` discovery/verdict machinery with the registered Data Machine Events `universal_web_scraper` handler. Its concrete output schema covers the operational canonical-events URL, separate canonical identity URL, verdict, event preview/count, extraction method, source kind/confidence, entity candidates, ownership evidence, existing coverage, warnings, route/binding, and recurring eligibility.

Admission is a hard mutation invariant:
- new submission performs a fresh server-side qualification and does not insert a row unless `recurring_eligible` is true
- approval performs another fresh qualification before updating moderation state or invoking any flow owner
- stale, one-off, ambiguous, unsupported, identity-changing, duplicate, or newly covered generic sources return an error without creating a recurring flow
- fresh source identity is persisted only with successful approval, so validation failures leave pending rows unchanged and retryable

Venue classification requires repeated single-venue event evidence, a canonical venue term, and a source host matching that venue's stored official website. Promoter/festival pages without ownership evidence remain `unknown`. Known ticketing, platform, and aggregator hosts remain unsupported or already covered instead of inheriting a venue binding. Artist classification requires a single performer across multiple venues.

## URL identity and execution
Operational submitted/discovered URLs retain their query string for qualification, scraping, persistence, and flow `source_url` configuration. Fragments are removed because they are not sent over HTTP. Dedup hashes and comparisons separately use the existing qualification canonicalizer, which drops tracking parameters while preserving allowlisted event-page identity parameters, normalizes default ports, and collapses slash/fragment variants.

The existing `canonical_url` column remains the executable discovered URL; `url_hash` is the canonical identity. Legacy rows remain readable, and canonical comparison scans preserve dedup against pre-canonical hashes without rewriting deployed records.

## Legacy artist migration
Rows with no stored `source_kind` remain identifiable as pre-Phase-1 artist submissions. They may use a tightly bounded approval-only exception when all of the following hold:
- the row is still pending and contains the previously accepted successful extraction evidence
- a moderator explicitly supplies an artist term or name matching the stored artist identity
- a fresh scraper run still extracts events
- fresh coverage is not duplicated, platform-owned, unsupported, unreachable, bot-blocked, flyer-only, or otherwise unsafe
- fresh evidence does not identify a venue or a different artist

This preserves one-event, incomplete-performer, no-term-yet, and multiple-events-at-one-venue pending artist rows without weakening admission for new generic submissions. Failed identity or routing validation does not rewrite the row, so a corrected moderation retry retains legacy compatibility.

## Compatibility
The existing network table remains `<base_prefix>artist_url_submissions`. Schema v2 adds nullable source identity and qualification fields. The checked-in client calls `/extrachill/v1/event-source/preview` and `/event-source/submit`; existing `/artist-url/*` REST routes and `extrachill-events/*-artist-url*` abilities remain Phase 1 aliases. The client allows a bounded 60-second qualification window and never offers recurring submission for an ineligible preview.

## Approval routing
- artist: fresh artist terms/names cannot be replaced by an unrelated explicit term; unmatched fresh artists resolve/create only the freshly proven name through the existing owner path
- venue: fresh qualification must prove the same canonical venue; the selected pipeline must have coherent event-import and located-upsert steps in the same flow, with exactly one canonical `location` identity across qualifying flows
- legacy artist: requires explicit matching moderator identity plus stored and fresh safety evidence
- unknown: cannot pass generic recurring admission or create a flow

`extrachill/add-venue` derives city/location from a concrete flow location binding rather than stripping ` Events` from a pipeline display name. Split unrelated import/upsert flows, missing locations, `AI_DECIDES`, and mixed locations are rejected. The owner also preselects the canonical venue taxonomy, fixing #630.

## Security
Authentication and admin permission gates remain at REST and ability boundaries. URL protocol validation, XHR/direct-navigation protection, canonical deduplication, server-side requalification, moderation, notifications, schedules, event deduplication, and first-run behavior are preserved. No client-provided qualification or unverified identity is trusted.

## Behavioral coverage
- operational query-dependent URLs reach qualification and flow execution unchanged while tracking variants share a dedup identity
- submission rejects ineligible sources without insertion
- approval requalifies and rejects newly covered/stale admission
- unmatched fresh artists reject unrelated explicit terms
- one-event and same-venue legacy artist rows remain approvable with matching explicit identity
- failed legacy identity validation leaves the row untouched and a valid retry succeeds
- official venue ownership succeeds while promoter/platform/aggregator pages remain unknown
- canonical dedup reads legacy tracking variants
- arbitrary, mixed, AI-decided, or location-ambiguous pipelines are rejected
- artist and venue approvals dispatch to their existing owner paths only after validation
- generic schemas, REST routes, and compatibility aliases register and delegate behaviorally
- client timeout and ineligible-preview UX execute under Jest

## Verification
- focused PHP: 67 tests, 188 assertions across intake, artist configuration/notifications, venue qualification/coverage, and URL canonicalization
- `npm run test:js`: 17 suites, 97 tests
- `npm run lint:js`
- `npm run build`
- PHP syntax checks for every changed PHP file
- `git diff --check`
- local Homeboy audit: pass, no introduced findings
- local Homeboy lint (PHPCS, ESLint, PHPStan): pass
- local Homeboy WP Codebox test launch requires runner-owned `WP_CODEBOX_DB_HOST`; GitHub Homeboy CI owns that environment and remains the authoritative full gate

## Phase 2
Phase 2 may remove artist compatibility endpoints and abilities only after the generic form is deployed, old records are confirmed readable/migrated, internal consumers use generic names, and production telemetry shows no old-route usage for an agreed deprecation window. No endpoint removal is included here.

Closes #628
Fixes #630