### PR TITLE
fix: align venue controls with theme buttons

### DIFF
--- a/blocks/venue-settings/src/booking-console.js
+++ b/blocks/venue-settings/src/booking-console.js
@@ -674,7 +674,9 @@ function BookingCard( { booking, active, holds, onSelect } ) {
 		<li>
 			<button
 				type="button"
-				className={ `ec-booking-card${ active ? ' is-active' : '' }` }
+				className={ `ec-booking-card button-3 button-medium button-block${
+					active ? ' is-active' : ''
+				}` }
 				onClick={ () => onSelect( booking.id ) }
 				aria-pressed={ active }
 			>
@@ -842,7 +844,7 @@ function Calendar( {
 										</a>
 										{ entry.support && (
 											<a
-												className="ec-booking-calendar__support-action"
+												className="ec-booking-calendar__support-action button-2 button-small"
 												href={
 													entry.support.workspace_url
 												}
@@ -1740,7 +1742,11 @@ export function BookingConsole( {
 						<button
 							type="button"
 							key={ option.id }
-							className={ view === option.id ? 'is-active' : '' }
+							className={
+								view === option.id
+									? 'button-1 button-medium is-active'
+									: 'button-3 button-medium'
+							}
 							aria-pressed={ view === option.id }
 							onClick={ () => setView( option.id ) }
 						>

--- a/blocks/venue-settings/src/booking-form-tab.test.js
+++ b/blocks/venue-settings/src/booking-form-tab.test.js
@@ -14,6 +14,7 @@ const intake = readFileSync(
 	path.resolve( __dirname, 'intake-tab.js' ),
 	'utf8'
 );
+const styles = readFileSync( path.resolve( __dirname, 'style.scss' ), 'utf8' );
 const wording = readFileSync(
 	path.resolve( __dirname, 'intake-public.js' ),
 	'utf8'
@@ -74,6 +75,10 @@ describe( 'booking form workspace', () => {
 	it( 'uses complete theme button variants', () => {
 		expect( workspace ).toContain( 'button-1 button-medium' );
 		expect( intake ).toContain( 'ec-booking-fields__add' );
+		expect( intake ).toContain(
+			'ec-booking-fields__add button-2 button-medium button-block'
+		);
+		expect( styles ).not.toContain( '.ec-booking-fields__add {' );
 		expect( intake ).toContain( 'button-danger button-small' );
 		expect( workspace + intake ).not.toContain( 'button-link-delete' );
 	} );

--- a/blocks/venue-settings/src/intake-tab.js
+++ b/blocks/venue-settings/src/intake-tab.js
@@ -244,7 +244,7 @@ export function IntakeTab( { config, setConfig, idPrefix = '' } ) {
 				</div>
 				<button
 					type="button"
-					className="ec-booking-fields__add"
+					className="ec-booking-fields__add button-2 button-medium button-block"
 					onClick={ () => {
 						const key = nextCustomFieldKey( fields );
 						setFields( [

--- a/blocks/venue-settings/src/style.scss
+++ b/blocks/venue-settings/src/style.scss
@@ -129,25 +129,6 @@
 	font-size: var(--font-size-sm);
 }
 
-.ec-booking-fields__add {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 100%;
-	padding: var(--spacing-sm) var(--spacing-md);
-	border: 1px dashed var(--border-color);
-	border-radius: var(--border-radius-md);
-	background: transparent;
-	color: var(--muted-text);
-	font: inherit;
-	cursor: pointer;
-}
-
-.ec-booking-fields__add:hover {
-	border-color: var(--accent);
-	color: var(--accent);
-}
-
 .ec-venue-settings__records {
 	display: grid;
 	gap: 0;
@@ -191,50 +172,26 @@
 }
 
 .ec-booking-console__toolbar {
+	display: grid;
+	grid-template-columns: auto minmax(16rem, 1fr) minmax(10rem, 14rem);
 	align-items: end;
+	gap: 1rem;
 }
 
-.ec-booking-console__toolbar .ec-search-box {
+.ec-booking-console__search,
+.ec-booking-console__search .ec-search-box,
+.ec-booking-console__search input {
+	width: 100%;
+}
+
+.ec-booking-console__search .ec-search-box {
 	margin-bottom: 0;
 }
 
 .ec-booking-console__view-switcher {
-	display: flex;
-	align-items: center;
-	gap: 0.65rem;
-	margin: 0;
-	padding: 0;
-	border: 0;
-}
-
-.ec-booking-console__view-switcher legend {
-	float: left;
-	font-size: 0.85rem;
-	font-weight: 750;
-}
-
-.ec-booking-console__view-switcher > div {
 	display: inline-flex;
-	padding: 0.2rem;
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius-md);
-	background: var(--card-background);
-}
-
-.ec-booking-console__view-switcher button {
-	padding: 0.4rem 0.75rem;
-	border: 0;
-	border-radius: var(--border-radius-sm);
-	background: transparent;
-	color: var(--text-color);
-	font: inherit;
-	font-weight: 700;
-	cursor: pointer;
-}
-
-.ec-booking-console__view-switcher button.is-active {
-	background: var(--header-background);
-	color: var(--header-text-color);
+	align-items: center;
+	gap: var(--spacing-xs);
 }
 
 .ec-booking-console__toolbar label {
@@ -244,20 +201,12 @@
 	font-weight: 700;
 }
 
-.ec-booking-card {
+.ec-booking-card.button-3 {
 	display: grid;
 	grid-template-columns: minmax(10rem, 1fr) minmax(10rem, auto) minmax(8rem, auto);
 	align-items: center;
 	gap: 1rem;
-	width: 100%;
-	padding: 1rem;
-	border: 0;
-	border-left: 3px solid transparent;
-	background: transparent;
-	color: inherit;
-	font: inherit;
 	text-align: left;
-	cursor: pointer;
 }
 
 .ec-booking-card:hover,
@@ -388,12 +337,6 @@
 
 .ec-booking-calendar__support-action {
 	display: block;
-	padding: 0.25rem 0.4rem;
-	border-radius: var(--border-radius-sm);
-	background: var(--card-background);
-	font-size: 0.7rem;
-	font-weight: 700;
-	line-height: 1.2;
 	text-align: center;
 }
 
@@ -536,7 +479,7 @@
 		flex-direction: column;
 	}
 
-	.ec-booking-card {
+	.ec-booking-card.button-3 {
 		grid-template-columns: 1fr;
 		gap: 0.5rem;
 	}

--- a/blocks/venue-settings/src/style.test.js
+++ b/blocks/venue-settings/src/style.test.js
@@ -28,10 +28,25 @@ describe( 'venue booking workspace composition', () => {
 		);
 		expect( consoleSource ).toContain( 'aria-pressed={ view ===' );
 		expect( consoleSource ).toContain(
+			"? 'button-1 button-medium is-active'"
+		);
+		expect( consoleSource ).toContain(
+			'ec-booking-card button-3 button-medium button-block'
+		);
+		expect( consoleSource ).toContain(
+			'ec-booking-calendar__support-action button-2 button-small'
+		);
+		expect( consoleSource ).toContain(
 			'className="ec-booking-console__toolbar"'
 		);
 		expect( consoleSource ).toContain(
 			'<ul className="ec-booking-console__list">'
+		);
+		expect( styles ).toContain(
+			'grid-template-columns: auto minmax(16rem, 1fr) minmax(10rem, 14rem);'
+		);
+		expect( styles ).not.toContain(
+			'.ec-booking-console__view-switcher button.is-active'
 		);
 	} );
 


### PR DESCRIPTION
## Summary
- compose Calendar/List, booking rows, local-support actions, and Add custom field from the established Extra Chill button variants
- remove block-local button color, border, typography, and hover skins
- keep venue CSS focused on layout and domain-specific selected states
- retain and cover the wide-search toolbar layout from #646

## Verification
- `npm run test:js -- --runInBand` (96 tests)
- `npm run lint:js`
- `npm run build:venue-settings`
- `git diff --check`

Closes #647