### PR TITLE
refactor: remove artist event source aliases

### DIFF
--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -1,37 +1,9 @@
 <?php
 /**
- * Artist URL Import Abilities
+ * Event Source Import Abilities
  *
- * Four abilities backing the URL-based artist tour import flow added in
- * extrachill-events#320 and migrated out of the generic data-machine-events
- * substrate in extrachill-events#200 (layer purity — the substrate must not
- * carry "artist" domain knowledge):
- *
- *   1. extrachill-events/preview-artist-url
- *      Non-destructive probe: scrapes the URL via the registered
- *      `universal_web_scraper` event-import handler and returns the
- *      detected format, the event count, a preview of the first few
- *      events, and a suggested artist (term ID if a fuzzy match exists,
- *      name otherwise).
- *
- *   2. extrachill-events/submit-artist-url
- *      Inserts a row into `artist_url_submissions` in
- *      `pending_review` status (or `scraping_failed` if the re-probe
- *      yields no events). Re-runs the preview server-side; never trusts
- *      client-provided detection.
- *
- *   3. extrachill-events/approve-artist-url-submission
- *      Admin-only. Resolves the artist taxonomy term (existing term, or
- *      a new term created via wp_insert_term), creates a flow on the
- *      single shared `Artist Tour Import` pipeline (find-or-create once,
- *      reused across every artist — architecture model B1), binds the
- *      artist to the flow's upsert step with `PRE_SELECTED` and leaves
- *      venue/location/festival on `AI_DECIDES`, then triggers a first
- *      run via `datamachine/run-flow`.
- *
- *   4. extrachill-events/reject-artist-url-submission
- *      Admin-only. Marks the submission row rejected with an optional
- *      reason. No side effects.
+ * Qualifies, previews, submits, approves, and rejects recurring artist and
+ * venue event sources through the canonical generic ability contracts.
  *
  * Substrate consumption (layer purity): the preview probe consumes the
  * generic scraping primitive by its *registered handler slug*
@@ -173,23 +145,19 @@ class ArtistUrlImportAbilities {
 	}
 
 	/**
-	 * Register all four abilities. Each registration is gated on
+	 * Register the event-source abilities. Registration is gated on
 	 * `wp_abilities_api_init` so registration is idempotent regardless
 	 * of when this class is instantiated.
 	 */
 	private function registerAbilities(): void {
 		$register_callback = function () {
 			$this->registerGenericAbilities();
-			$this->registerPreviewAbility();
-			$this->registerSubmitAbility();
-			$this->registerApproveAbility();
-			$this->registerRejectAbility();
 		};
 
 		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
-	/** Register the Phase 1 source-neutral contracts. */
+	/** Register the source-neutral contracts. */
 	private function registerGenericAbilities(): void {
 		$qualify_schema = array(
 			'type'       => 'object',
@@ -220,7 +188,7 @@ class ArtistUrlImportAbilities {
 			'extrachill-events/preview-event-source',
 			array(
 				'label'               => __( 'Preview Event Source', 'extrachill-events' ),
-				'description'         => __( 'Compatibility-shaped preview of qualified event-source intake.', 'extrachill-events' ),
+				'description'         => __( 'Preview a qualified recurring event source.', 'extrachill-events' ),
 				'category'            => 'extrachill-events',
 				'input_schema'        => $qualify_schema,
 				'output_schema'       => $this->qualificationOutputSchema(),
@@ -455,141 +423,6 @@ class ArtistUrlImportAbilities {
 	// Ability registration
 	// ────────────────────────────────────────────────────────────────────
 
-	private function registerPreviewAbility(): void {
-		wp_register_ability(
-			'extrachill-events/preview-artist-url',
-			array(
-				'label'               => __( 'Preview Artist Tour URL', 'extrachill-events' ),
-				'description'         => __( 'Probe a tour/events URL via the universal web scraper. Returns detected format, event count, preview events, and a suggested artist binding. Non-destructive — no submission row is created.', 'extrachill-events' ),
-				'category'            => 'extrachill-events',
-				'input_schema'        => array(
-					'type'       => 'object',
-					'required'   => array( 'url' ),
-					'properties' => array(
-						'url' => array(
-							'type'        => 'string',
-							'format'      => 'uri',
-							'description' => __( 'Tour/events page URL to probe.', 'extrachill-events' ),
-						),
-					),
-				),
-				'output_schema'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'success'                  => array( 'type' => 'boolean' ),
-						'detected_format'          => array( 'type' => 'string' ),
-						'events_found'             => array( 'type' => 'integer' ),
-						'events_preview'           => array( 'type' => 'array' ),
-						'suggested_artist_name'    => array( 'type' => 'string' ),
-						'suggested_artist_term_id' => array( 'type' => array( 'integer', 'null' ) ),
-						'source_metadata'          => array( 'type' => 'object' ),
-					),
-				),
-				'execute_callback'    => array( $this, 'executeArtistPreview' ),
-				'permission_callback' => array( $this, 'permissionLoggedIn' ),
-				'meta'                => array( 'show_in_rest' => true ),
-			)
-		);
-	}
-
-	private function registerSubmitAbility(): void {
-		wp_register_ability(
-			'extrachill-events/submit-artist-url',
-			array(
-				'label'               => __( 'Submit Artist Tour URL', 'extrachill-events' ),
-				'description'         => __( 'Submit a tour/events URL for admin review. Re-probes the URL server-side and inserts a moderation-queue row.', 'extrachill-events' ),
-				'category'            => 'extrachill-events',
-				'input_schema'        => array(
-					'type'       => 'object',
-					'required'   => array( 'url' ),
-					'properties' => array(
-						'url'           => array(
-							'type'   => 'string',
-							'format' => 'uri',
-						),
-						'contact_email' => array( 'type' => 'string' ),
-						'contact_name'  => array( 'type' => 'string' ),
-					),
-				),
-				'output_schema'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'success'       => array( 'type' => 'boolean' ),
-						'submission_id' => array( 'type' => 'integer' ),
-						'status'        => array( 'type' => 'string' ),
-						'message'       => array( 'type' => 'string' ),
-						'events_found'  => array( 'type' => 'integer' ),
-					),
-				),
-				'execute_callback'    => array( $this, 'executeArtistSubmit' ),
-				'permission_callback' => array( $this, 'permissionLoggedIn' ),
-				'meta'                => array( 'show_in_rest' => true ),
-			)
-		);
-	}
-
-	private function registerApproveAbility(): void {
-		wp_register_ability(
-			'extrachill-events/approve-artist-url-submission',
-			array(
-				'label'               => __( 'Approve Artist URL Submission', 'extrachill-events' ),
-				'description'         => __( 'Approve a pending submission: resolves the artist term, creates a pipeline+flow with universal_web_scraper, runs the first scrape immediately.', 'extrachill-events' ),
-				'category'            => 'extrachill-events',
-				'input_schema'        => array(
-					'type'       => 'object',
-					'required'   => array( 'submission_id' ),
-					'properties' => array(
-						'submission_id'     => array( 'type' => 'integer' ),
-						'artist_term_id'    => array( 'type' => 'integer' ),
-						'artist_name'       => array( 'type' => 'string' ),
-						'schedule_interval' => array( 'type' => 'string' ),
-					),
-				),
-				'output_schema'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'success'                     => array( 'type' => 'boolean' ),
-						'pipeline_id'                 => array( 'type' => 'integer' ),
-						'flow_id'                     => array( 'type' => 'integer' ),
-						'artist_term_id'              => array( 'type' => 'integer' ),
-						'events_imported_immediately' => array( 'type' => array( 'integer', 'null' ) ),
-					),
-				),
-				'execute_callback'    => array( $this, 'executeArtistApprove' ),
-				'permission_callback' => array( $this, 'permissionAdmin' ),
-				'meta'                => array( 'show_in_rest' => true ),
-			)
-		);
-	}
-
-	private function registerRejectAbility(): void {
-		wp_register_ability(
-			'extrachill-events/reject-artist-url-submission',
-			array(
-				'label'               => __( 'Reject Artist URL Submission', 'extrachill-events' ),
-				'description'         => __( 'Mark a pending submission as rejected with an optional reason.', 'extrachill-events' ),
-				'category'            => 'extrachill-events',
-				'input_schema'        => array(
-					'type'       => 'object',
-					'required'   => array( 'submission_id' ),
-					'properties' => array(
-						'submission_id' => array( 'type' => 'integer' ),
-						'reason'        => array( 'type' => 'string' ),
-					),
-				),
-				'output_schema'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'success' => array( 'type' => 'boolean' ),
-					),
-				),
-				'execute_callback'    => array( $this, 'executeReject' ),
-				'permission_callback' => array( $this, 'permissionAdmin' ),
-				'meta'                => array( 'show_in_rest' => true ),
-			)
-		);
-	}
-
 	// ────────────────────────────────────────────────────────────────────
 	// Permission callbacks
 	// ────────────────────────────────────────────────────────────────────
@@ -610,35 +443,12 @@ class ArtistUrlImportAbilities {
 		return current_user_can( 'manage_options' );
 	}
 
-	// ────────────────────────────────────────────────────────────────────
-	// preview-artist-url
-	// ────────────────────────────────────────────────────────────────────
-
-	/** Artist ability compatibility alias. */
-	public function executeArtistPreview( array $input ) {
-		$input['compat_artist'] = true;
-		return $this->executePreview( $input );
-	}
-
-	/** Artist submission compatibility alias. */
-	public function executeArtistSubmit( array $input ) {
-		$input['compat_artist'] = true;
-		return $this->executeSubmit( $input );
-	}
-
-	/** Artist approval compatibility alias. */
-	public function executeArtistApprove( array $input ) {
-		$input['source_kind']   = 'artist';
-		$input['compat_artist'] = true;
-		return $this->executeApprove( $input );
-	}
-
 	/** Testable admission seam; mutations must always call this fresh. */
-	protected function qualifyForAdmission( string $url, bool $compat_artist = false ) {
+	protected function qualifyForAdmission( string $url, bool $legacy_artist = false ) {
 		return $this->executeQualifyEventSource(
 			array(
 				'url'           => $url,
-				'compat_artist' => $compat_artist,
+				'legacy_artist' => $legacy_artist,
 			)
 		);
 	}
@@ -703,7 +513,7 @@ class ArtistUrlImportAbilities {
 				'type'    => 'unsupported_' . $host_scope,
 			);
 		}
-		$classification = $this->classifySource( $events_url, $probe, $qualification, ! empty( $input['compat_artist'] ) );
+		$classification = $this->classifySource( $events_url, $probe, $qualification, ! empty( $input['legacy_artist'] ) );
 		$warnings       = array_values( array_unique( array_merge( (array) ( $qualification['warnings'] ?? array() ), $classification['warnings'] ) ) );
 		if ( ! empty( $coverage['covered'] ) ) {
 			$warnings[] = __( 'This source is already covered and should not create another recurring flow.', 'extrachill-events' );
@@ -948,7 +758,7 @@ class ArtistUrlImportAbilities {
 			);
 		}
 
-		$result = $this->qualifyForAdmission( $normalized, ! empty( $input['compat_artist'] ) );
+		$result = $this->qualifyForAdmission( $normalized );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
@@ -977,7 +787,7 @@ class ArtistUrlImportAbilities {
 	}
 
 	// ────────────────────────────────────────────────────────────────────
-	// submit-artist-url
+	// Submit event source.
 	// ────────────────────────────────────────────────────────────────────
 
 	/**
@@ -1024,7 +834,7 @@ class ArtistUrlImportAbilities {
 		}
 
 		// Re-qualify server-side regardless of what the preview saw.
-		$qualification = $this->qualifyForAdmission( $normalized, ! empty( $input['compat_artist'] ) );
+		$qualification = $this->qualifyForAdmission( $normalized );
 
 		if ( is_wp_error( $qualification ) ) {
 			return $qualification;
@@ -1129,7 +939,7 @@ class ArtistUrlImportAbilities {
 	}
 
 	// ────────────────────────────────────────────────────────────────────
-	// approve-artist-url-submission
+	// Approve event source submission.
 	// ────────────────────────────────────────────────────────────────────
 
 	/**
@@ -1159,9 +969,8 @@ class ArtistUrlImportAbilities {
 			);
 		}
 
-		$is_legacy     = ! empty( $submission['compatibility_legacy'] );
-		$compat_artist = ! empty( $input['compat_artist'] ) || $is_legacy;
-		$fresh         = $this->qualifyForAdmission( (string) ( $submission['canonical_url'] ?? $submission['url'] ), $compat_artist );
+		$is_legacy = ! empty( $submission['compatibility_legacy'] );
+		$fresh     = $this->qualifyForAdmission( (string) ( $submission['canonical_url'] ?? $submission['url'] ), $is_legacy );
 		if ( is_wp_error( $fresh ) ) {
 			return $fresh;
 		}
@@ -1620,7 +1429,7 @@ class ArtistUrlImportAbilities {
 	}
 
 	// ────────────────────────────────────────────────────────────────────
-	// reject-artist-url-submission
+	// Reject event source submission.
 	// ────────────────────────────────────────────────────────────────────
 
 	/**

--- a/inc/Api/ArtistUrlImportRoutes.php
+++ b/inc/Api/ArtistUrlImportRoutes.php
@@ -1,17 +1,9 @@
 <?php
 /**
- * Artist URL Import REST Routes
+ * Event Source Import REST Routes
  *
  * Registers generic event-source routes under this plugin's own
- * `extrachill/v1` namespace. The four shipped `artist-url` routes remain
- * Phase 1 compatibility aliases and delegate through the artist ability
- * aliases to the same generic intake implementation.
- *
- * The one-release `datamachine/v1/artist-url/*` compatibility aliases that
- * shipped with the #200 migration were retired in extrachill-events#256: the
- * event-submission block was repointed to the canonical `extrachill/v1`
- * paths in the same #201 change, no in-repo consumer referenced the aliases,
- * and the compat window is closed. Only the canonical namespace is served.
+ * `extrachill/v1` namespace.
  *
  * @package ExtraChillEvents\Api
  * @since   0.35.0
@@ -23,111 +15,9 @@ use ExtraChillEvents\Api\Controllers\ArtistUrlImport;
 
 defined( 'ABSPATH' ) || exit;
 
-const ARTIST_URL_NAMESPACE = 'extrachill/v1';
+const EVENT_SOURCE_NAMESPACE = 'extrachill/v1';
 
-/**
- * Register the artist-url routes for a given namespace.
- *
- * @param string $route_namespace REST namespace.
- * @return void
- */
-function register_artist_url_routes_for( string $route_namespace ): void {
-	$controller = new ArtistUrlImport();
-
-	register_rest_route(
-		$route_namespace,
-		'/artist-url/preview',
-		array(
-			'methods'             => 'POST',
-			'callback'            => array( $controller, 'preview' ),
-			'permission_callback' => array( ArtistUrlImport::class, 'permission_logged_in' ),
-			'args'                => array(
-				'url' => array(
-					'required'          => true,
-					'type'              => 'string',
-					'sanitize_callback' => 'esc_url_raw',
-				),
-			),
-		)
-	);
-
-	register_rest_route(
-		$route_namespace,
-		'/artist-url/submit',
-		array(
-			'methods'             => 'POST',
-			'callback'            => array( $controller, 'submit' ),
-			'permission_callback' => array( ArtistUrlImport::class, 'permission_logged_in' ),
-			'args'                => array(
-				'url'           => array(
-					'required'          => true,
-					'type'              => 'string',
-					'sanitize_callback' => 'esc_url_raw',
-				),
-				'contact_email' => array(
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_email',
-				),
-				'contact_name'  => array(
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_text_field',
-				),
-			),
-		)
-	);
-
-	register_rest_route(
-		$route_namespace,
-		'/artist-url/(?P<id>\d+)/approve',
-		array(
-			'methods'             => 'POST',
-			'callback'            => array( $controller, 'approve' ),
-			'permission_callback' => array( ArtistUrlImport::class, 'permission_admin' ),
-			'args'                => array(
-				'id'                => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
-				),
-				'artist_term_id'    => array(
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
-				),
-				'artist_name'       => array(
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_text_field',
-				),
-				'schedule_interval' => array(
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_key',
-				),
-			),
-		)
-	);
-
-	register_rest_route(
-		$route_namespace,
-		'/artist-url/(?P<id>\d+)/reject',
-		array(
-			'methods'             => 'POST',
-			'callback'            => array( $controller, 'reject' ),
-			'permission_callback' => array( ArtistUrlImport::class, 'permission_admin' ),
-			'args'                => array(
-				'id'     => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
-				),
-				'reason' => array(
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_textarea_field',
-				),
-			),
-		)
-	);
-}
-
-/** Register the source-neutral Phase 1 routes. */
+/** Register the source-neutral routes. */
 function register_event_source_routes_for( string $route_namespace ): void {
 	$controller = new ArtistUrlImport();
 	register_rest_route(
@@ -244,17 +134,9 @@ function register_event_source_routes_for( string $route_namespace ): void {
 	);
 }
 
-/**
- * Register all artist-url routes on rest_api_init.
- *
- * Both generic event-source routes and shipped artist compatibility routes
- * are registered in the canonical `extrachill/v1` namespace.
- *
- * @return void
- */
-function register_artist_url_routes(): void {
-	register_event_source_routes_for( ARTIST_URL_NAMESPACE );
-	register_artist_url_routes_for( ARTIST_URL_NAMESPACE );
+/** Register event-source routes on rest_api_init. */
+function register_event_source_routes(): void {
+	register_event_source_routes_for( EVENT_SOURCE_NAMESPACE );
 }
 
-add_action( 'rest_api_init', __NAMESPACE__ . '\\register_artist_url_routes' );
+add_action( 'rest_api_init', __NAMESPACE__ . '\\register_event_source_routes' );

--- a/inc/Api/Controllers/ArtistUrlImport.php
+++ b/inc/Api/Controllers/ArtistUrlImport.php
@@ -2,7 +2,7 @@
 /**
  * Artist URL Import REST Controller
  *
- * Thin wrappers around the four ArtistUrlImportAbilities. Each route is
+ * Thin wrappers around the event-source abilities. Each route is
  * just `wp_get_ability( ... )->execute( $input )` — business logic
  * lives in the ability, not here.
  *
@@ -106,54 +106,6 @@ class ArtistUrlImport {
 	// ────────────────────────────────────────────────────────────────────
 	// Route callbacks
 	// ────────────────────────────────────────────────────────────────────
-
-	public function preview( \WP_REST_Request $request ) {
-		if ( ! self::looks_like_xhr( $request ) ) {
-			return self::direct_nav_404();
-		}
-
-		return self::run_ability(
-			'extrachill-events/preview-artist-url',
-			array( 'url' => (string) $request->get_param( 'url' ) )
-		);
-	}
-
-	public function submit( \WP_REST_Request $request ) {
-		if ( ! self::looks_like_xhr( $request ) ) {
-			return self::direct_nav_404();
-		}
-
-		return self::run_ability(
-			'extrachill-events/submit-artist-url',
-			array(
-				'url'           => (string) $request->get_param( 'url' ),
-				'contact_email' => (string) $request->get_param( 'contact_email' ),
-				'contact_name'  => (string) $request->get_param( 'contact_name' ),
-			)
-		);
-	}
-
-	public function approve( \WP_REST_Request $request ) {
-		return self::run_ability(
-			'extrachill-events/approve-artist-url-submission',
-			array(
-				'submission_id'     => (int) $request->get_param( 'id' ),
-				'artist_term_id'    => (int) $request->get_param( 'artist_term_id' ),
-				'artist_name'       => (string) $request->get_param( 'artist_name' ),
-				'schedule_interval' => (string) $request->get_param( 'schedule_interval' ),
-			)
-		);
-	}
-
-	public function reject( \WP_REST_Request $request ) {
-		return self::run_ability(
-			'extrachill-events/reject-artist-url-submission',
-			array(
-				'submission_id' => (int) $request->get_param( 'id' ),
-				'reason'        => (string) $request->get_param( 'reason' ),
-			)
-		);
-	}
 
 	public function preview_event_source( \WP_REST_Request $request ) {
 		if ( ! self::looks_like_xhr( $request ) ) {

--- a/inc/admin/ArtistUrlSubmissionsAdmin.php
+++ b/inc/admin/ArtistUrlSubmissionsAdmin.php
@@ -3,8 +3,8 @@
  * Artist URL Submissions Admin
  *
  * Adds a submenu under the Events post-type menu for moderating
- * URL-based artist tour import submissions queued by the
- * `extrachill-events/submit-artist-url` ability.
+ * recurring event-source submissions queued by the
+ * `extrachill-events/submit-event-source` ability.
  *
  * Migrated out of data-machine-events in extrachill-events#200. The screen
  * still hangs off the data-machine-events Events post-type menu, but it

--- a/tests/Unit/Abilities/EventSourceIntakeTest.php
+++ b/tests/Unit/Abilities/EventSourceIntakeTest.php
@@ -286,28 +286,9 @@ final class EventSourceAbilityDouble {
 class TestableEventSourceIntake extends ArtistUrlImportAbilities {
 	public array $qualifications = array();
 
-	protected function qualifyForAdmission( string $url, bool $compat_artist = false ) {
+	protected function qualifyForAdmission( string $url, bool $legacy_artist = false ) {
 		$result = array_shift( $this->qualifications );
-		return is_callable( $result ) ? $result( $url, $compat_artist ) : $result;
-	}
-}
-
-class CompatibilityEventSourceIntake extends ArtistUrlImportAbilities {
-	public array $received = array();
-
-	public function executePreview( array $input ) {
-		$this->received['preview'] = $input;
-		return array( 'path' => 'preview' );
-	}
-
-	public function executeSubmit( array $input ) {
-		$this->received['submit'] = $input;
-		return array( 'path' => 'submit' );
-	}
-
-	public function executeApprove( array $input ) {
-		$this->received['approve'] = $input;
-		return array( 'path' => 'approve' );
+		return is_callable( $result ) ? $result( $url, $legacy_artist ) : $result;
 	}
 }
 
@@ -686,18 +667,7 @@ final class EventSourceIntakeTest extends BookingTestCase {
 		);
 	}
 
-	public function test_ability_aliases_delegate_with_compatibility_flags(): void {
-		$intake = ( new ReflectionClass( CompatibilityEventSourceIntake::class ) )->newInstanceWithoutConstructor();
-		$this->assertSame( 'preview', $intake->executeArtistPreview( array( 'url' => 'https://artist.test' ) )['path'] );
-		$this->assertTrue( $intake->received['preview']['compat_artist'] );
-		$this->assertSame( 'submit', $intake->executeArtistSubmit( array( 'url' => 'https://artist.test' ) )['path'] );
-		$this->assertTrue( $intake->received['submit']['compat_artist'] );
-		$this->assertSame( 'approve', $intake->executeArtistApprove( array( 'submission_id' => 1 ) )['path'] );
-		$this->assertSame( 'artist', $intake->received['approve']['source_kind'] );
-		$this->assertTrue( $intake->received['approve']['compat_artist'] );
-	}
-
-	public function test_generic_ability_schemas_and_rest_routes_register_behaviorally(): void {
+	public function test_only_generic_ability_schemas_and_rest_routes_register(): void {
 		$method = new ReflectionMethod( ArtistUrlImportAbilities::class, 'registerGenericAbilities' );
 		$method->setAccessible( true );
 		$method->invoke( $this->intake );
@@ -706,17 +676,25 @@ final class EventSourceIntakeTest extends BookingTestCase {
 		$approve    = $registered['extrachill-events/approve-event-source-submission'];
 		$this->assertArrayHasKey( 'recurring_eligible', $qualify['output_schema']['properties'] );
 		$this->assertCount( 2, $approve['output_schema']['oneOf'] );
+		foreach ( array( 'preview', 'submit', 'approve', 'reject' ) as $action ) {
+			$this->assertArrayNotHasKey( "extrachill-events/{$action}-artist-url" . ( in_array( $action, array( 'approve', 'reject' ), true ) ? '-submission' : '' ), $registered );
+		}
 
 		\ExtraChillEvents\Api\register_event_source_routes_for( 'extrachill/v1' );
-		\ExtraChillEvents\Api\register_artist_url_routes_for( 'extrachill/v1' );
 		$this->assertArrayHasKey( 'extrachill/v1/event-source/preview', $GLOBALS['event_source_registered_routes'] );
-		$this->assertArrayHasKey( 'extrachill/v1/artist-url/preview', $GLOBALS['event_source_registered_routes'] );
+		$this->assertCount( 4, $GLOBALS['event_source_registered_routes'] );
+		foreach ( array_keys( $GLOBALS['event_source_registered_routes'] ) as $route ) {
+			$this->assertStringNotContainsString( '/artist-url/', $route );
+		}
+		foreach ( array_keys( $registered ) as $ability_name ) {
+			$this->assertStringNotContainsString( 'artist-url', $ability_name );
+		}
 	}
 
-	public function test_rest_compatibility_callback_invokes_artist_alias(): void {
+	public function test_generic_rest_callback_invokes_event_source_ability(): void {
 		$ability = new EventSourceAbilityDouble( array( 'success' => true ) );
-		$GLOBALS['ec_test_ability_resolver'] = static fn( $name ) => 'extrachill-events/preview-artist-url' === $name ? $ability : null;
-		$response = ( new ArtistUrlImport() )->preview( new WP_REST_Request( array( 'url' => 'https://artist.test/tour' ) ) );
+		$GLOBALS['ec_test_ability_resolver'] = static fn( $name ) => 'extrachill-events/preview-event-source' === $name ? $ability : null;
+		$response = ( new ArtistUrlImport() )->preview_event_source( new WP_REST_Request( array( 'url' => 'https://artist.test/tour' ) ) );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertSame( 'https://artist.test/tour', $ability->calls[0]['url'] );

--- a/tests/Unit/Core/FeatureProviderBootstrapTest.php
+++ b/tests/Unit/Core/FeatureProviderBootstrapTest.php
@@ -19,7 +19,7 @@ final class FeatureProviderBootstrapTest extends TestCase {
 		$this->assertTrue( $result['owner_site'] );
 		$this->assertTrue( $result['public_registered'] );
 		$this->assertTrue( $result['ingestion_hooked'] );
-		$this->assertTrue( $result['artist_url_registered'] );
+		$this->assertTrue( $result['event_source_registered'] );
 		$this->assertTrue( $result['booking_registered'] );
 		$this->assertTrue( $result['ability_lifecycle_hooked'] );
 	}
@@ -32,7 +32,7 @@ final class FeatureProviderBootstrapTest extends TestCase {
 		$this->assertTrue( $result['public_registered'] );
 		$this->assertTrue( $result['ingestion_hooked'] );
 		$this->assertTrue( $result['ability_lifecycle_hooked'] );
-		$this->assertTrue( $result['artist_url_registered'] );
+		$this->assertTrue( $result['event_source_registered'] );
 		$this->assertTrue( $result['booking_registered'] );
 	}
 
@@ -78,7 +78,7 @@ final class FeatureProviderBootstrapTest extends TestCase {
 		$this->assertFalse( $result['optional_scheduler_seen'] );
 		$this->assertFalse( $result['optional_users_seen'] );
 		$this->assertTrue( $result['optional_loader_present'] );
-		$this->assertTrue( $result['artist_url_registered'] );
+		$this->assertTrue( $result['event_source_registered'] );
 		$this->assertTrue( $result['booking_registered'] );
 		$this->assertTrue( $result['public_registered'] );
 		$this->assertTrue( $result['ingestion_hooked'] );
@@ -90,7 +90,7 @@ final class FeatureProviderBootstrapTest extends TestCase {
 
 		$this->assertSame( array( 'ingestion' ), $result['provider_failures'] );
 		$this->assertFalse( $result['ingestion_hooked'] );
-		$this->assertTrue( $result['artist_url_registered'] );
+		$this->assertTrue( $result['event_source_registered'] );
 		$this->assertTrue( $result['booking_registered'] );
 		$this->assertTrue( $result['public_registered'] );
 		$this->assertTrue( $result['ability_lifecycle_hooked'] );

--- a/tests/fixtures/bootstrap-matrix.php
+++ b/tests/fixtures/bootstrap-matrix.php
@@ -130,7 +130,7 @@ namespace {
 			'optional_loader_present'  => function_exists( 'extrachill_events_init_data_machine_integration' ),
 			'optional_dependency_seen' => defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ),
 			'ingestion_hooked'         => in_array( 'datamachine_tasks', array_column( $GLOBALS['bootstrap_matrix_hooks'], 0 ), true ),
-			'artist_url_registered'    => function_exists( 'ExtraChillEvents\\Api\\register_artist_url_routes' ),
+			'event_source_registered'  => function_exists( 'ExtraChillEvents\\Api\\register_event_source_routes' ),
 			'booking_registered'       => class_exists( 'ExtraChillEvents\\Core\\BookingRepository', false ),
 			'optional_scheduler_seen'  => function_exists( 'as_schedule_single_action' ),
 			'optional_users_seen'      => function_exists( 'ec_users_notify_with_receipts' ),


### PR DESCRIPTION
## Summary
- remove the obsolete `/artist-url/*` REST routes, artist-specific ability aliases, compatibility controller callbacks, and alias-only dispatch flags
- keep the admin moderation flow and public client on canonical generic event-source contracts
- add contract coverage proving only generic routes and abilities register while artist and legacy artist sources continue through the generic model

## Consumer Evidence
GitHub organization-wide code search found no consumers outside this repository for `/artist-url/preview`, `/artist-url/submit`, `preview-artist-url`, `submit-artist-url`, or the artist-specific approval/rejection ability names. PR #631 already moved the checked-in public client to `/extrachill/v1/event-source/*`, and the generic feature has not been released or deployed, so these aliases are retired before becoming released API surface.

## Historical Data Compatibility
The physical `<base_prefix>artist_url_submissions` table, historical rows, legacy-row interpretation, artist classification, admission checks, artist pipeline routing, and notification attribution remain intact. This PR does not rename or drop storage, rewrite approved rows, or weaken the generic qualification and approval invariants.

## Verification
- focused event-source PHP: 20 tests, 62 assertions
- provider bootstrap PHP: 9 tests, 70 assertions
- all JavaScript tests: 17 suites, 97 tests
- `npm run lint:js`
- `npm run build` with no generated drift
- PHP syntax checks for every edited PHP file
- `git diff --check`
- Homeboy PR audit: pass, zero introduced findings
- Homeboy lint: pass with zero PHPCS, ESLint, or PHPStan findings
- Homeboy umbrella test launch reached the WP Codebox adapter but could not run because the local runner does not expose its owned `WP_CODEBOX_DB_HOST` secret; focused PHP and JS suites above pass locally
- reviewed for secrets, production paths, table/data removal, changelog/version edits, and unrelated generated files

## Deployment Note
When this change is eventually deployed, purge the Events page/full-page cache so cached HTML cannot reference an older event-submission client. Browser tabs opened before deployment remain an accepted transient boundary.

Closes #629