### PR TITLE
fix: alternate venue badge contrast

### DIFF
--- a/assets/css/venue-badges.css
+++ b/assets/css/venue-badges.css
@@ -1,0 +1,26 @@
+/**
+ * Venue Badge Styles
+ *
+ * Venue colors alternate by position instead of assigning arbitrary colors
+ * to individual venues. Location badges retain their existing city colors.
+ *
+ * @package ExtraChillEvents
+ */
+
+.taxonomy-badge.venue-badge {
+	background-color: var(--badge-venue-default-bg, #000000);
+	color: var(--badge-venue-default-text, #ffffff);
+	border-color: var(--badge-venue-default-bg, #000000);
+}
+
+.taxonomy-badges > .taxonomy-badge.venue-badge:nth-child(even of .venue-badge) {
+	background-color: var(--badge-venue-default-text, #ffffff);
+	color: var(--badge-venue-default-bg, #000000);
+	border-color: var(--badge-venue-default-bg, #000000);
+}
+
+.taxonomy-badge.venue-badge:hover,
+.taxonomy-badges > .taxonomy-badge.venue-badge:nth-child(even of .venue-badge):hover {
+	background-color: var(--badge-venue-default-bg, #000000);
+	color: var(--badge-venue-default-text, #ffffff);
+}

--- a/inc/core/data-machine-events/assets.php
+++ b/inc/core/data-machine-events/assets.php
@@ -16,8 +16,23 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Initialize asset hooks
  */
 function extrachill_events_init_assets() {
+	add_action( 'wp_enqueue_scripts', 'extrachill_events_enqueue_venue_badge_styles' );
 	add_action( 'wp_enqueue_scripts', 'extrachill_events_enqueue_single_styles' );
 	add_action( 'wp_enqueue_scripts', 'extrachill_events_enqueue_calendar_styles' );
+}
+
+/** Enqueue Events-owned venue badge colors after the generic theme badges. */
+function extrachill_events_enqueue_venue_badge_styles() {
+	$venue_badges_css = EXTRACHILL_EVENTS_PLUGIN_DIR . 'assets/css/venue-badges.css';
+
+	if ( file_exists( $venue_badges_css ) ) {
+		wp_enqueue_style(
+			'extrachill-events-venue-badges',
+			EXTRACHILL_EVENTS_PLUGIN_URL . 'assets/css/venue-badges.css',
+			array( 'extrachill-taxonomy-badges' ),
+			filemtime( $venue_badges_css )
+		);
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary
- move venue-specific badge presentation into Extra Chill Events, which owns venue classes and surfaces
- alternate venue badges black/white then white/black within badge collections
- keep isolated venue badges black/white and preserve existing city colors
- load the Events override after the theme's generic taxonomy badge stylesheet

## Verification
- `php -l inc/core/data-machine-events/assets.php`
- `git diff --check`

Closes #633

Supersedes Extra-Chill/extrachill#77, which was closed after correcting the ownership boundary.