### PR TITLE
fix: simplify booking form builder

### DIFF
--- a/blocks/venue-settings/src/booking-form-tab.js
+++ b/blocks/venue-settings/src/booking-form-tab.js
@@ -54,6 +54,7 @@ export function BookingFormTab( {
 	idPrefix = '',
 } ) {
 	const [ copied, setCopied ] = useState( false );
+	const [ previewOpen, setPreviewOpen ] = useState( true );
 	const initializedWebsite = useRef( false );
 	const errors = validateConfig( config );
 	const dirty = ! sameDocument( config, baseline );
@@ -76,6 +77,13 @@ export function BookingFormTab( {
 			embed: { allowed_parent_origins: [ origin ] },
 		} );
 	}, [ config, profile?.website, setConfig, websites.length ] );
+	useEffect( () => {
+		const mobilePreview = window.matchMedia( '(max-width: 960px)' );
+		const syncPreview = () => setPreviewOpen( ! mobilePreview.matches );
+		syncPreview();
+		mobilePreview.addEventListener( 'change', syncPreview );
+		return () => mobilePreview.removeEventListener( 'change', syncPreview );
+	}, [] );
 	const copyEmbed = async () => {
 		await navigator.clipboard.writeText( embedSnippet );
 		setCopied( true );
@@ -89,6 +97,32 @@ export function BookingFormTab( {
 					setConfig={ setConfig }
 					idPrefix={ idPrefix }
 				/>
+				{ errors.length > 0 && (
+					<InlineStatus tone="error">
+						<strong>Resolve before saving:</strong>
+						<ul>
+							{ errors.map( ( error ) => (
+								<li key={ error }>{ error }</li>
+							) ) }
+						</ul>
+					</InlineStatus>
+				) }
+				<Status state={ status } />
+				<ActionRow>
+					<button
+						type="button"
+						className="button-1 button-medium"
+						disabled={ ! dirty || saving || errors.length > 0 }
+						onClick={ onSave }
+					>
+						{ saving ? 'Saving...' : 'Save booking form' }
+					</button>
+					{ dirty && (
+						<span className="ec-venue-settings__dirty">
+							Unsaved booking form changes
+						</span>
+					) }
+				</ActionRow>
 				<Panel>
 					<PanelHeader
 						title="Embed your booking form"
@@ -121,17 +155,6 @@ export function BookingFormTab( {
 					</FieldGroup>
 					{ embedSnippet ? (
 						<>
-							<FieldGroup
-								label="Embed code"
-								htmlFor={ `${ idPrefix }venue-booking-embed-code` }
-							>
-								<textarea
-									id={ `${ idPrefix }venue-booking-embed-code` }
-									rows="8"
-									readOnly
-									value={ embedSnippet }
-								/>
-							</FieldGroup>
 							<ActionRow>
 								<button
 									type="button"
@@ -146,6 +169,20 @@ export function BookingFormTab( {
 									</span>
 								) }
 							</ActionRow>
+							<details className="ec-booking-embed-advanced">
+								<summary>Show advanced embed code</summary>
+								<FieldGroup
+									label="Embed code"
+									htmlFor={ `${ idPrefix }venue-booking-embed-code` }
+								>
+									<textarea
+										id={ `${ idPrefix }venue-booking-embed-code` }
+										rows="8"
+										readOnly
+										value={ embedSnippet }
+									/>
+								</FieldGroup>
+							</details>
 						</>
 					) : (
 						<p className="ec-venue-settings__save-note">
@@ -153,52 +190,43 @@ export function BookingFormTab( {
 						</p>
 					) }
 				</Panel>
-				{ errors.length > 0 && (
-					<InlineStatus tone="error">
-						<strong>Resolve before saving:</strong>
-						<ul>
-							{ errors.map( ( error ) => (
-								<li key={ error }>{ error }</li>
-							) ) }
-						</ul>
-					</InlineStatus>
-				) }
-				<Status state={ status } />
-				<ActionRow>
-					<button
-						type="button"
-						className="button-1 button-medium"
-						disabled={ ! dirty || saving || errors.length > 0 }
-						onClick={ onSave }
-					>
-						{ saving ? 'Saving...' : 'Save booking form' }
-					</button>
-					{ dirty && (
-						<span className="ec-venue-settings__dirty">
-							Unsaved booking form changes
-						</span>
-					) }
-				</ActionRow>
 			</div>
 			<aside
 				className="ec-booking-form-editor__preview"
 				aria-label="Booking form preview"
 			>
-				<PanelHeader
-					title="Preview"
-					description="Live preview of your public booking form."
-				/>
-				<div className="ec-venue-booking-inquiry">
-					<BookingInquiry
-						config={ previewConfig(
-							config,
-							venueName,
-							profile,
-							idPrefix
-						) }
-						wrapper={ null }
-						preview
+				<button
+					type="button"
+					className="ec-booking-form-editor__preview-toggle button-2 button-medium button-block"
+					aria-expanded={ previewOpen }
+					aria-controls={ `${ idPrefix }booking-form-preview` }
+					onClick={ () => setPreviewOpen( ( open ) => ! open ) }
+				>
+					{ previewOpen
+						? 'Hide booking form preview'
+						: 'Preview booking form' }
+				</button>
+				<div
+					id={ `${ idPrefix }booking-form-preview` }
+					className="ec-booking-form-editor__preview-content"
+					hidden={ ! previewOpen }
+				>
+					<PanelHeader
+						title="Preview"
+						description="Live preview of your public booking form."
 					/>
+					<div className="ec-venue-booking-inquiry">
+						<BookingInquiry
+							config={ previewConfig(
+								config,
+								venueName,
+								profile,
+								idPrefix
+							) }
+							wrapper={ null }
+							preview
+						/>
+					</div>
 				</div>
 			</aside>
 		</div>

--- a/blocks/venue-settings/src/booking-form-tab.test.js
+++ b/blocks/venue-settings/src/booking-form-tab.test.js
@@ -25,12 +25,17 @@ const publicForm = readFileSync(
 );
 
 describe( 'booking form workspace', () => {
-	it( 'puts form building first and keeps preview visible', () => {
+	it( 'prioritizes form building and keeps technical details optional', () => {
 		expect( workspace.indexOf( '<IntakeTab' ) ).toBeLessThan(
 			workspace.indexOf( 'Embed your booking form' )
 		);
+		expect( workspace.indexOf( 'Save booking form' ) ).toBeLessThan(
+			workspace.indexOf( 'Embed your booking form' )
+		);
 		expect( workspace ).toContain( 'Copy embed code' );
+		expect( workspace ).toContain( 'Show advanced embed code' );
 		expect( workspace ).toContain( 'ec-booking-form-editor__preview' );
+		expect( workspace ).toContain( 'Preview booking form' );
 		expect( workspace ).toContain(
 			'Live preview of your public booking form.'
 		);

--- a/blocks/venue-settings/src/style.scss
+++ b/blocks/venue-settings/src/style.scss
@@ -64,8 +64,12 @@
 	box-shadow: var(--shadow-sm, 0 1px 2px rgb(0 0 0 / 8%));
 }
 
-.ec-booking-form-editor__preview > .ec-panel-header {
+.ec-booking-form-editor__preview-content > .ec-panel-header {
 	margin-block-end: var(--spacing-md);
+}
+
+.ec-booking-form-editor__preview-toggle.button-2 {
+	display: none;
 }
 
 .ec-booking-form-editor__preview .ec-venue-booking-inquiry {
@@ -100,9 +104,13 @@
 
 .ec-booking-field__row {
 	display: grid;
-	grid-template-columns: auto minmax(10rem, 1fr) minmax(8rem, 0.55fr) auto auto;
+	grid-template-columns: auto minmax(0, 1fr) minmax(9rem, 0.65fr);
 	gap: var(--spacing-sm);
 	align-items: center;
+}
+
+.ec-booking-field__required {
+	grid-column: 2;
 }
 
 .ec-booking-field__position {
@@ -132,6 +140,8 @@
 .ec-booking-field__actions {
 	display: flex;
 	gap: var(--spacing-xs);
+	grid-column: 3;
+	justify-content: flex-end;
 }
 
 .ec-booking-field__choices {
@@ -142,6 +152,19 @@
 	margin: var(--spacing-xs) 0 0;
 	color: var(--muted-text);
 	font-size: var(--font-size-sm);
+}
+
+.ec-booking-embed-advanced {
+	margin-block-start: var(--spacing-md);
+}
+
+.ec-booking-embed-advanced > summary {
+	cursor: pointer;
+	font-weight: 650;
+}
+
+.ec-booking-embed-advanced[open] > summary {
+	margin-block-end: var(--spacing-sm);
 }
 
 .ec-venue-settings__records {
@@ -440,6 +463,15 @@
 
 	.ec-booking-form-editor__preview {
 		position: static;
+		padding: 0;
+	}
+
+	.ec-booking-form-editor__preview-toggle.button-2 {
+		display: flex;
+	}
+
+	.ec-booking-form-editor__preview-content {
+		padding: 0 var(--spacing-md) var(--spacing-md);
 	}
 }
 
@@ -458,8 +490,8 @@
 		justify-content: center;
 	}
 
-	.ec-booking-form-editor__preview {
-		padding: var(--spacing-sm);
+	.ec-booking-form-editor__preview-content {
+		padding: 0 var(--spacing-sm) var(--spacing-sm);
 	}
 
 	.ec-booking-standard-fields__list {

--- a/blocks/venue-settings/src/style.test.js
+++ b/blocks/venue-settings/src/style.test.js
@@ -61,4 +61,12 @@ describe( 'venue booking workspace composition', () => {
 		expect( styles ).not.toMatch( /max-width:\s*(?:700|720)px/ );
 		expect( styles ).toContain( '@media screen and (max-width: 480px)' );
 	} );
+
+	it( 'keeps technical and mobile preview details progressive', () => {
+		expect( styles ).toContain( '.ec-booking-embed-advanced' );
+		expect( styles ).toContain(
+			'.ec-booking-form-editor__preview-toggle.button-2'
+		);
+		expect( styles ).toContain( '@media screen and (max-width: 960px)' );
+	} );
 } );


### PR DESCRIPTION
## Summary
- make form building and save the primary workflow before embed setup
- restructure custom fields into readable two-line controls
- hide raw iframe markup behind an advanced disclosure
- keep desktop preview visible while collapsing it by default on smaller screens

## Verification
- `npm run lint:js`
- `npm run test:js -- --runInBand` (99 tests)
- `npm run build`
- WP Codebox 0.20.0 authenticated browser actions at 1440x1100 and 390x844
- mobile preview toggle interaction and visible-state assertion

Closes #652