### PR TITLE
fix: clarify venue booking workspace

### DIFF
--- a/blocks/venue-settings/src/booking-console.js
+++ b/blocks/venue-settings/src/booking-console.js
@@ -15,7 +15,6 @@ import {
 	Panel,
 	PanelHeader,
 	SearchBox,
-	Tabs,
 } from '@extrachill/components';
 
 /**
@@ -23,18 +22,37 @@ import {
  */
 import { errorDetails, runAbility } from './api';
 
-export const BOOKING_STATUSES = [
-	'submitted',
-	'needs_info',
-	'under_review',
-	'negotiating',
-	'held',
-	'confirmed',
-	'declined',
-	'withdrawn',
-	'cancelled',
-	'completed',
-];
+export const BOOKING_TRANSITIONS = {
+	submitted: [ 'needs_info', 'under_review', 'declined', 'withdrawn' ],
+	needs_info: [ 'submitted', 'under_review', 'declined', 'withdrawn' ],
+	under_review: [ 'needs_info', 'negotiating', 'declined', 'withdrawn' ],
+	negotiating: [
+		'needs_info',
+		'under_review',
+		'held',
+		'confirmed',
+		'declined',
+		'withdrawn',
+	],
+	held: [ 'negotiating', 'confirmed', 'declined', 'withdrawn', 'cancelled' ],
+	confirmed: [ 'cancelled', 'completed' ],
+	declined: [],
+	withdrawn: [],
+	cancelled: [],
+	completed: [],
+};
+
+const STATUS_FILTERS = {
+	active: [
+		'submitted',
+		'needs_info',
+		'under_review',
+		'negotiating',
+		'held',
+	],
+	confirmed: [ 'confirmed', 'completed' ],
+	closed: [ 'declined', 'withdrawn', 'cancelled' ],
+};
 
 const STATUS_LABELS = {
 	submitted: 'Submitted',
@@ -137,25 +155,34 @@ export const calendarEntries = ( bookings, events, supportEvents = [] ) => {
 	];
 };
 
-export const filterBookings = ( bookings, search ) => {
+export const filterBookings = ( bookings, search, statusFilter = '' ) => {
 	const query = search.trim().toLowerCase();
-	if ( ! query ) {
+	if ( ! query && ! statusFilter ) {
 		return bookings;
 	}
-	return bookings.filter( ( booking ) =>
-		[
-			booking.artist_name,
-			booking.contact_name,
-			booking.contact_email,
-			booking.public_id,
-			booking.status,
-			booking.venue_name,
-		]
-			.filter( Boolean )
-			.some( ( value ) =>
-				String( value ).toLowerCase().includes( query )
-			)
-	);
+	return bookings.filter( ( booking ) => {
+		if (
+			statusFilter &&
+			! STATUS_FILTERS[ statusFilter ]?.includes( booking.status )
+		) {
+			return false;
+		}
+		return (
+			! query ||
+			[
+				booking.artist_name,
+				booking.contact_name,
+				booking.contact_email,
+				booking.public_id,
+				booking.status,
+				booking.venue_name,
+			]
+				.filter( Boolean )
+				.some( ( value ) =>
+					String( value ).toLowerCase().includes( query )
+				)
+		);
+	} );
 };
 
 const formatDate = ( value, fallback = 'Not set' ) => {
@@ -644,27 +671,35 @@ function ErrorState( { message, onRetry } ) {
 
 function BookingCard( { booking, active, holds, onSelect } ) {
 	return (
-		<button
-			type="button"
-			className={ `ec-panel ec-booking-card${
-				active ? ' is-active' : ''
-			}` }
-			onClick={ () => onSelect( booking.id ) }
-			aria-pressed={ active }
-		>
-			<span className="ec-booking-card__title">
-				{ booking.artist_name }
-			</span>
-			{ booking.venue_name && <span>{ booking.venue_name }</span> }
-			<BookingStatus status={ booking.status } />
-			<span>{ formatDate( booking.requested_start_at ) }</span>
-			{ holds.length > 0 && (
-				<span>
-					{ holds.length } active{ ' ' }
-					{ holds.length === 1 ? 'hold' : 'holds' }
+		<li>
+			<button
+				type="button"
+				className={ `ec-booking-card${ active ? ' is-active' : '' }` }
+				onClick={ () => onSelect( booking.id ) }
+				aria-pressed={ active }
+			>
+				<span className="ec-booking-card__identity">
+					<strong className="ec-booking-card__title">
+						{ booking.artist_name }
+					</strong>
+					{ booking.venue_name && (
+						<span>{ booking.venue_name }</span>
+					) }
 				</span>
-			) }
-		</button>
+				<span className="ec-booking-card__date">
+					{ formatDate( booking.requested_start_at ) }
+				</span>
+				<span className="ec-booking-card__state">
+					<BookingStatus status={ booking.status } />
+					{ holds.length > 0 && (
+						<small>
+							{ holds.length } active{ ' ' }
+							{ holds.length === 1 ? 'hold' : 'holds' }
+						</small>
+					) }
+				</span>
+			</button>
+		</li>
 	);
 }
 
@@ -795,7 +830,10 @@ function Calendar( {
 								);
 								const className = `ec-booking-calendar__item ec-booking-calendar__item--${ entry.status }`;
 								return entry.type === 'event' ? (
-									<span key={ `event-${ entry.id }` }>
+									<div
+										className="ec-booking-calendar__event"
+										key={ `event-${ entry.id }` }
+									>
 										<a
 											className={ className }
 											href={ entry.permalink }
@@ -804,17 +842,18 @@ function Calendar( {
 										</a>
 										{ entry.support && (
 											<a
+												className="ec-booking-calendar__support-action"
 												href={
 													entry.support.workspace_url
 												}
 											>
 												{ entry.support.status ===
 												'not_seeking'
-													? 'Find local support'
-													: 'Manage local support' }
+													? 'Open support request'
+													: 'Manage support request' }
 											</a>
 										) }
-									</span>
+									</div>
 								) : (
 									<button
 										type="button"
@@ -1050,6 +1089,7 @@ function BookingDetail( {
 		}
 	};
 	const activeHolds = holds.filter( ( hold ) => hold.status === 'active' );
+	const availableTransitions = BOOKING_TRANSITIONS[ booking.status ] || [];
 	return (
 		<Panel className="ec-booking-detail">
 			<PanelHeader
@@ -1106,57 +1146,57 @@ function BookingDetail( {
 
 			<section className="ec-booking-detail__section ec-booking-detail__actions">
 				<h3>Operations</h3>
-				<Grid minColumnWidth="16rem" maxColumns={ 1 }>
-					<FieldGroup
-						label="Lifecycle status"
-						htmlFor="booking-transition"
-					>
-						<select
-							id="booking-transition"
-							value={ transition }
-							onChange={ ( event ) =>
-								setTransition( event.target.value )
-							}
+				{ availableTransitions.length ? (
+					<Grid minColumnWidth="16rem" maxColumns={ 1 }>
+						<FieldGroup
+							label="Lifecycle status"
+							htmlFor="booking-transition"
 						>
-							<option value="">
-								Choose canonical transition
-							</option>
-							{ BOOKING_STATUSES.filter(
-								( item ) => item !== booking.status
-							).map( ( item ) => (
-								<option key={ item } value={ item }>
-									{ statusLabel( item ) }
-								</option>
-							) ) }
-						</select>
-						<input
-							value={ note }
-							onChange={ ( event ) =>
-								setNote( event.target.value )
-							}
-							placeholder="Optional transition note"
-						/>
-						<button
-							type="button"
-							className="button-1"
-							disabled={ ! transition || pending !== '' }
-							onClick={ () =>
-								mutate(
-									'Transition',
-									'extrachill/transition-venue-booking',
-									{
-										booking_id: booking.id,
-										to_status: transition,
-										expected_version: booking.version,
-										note: note || null,
-									}
-								)
-							}
-						>
-							Apply transition
-						</button>
-					</FieldGroup>
-				</Grid>
+							<select
+								id="booking-transition"
+								value={ transition }
+								onChange={ ( event ) =>
+									setTransition( event.target.value )
+								}
+							>
+								<option value="">Choose next status</option>
+								{ availableTransitions.map( ( item ) => (
+									<option key={ item } value={ item }>
+										{ statusLabel( item ) }
+									</option>
+								) ) }
+							</select>
+							<input
+								value={ note }
+								onChange={ ( event ) =>
+									setNote( event.target.value )
+								}
+								placeholder="Optional transition note"
+							/>
+							<button
+								type="button"
+								className="button-1"
+								disabled={ ! transition || pending !== '' }
+								onClick={ () =>
+									mutate(
+										'Transition',
+										'extrachill/transition-venue-booking',
+										{
+											booking_id: booking.id,
+											to_status: transition,
+											expected_version: booking.version,
+											note: note || null,
+										}
+									)
+								}
+							>
+								Apply transition
+							</button>
+						</FieldGroup>
+					</Grid>
+				) : (
+					<p>This booking is in a final state.</p>
+				) }
 			</section>
 
 			<section className="ec-booking-detail__section">
@@ -1489,9 +1529,6 @@ export function BookingConsole( {
 						input.range_start = range.start;
 						input.range_end = range.end;
 					}
-					if ( filterStatus ) {
-						input.status = filterStatus;
-					}
 					const [ bookingResult, holdResult, eventResult ] =
 						await Promise.allSettled( [
 							listAllVenueRecords(
@@ -1640,7 +1677,7 @@ export function BookingConsole( {
 
 	useEffect( () => {
 		loadList();
-	}, [ filterStatus, month, view ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ month, view ] ); // eslint-disable-line react-hooks/exhaustive-deps
 	useEffect( () => {
 		loadDetail();
 	}, [ selectedId ] ); // eslint-disable-line react-hooks/exhaustive-deps
@@ -1678,7 +1715,7 @@ export function BookingConsole( {
 	const refreshAfterMutation = async () => {
 		await Promise.all( [ loadList(), loadDetail() ] );
 	};
-	const visible = filterBookings( bookings, search );
+	const visible = filterBookings( bookings, search, filterStatus );
 	const selectedHolds = holds.filter(
 		( hold ) => hold.booking_id === selectedId
 	);
@@ -1690,14 +1727,25 @@ export function BookingConsole( {
 
 	return (
 		<div className="ec-booking-console">
-			<Tabs
-				tabs={ [
-					{ id: 'calendar', label: 'Calendar' },
-					{ id: 'list', label: 'List' },
-				] }
-				active={ view }
-				onChange={ setView }
-			/>
+			<fieldset className="ec-booking-console__view-switcher">
+				<legend>View</legend>
+				<div>
+					{ [
+						{ id: 'calendar', label: 'Calendar' },
+						{ id: 'list', label: 'List' },
+					].map( ( option ) => (
+						<button
+							type="button"
+							key={ option.id }
+							className={ view === option.id ? 'is-active' : '' }
+							aria-pressed={ view === option.id }
+							onClick={ () => setView( option.id ) }
+						>
+							{ option.label }
+						</button>
+					) ) }
+				</div>
+			</fieldset>
 			<Grid
 				className="ec-booking-console__toolbar"
 				minColumnWidth="12rem"
@@ -1718,12 +1766,10 @@ export function BookingConsole( {
 							setFilterStatus( event.target.value )
 						}
 					>
-						<option value="">All statuses</option>
-						{ BOOKING_STATUSES.map( ( item ) => (
-							<option value={ item } key={ item }>
-								{ statusLabel( item ) }
-							</option>
-						) ) }
+						<option value="">All bookings</option>
+						<option value="active">Active inquiries</option>
+						<option value="confirmed">Confirmed shows</option>
+						<option value="closed">Closed inquiries</option>
 					</select>
 				</label>
 			</Grid>
@@ -1751,11 +1797,7 @@ export function BookingConsole( {
 								description="A bounded venue-authorized list across the selected venue scope. Filters are reapplied by canonical abilities."
 							/>
 							{ visible.length ? (
-								<Grid
-									className="ec-booking-console__list"
-									minColumnWidth="15rem"
-									gap="0.75rem"
-								>
+								<ul className="ec-booking-console__list">
 									{ visible.map( ( booking ) => (
 										<BookingCard
 											key={ booking.id }
@@ -1767,7 +1809,7 @@ export function BookingConsole( {
 											onSelect={ selectBooking }
 										/>
 									) ) }
-								</Grid>
+								</ul>
 							) : (
 								<EmptyState>
 									No bookings match this venue scope and

--- a/blocks/venue-settings/src/style.scss
+++ b/blocks/venue-settings/src/style.scss
@@ -198,6 +198,45 @@
 	margin-bottom: 0;
 }
 
+.ec-booking-console__view-switcher {
+	display: flex;
+	align-items: center;
+	gap: 0.65rem;
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+
+.ec-booking-console__view-switcher legend {
+	float: left;
+	font-size: 0.85rem;
+	font-weight: 750;
+}
+
+.ec-booking-console__view-switcher > div {
+	display: inline-flex;
+	padding: 0.2rem;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	background: var(--card-background);
+}
+
+.ec-booking-console__view-switcher button {
+	padding: 0.4rem 0.75rem;
+	border: 0;
+	border-radius: var(--border-radius-sm);
+	background: transparent;
+	color: var(--text-color);
+	font: inherit;
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.ec-booking-console__view-switcher button.is-active {
+	background: var(--header-background);
+	color: var(--header-text-color);
+}
+
 .ec-booking-console__toolbar label {
 	display: grid;
 	gap: 0.35rem;
@@ -206,7 +245,15 @@
 }
 
 .ec-booking-card {
+	display: grid;
+	grid-template-columns: minmax(10rem, 1fr) minmax(10rem, auto) minmax(8rem, auto);
+	align-items: center;
+	gap: 1rem;
 	width: 100%;
+	padding: 1rem;
+	border: 0;
+	border-left: 3px solid transparent;
+	background: transparent;
 	color: inherit;
 	font: inherit;
 	text-align: left;
@@ -215,13 +262,34 @@
 
 .ec-booking-card:hover,
 .ec-booking-card.is-active {
-	border-color: var(--focus-border-color);
-	box-shadow: 0 0 0 2px color-mix(in srgb, var(--focus-border-color) 18%, transparent);
+	border-left-color: var(--focus-border-color);
+	background: color-mix(in srgb, var(--focus-border-color) 7%, transparent);
 }
 
 .ec-booking-card__title {
 	font-size: 1.05rem;
 	font-weight: 750;
+}
+
+.ec-booking-card__identity,
+.ec-booking-card__state {
+	display: grid;
+	gap: 0.25rem;
+}
+
+.ec-booking-card__state {
+	justify-items: start;
+}
+
+.ec-booking-console__list {
+	margin: 0;
+	padding: 0;
+	border-block-start: 1px solid var(--border-color);
+	list-style: none;
+}
+
+.ec-booking-console__list li {
+	border-block-end: 1px solid var(--border-color);
 }
 
 .ec-booking-calendar__weekdays,
@@ -311,6 +379,22 @@
 
 .ec-booking-calendar__item span {
 	font-weight: 750;
+}
+
+.ec-booking-calendar__event {
+	display: grid;
+	gap: 0.2rem;
+}
+
+.ec-booking-calendar__support-action {
+	display: block;
+	padding: 0.25rem 0.4rem;
+	border-radius: var(--border-radius-sm);
+	background: var(--card-background);
+	font-size: 0.7rem;
+	font-weight: 700;
+	line-height: 1.2;
+	text-align: center;
 }
 
 .ec-booking-detail__header {
@@ -436,6 +520,11 @@
 	.ec-booking-console__timeline li {
 		align-items: flex-start;
 		flex-direction: column;
+	}
+
+	.ec-booking-card {
+		grid-template-columns: 1fr;
+		gap: 0.5rem;
 	}
 
 	.ec-venue-settings__records li {

--- a/blocks/venue-settings/src/style.test.js
+++ b/blocks/venue-settings/src/style.test.js
@@ -19,12 +19,16 @@ describe( 'venue booking workspace composition', () => {
 		);
 		expect( consoleSource ).toContain( '<Badge tone=' );
 		expect( consoleSource ).toContain( '<PanelHeader' );
-		expect( consoleSource ).toContain( '<Tabs' );
-		expect( consoleSource ).not.toContain( 'aria-pressed={ view ===' );
+		expect( consoleSource ).toContain(
+			'className="ec-booking-console__view-switcher"'
+		);
+		expect( consoleSource ).toContain( 'aria-pressed={ view ===' );
 		expect( consoleSource ).toContain(
 			'className="ec-booking-console__toolbar"'
 		);
-		expect( consoleSource ).toContain( '`ec-panel ec-booking-card${' );
+		expect( consoleSource ).toContain(
+			'<ul className="ec-booking-console__list">'
+		);
 	} );
 
 	it( 'uses canonical semantic tokens for unique calendar states', () => {

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -291,7 +291,7 @@ export function VenueSettingsApp( { context } ) {
 	const tabs = [
 		...( accessibleVenues.length
 			? [
-					{ id: 'calendar', label: 'Calendar' },
+					{ id: 'calendar', label: 'Bookings' },
 					{ id: 'venue', label: 'Venue' },
 					{ id: 'booking-form', label: 'Booking Form' },
 					{ id: 'settings', label: 'Settings' },

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -478,7 +478,7 @@ describe( 'venue settings authorization-facing states', () => {
 				),
 			].map( ( button ) => button.textContent )
 		).toEqual( [
-			'Calendar',
+			'Bookings',
 			'Venue',
 			'Booking Form',
 			'Settings',
@@ -657,9 +657,8 @@ describe( 'venue settings authorization-facing states', () => {
 					'[data-context-surface="venue-settings"] > button'
 				),
 			].map( ( button ) => button.textContent )
-		).toEqual( [ 'Calendar', 'Venue', 'Booking Form', 'Settings' ] );
+		).toEqual( [ 'Bookings', 'Venue', 'Booking Form', 'Settings' ] );
 		for ( const retired of [
-			'Bookings',
 			'Local Support',
 			'Profile',
 			'Booking',
@@ -678,6 +677,19 @@ describe( 'venue settings authorization-facing states', () => {
 	} );
 
 	it( 'shows exactly five venue tabs to authorized managers', async () => {
+		apiFetch.mockImplementation( ( request ) => {
+			const input = requestInput( request );
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'list-venue-bookings' ) ) {
+				return Promise.resolve( [ booking( 9 ) ] );
+			}
+			return Promise.resolve( [] );
+		} );
 		const { container, root } = await renderApp(
 			context( {
 				user: { id: 1, name: 'Admin', is_admin: true },
@@ -691,7 +703,7 @@ describe( 'venue settings authorization-facing states', () => {
 				),
 			].map( ( button ) => button.textContent )
 		).toEqual( [
-			'Calendar',
+			'Bookings',
 			'Venue',
 			'Booking Form',
 			'Settings',
@@ -700,6 +712,9 @@ describe( 'venue settings authorization-facing states', () => {
 		expect( container.textContent ).not.toContain( 'Venue claims' );
 		await act( async () => buttonByText( container, 'List' ).click() );
 		expect( container.textContent ).toContain( 'Booking pipeline' );
+		expect(
+			container.querySelector( 'ul.ec-booking-console__list' )
+		).not.toBeNull();
 		await act( async () => root.unmount() );
 	} );
 
@@ -734,18 +749,22 @@ describe( 'venue settings authorization-facing states', () => {
 			true
 		);
 		expect( buttonByText( container, 'My Venues' ) ).toBeDefined();
-		const viewTabs = [
-			...container.querySelectorAll( '[role="tab"]' ),
-		].filter( ( tab ) =>
-			[ 'Calendar', 'List' ].includes( tab.textContent )
+		const viewSwitcher = container.querySelector(
+			'.ec-booking-console__view-switcher'
 		);
-		expect( viewTabs ).toHaveLength( 2 );
-		expect( buttonByText( container, 'List' ).className ).toContain(
-			'ec-tabs__tab'
+		expect( viewSwitcher.querySelector( 'legend' ).textContent ).toBe(
+			'View'
 		);
-		expect( buttonByText( container, 'List' ).className ).not.toContain(
-			'button-2'
-		);
+		expect(
+			[ ...viewSwitcher.querySelectorAll( 'button' ) ].map(
+				( button ) => button.textContent
+			)
+		).toEqual( [ 'Calendar', 'List' ] );
+		expect(
+			container.querySelectorAll(
+				'[data-context-surface="venue-settings"] > button'
+			)
+		).toHaveLength( 4 );
 		await act( async () => root.unmount() );
 	} );
 
@@ -831,10 +850,10 @@ describe( 'venue settings authorization-facing states', () => {
 			} )
 		);
 		expect( container.textContent ).toContain( 'Kid Lake at Venue 44' );
-		expect( container.textContent ).toContain( 'Find local support' );
+		expect( container.textContent ).toContain( 'Open support request' );
 		expect(
 			[ ...container.querySelectorAll( 'a' ) ]
-				.find( ( link ) => link.textContent === 'Find local support' )
+				.find( ( link ) => link.textContent === 'Open support request' )
 				.getAttribute( 'href' )
 		).toBe( 'https://events.example/local-support/?event_id=901' );
 		await act( async () => root.unmount() );
@@ -1079,6 +1098,17 @@ describe( 'venue settings authorization-facing states', () => {
 		);
 		expect( container.textContent ).toContain( 'Booking #9' );
 		expect( container.textContent ).toContain( 'Booking Submitted' );
+		expect(
+			[ ...container.querySelector( '#booking-transition' ).options ].map(
+				( option ) => option.value
+			)
+		).toEqual( [
+			'',
+			'needs_info',
+			'under_review',
+			'declined',
+			'withdrawn',
+		] );
 		await act( async () => {
 			const select = container.querySelector( '#booking-transition' );
 			select.value = 'under_review';


### PR DESCRIPTION
## Summary
- replace the nested Calendar/List tab set with a clearly labeled view switch inside the Bookings workspace
- render booking results as a true single-column list and group status filtering into useful workflow buckets
- expose only valid next lifecycle states and attach explicit support-request actions to their published events
- update focused composition and interaction coverage

## Verification
- `npm run test:js -- --runInBand` (96 tests)
- `npm run lint:js`
- `npm run build:venue-settings`
- `git diff --check`

Closes #641