### PR TITLE
fix: prefill booking embed website

### DIFF
--- a/blocks/venue-settings/src/booking-embed.js
+++ b/blocks/venue-settings/src/booking-embed.js
@@ -24,6 +24,15 @@ export const normalizeBookingOrigin = ( value ) => {
 	}
 };
 
+export const bookingOriginFromWebsite = ( value ) => {
+	try {
+		const url = new URL( value );
+		return normalizeBookingOrigin( url.origin );
+	} catch {
+		return null;
+	}
+};
+
 const escapeAttribute = ( value ) =>
 	String( value )
 		.replaceAll( '&', '&amp;' )

--- a/blocks/venue-settings/src/booking-embed.test.js
+++ b/blocks/venue-settings/src/booking-embed.test.js
@@ -6,6 +6,7 @@
 import {
 	bookingButtonSnippet,
 	bookingEmbedSnippet,
+	bookingOriginFromWebsite,
 	normalizeBookingOrigin,
 } from './booking-embed';
 
@@ -25,6 +26,14 @@ describe( 'venue booking embed generator', () => {
 		].forEach( ( origin ) =>
 			expect( normalizeBookingOrigin( origin ) ).toBeNull()
 		);
+	} );
+
+	it( 'derives an embed origin from a venue website URL', () => {
+		expect(
+			bookingOriginFromWebsite( 'https://Venue.Example/about?ref=events' )
+		).toBe( 'https://venue.example' );
+		expect( bookingOriginFromWebsite( 'http://venue.example' ) ).toBeNull();
+		expect( bookingOriginFromWebsite( '' ) ).toBeNull();
 	} );
 
 	it( 'builds accessible link and iframe markup without hand-edited IDs', () => {

--- a/blocks/venue-settings/src/booking-form-tab.js
+++ b/blocks/venue-settings/src/booking-form-tab.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -18,7 +18,7 @@ import {
  * Internal dependencies
  */
 import { BookingInquiry } from '../../venue-booking-inquiry/src/view';
-import { bookingEmbedSnippet } from './booking-embed';
+import { bookingEmbedSnippet, bookingOriginFromWebsite } from './booking-embed';
 import { IntakeTab } from './intake-tab';
 import { Status } from './status';
 import { sameDocument, validateConfig } from './state';
@@ -54,12 +54,28 @@ export function BookingFormTab( {
 	idPrefix = '',
 } ) {
 	const [ copied, setCopied ] = useState( false );
+	const initializedWebsite = useRef( false );
 	const errors = validateConfig( config );
 	const dirty = ! sameDocument( config, baseline );
 	const websites = config.embed.allowed_parent_origins;
 	const embedSnippet = websites.length
 		? bookingEmbedSnippet( bookingUrl, venueName, websites[ 0 ] )
 		: '';
+	useEffect( () => {
+		if ( initializedWebsite.current || websites.length ) {
+			initializedWebsite.current = true;
+			return;
+		}
+		const origin = bookingOriginFromWebsite( profile?.website || '' );
+		if ( ! origin ) {
+			return;
+		}
+		initializedWebsite.current = true;
+		setConfig( {
+			...config,
+			embed: { allowed_parent_origins: [ origin ] },
+		} );
+	}, [ config, profile?.website, setConfig, websites.length ] );
 	const copyEmbed = async () => {
 		await navigator.clipboard.writeText( embedSnippet );
 		setCopied( true );

--- a/blocks/venue-settings/src/booking-form-tab.test.js
+++ b/blocks/venue-settings/src/booking-form-tab.test.js
@@ -39,6 +39,18 @@ describe( 'booking form workspace', () => {
 		expect( wording ).toContain( 'Edit standard wording' );
 	} );
 
+	it( 'prefills an empty embed website from the venue profile', () => {
+		expect( workspace ).toContain(
+			"bookingOriginFromWebsite( profile?.website || '' )"
+		);
+		expect( workspace ).toContain(
+			'embed: { allowed_parent_origins: [ origin ] }'
+		);
+		expect( workspace ).toContain(
+			'initializedWebsite.current || websites.length'
+		);
+	} );
+
 	it( 'hides schema and legal implementation vocabulary', () => {
 		for ( const vocabulary of [
 			'label="Key"',


### PR DESCRIPTION
## Summary
- prefill an empty booking embed website from the already-loaded canonical venue profile
- normalize full venue website URLs to the exact public HTTPS origin required by embed authorization
- preserve explicitly configured embed origins and allow managers to clear or replace the suggestion
- add focused normalization and workspace regression coverage

## Verification
- `npm run test:js -- --runInBand` (98 tests)
- `npm run lint:js`
- `npm run build:venue-settings`
- `git diff --check`

Closes #649