### PR TITLE
fix: normalize venue pipeline location selections

### DIFF
--- a/inc/Abilities/VenueAddAbilities.php
+++ b/inc/Abilities/VenueAddAbilities.php
@@ -314,9 +314,10 @@ class VenueAddAbilities {
 					continue;
 				}
 				$has_event_upsert = true;
-				$value            = (string) ( $upsert['taxonomy_location_selection'] ?? '' );
-				if ( ctype_digit( $value ) && (int) $value > 0 ) {
-					$flow_locations[ (int) $value ] = true;
+				$value            = $upsert['taxonomy_location_selection'] ?? '';
+				$location         = $this->resolveCanonicalLocationTerm( $value );
+				if ( $location ) {
+					$flow_locations[ (int) $location->term_id ] = true;
 				} else {
 					$invalid_structure = true;
 				}
@@ -349,6 +350,38 @@ class VenueAddAbilities {
 			'location'         => $location,
 			'location_term_id' => $location_id,
 		);
+	}
+
+	/**
+	 * Resolve a supported flow location selection to one canonical term.
+	 *
+	 * @param mixed $value Location term ID or exact canonical name.
+	 */
+	private function resolveCanonicalLocationTerm( $value ): ?\WP_Term {
+		$value = is_int( $value ) || is_string( $value ) ? trim( (string) $value ) : '';
+		if ( '' === $value ) {
+			return null;
+		}
+
+		if ( ctype_digit( $value ) && (int) $value > 0 ) {
+			$term = get_term( (int) $value, 'location' );
+			return $term instanceof \WP_Term ? $term : null;
+		}
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'location',
+				'name'       => $value,
+				'hide_empty' => false,
+				'number'     => 2,
+			)
+		);
+
+		if ( is_wp_error( $terms ) || 1 !== count( $terms ) ) {
+			return null;
+		}
+
+		return $terms[0] instanceof \WP_Term ? $terms[0] : null;
 	}
 
 	/**

--- a/tests/Unit/Abilities/EventSourceIntakeTest.php
+++ b/tests/Unit/Abilities/EventSourceIntakeTest.php
@@ -120,7 +120,11 @@ if ( ! function_exists( 'get_term' ) ) {
 if ( ! function_exists( 'get_terms' ) ) {
 	function get_terms( $args = array() ) {
 		if ( 'location' === ( $args['taxonomy'] ?? '' ) ) {
-			return array_values( array_filter( $GLOBALS['event_source_term_ids'], static fn( $term, $key ) => str_starts_with( $key, 'location:' ), ARRAY_FILTER_USE_BOTH ) );
+			$terms = array_values( array_filter( $GLOBALS['event_source_term_ids'], static fn( $term, $key ) => str_starts_with( $key, 'location:' ), ARRAY_FILTER_USE_BOTH ) );
+			if ( isset( $args['name'] ) ) {
+				$terms = array_values( array_filter( $terms, static fn( $term ) => 0 === strcasecmp( $term->name, (string) $args['name'] ) ) );
+			}
+			return isset( $args['number'] ) && (int) $args['number'] > 0 ? array_slice( $terms, 0, (int) $args['number'] ) : $terms;
 		}
 		return array( 72 => 'The Band' );
 	}
@@ -649,6 +653,57 @@ final class EventSourceIntakeTest extends BookingTestCase {
 
 		$this->assertSame( 10, $result['location_term_id'] );
 		$this->assertSame( 'Charleston', $result['location']->name );
+	}
+
+	public function test_city_pipeline_normalizes_mixed_location_representations(): void {
+		$GLOBALS['event_source_term_ids']['location:7682'] = new WP_Term( 7682, 'Phoenix' );
+		$this->wpdb->pipelines[41]                         = array( 'pipeline_id' => 41, 'pipeline_name' => 'Phoenix Events' );
+		foreach ( array( 7682, '7682', 'Phoenix' ) as $value ) {
+			$this->wpdb->flows[] = array(
+				'pipeline_id' => 41,
+				'flow_config' => wp_json_encode(
+					array(
+						'import' => array( 'step_type' => 'event_import' ),
+						'upsert' => array(
+							'step_type'       => 'upsert',
+							'handler_configs' => array( 'upsert_event' => array( 'taxonomy_location_selection' => $value ) ),
+						),
+					)
+				),
+			);
+		}
+
+		$validator = ( new ReflectionClass( VenueAddAbilities::class ) )->newInstanceWithoutConstructor();
+		$result    = $validator->validateCityPipeline( 41 );
+
+		$this->assertSame( 7682, $result['location_term_id'] );
+		$this->assertSame( 'Phoenix', $result['location']->name );
+	}
+
+	public function test_city_pipeline_rejects_conflicting_canonical_locations(): void {
+		$GLOBALS['event_source_term_ids']['location:7682'] = new WP_Term( 7682, 'Phoenix' );
+		$GLOBALS['event_source_term_ids']['location:7683'] = new WP_Term( 7683, 'Tucson' );
+		$this->wpdb->pipelines[41]                         = array( 'pipeline_id' => 41, 'pipeline_name' => 'Arizona Events' );
+		foreach ( array( 'Phoenix', 7683 ) as $value ) {
+			$this->wpdb->flows[] = array(
+				'pipeline_id' => 41,
+				'flow_config' => wp_json_encode(
+					array(
+						'import' => array( 'step_type' => 'event_import' ),
+						'upsert' => array(
+							'step_type'       => 'upsert',
+							'handler_configs' => array( 'upsert_event' => array( 'taxonomy_location_selection' => $value ) ),
+						),
+					)
+				),
+			);
+		}
+
+		$validator = ( new ReflectionClass( VenueAddAbilities::class ) )->newInstanceWithoutConstructor();
+		$result    = $validator->validateCityPipeline( 41 );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_city_pipeline', $result->get_error_code() );
 	}
 
 	public function test_canonical_dedup_reads_legacy_tracking_variants(): void {


### PR DESCRIPTION
## Summary
- Resolve integer IDs, numeric-string IDs, and exact canonical location names to `WP_Term` identity before comparing pipeline flow locations.
- Preserve the existing per-flow structure checks and reject unresolved, ambiguous, or genuinely conflicting market selections.
- Add regressions for mixed `7682`, `\"7682\"`, and `\"Phoenix\"` values plus conflicting Phoenix/Tucson selections.

## Root Cause
`VenueAddAbilities::validateCityPipeline()` string-cast `taxonomy_location_selection` and accepted only digit strings. Existing Phoenix flows also store the canonical name `Phoenix`, so that valid representation set the pipeline's structural-invalid flag before the uniqueness comparison.

## Normalization And Safety
The wrapper now resolves positive integer and numeric-string values with WordPress `get_term()` and resolves canonical names with an exact `get_terms()` query capped at two results. Name resolution succeeds only when exactly one canonical `location` term matches. Comparison remains keyed by canonical term ID.

The one-canonical-location guard remains intact: every event-import flow must still contain exactly one valid upsert location, all coherent flows must still resolve to one shared term ID, and unresolved, ambiguous, malformed, or conflicting selections still return `invalid_city_pipeline`.

## Owning Layer
This stays in `extrachill-events` because `extrachill venues add` and Extra Chill's canonical city-pipeline policy are wrapper-owned. It uses WordPress taxonomy APIs directly and adds no parallel resolver or shared infrastructure.

## Verification
- `vendor/bin/phpunit --configuration phpunit.xml.dist tests/Unit/Abilities/EventSourceIntakeTest.php` using the managed primary dependency tooling: 22 tests, 66 assertions passed.
- `vendor/bin/phpunit --configuration phpunit-artist-unit.xml.dist`: 30 tests, 136 assertions passed.
- `vendor/bin/phpunit --configuration phpunit-local-scene-unit.xml.dist`: 29 tests, 188 assertions passed.
- `vendor/bin/phpunit --configuration phpunit-membership.xml.dist`: 49 tests, 356 assertions passed.
- `php -l inc/Abilities/VenueAddAbilities.php` and `php -l tests/Unit/Abilities/EventSourceIntakeTest.php`: passed.
- `homeboy review lint --changed-since=origin/main`: passed with PHPCS and PHPStan, run `5607b56b-bdb8-4127-bb3c-e4b377386f0c`.
- `WP_CODEBOX_DB_HOST=127.0.0.1 WP_CODEBOX_DB_PORT=3306 WP_CODEBOX_DB_USER=root WP_CODEBOX_DB_PASSWORD='' homeboy review test --changed-since=origin/main`: selected `EventSourceIntakeTest.php`, but the local managed runtime could not provision its external MySQL service and executed zero tests. The focused direct suite above covers the selected file and passes; GitHub CI will run the declared MySQL service.

Fixes #639