### PR TITLE
refactor: simplify booking field editor

### DIFF
--- a/blocks/venue-settings/src/booking-form-tab.js
+++ b/blocks/venue-settings/src/booking-form-tab.js
@@ -9,7 +9,6 @@ import { useState } from '@wordpress/element';
 import {
 	ActionRow,
 	FieldGroup,
-	Grid,
 	InlineStatus,
 	Panel,
 	PanelHeader,
@@ -67,75 +66,112 @@ export function BookingFormTab( {
 	};
 
 	return (
-		<Grid minColumnWidth="100%">
-			<Panel>
-				<PanelHeader
-					title="Embed your booking form"
-					description="Authorize your venue website, then copy the secure embed code into the page where you want the form to appear."
-				/>
-				<FieldGroup
-					label="Website where you'll embed this form"
-					htmlFor={ `${ idPrefix }venue-booking-websites` }
-					help="Enter the HTTPS address of your website, such as https://venue.example. You can place the form on any page of that website. Add another website on a new line if needed."
-				>
-					<textarea
-						id={ `${ idPrefix }venue-booking-websites` }
-						rows="4"
-						value={ websites.join( '\n' ) }
-						onChange={ ( event ) =>
-							setConfig( {
-								...config,
-								embed: {
-									allowed_parent_origins: event.target.value
-										.split( /\r?\n/ )
-										.map( ( website ) => website.trim() )
-										.filter( Boolean ),
-								},
-							} )
-						}
+		<div className="ec-booking-form-editor">
+			<div className="ec-booking-form-editor__controls">
+				<Panel>
+					<PanelHeader
+						title="Embed your booking form"
+						description="Authorize your venue website, then copy the secure embed code into the page where you want the form to appear."
 					/>
-				</FieldGroup>
-				{ embedSnippet ? (
-					<>
-						<FieldGroup
-							label="Embed code"
-							htmlFor={ `${ idPrefix }venue-booking-embed-code` }
-						>
-							<textarea
-								id={ `${ idPrefix }venue-booking-embed-code` }
-								rows="8"
-								readOnly
-								value={ embedSnippet }
-							/>
-						</FieldGroup>
-						<ActionRow>
-							<button
-								type="button"
-								className="button-1 button-medium"
-								onClick={ copyEmbed }
+					<FieldGroup
+						label="Website where you'll embed this form"
+						htmlFor={ `${ idPrefix }venue-booking-websites` }
+						help="Enter the HTTPS address of your website, such as https://venue.example. You can place the form on any page of that website. Add another website on a new line if needed."
+					>
+						<textarea
+							id={ `${ idPrefix }venue-booking-websites` }
+							rows="4"
+							value={ websites.join( '\n' ) }
+							onChange={ ( event ) =>
+								setConfig( {
+									...config,
+									embed: {
+										allowed_parent_origins:
+											event.target.value
+												.split( /\r?\n/ )
+												.map( ( website ) =>
+													website.trim()
+												)
+												.filter( Boolean ),
+									},
+								} )
+							}
+						/>
+					</FieldGroup>
+					{ embedSnippet ? (
+						<>
+							<FieldGroup
+								label="Embed code"
+								htmlFor={ `${ idPrefix }venue-booking-embed-code` }
 							>
-								Copy embed code
-							</button>
-							{ copied && (
-								<span role="status">Embed code copied.</span>
-							) }
-						</ActionRow>
-					</>
-				) : (
-					<p className="ec-venue-settings__save-note">
-						Add your website to generate its embed code.
-					</p>
+								<textarea
+									id={ `${ idPrefix }venue-booking-embed-code` }
+									rows="8"
+									readOnly
+									value={ embedSnippet }
+								/>
+							</FieldGroup>
+							<ActionRow>
+								<button
+									type="button"
+									className="button-1 button-medium"
+									onClick={ copyEmbed }
+								>
+									Copy embed code
+								</button>
+								{ copied && (
+									<span role="status">
+										Embed code copied.
+									</span>
+								) }
+							</ActionRow>
+						</>
+					) : (
+						<p className="ec-venue-settings__save-note">
+							Add your website to generate its embed code.
+						</p>
+					) }
+				</Panel>
+				<IntakeTab
+					config={ config }
+					setConfig={ setConfig }
+					idPrefix={ idPrefix }
+				/>
+				{ errors.length > 0 && (
+					<InlineStatus tone="error">
+						<strong>Resolve before saving:</strong>
+						<ul>
+							{ errors.map( ( error ) => (
+								<li key={ error }>{ error }</li>
+							) ) }
+						</ul>
+					</InlineStatus>
 				) }
-			</Panel>
-			<IntakeTab
-				config={ config }
-				setConfig={ setConfig }
-				idPrefix={ idPrefix }
-			/>
-			<details>
-				<summary>
-					<strong>Preview booking form</strong>
-				</summary>
+				<Status state={ status } />
+				<ActionRow>
+					<button
+						type="button"
+						className="button-1 button-medium"
+						disabled={ ! dirty || saving || errors.length > 0 }
+						onClick={ onSave }
+					>
+						{ saving ? 'Saving...' : 'Save booking form' }
+					</button>
+					{ dirty && (
+						<span className="ec-venue-settings__dirty">
+							Unsaved booking form changes
+						</span>
+					) }
+				</ActionRow>
+			</div>
+			<aside
+				className="ec-booking-form-editor__preview"
+				aria-label="Booking form preview"
+			>
+				<PanelHeader
+					title="Preview"
+					description="Live preview of your public booking form."
+				/>
 				<div className="ec-venue-booking-inquiry">
 					<BookingInquiry
 						config={ previewConfig(
@@ -148,33 +184,7 @@ export function BookingFormTab( {
 						preview
 					/>
 				</div>
-			</details>
-			{ errors.length > 0 && (
-				<InlineStatus tone="error">
-					<strong>Resolve before saving:</strong>
-					<ul>
-						{ errors.map( ( error ) => (
-							<li key={ error }>{ error }</li>
-						) ) }
-					</ul>
-				</InlineStatus>
-			) }
-			<Status state={ status } />
-			<ActionRow>
-				<button
-					type="button"
-					className="button-1 button-medium"
-					disabled={ ! dirty || saving || errors.length > 0 }
-					onClick={ onSave }
-				>
-					{ saving ? 'Saving...' : 'Save booking form' }
-				</button>
-				{ dirty && (
-					<span className="ec-venue-settings__dirty">
-						Unsaved booking form changes
-					</span>
-				) }
-			</ActionRow>
-		</Grid>
+			</aside>
+		</div>
 	);
 }

--- a/blocks/venue-settings/src/booking-form-tab.test.js
+++ b/blocks/venue-settings/src/booking-form-tab.test.js
@@ -24,14 +24,15 @@ const publicForm = readFileSync(
 );
 
 describe( 'booking form workspace', () => {
-	it( 'puts secure embed setup first and keeps preview collapsed', () => {
+	it( 'puts secure embed setup first and keeps preview visible', () => {
 		expect( workspace.indexOf( 'Embed your booking form' ) ).toBeLessThan(
 			workspace.indexOf( '<IntakeTab' )
 		);
 		expect( workspace ).toContain( 'Copy embed code' );
-		expect( workspace ).toContain( '<details' );
-		expect( workspace ).toContain( '<summary>' );
-		expect( workspace ).toContain( 'Preview booking form' );
+		expect( workspace ).toContain( 'ec-booking-form-editor__preview' );
+		expect( workspace ).toContain(
+			'Live preview of your public booking form.'
+		);
 		expect( workspace ).not.toContain( 'previewDevice' );
 		expect( workspace ).not.toContain( 'QR' );
 		expect( wording ).toContain( 'Edit standard wording' );
@@ -60,15 +61,19 @@ describe( 'booking form workspace', () => {
 		expect( wording ).toContain( 'Contact email (required)' );
 		expect( intake ).toContain( 'Custom fields' );
 		expect( intake ).toContain( 'Add custom field' );
-		expect( intake ).toContain( 'Field type' );
+		expect( intake ).toContain( 'ec-booking-field__type' );
 		expect( intake ).toContain( 'Multiple choice' );
 		expect( intake ).toContain( 'Enter one choice per line.' );
+		expect( intake ).toContain( 'ec-booking-field__row' );
+		expect( intake ).toContain( 'Move ${ field.label } up' );
+		expect( intake ).toContain( 'Move ${ field.label } down' );
 		expect( intake ).not.toContain( 'Add question' );
+		expect( intake ).not.toContain( 'fieldset' );
 	} );
 
 	it( 'uses complete theme button variants', () => {
 		expect( workspace ).toContain( 'button-1 button-medium' );
-		expect( intake ).toContain( 'button-2 button-medium' );
+		expect( intake ).toContain( 'ec-booking-fields__add' );
 		expect( intake ).toContain( 'button-danger button-small' );
 		expect( workspace + intake ).not.toContain( 'button-link-delete' );
 	} );

--- a/blocks/venue-settings/src/intake-field-order.js
+++ b/blocks/venue-settings/src/intake-field-order.js
@@ -1,0 +1,11 @@
+export const hasValidFieldOrder = ( fields ) =>
+	fields.every( ( field, index ) => {
+		if ( ! field.visible_when ) {
+			return true;
+		}
+		return fields
+			.slice( 0, index )
+			.some(
+				( candidate ) => candidate.key === field.visible_when.field
+			);
+	} );

--- a/blocks/venue-settings/src/intake-public.js
+++ b/blocks/venue-settings/src/intake-public.js
@@ -28,12 +28,12 @@ export default function PublicBookingDetails( {
 		[ 'message_help', 'Additional details help' ],
 	];
 	return (
-		<Panel>
+		<Panel className="ec-booking-standard-fields">
 			<PanelHeader
 				title="Standard fields"
 				description="Every venue booking form includes these basic fields. Add venue-specific fields in the Custom fields section below."
 			/>
-			<ul>
+			<ul className="ec-booking-standard-fields__list">
 				{ STANDARD_FIELDS.map( ( field ) => (
 					<li key={ field }>{ field }</li>
 				) ) }

--- a/blocks/venue-settings/src/intake-tab.js
+++ b/blocks/venue-settings/src/intake-tab.js
@@ -7,6 +7,7 @@ import { FieldGroup, Panel, PanelHeader } from '@extrachill/components';
  * Internal dependencies
  */
 import PublicBookingDetails from './intake-public';
+import { hasValidFieldOrder } from './intake-field-order';
 import { normalizeKey } from './state';
 
 const FIELD_TYPES = [
@@ -42,6 +43,28 @@ export function IntakeTab( { config, setConfig, idPrefix = '' } ) {
 				candidate === field ? { ...candidate, ...patch } : candidate
 			)
 		);
+	const moveField = ( index, offset ) => {
+		const target = index + offset;
+		if ( target < 0 || target >= fields.length ) {
+			return;
+		}
+		const reordered = [ ...fields ];
+		const [ field ] = reordered.splice( index, 1 );
+		reordered.splice( target, 0, field );
+		if ( hasValidFieldOrder( reordered ) ) {
+			setFields( reordered );
+		}
+	};
+	const canMove = ( index, offset ) => {
+		const target = index + offset;
+		if ( target < 0 || target >= fields.length ) {
+			return false;
+		}
+		const reordered = [ ...fields ];
+		const [ field ] = reordered.splice( index, 1 );
+		reordered.splice( target, 0, field );
+		return hasValidFieldOrder( reordered );
+	};
 	return (
 		<>
 			<PublicBookingDetails
@@ -54,142 +77,191 @@ export function IntakeTab( { config, setConfig, idPrefix = '' } ) {
 					title="Custom fields"
 					description="Add only the venue-specific information your team needs beyond the standard booking fields."
 				/>
-				{ fields.length === 0 && <p>No custom fields added.</p> }
-				{ fields.map( ( field, rowIndex ) => {
-					const isReferenced = fields.some(
-						( candidate ) =>
-							field.key === candidate.visible_when?.field
-					);
-					return (
-						<fieldset
-							className="ec-venue-settings__repeater"
-							key={ field.key }
-						>
-							<legend>Custom field</legend>
-							<FieldGroup
-								label="Field label"
-								htmlFor={ `${ idPrefix }intake-label-${ rowIndex }` }
-								required
-							>
-								<input
-									id={ `${ idPrefix }intake-label-${ rowIndex }` }
-									value={ field.label }
-									onChange={ ( event ) =>
-										updateField( field, {
-											label: event.target.value,
-										} )
-									}
-								/>
-							</FieldGroup>
-							<FieldGroup
-								label="Field type"
-								htmlFor={ `${ idPrefix }intake-type-${ rowIndex }` }
-							>
-								<select
-									id={ `${ idPrefix }intake-type-${ rowIndex }` }
-									value={ field.type }
-									onChange={ ( event ) =>
-										updateField( field, {
-											type: event.target.value,
-											options:
-												event.target.value === 'select'
-													? field.options
-													: [],
-										} )
-									}
-								>
-									{ FIELD_TYPES.map( ( [ value, label ] ) => (
-										<option key={ value } value={ value }>
-											{ label }
-										</option>
-									) ) }
-								</select>
-							</FieldGroup>
-							{ field.type === 'select' && (
-								<FieldGroup
-									label="Choices"
-									htmlFor={ `${ idPrefix }intake-options-${ rowIndex }` }
-									help="Enter one choice per line."
-									required
-								>
-									<textarea
-										id={ `${ idPrefix }intake-options-${ rowIndex }` }
-										rows="4"
-										value={ field.options.join( '\n' ) }
+				{ fields.length === 0 && (
+					<p className="ec-booking-fields__empty">
+						No custom fields added.
+					</p>
+				) }
+				<div className="ec-booking-fields">
+					{ fields.map( ( field, rowIndex ) => {
+						const isReferenced = fields.some(
+							( candidate ) =>
+								field.key === candidate.visible_when?.field
+						);
+						return (
+							<div className="ec-booking-field" key={ field.key }>
+								<div className="ec-booking-field__row">
+									<span
+										className="ec-booking-field__position"
+										aria-hidden="true"
+									>
+										{ rowIndex + 1 }
+									</span>
+									<input
+										id={ `${ idPrefix }intake-label-${ rowIndex }` }
+										className="ec-booking-field__label"
+										aria-label={ `Field ${
+											rowIndex + 1
+										} label` }
+										value={ field.label }
+										placeholder="Field label"
+										required
 										onChange={ ( event ) =>
 											updateField( field, {
-												options: event.target.value
-													.split( /\r?\n/ )
-													.map( ( option ) =>
-														option.trim()
-													)
-													.filter( Boolean ),
+												label: event.target.value,
 											} )
 										}
 									/>
-								</FieldGroup>
-							) }
-							<label
-								className="ec-checkbox-row"
-								htmlFor={ `${ idPrefix }intake-required-${ rowIndex }` }
-							>
-								<input
-									id={ `${ idPrefix }intake-required-${ rowIndex }` }
-									type="checkbox"
-									checked={ field.required }
-									onChange={ ( event ) =>
-										updateField( field, {
-											required: event.target.checked,
-										} )
-									}
-								/>{ ' ' }
-								Required
-							</label>
-							<button
-								type="button"
-								className="button-danger button-small"
-								disabled={ isReferenced }
-								onClick={ () =>
-									setFields(
-										fields.filter(
-											( candidate ) => candidate !== field
-										)
-									)
-								}
-							>
-								Remove field
-							</button>
-							{ isReferenced && (
-								<p className="ec-venue-settings__save-note">
-									This field controls another saved field and
-									cannot be removed.
-								</p>
-							) }
-						</fieldset>
-					);
-				} ) }
-				<div className="ec-action-row">
-					<button
-						type="button"
-						className="button-2 button-medium"
-						onClick={ () => {
-							const key = nextCustomFieldKey( fields );
-							setFields( [
-								...fields,
-								{
-									key: normalizeKey( key ),
-									label: 'New field',
-									type: 'text',
-									required: false,
-									options: [],
-									visible_when: null,
-								},
-							] );
-						} }
-					>
-						Add custom field
-					</button>
+									<select
+										id={ `${ idPrefix }intake-type-${ rowIndex }` }
+										className="ec-booking-field__type"
+										aria-label={ `${
+											field.label ||
+											`Field ${ rowIndex + 1 }`
+										} type` }
+										value={ field.type }
+										onChange={ ( event ) =>
+											updateField( field, {
+												type: event.target.value,
+												options:
+													event.target.value ===
+													'select'
+														? field.options
+														: [],
+											} )
+										}
+									>
+										{ FIELD_TYPES.map(
+											( [ value, label ] ) => (
+												<option
+													key={ value }
+													value={ value }
+												>
+													{ label }
+												</option>
+											)
+										) }
+									</select>
+									<label
+										className="ec-booking-field__required"
+										htmlFor={ `${ idPrefix }intake-required-${ rowIndex }` }
+									>
+										<input
+											id={ `${ idPrefix }intake-required-${ rowIndex }` }
+											aria-label={ `${
+												field.label ||
+												`Field ${ rowIndex + 1 }`
+											} required` }
+											type="checkbox"
+											checked={ field.required }
+											onChange={ ( event ) =>
+												updateField( field, {
+													required:
+														event.target.checked,
+												} )
+											}
+										/>
+										Required
+									</label>
+									<div className="ec-booking-field__actions">
+										<button
+											type="button"
+											className="button-3 button-small"
+											disabled={
+												! canMove( rowIndex, -1 )
+											}
+											onClick={ () =>
+												moveField( rowIndex, -1 )
+											}
+											aria-label={ `Move ${ field.label } up` }
+										>
+											Up
+										</button>
+										<button
+											type="button"
+											className="button-3 button-small"
+											disabled={
+												! canMove( rowIndex, 1 )
+											}
+											onClick={ () =>
+												moveField( rowIndex, 1 )
+											}
+											aria-label={ `Move ${ field.label } down` }
+										>
+											Down
+										</button>
+										<button
+											type="button"
+											className="button-danger button-small"
+											disabled={ isReferenced }
+											onClick={ () =>
+												setFields(
+													fields.filter(
+														( candidate ) =>
+															candidate !== field
+													)
+												)
+											}
+										>
+											Remove
+										</button>
+									</div>
+								</div>
+								{ field.type === 'select' && (
+									<FieldGroup
+										className="ec-booking-field__choices"
+										label="Choices"
+										htmlFor={ `${ idPrefix }intake-options-${ rowIndex }` }
+										help="Enter one choice per line."
+										required
+									>
+										<textarea
+											id={ `${ idPrefix }intake-options-${ rowIndex }` }
+											rows="4"
+											value={ field.options.join( '\n' ) }
+											onChange={ ( event ) =>
+												updateField( field, {
+													options: event.target.value
+														.split( /\r?\n/ )
+														.map( ( option ) =>
+															option.trim()
+														)
+														.filter( Boolean ),
+												} )
+											}
+										/>
+									</FieldGroup>
+								) }
+								{ isReferenced && (
+									<p className="ec-booking-field__note">
+										This field controls another saved field
+										and cannot be removed.
+									</p>
+								) }
+							</div>
+						);
+					} ) }
 				</div>
+				<button
+					type="button"
+					className="ec-booking-fields__add"
+					onClick={ () => {
+						const key = nextCustomFieldKey( fields );
+						setFields( [
+							...fields,
+							{
+								key: normalizeKey( key ),
+								label: 'New field',
+								type: 'text',
+								required: false,
+								options: [],
+								visible_when: null,
+							},
+						] );
+					} }
+				>
+					Add custom field
+				</button>
 			</Panel>
 		</>
 	);

--- a/blocks/venue-settings/src/intake-tab.test.js
+++ b/blocks/venue-settings/src/intake-tab.test.js
@@ -1,0 +1,27 @@
+/* global describe, expect, it */
+
+/**
+ * Internal dependencies
+ */
+import { hasValidFieldOrder } from './intake-field-order';
+
+describe( 'booking custom field order', () => {
+	it( 'allows independent fields in any order', () => {
+		expect(
+			hasValidFieldOrder( [
+				{ key: 'draw', visible_when: null },
+				{ key: 'genre', visible_when: null },
+			] )
+		).toBe( true );
+	} );
+
+	it( 'requires a controlling field to remain before its dependent field', () => {
+		const controller = { key: 'event_type', visible_when: null };
+		const dependent = {
+			key: 'other_event',
+			visible_when: { field: 'event_type', value: 'Other' },
+		};
+		expect( hasValidFieldOrder( [ controller, dependent ] ) ).toBe( true );
+		expect( hasValidFieldOrder( [ dependent, controller ] ) ).toBe( false );
+	} );
+} );

--- a/blocks/venue-settings/src/style.scss
+++ b/blocks/venue-settings/src/style.scss
@@ -40,18 +40,112 @@
 	margin-block-end: 1rem;
 }
 
-.ec-venue-settings__repeater {
+.ec-booking-form-editor {
 	display: grid;
-	gap: 0.8rem;
-	margin: 0 0 1rem;
-	padding: 1rem;
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius-md);
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 28rem), 1fr));
+	gap: var(--spacing-lg);
+	align-items: start;
 }
 
-.ec-venue-settings__repeater legend {
-	padding-inline: 0.4rem;
+.ec-booking-form-editor__controls {
+	display: grid;
+	gap: var(--spacing-md);
+}
+
+.ec-booking-form-editor__preview {
+	position: sticky;
+	top: var(--spacing-md);
+	min-width: 0;
+}
+
+.ec-booking-standard-fields__list {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: var(--spacing-xs) var(--spacing-md);
+	margin-block: 0 var(--spacing-md);
+	padding-inline-start: var(--spacing-lg);
+}
+
+.ec-booking-fields {
+	display: grid;
+	gap: var(--spacing-sm);
+	margin-block-end: var(--spacing-md);
+}
+
+.ec-booking-fields__empty {
+	color: var(--muted-text);
+}
+
+.ec-booking-field {
+	padding: var(--spacing-sm);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	background: var(--background-color);
+}
+
+.ec-booking-field__row {
+	display: grid;
+	grid-template-columns: auto minmax(10rem, 1fr) minmax(8rem, 0.55fr) auto auto;
+	gap: var(--spacing-sm);
+	align-items: center;
+}
+
+.ec-booking-field__position {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.75rem;
+	height: 1.75rem;
+	border-radius: var(--border-radius-circle);
+	background: var(--card-background);
+	color: var(--muted-text);
+	font-size: var(--font-size-sm);
 	font-weight: 700;
+}
+
+.ec-venue-settings .ec-booking-field__required {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--spacing-xs);
+	white-space: nowrap;
+}
+
+.ec-venue-settings .ec-booking-field__required input {
+	width: auto;
+}
+
+.ec-booking-field__actions {
+	display: flex;
+	gap: var(--spacing-xs);
+}
+
+.ec-booking-field__choices {
+	margin-block-start: var(--spacing-sm);
+}
+
+.ec-booking-field__note {
+	margin: var(--spacing-xs) 0 0;
+	color: var(--muted-text);
+	font-size: var(--font-size-sm);
+}
+
+.ec-booking-fields__add {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	padding: var(--spacing-sm) var(--spacing-md);
+	border: 1px dashed var(--border-color);
+	border-radius: var(--border-radius-md);
+	background: transparent;
+	color: var(--muted-text);
+	font: inherit;
+	cursor: pointer;
+}
+
+.ec-booking-fields__add:hover {
+	border-color: var(--accent);
+	color: var(--accent);
 }
 
 .ec-venue-settings__records {
@@ -298,6 +392,24 @@
 }
 
 @media screen and (max-width: 480px) {
+	.ec-booking-form-editor__preview {
+		position: static;
+	}
+
+	.ec-booking-standard-fields__list {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.ec-booking-field__row {
+		grid-template-columns: auto minmax(0, 1fr);
+	}
+
+	.ec-booking-field__type,
+	.ec-booking-field__required,
+	.ec-booking-field__actions {
+		grid-column: 2;
+	}
+
 	.ec-booking-calendar__weekdays {
 		display: none;
 	}


### PR DESCRIPTION
## Summary
- replace expanded custom-field fieldsets with compact inline editor rows
- add safe field reordering and contextual multiple-choice editing
- keep the public booking preview visible beside the editor and responsive below it
- preserve the existing booking configuration and storage contract

## Verification
- `npm run lint:js`
- `npm run test:js -- --runInBand` (96 tests)
- `npm run build`
- `npm run build:venue-settings`
- `git diff --check`

Closes #640