### PR TITLE
fix: prevent booking editor column overlap

### DIFF
--- a/blocks/venue-settings/src/booking-form-tab.js
+++ b/blocks/venue-settings/src/booking-form-tab.js
@@ -68,6 +68,11 @@ export function BookingFormTab( {
 	return (
 		<div className="ec-booking-form-editor">
 			<div className="ec-booking-form-editor__controls">
+				<IntakeTab
+					config={ config }
+					setConfig={ setConfig }
+					idPrefix={ idPrefix }
+				/>
 				<Panel>
 					<PanelHeader
 						title="Embed your booking form"
@@ -132,11 +137,6 @@ export function BookingFormTab( {
 						</p>
 					) }
 				</Panel>
-				<IntakeTab
-					config={ config }
-					setConfig={ setConfig }
-					idPrefix={ idPrefix }
-				/>
 				{ errors.length > 0 && (
 					<InlineStatus tone="error">
 						<strong>Resolve before saving:</strong>

--- a/blocks/venue-settings/src/booking-form-tab.test.js
+++ b/blocks/venue-settings/src/booking-form-tab.test.js
@@ -25,9 +25,9 @@ const publicForm = readFileSync(
 );
 
 describe( 'booking form workspace', () => {
-	it( 'puts secure embed setup first and keeps preview visible', () => {
-		expect( workspace.indexOf( 'Embed your booking form' ) ).toBeLessThan(
-			workspace.indexOf( '<IntakeTab' )
+	it( 'puts form building first and keeps preview visible', () => {
+		expect( workspace.indexOf( '<IntakeTab' ) ).toBeLessThan(
+			workspace.indexOf( 'Embed your booking form' )
 		);
 		expect( workspace ).toContain( 'Copy embed code' );
 		expect( workspace ).toContain( 'ec-booking-form-editor__preview' );

--- a/blocks/venue-settings/src/style.scss
+++ b/blocks/venue-settings/src/style.scss
@@ -42,7 +42,7 @@
 
 .ec-booking-form-editor {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(min(100%, 28rem), 1fr));
+	grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
 	gap: var(--spacing-lg);
 	align-items: start;
 }
@@ -50,12 +50,27 @@
 .ec-booking-form-editor__controls {
 	display: grid;
 	gap: var(--spacing-md);
+	min-width: 0;
 }
 
 .ec-booking-form-editor__preview {
 	position: sticky;
 	top: var(--spacing-md);
 	min-width: 0;
+	padding: var(--spacing-md);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	background: var(--card-background);
+	box-shadow: var(--shadow-sm, 0 1px 2px rgb(0 0 0 / 8%));
+}
+
+.ec-booking-form-editor__preview > .ec-panel-header {
+	margin-block-end: var(--spacing-md);
+}
+
+.ec-booking-form-editor__preview .ec-venue-booking-inquiry {
+	min-width: 0;
+	overflow: hidden;
 }
 
 .ec-booking-standard-fields__list {
@@ -418,6 +433,16 @@
 	text-align: center;
 }
 
+@media screen and (max-width: 960px) {
+	.ec-booking-form-editor {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.ec-booking-form-editor__preview {
+		position: static;
+	}
+}
+
 @media screen and (max-width: 480px) {
 	.ec-booking-console__toolbar {
 		grid-template-columns: 1fr;
@@ -434,7 +459,7 @@
 	}
 
 	.ec-booking-form-editor__preview {
-		position: static;
+		padding: var(--spacing-sm);
 	}
 
 	.ec-booking-standard-fields__list {


### PR DESCRIPTION
## Summary
- prioritize form-building controls before secondary embed setup
- prevent the live preview from overlapping editor panels with bounded grid columns
- frame the preview and stack the workspace at tablet/mobile widths

## Verification
- `npm run lint:js`
- `npm run test:js -- --runInBand` (96 tests)
- `npm run build`
- WP Codebox 0.20.0 authenticated browser actions at 1440x1100 and 390x844

Closes #640