### PR TITLE
fix: consolidate venue booking toolbar

### DIFF
--- a/blocks/venue-settings/src/booking-console.js
+++ b/blocks/venue-settings/src/booking-console.js
@@ -1727,9 +1727,12 @@ export function BookingConsole( {
 
 	return (
 		<div className="ec-booking-console">
-			<fieldset className="ec-booking-console__view-switcher">
-				<legend>View</legend>
-				<div>
+			<div className="ec-booking-console__toolbar">
+				<div
+					className="ec-booking-console__view-switcher"
+					role="group"
+					aria-label="Booking view"
+				>
 					{ [
 						{ id: 'calendar', label: 'Calendar' },
 						{ id: 'list', label: 'List' },
@@ -1745,18 +1748,14 @@ export function BookingConsole( {
 						</button>
 					) ) }
 				</div>
-			</fieldset>
-			<Grid
-				className="ec-booking-console__toolbar"
-				minColumnWidth="12rem"
-				maxColumns={ 2 }
-			>
-				<SearchBox
-					value={ search }
-					onSearch={ setSearch }
-					onClear={ () => setSearch( '' ) }
-					placeholder="Search artist, contact, email, or booking ID"
-				/>
+				<div className="ec-booking-console__search">
+					<SearchBox
+						value={ search }
+						onSearch={ setSearch }
+						onClear={ () => setSearch( '' ) }
+						placeholder="Search artist, contact, email, or booking ID"
+					/>
+				</div>
 				<label htmlFor="booking-status-filter">
 					Status
 					<select
@@ -1772,7 +1771,7 @@ export function BookingConsole( {
 						<option value="closed">Closed inquiries</option>
 					</select>
 				</label>
-			</Grid>
+			</div>
 			{ error && <ErrorState message={ error } onRetry={ loadList } /> }
 			{ loading ? (
 				<Panel>

--- a/blocks/venue-settings/src/style.scss
+++ b/blocks/venue-settings/src/style.scss
@@ -476,6 +476,20 @@
 }
 
 @media screen and (max-width: 480px) {
+	.ec-booking-console__toolbar {
+		grid-template-columns: 1fr;
+		align-items: stretch;
+	}
+
+	.ec-booking-console__view-switcher,
+	.ec-booking-console__view-switcher button {
+		width: 100%;
+	}
+
+	.ec-booking-console__view-switcher button {
+		justify-content: center;
+	}
+
 	.ec-booking-form-editor__preview {
 		position: static;
 	}

--- a/blocks/venue-settings/src/style.test.js
+++ b/blocks/venue-settings/src/style.test.js
@@ -22,6 +22,10 @@ describe( 'venue booking workspace composition', () => {
 		expect( consoleSource ).toContain(
 			'className="ec-booking-console__view-switcher"'
 		);
+		expect( consoleSource ).not.toContain( '<legend>View</legend>' );
+		expect( consoleSource ).toContain(
+			'className="ec-booking-console__search"'
+		);
 		expect( consoleSource ).toContain( 'aria-pressed={ view ===' );
 		expect( consoleSource ).toContain(
 			'className="ec-booking-console__toolbar"'

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -752,9 +752,21 @@ describe( 'venue settings authorization-facing states', () => {
 		const viewSwitcher = container.querySelector(
 			'.ec-booking-console__view-switcher'
 		);
-		expect( viewSwitcher.querySelector( 'legend' ).textContent ).toBe(
-			'View'
+		expect( viewSwitcher.parentElement.classList ).toContain(
+			'ec-booking-console__toolbar'
 		);
+		expect( viewSwitcher.querySelector( 'legend' ) ).toBeNull();
+		expect( viewSwitcher.getAttribute( 'aria-label' ) ).toBe(
+			'Booking view'
+		);
+		expect(
+			viewSwitcher.parentElement.querySelector(
+				'.ec-booking-console__search'
+			)
+		).not.toBeNull();
+		expect(
+			viewSwitcher.parentElement.querySelector( '#booking-status-filter' )
+		).not.toBeNull();
 		expect(
 			[ ...viewSwitcher.querySelectorAll( 'button' ) ].map(
 				( button ) => button.textContent


### PR DESCRIPTION
## Summary
- place Calendar/List, Search, and Status in one responsive booking toolbar
- remove the redundant visible View label while retaining an accessible group label
- let Search consume the available horizontal space instead of sharing an equal-width grid column
- stack all controls cleanly at the existing mobile breakpoint

## Verification
- `npm run test:js -- --runInBand` (96 tests)
- `npm run lint:js`
- `npm run build:venue-settings`
- `git diff --check`

Closes #645