### PR TITLE
fix: improve venue booking operations

### DIFF
--- a/blocks/venue-settings/src/booking-console.js
+++ b/blocks/venue-settings/src/booking-console.js
@@ -875,8 +875,54 @@ function Calendar( {
 	);
 }
 
+function RecordValue( { value } ) {
+	if ( Array.isArray( value ) ) {
+		return value.length ? (
+			<ul>
+				{ value.map( ( item, index ) => (
+					<li key={ `${ item }-${ index }` }>
+						<RecordValue value={ item } />
+					</li>
+				) ) }
+			</ul>
+		) : (
+			'None'
+		);
+	}
+	if ( value && typeof value === 'object' ) {
+		return (
+			<dl>
+				{ Object.entries( value ).map( ( [ key, nested ] ) => (
+					<div key={ key }>
+						<dt>{ key.replaceAll( '_', ' ' ) }</dt>
+						<dd>
+							<RecordValue value={ nested } />
+						</dd>
+					</div>
+				) ) }
+			</dl>
+		);
+	}
+	const text = String( value ?? 'Not set' );
+	return /^https?:\/\//i.test( text ) ? (
+		<a href={ text } target="_blank" rel="noreferrer">
+			{ text }
+		</a>
+	) : (
+		text
+	);
+}
+
 function JsonRecord( { title, value, empty } ) {
-	const entries = Object.entries( value?.data || value || {} );
+	const entries = Object.entries( value?.data || value || {} ).flatMap(
+		( [ key, item ] ) =>
+			key === 'fields' &&
+			item &&
+			typeof item === 'object' &&
+			! Array.isArray( item )
+				? Object.entries( item )
+				: [ [ key, item ] ]
+	);
 	return (
 		<section className="ec-booking-detail__section">
 			<h3>{ title }</h3>
@@ -886,9 +932,7 @@ function JsonRecord( { title, value, empty } ) {
 						<div key={ key }>
 							<dt>{ key.replaceAll( '_', ' ' ) }</dt>
 							<dd>
-								{ Array.isArray( item )
-									? item.join( ', ' ) || 'None'
-									: String( item ?? 'Not set' ) }
+								<RecordValue value={ item } />
 							</dd>
 						</div>
 					) ) }
@@ -1102,7 +1146,7 @@ function BookingDetail( {
 						<span>{ booking.artist_name }</span>
 					</>
 				}
-				description={ `Booking #${ booking.id } · version ${ booking.version }` }
+				description={ `Booking #${ booking.id }` }
 				actions={
 					<button
 						type="button"
@@ -1150,10 +1194,7 @@ function BookingDetail( {
 				<h3>Operations</h3>
 				{ availableTransitions.length ? (
 					<Grid minColumnWidth="16rem" maxColumns={ 1 }>
-						<FieldGroup
-							label="Lifecycle status"
-							htmlFor="booking-transition"
-						>
+						<FieldGroup label="Status" htmlFor="booking-transition">
 							<select
 								id="booking-transition"
 								value={ transition }
@@ -1204,7 +1245,7 @@ function BookingDetail( {
 			<section className="ec-booking-detail__section">
 				<h3>Performance and holds</h3>
 				<Grid minColumnWidth="16rem" maxColumns={ 2 }>
-					<FieldGroup label="Space key" htmlFor="booking-space">
+					<FieldGroup label="Space" htmlFor="booking-space">
 						<input
 							id="booking-space"
 							value={ space }
@@ -1318,120 +1359,126 @@ function BookingDetail( {
 				value={ booking.intake }
 				empty="No intake answers were supplied."
 			/>
-			<DealEditor
-				key={ `deal-${ booking.id }-${ booking.version }` }
-				booking={ booking }
-				defaultDeal={ defaultDeal }
-				pending={ pending }
-				onSave={ ( deal ) =>
-					mutate(
-						'Deal update',
-						'extrachill/update-venue-booking-deal',
-						{
-							booking_id: booking.id,
-							expected_version: booking.version,
-							deal,
-						}
-					)
-				}
-			/>
-			<ProductionEditor
-				key={ `production-${ booking.id }-${ booking.version }` }
-				booking={ booking }
-				pending={ pending }
-				onSave={ ( production ) =>
-					mutate(
-						'Production update',
-						'extrachill/update-venue-booking-production',
-						{
-							booking_id: booking.id,
-							expected_version: booking.version,
-							production,
-						}
-					)
-				}
-			/>
-
-			<section className="ec-booking-detail__section">
-				<h3>Canonical event</h3>
-				<p>
-					{ booking.event_id
-						? `Linked event #${ booking.event_id } is synchronized through booking-owned abilities.`
-						: 'No canonical event has been created.' }
-				</p>
-				{ operations.conversion.status === 'failed' && (
-					<InlineStatus
-						tone={
-							operations.conversion.retryable
-								? 'warning'
-								: 'error'
-						}
-					>
-						Conversion attempt { operations.conversion.attempt }{ ' ' }
-						failed
-						{ operations.conversion.failure_code
-							? ` (${ operations.conversion.failure_code })`
-							: '' }
-						.{ ' ' }
-						{ operations.conversion.retryable
-							? 'Retry is available.'
-							: 'Manual review is required before retrying.' }
-					</InlineStatus>
-				) }
-				{ operations.conversion.status === 'pending' && (
-					<InlineStatus tone="warning">
-						Conversion attempt { operations.conversion.attempt } has
-						no terminal result yet.
-					</InlineStatus>
-				) }
-				{ booking.event_id && operations.sync.status !== 'none' && (
-					<InlineStatus
-						tone={
-							[ 'failed', 'conflict', 'retryable' ].includes(
-								operations.sync.status
-							)
-								? 'warning'
-								: 'info'
-						}
-					>
-						Event synchronization:{ ' ' }
-						{ activityLabel( operations.sync.status ) }
-						{ operations.sync.code
-							? ` (${ operations.sync.code })`
-							: '' }
-						.
-						{ operations.sync.retryable
-							? ' Reconciliation can be retried.'
-							: '' }
-					</InlineStatus>
-				) }
-				<button
-					type="button"
-					className="button-1"
-					disabled={
-						pending !== '' ||
-						( ! booking.event_id &&
-							operations.conversion.status === 'failed' &&
-							! operations.conversion.retryable )
-					}
-					onClick={ () =>
+			<details className="ec-booking-detail__disclosure">
+				<summary>Deal and production</summary>
+				<DealEditor
+					key={ `deal-${ booking.id }-${ booking.version }` }
+					booking={ booking }
+					defaultDeal={ defaultDeal }
+					pending={ pending }
+					onSave={ ( deal ) =>
 						mutate(
-							booking.event_id
-								? 'Event reconciliation'
-								: 'Event conversion',
-							booking.event_id
-								? 'extrachill/reconcile-booking-event'
-								: 'extrachill/convert-booking-to-event',
+							'Deal update',
+							'extrachill/update-venue-booking-deal',
 							{
 								booking_id: booking.id,
 								expected_version: booking.version,
+								deal,
 							}
 						)
 					}
-				>
-					{ eventActionLabel( booking, operations ) }
-				</button>
-			</section>
+				/>
+				<ProductionEditor
+					key={ `production-${ booking.id }-${ booking.version }` }
+					booking={ booking }
+					pending={ pending }
+					onSave={ ( production ) =>
+						mutate(
+							'Production update',
+							'extrachill/update-venue-booking-production',
+							{
+								booking_id: booking.id,
+								expected_version: booking.version,
+								production,
+							}
+						)
+					}
+				/>
+			</details>
+
+			<details className="ec-booking-detail__disclosure">
+				<summary>Event listing</summary>
+				<section className="ec-booking-detail__section">
+					<h3>Event listing</h3>
+					<p>
+						{ booking.event_id
+							? `Linked event #${ booking.event_id } is synchronized through booking-owned abilities.`
+							: 'No canonical event has been created.' }
+					</p>
+					{ operations.conversion.status === 'failed' && (
+						<InlineStatus
+							tone={
+								operations.conversion.retryable
+									? 'warning'
+									: 'error'
+							}
+						>
+							Conversion attempt { operations.conversion.attempt }{ ' ' }
+							failed
+							{ operations.conversion.failure_code
+								? ` (${ operations.conversion.failure_code })`
+								: '' }
+							.{ ' ' }
+							{ operations.conversion.retryable
+								? 'Retry is available.'
+								: 'Manual review is required before retrying.' }
+						</InlineStatus>
+					) }
+					{ operations.conversion.status === 'pending' && (
+						<InlineStatus tone="warning">
+							Conversion attempt { operations.conversion.attempt }{ ' ' }
+							has no terminal result yet.
+						</InlineStatus>
+					) }
+					{ booking.event_id && operations.sync.status !== 'none' && (
+						<InlineStatus
+							tone={
+								[ 'failed', 'conflict', 'retryable' ].includes(
+									operations.sync.status
+								)
+									? 'warning'
+									: 'info'
+							}
+						>
+							Event synchronization:{ ' ' }
+							{ activityLabel( operations.sync.status ) }
+							{ operations.sync.code
+								? ` (${ operations.sync.code })`
+								: '' }
+							.
+							{ operations.sync.retryable
+								? ' Reconciliation can be retried.'
+								: '' }
+						</InlineStatus>
+					) }
+					<button
+						type="button"
+						className="button-1"
+						disabled={
+							pending !== '' ||
+							( ! booking.event_id &&
+								operations.conversion.status === 'failed' &&
+								! operations.conversion.retryable )
+						}
+						onClick={ () =>
+							mutate(
+								booking.event_id
+									? 'Event reconciliation'
+									: 'Event conversion',
+								booking.event_id
+									? 'extrachill/reconcile-booking-event'
+									: 'extrachill/convert-booking-to-event',
+								{
+									booking_id: booking.id,
+									expected_version: booking.version,
+								}
+							)
+						}
+					>
+						{ eventActionLabel( booking, operations ) }
+					</button>
+				</section>
+			</details>
 
 			<Correspondence
 				booking={ booking }
@@ -1439,12 +1486,10 @@ function BookingDetail( {
 				onRefresh={ onRefreshCommunications }
 			/>
 
-			<InlineStatus tone="info">
-				Marketing execution, finance and settlement, promoter tools, and
-				private-file operations are not included in this focused console
-				slice.
-			</InlineStatus>
-			<ActivityTimeline operations={ operations } />
+			<details className="ec-booking-detail__disclosure">
+				<summary>Activity history</summary>
+				<ActivityTimeline operations={ operations } />
+			</details>
 		</Panel>
 	);
 }
@@ -1709,6 +1754,7 @@ export function BookingConsole( {
 		setSelectedId( 0 );
 		setSelected( null );
 		setDetailLoading( false );
+		setDetailError( '' );
 		const url = new URL( window.location.href );
 		url.searchParams.delete( 'booking_id' );
 		url.searchParams.delete( 'booking_venue_id' );
@@ -1729,104 +1775,127 @@ export function BookingConsole( {
 
 	return (
 		<div className="ec-booking-console">
-			<div className="ec-booking-console__toolbar">
-				<div
-					className="ec-booking-console__view-switcher"
-					role="group"
-					aria-label="Booking view"
-				>
-					{ [
-						{ id: 'calendar', label: 'Calendar' },
-						{ id: 'list', label: 'List' },
-					].map( ( option ) => (
-						<button
-							type="button"
-							key={ option.id }
-							className={
-								view === option.id
-									? 'button-1 button-medium is-active'
-									: 'button-3 button-medium'
-							}
-							aria-pressed={ view === option.id }
-							onClick={ () => setView( option.id ) }
-						>
-							{ option.label }
-						</button>
-					) ) }
-				</div>
-				<div className="ec-booking-console__search">
-					<SearchBox
-						value={ search }
-						onSearch={ setSearch }
-						onClear={ () => setSearch( '' ) }
-						placeholder="Search artist, contact, email, or booking ID"
-					/>
-				</div>
-				<label htmlFor="booking-status-filter">
-					Status
-					<select
-						id="booking-status-filter"
-						value={ filterStatus }
-						onChange={ ( event ) =>
-							setFilterStatus( event.target.value )
-						}
-					>
-						<option value="">All bookings</option>
-						<option value="active">Active inquiries</option>
-						<option value="confirmed">Confirmed shows</option>
-						<option value="closed">Closed inquiries</option>
-					</select>
-				</label>
-			</div>
-			{ error && <ErrorState message={ error } onRetry={ loadList } /> }
-			{ loading ? (
-				<Panel>
-					<p aria-live="polite">Loading venue bookings...</p>
-				</Panel>
-			) : (
+			{ ( selectedId === 0 || detailLoading ) && (
 				<>
-					{ view === 'calendar' ? (
-						<Calendar
-							bookings={ visible }
-							events={ events }
-							holds={ holds }
-							month={ month }
-							onMonthChange={ setMonth }
-							onSelect={ selectBooking }
-							supportEvents={ supportEvents }
-						/>
-					) : (
-						<Panel>
-							<PanelHeader
-								title="Booking pipeline"
-								description="A bounded venue-authorized list across the selected venue scope. Filters are reapplied by canonical abilities."
+					<div className="ec-booking-console__toolbar">
+						<div
+							className="ec-booking-console__view-switcher"
+							role="group"
+							aria-label="Booking view"
+						>
+							{ [
+								{ id: 'calendar', label: 'Calendar' },
+								{ id: 'list', label: 'List' },
+							].map( ( option ) => (
+								<button
+									type="button"
+									key={ option.id }
+									className={
+										view === option.id
+											? 'button-1 button-medium is-active'
+											: 'button-3 button-medium'
+									}
+									aria-pressed={ view === option.id }
+									onClick={ () => setView( option.id ) }
+								>
+									{ option.label }
+								</button>
+							) ) }
+						</div>
+						<div className="ec-booking-console__search">
+							<SearchBox
+								value={ search }
+								onSearch={ setSearch }
+								onClear={ () => setSearch( '' ) }
+								placeholder="Search artist, contact, email, or booking ID"
 							/>
-							{ visible.length ? (
-								<ul className="ec-booking-console__list">
-									{ visible.map( ( booking ) => (
-										<BookingCard
-											key={ booking.id }
-											booking={ booking }
-											active={ booking.id === selectedId }
-											holds={ activeHoldsFor(
-												booking.id
-											) }
-											onSelect={ selectBooking }
-										/>
-									) ) }
-								</ul>
-							) : (
-								<EmptyState>
-									No bookings match this venue scope and
-									filter.
-								</EmptyState>
-							) }
+						</div>
+						<label htmlFor="booking-status-filter">
+							Status
+							<select
+								id="booking-status-filter"
+								value={ filterStatus }
+								onChange={ ( event ) =>
+									setFilterStatus( event.target.value )
+								}
+							>
+								<option value="">All bookings</option>
+								<option value="active">Active inquiries</option>
+								<option value="confirmed">
+									Confirmed shows
+								</option>
+								<option value="closed">Closed inquiries</option>
+							</select>
+						</label>
+					</div>
+					{ error && (
+						<ErrorState message={ error } onRetry={ loadList } />
+					) }
+					{ loading ? (
+						<Panel>
+							<p aria-live="polite">Loading venue bookings...</p>
 						</Panel>
+					) : (
+						<>
+							{ view === 'calendar' ? (
+								<Calendar
+									bookings={ visible }
+									events={ events }
+									holds={ holds }
+									month={ month }
+									onMonthChange={ setMonth }
+									onSelect={ selectBooking }
+									supportEvents={ supportEvents }
+								/>
+							) : (
+								<Panel>
+									<PanelHeader
+										title="Booking pipeline"
+										description="Review and manage booking inquiries for this venue."
+									/>
+									{ visible.length ? (
+										<ul className="ec-booking-console__list">
+											{ visible.map( ( booking ) => (
+												<BookingCard
+													key={ booking.id }
+													booking={ booking }
+													active={
+														booking.id ===
+														selectedId
+													}
+													holds={ activeHoldsFor(
+														booking.id
+													) }
+													onSelect={ selectBooking }
+												/>
+											) ) }
+										</ul>
+									) : (
+										<EmptyState>
+											No bookings match this venue scope
+											and filter.
+										</EmptyState>
+									) }
+								</Panel>
+							) }
+						</>
 					) }
 				</>
 			) }
 			{ detailError && (
-				<ErrorState message={ detailError } onRetry={ loadDetail } />
+				<div className="ec-booking-detail__error">
+					<ErrorState
+						message={ detailError }
+						onRetry={ loadDetail }
+					/>
+					<button
+						type="button"
+						className="button-2"
+						onClick={ closeDetail }
+					>
+						Back to bookings
+					</button>
+				</div>
 			) }
 			{ detailLoading && (
 				<Panel>

--- a/blocks/venue-settings/src/booking-tab.js
+++ b/blocks/venue-settings/src/booking-tab.js
@@ -21,6 +21,26 @@ import {
 	validateConfig,
 } from './state';
 
+const HOLD_DURATIONS = [
+	[ 60, '1 hour' ],
+	[ 240, '4 hours' ],
+	[ 720, '12 hours' ],
+	[ 1440, '1 day' ],
+	[ 4320, '3 days' ],
+	[ 10080, '7 days' ],
+	[ 20160, '14 days' ],
+];
+const DEAL_TYPES = [
+	[ 'custom', 'Custom terms' ],
+	[ 'guarantee', 'Guarantee' ],
+	[ 'door_split', 'Door split' ],
+];
+const CURRENCIES = [ 'USD', 'CAD', 'EUR', 'GBP' ];
+const MARKETING_CHANNEL_LABELS = {
+	social: 'Social media',
+	newsletter: 'Newsletter',
+};
+
 function SpacesEditor( { spaces, onChange, idPrefix } ) {
 	const update = ( index, patch ) =>
 		onChange(
@@ -66,22 +86,25 @@ function SpacesEditor( { spaces, onChange, idPrefix } ) {
 							}
 						/>
 					</FieldGroup>
-					<FieldGroup
-						label="Key"
-						htmlFor={ `${ idPrefix }space-key-${ index }` }
-						help="Stable machine-readable key used by booking records."
-						required
-					>
-						<input
-							id={ `${ idPrefix }space-key-${ index }` }
-							value={ space.key }
-							onChange={ ( event ) =>
-								update( index, {
-									key: normalizeKey( event.target.value ),
-								} )
-							}
-						/>
-					</FieldGroup>
+					<details className="ec-venue-settings__advanced">
+						<summary>Advanced space identifier</summary>
+						<FieldGroup
+							label="Space identifier"
+							htmlFor={ `${ idPrefix }space-key-${ index }` }
+							help="Keep this stable after bookings use the space."
+							required
+						>
+							<input
+								id={ `${ idPrefix }space-key-${ index }` }
+								value={ space.key }
+								onChange={ ( event ) =>
+									update( index, {
+										key: normalizeKey( event.target.value ),
+									} )
+								}
+							/>
+						</FieldGroup>
+					</details>
 					<label htmlFor={ `${ idPrefix }space-default-${ index }` }>
 						<input
 							id={ `${ idPrefix }space-default-${ index }` }
@@ -96,8 +119,16 @@ function SpacesEditor( { spaces, onChange, idPrefix } ) {
 					</label>
 					<button
 						type="button"
-						className="button-link-delete"
+						className="button-link-delete button-small"
 						onClick={ () =>
+							// eslint-disable-next-line no-alert -- Removing a routable booking space requires confirmation.
+							window.confirm(
+								`Remove ${
+									space.name ||
+									space.key ||
+									'this booking space'
+								}? Existing bookings will keep their saved space identifier.`
+							) &&
 							onChange(
 								spaces.filter(
 									( _, current ) => current !== index
@@ -164,15 +195,12 @@ export function BookingTab( {
 					Accept booking inquiries
 				</label>
 				<FieldGroup
-					label="Default hold duration (minutes)"
+					label="Default hold duration"
 					htmlFor={ `${ idPrefix }venue-hold-ttl` }
-					help="Between 5 minutes and 14 days."
+					help="How long a temporary date hold remains active."
 				>
-					<input
+					<select
 						id={ `${ idPrefix }venue-hold-ttl` }
-						type="number"
-						min="5"
-						max={ HOLD_TTL_MAX_MINUTES }
 						value={ config.hold_ttl_minutes }
 						onChange={ ( event ) =>
 							setConfig( {
@@ -180,48 +208,63 @@ export function BookingTab( {
 								hold_ttl_minutes: Number( event.target.value ),
 							} )
 						}
-					/>
+					>
+						{ ! HOLD_DURATIONS.some(
+							( [ minutes ] ) =>
+								minutes === config.hold_ttl_minutes
+						) && (
+							<option value={ config.hold_ttl_minutes }>
+								{ config.hold_ttl_minutes } minutes (current)
+							</option>
+						) }
+						{ HOLD_DURATIONS.filter(
+							( [ minutes ] ) => minutes <= HOLD_TTL_MAX_MINUTES
+						).map( ( [ minutes, label ] ) => (
+							<option key={ minutes } value={ minutes }>
+								{ label }
+							</option>
+						) ) }
+					</select>
 				</FieldGroup>
-				<FieldGroup
-					label="Ticket provider reference"
-					htmlFor={ `${ idPrefix }venue-ticket-provider` }
-					help="Account, venue, or provider reference used when ticket records are connected."
-				>
-					<input
-						id={ `${ idPrefix }venue-ticket-provider` }
-						value={ config.ticket_provider_reference || '' }
-						onChange={ ( event ) =>
-							setConfig( {
-								...config,
-								ticket_provider_reference:
-									event.target.value || null,
-							} )
-						}
-					/>
-				</FieldGroup>
-				<FieldGroup
-					label="Default marketing channels"
-					htmlFor={ `${ idPrefix }venue-marketing-channels` }
-					help="Comma-separated canonical channel keys, for example instagram, newsletter."
-				>
-					<input
-						id={ `${ idPrefix }venue-marketing-channels` }
-						value={ config.marketing_channels.join( ', ' ) }
-						onChange={ ( event ) =>
-							setConfig( {
-								...config,
-								marketing_channels: [
-									...new Set(
-										event.target.value
-											.split( ',' )
-											.map( normalizeKey )
-											.filter( Boolean )
-									),
-								],
-							} )
-						}
-					/>
-				</FieldGroup>
+				<details className="ec-venue-settings__advanced">
+					<summary>Advanced integrations</summary>
+					<FieldGroup
+						label="Ticket provider reference"
+						htmlFor={ `${ idPrefix }venue-ticket-provider` }
+						help="Account, venue, or provider reference used when ticket records are connected."
+					>
+						<input
+							id={ `${ idPrefix }venue-ticket-provider` }
+							value={ config.ticket_provider_reference || '' }
+							onChange={ ( event ) =>
+								setConfig( {
+									...config,
+									ticket_provider_reference:
+										event.target.value || null,
+								} )
+							}
+						/>
+					</FieldGroup>
+					<div className="ec-venue-settings__choices">
+						<strong>Marketing automation</strong>
+						{ config.marketing_channels.length ? (
+							<ul>
+								{ config.marketing_channels.map( ( key ) => (
+									<li key={ key }>
+										{ MARKETING_CHANNEL_LABELS[ key ] ||
+											key.replaceAll( '_', ' ' ) }
+									</li>
+								) ) }
+							</ul>
+						) : (
+							<p>No marketing automation is configured.</p>
+						) }
+						<small>
+							Marketing automation is managed with its delivery
+							policies.
+						</small>
+					</div>
+				</details>
 			</Panel>
 			<SpacesEditor
 				spaces={ config.spaces }
@@ -238,7 +281,7 @@ export function BookingTab( {
 						label="Deal type"
 						htmlFor={ `${ idPrefix }venue-deal-type` }
 					>
-						<input
+						<select
 							id={ `${ idPrefix }venue-deal-type` }
 							value={ deal.type }
 							onChange={ ( event ) =>
@@ -246,7 +289,20 @@ export function BookingTab( {
 									type: normalizeKey( event.target.value ),
 								} )
 							}
-						/>
+						>
+							{ ! DEAL_TYPES.some(
+								( [ value ] ) => value === deal.type
+							) && (
+								<option value={ deal.type }>
+									{ deal.type }
+								</option>
+							) }
+							{ DEAL_TYPES.map( ( [ value, label ] ) => (
+								<option key={ value } value={ value }>
+									{ label }
+								</option>
+							) ) }
+						</select>
 					</FieldGroup>
 					<FieldGroup
 						label="Guarantee"
@@ -314,16 +370,26 @@ export function BookingTab( {
 						label="Currency"
 						htmlFor={ `${ idPrefix }venue-currency` }
 					>
-						<input
+						<select
 							id={ `${ idPrefix }venue-currency` }
-							maxLength="3"
 							value={ deal.currency }
 							onChange={ ( event ) =>
 								setDeal( {
 									currency: event.target.value.toUpperCase(),
 								} )
 							}
-						/>
+						>
+							{ ! CURRENCIES.includes( deal.currency ) && (
+								<option value={ deal.currency }>
+									{ deal.currency }
+								</option>
+							) }
+							{ CURRENCIES.map( ( currency ) => (
+								<option key={ currency } value={ currency }>
+									{ currency }
+								</option>
+							) ) }
+						</select>
 					</FieldGroup>
 				</Grid>
 			</Panel>

--- a/blocks/venue-settings/src/style.scss
+++ b/blocks/venue-settings/src/style.scss
@@ -167,6 +167,43 @@
 	margin-block-end: var(--spacing-sm);
 }
 
+.ec-venue-settings__advanced {
+	margin-block-start: var(--spacing-md);
+}
+
+.ec-venue-settings__advanced > summary {
+	cursor: pointer;
+	font-weight: 650;
+}
+
+.ec-venue-settings__advanced[open] > summary {
+	margin-block-end: var(--spacing-sm);
+}
+
+.ec-venue-settings__choices {
+	display: grid;
+	gap: var(--spacing-xs);
+	margin: 0;
+}
+
+.ec-venue-settings__choices > strong {
+	font-weight: 700;
+}
+
+.ec-venue-settings .button-link-delete {
+	border: 0;
+	background: transparent;
+	color: var(--error-color);
+	cursor: pointer;
+	text-decoration: underline;
+}
+
+.ec-booking-detail__error {
+	display: grid;
+	gap: var(--spacing-sm);
+	justify-items: start;
+}
+
 .ec-venue-settings__records {
 	display: grid;
 	gap: 0;
@@ -423,6 +460,18 @@
 
 .ec-booking-detail__facts--summary {
 	margin-block-start: 1rem;
+}
+
+.ec-booking-detail__disclosure {
+	margin-block-start: 1.5rem;
+	border-block-start: 1px solid var(--border-color);
+	padding-block-start: 1rem;
+}
+
+.ec-booking-detail__disclosure > summary {
+	cursor: pointer;
+	font-size: var(--font-size-lg);
+	font-weight: 750;
 }
 
 .ec-booking-console__timeline {

--- a/blocks/venue-settings/src/team-tab.js
+++ b/blocks/venue-settings/src/team-tab.js
@@ -28,6 +28,8 @@ export function TeamTab( {
 	onRefresh,
 	idPrefix = '',
 } ) {
+	const personLabel = ( person ) =>
+		person.display_name || person.email || `User #${ person.user_id }`;
 	const [ email, setEmail ] = useState( '' );
 	const [ owner, setOwner ] = useState( false );
 	const [ action, setAction ] = useState( null );
@@ -110,7 +112,7 @@ export function TeamTab( {
 			<Panel>
 				<PanelHeader
 					title="Memberships"
-					description="Capability access is controlled by WordPress; ownership only controls team administration."
+					description="Members can work with this venue. Owners can also manage the team."
 				/>
 				{ members.length === 0 ? (
 					<p>No membership records found.</p>
@@ -119,7 +121,10 @@ export function TeamTab( {
 						{ members.map( ( member ) => (
 							<li key={ member.id }>
 								<div>
-									<strong>User #{ member.user_id }</strong>
+									<strong>{ personLabel( member ) }</strong>
+									{ member.email && (
+										<div>{ member.email }</div>
+									) }
 									<div>
 										<Badge>{ member.status }</Badge>{ ' ' }
 										{ member.is_owner && (
@@ -159,7 +164,9 @@ export function TeamTab( {
 											onClick={ () =>
 												// eslint-disable-next-line no-alert -- Destructive membership action requires explicit confirmation.
 												window.confirm(
-													'Revoke this venue membership?'
+													`Revoke venue access for ${ personLabel(
+														member
+													) }?`
 												) &&
 												mutate(
 													'extrachill/revoke-venue-membership',
@@ -195,8 +202,11 @@ export function TeamTab( {
 							<li key={ invitation.id }>
 								<div>
 									<strong>
-										User #{ invitation.user_id }
+										{ personLabel( invitation ) }
 									</strong>
+									{ invitation.email && (
+										<div>{ invitation.email }</div>
+									) }
 									<div>
 										<Badge>{ invitation.status }</Badge>{ ' ' }
 										<Badge>

--- a/blocks/venue-settings/src/venue-workspace-header.js
+++ b/blocks/venue-settings/src/venue-workspace-header.js
@@ -58,8 +58,12 @@ export function VenueWorkspaceHeader( { venues, selected, onSwitchVenue } ) {
 	return (
 		<>
 			<BlockShellHeader
-				title="Manage venues"
-				description="Manage every venue together or open one venue."
+				title={ selected ? selected.name : 'Manage venues' }
+				description={
+					selected
+						? 'Manage bookings, public details, settings, and team access for this venue.'
+						: 'Manage every venue together or open one venue.'
+				}
 				actions={
 					selected ? (
 						<button
@@ -67,7 +71,7 @@ export function VenueWorkspaceHeader( { venues, selected, onSwitchVenue } ) {
 							className="button-2"
 							onClick={ () => onSwitchVenue( 0 ) }
 						>
-							My Venues
+							Back to My Venues
 						</button>
 					) : null
 				}

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -124,7 +124,10 @@ const profile = ( id ) => ( {
 	country: '',
 	phone: '',
 	website: '',
+	ticketing_url: '',
 	capacity: '',
+	logo_attachment_id: 0,
+	logo: null,
 	revision: String( id ).padStart( 64, '0' ),
 } );
 const config = ( id ) => ( {
@@ -374,7 +377,9 @@ describe( 'venue settings authorization-facing states', () => {
 				/>
 			);
 		} );
-		await act( async () => buttonByText( container, 'My Venues' ).click() );
+		await act( async () =>
+			buttonByText( container, 'Back to My Venues' ).click()
+		);
 		expect( onSwitchVenue ).toHaveBeenLastCalledWith( 0 );
 
 		await act( async () => root.unmount() );
@@ -748,7 +753,7 @@ describe( 'venue settings authorization-facing states', () => {
 		expect( administrator.classList.contains( 'ec-badge--solid' ) ).toBe(
 			true
 		);
-		expect( buttonByText( container, 'My Venues' ) ).toBeDefined();
+		expect( buttonByText( container, 'Back to My Venues' ) ).toBeDefined();
 		const viewSwitcher = container.querySelector(
 			'.ec-booking-console__view-switcher'
 		);
@@ -889,16 +894,22 @@ describe( 'venue settings authorization-facing states', () => {
 		await act( async () => root.unmount() );
 	} );
 
-	it( 'shows the fourteen-day hold limit in booking settings', async () => {
+	it( 'shows human-readable hold duration choices in booking settings', async () => {
 		const { container, root } = await renderApp( context() );
 		await act( async () => buttonByText( container, 'Settings' ).click() );
 
-		expect( container.querySelector( '#venue-hold-ttl' ).max ).toBe(
-			'20160'
-		);
+		const holdDuration = container.querySelector( '#venue-hold-ttl' );
+		expect( holdDuration.tagName ).toBe( 'SELECT' );
+		expect(
+			[ ...holdDuration.options ].some(
+				( option ) =>
+					option.value === '20160' && option.text === '14 days'
+			)
+		).toBe( true );
 		expect( container.textContent ).toContain(
-			'Between 5 minutes and 14 days.'
+			'No marketing automation is configured.'
 		);
+		expect( container.textContent ).not.toContain( 'Comma-separated' );
 		await act( async () => root.unmount() );
 	} );
 
@@ -1094,7 +1105,20 @@ describe( 'venue settings authorization-facing states', () => {
 				return Promise.resolve( bookingActivity() );
 			}
 			if ( request.path.includes( 'get-venue-booking' ) ) {
-				return Promise.resolve( booking( input.booking_id ) );
+				return Promise.resolve( {
+					...booking( input.booking_id ),
+					intake: {
+						version: 1,
+						data: {
+							fields: {
+								hometown: 'Charleston',
+								press_links: [
+									'https://example.com/press-kit',
+								],
+							},
+						},
+					},
+				} );
 			}
 			if ( request.path.includes( 'transition-venue-booking' ) ) {
 				return Promise.resolve( {
@@ -1110,6 +1134,10 @@ describe( 'venue settings authorization-facing states', () => {
 		);
 		expect( container.textContent ).toContain( 'Booking #9' );
 		expect( container.textContent ).toContain( 'Booking Submitted' );
+		expect( container.textContent ).toContain( 'Charleston' );
+		expect(
+			container.querySelector( 'a[href="https://example.com/press-kit"]' )
+		).not.toBeNull();
 		expect(
 			[ ...container.querySelector( '#booking-transition' ).options ].map(
 				( option ) => option.value
@@ -1140,6 +1168,38 @@ describe( 'venue settings authorization-facing states', () => {
 					request.data.input.to_status === 'under_review'
 			)
 		).toBe( true );
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'returns to the booking list after a detail request fails', async () => {
+		apiFetch.mockImplementation( ( request ) => {
+			const input = request.data?.input || requestInput( request.path );
+			if ( request.path.includes( 'get-venue-profile' ) ) {
+				return Promise.resolve( profile( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking-config' ) ) {
+				return Promise.resolve( config( input.venue_term_id ) );
+			}
+			if ( request.path.includes( 'get-venue-booking' ) ) {
+				return Promise.reject( {
+					message: 'Booking detail unavailable.',
+				} );
+			}
+			return Promise.resolve( [] );
+		} );
+		const { container, root } = await renderApp(
+			context( { booking_id: 19 } )
+		);
+		expect( container.textContent ).toContain(
+			'Booking detail unavailable.'
+		);
+		await act( async () =>
+			buttonByText( container, 'Back to bookings' ).click()
+		);
+		expect( container.textContent ).not.toContain(
+			'Booking detail unavailable.'
+		);
+		expect( buttonByText( container, 'Calendar' ) ).toBeDefined();
 		await act( async () => root.unmount() );
 	} );
 
@@ -1461,6 +1521,9 @@ describe( 'venue settings authorization-facing states', () => {
 		);
 		expect( container.textContent ).toContain( 'Booking #23' );
 		await act( async () =>
+			buttonByText( container, 'Close detail' ).click()
+		);
+		await act( async () =>
 			buttonContaining( container, 'Pending Artist' ).click()
 		);
 		expect( container.textContent ).toContain(
@@ -1522,6 +1585,9 @@ describe( 'venue settings authorization-facing states', () => {
 		} );
 		await act( async () =>
 			buttonByText( container, 'Apply transition' ).click()
+		);
+		await act( async () =>
+			buttonByText( container, 'Close detail' ).click()
 		);
 		await act( async () =>
 			buttonContaining( container, 'Mutation Artist B' ).click()

--- a/inc/Abilities/VenueMembershipAbilities.php
+++ b/inc/Abilities/VenueMembershipAbilities.php
@@ -207,6 +207,8 @@ class VenueMembershipAbilities {
 				'id'                 => array( 'type' => 'integer' ),
 				'venue_term_id'      => array( 'type' => 'integer' ),
 				'user_id'            => array( 'type' => 'integer' ),
+				'display_name'        => array( 'type' => 'string' ),
+				'email'               => array( 'type' => 'string' ),
 				'is_owner'           => array( 'type' => 'boolean' ),
 				'status'             => array(
 					'type' => 'string',

--- a/inc/Abilities/VenueMembershipAbilities.php
+++ b/inc/Abilities/VenueMembershipAbilities.php
@@ -207,8 +207,8 @@ class VenueMembershipAbilities {
 				'id'                 => array( 'type' => 'integer' ),
 				'venue_term_id'      => array( 'type' => 'integer' ),
 				'user_id'            => array( 'type' => 'integer' ),
-				'display_name'        => array( 'type' => 'string' ),
-				'email'               => array( 'type' => 'string' ),
+				'display_name'       => array( 'type' => 'string' ),
+				'email'              => array( 'type' => 'string' ),
 				'is_owner'           => array( 'type' => 'boolean' ),
 				'status'             => array(
 					'type' => 'string',

--- a/inc/Abilities/VenueProfileAbilities.php
+++ b/inc/Abilities/VenueProfileAbilities.php
@@ -170,13 +170,28 @@ class VenueProfileAbilities {
 		$logo = array(
 			'type'                 => array( 'object', 'null' ),
 			'properties'           => array(
-				'attachment_id' => array( 'type' => 'integer', 'minimum' => 1 ),
-				'site_id'       => array( 'type' => 'integer', 'minimum' => 1 ),
-				'url'           => array( 'type' => 'string', 'format' => 'uri' ),
+				'attachment_id' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'site_id'       => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'url'           => array(
+					'type'   => 'string',
+					'format' => 'uri',
+				),
 				'alt'           => $text,
 				'mime_type'     => $text,
-				'width'         => array( 'type' => 'integer', 'minimum' => 0 ),
-				'height'        => array( 'type' => 'integer', 'minimum' => 0 ),
+				'width'         => array(
+					'type'    => 'integer',
+					'minimum' => 0,
+				),
+				'height'        => array(
+					'type'    => 'integer',
+					'minimum' => 0,
+				),
 			),
 			'required'             => array( 'attachment_id', 'site_id', 'url', 'alt', 'mime_type', 'width', 'height' ),
 			'additionalProperties' => false,
@@ -184,27 +199,27 @@ class VenueProfileAbilities {
 		return array(
 			'type'                 => 'object',
 			'properties'           => array(
-				'term_id'     => array(
+				'term_id'            => array(
 					'type'    => 'integer',
 					'minimum' => 1,
 				),
-				'name'        => $text,
-				'description' => $text,
-				'address'     => $text,
-				'city'        => $text,
-				'state'       => $text,
-				'zip'         => $text,
-				'country'     => $text,
-				'phone'       => $text,
-				'website'     => $text,
-				'ticketing_url' => $text,
-				'capacity'    => $text,
+				'name'               => $text,
+				'description'        => $text,
+				'address'            => $text,
+				'city'               => $text,
+				'state'              => $text,
+				'zip'                => $text,
+				'country'            => $text,
+				'phone'              => $text,
+				'website'            => $text,
+				'ticketing_url'      => $text,
+				'capacity'           => $text,
 				'logo_attachment_id' => array(
 					'type'    => 'integer',
 					'minimum' => 0,
 				),
-				'logo'        => $logo,
-				'revision'    => array(
+				'logo'               => $logo,
+				'revision'           => array(
 					'type'    => 'string',
 					'pattern' => '^[a-f0-9]{64}$',
 				),

--- a/inc/Abilities/VenueProfileAbilities.php
+++ b/inc/Abilities/VenueProfileAbilities.php
@@ -167,6 +167,20 @@ class VenueProfileAbilities {
 	/** Return the canonical DME profile schema. */
 	private function profile_schema(): array {
 		$text = array( 'type' => 'string' );
+		$logo = array(
+			'type'                 => array( 'object', 'null' ),
+			'properties'           => array(
+				'attachment_id' => array( 'type' => 'integer', 'minimum' => 1 ),
+				'site_id'       => array( 'type' => 'integer', 'minimum' => 1 ),
+				'url'           => array( 'type' => 'string', 'format' => 'uri' ),
+				'alt'           => $text,
+				'mime_type'     => $text,
+				'width'         => array( 'type' => 'integer', 'minimum' => 0 ),
+				'height'        => array( 'type' => 'integer', 'minimum' => 0 ),
+			),
+			'required'             => array( 'attachment_id', 'site_id', 'url', 'alt', 'mime_type', 'width', 'height' ),
+			'additionalProperties' => false,
+		);
 		return array(
 			'type'                 => 'object',
 			'properties'           => array(
@@ -185,12 +199,17 @@ class VenueProfileAbilities {
 				'website'     => $text,
 				'ticketing_url' => $text,
 				'capacity'    => $text,
+				'logo_attachment_id' => array(
+					'type'    => 'integer',
+					'minimum' => 0,
+				),
+				'logo'        => $logo,
 				'revision'    => array(
 					'type'    => 'string',
 					'pattern' => '^[a-f0-9]{64}$',
 				),
 			),
-			'required'             => array( 'term_id', 'name', 'description', 'address', 'city', 'state', 'zip', 'country', 'phone', 'website', 'ticketing_url', 'capacity', 'revision' ),
+			'required'             => array( 'term_id', 'name', 'description', 'address', 'city', 'state', 'zip', 'country', 'phone', 'website', 'ticketing_url', 'capacity', 'logo_attachment_id', 'logo', 'revision' ),
 			'additionalProperties' => false,
 		);
 	}

--- a/inc/Core/VenueMembershipService.php
+++ b/inc/Core/VenueMembershipService.php
@@ -66,6 +66,18 @@ class VenueMembershipService {
 		if ( is_wp_error( $allowed ) ) {
 			return $allowed;
 		}
-		return $this->memberships->list_for_venue( $venue_term_id, $filters, $actor_user_id );
+		$memberships = $this->memberships->list_for_venue( $venue_term_id, $filters, $actor_user_id );
+		if ( ! is_array( $memberships ) ) {
+			return $memberships;
+		}
+		return array_map(
+			static function ( array $membership ): array {
+				$user = get_userdata( $membership['user_id'] );
+				$membership['display_name'] = $user instanceof \WP_User ? (string) $user->display_name : '';
+				$membership['email']        = $user instanceof \WP_User ? (string) $user->user_email : '';
+				return $membership;
+			},
+			$memberships
+		);
 	}
 }

--- a/inc/Core/VenueMembershipService.php
+++ b/inc/Core/VenueMembershipService.php
@@ -72,7 +72,7 @@ class VenueMembershipService {
 		}
 		return array_map(
 			static function ( array $membership ): array {
-				$user = get_userdata( $membership['user_id'] );
+				$user                       = get_userdata( $membership['user_id'] );
 				$membership['display_name'] = $user instanceof \WP_User ? (string) $user->display_name : '';
 				$membership['email']        = $user instanceof \WP_User ? (string) $user->user_email : '';
 				return $membership;

--- a/inc/Core/VenueOnboardingService.php
+++ b/inc/Core/VenueOnboardingService.php
@@ -161,8 +161,8 @@ class VenueOnboardingService {
 		}
 		return array_map(
 			function ( array $invitation ): array {
-				$invitation = $this->repository->public_invitation( $invitation );
-				$user       = get_userdata( $invitation['user_id'] );
+				$invitation                 = $this->repository->public_invitation( $invitation );
+				$user                       = get_userdata( $invitation['user_id'] );
 				$invitation['display_name'] = $user instanceof \WP_User ? (string) $user->display_name : '';
 				$invitation['email']        = $user instanceof \WP_User ? (string) $user->user_email : '';
 				return $invitation;

--- a/inc/Core/VenueOnboardingService.php
+++ b/inc/Core/VenueOnboardingService.php
@@ -159,7 +159,16 @@ class VenueOnboardingService {
 		if ( ! is_array( $result ) ) {
 			return $result;
 		}
-		return array_map( array( $this->repository, 'public_invitation' ), $result );
+		return array_map(
+			function ( array $invitation ): array {
+				$invitation = $this->repository->public_invitation( $invitation );
+				$user       = get_userdata( $invitation['user_id'] );
+				$invitation['display_name'] = $user instanceof \WP_User ? (string) $user->display_name : '';
+				$invitation['email']        = $user instanceof \WP_User ? (string) $user->user_email : '';
+				return $invitation;
+			},
+			$result
+		);
 	}
 
 	/**

--- a/tests/VenueMembershipAuthorizationTest.php
+++ b/tests/VenueMembershipAuthorizationTest.php
@@ -1254,6 +1254,9 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$service = new VenueMembershipService();
 		$service->create( 1, 55, 2, true );
 		$service->create( 2, 55, 3, false );
+		$members = $service->list( 2, 55 );
+		$this->assertSame( 'User 3', $members[1]['display_name'] );
+		$this->assertSame( 'member3@example.com', $members[1]['email'] );
 
 		$GLOBALS['wpdb']->before_list = static function ( VenueMembershipWpdb $wpdb ): void {
 			foreach ( $wpdb->rows['wp_7_ec_venue_members'] as &$row ) {
@@ -1540,8 +1543,11 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->create_member( 55, 2, true );
 		$service  = new VenueOnboardingService();
 		$existing = $service->invite( 2, 55, 'existing@example.com', false );
+		$listed   = $service->list_invitations( 2, 55 );
 
 		$this->assertFalse( $existing['account_created'] );
+		$this->assertSame( 'User 7', $listed[0]['display_name'] );
+		$this->assertSame( 'existing@example.com', $listed[0]['email'] );
 		$this->assertTrue( $existing['delivery_queued'] );
 		$this->assertSame( 0, $GLOBALS['venue_membership_test']['reset_key_calls'] );
 		$this->assertSame( array(), $GLOBALS['venue_membership_test']['sent_emails'] );
@@ -1971,6 +1977,14 @@ final class VenueMembershipAuthorizationTest extends BookingTestCase {
 		$this->assertSame( 'string', $update['input_schema']['properties']['expected_revision']['type'] );
 		$this->assertSame( 'string', $get['output_schema']['properties']['ticketing_url']['type'] );
 		$this->assertContains( 'ticketing_url', $get['output_schema']['required'] );
+		$this->assertSame( 'integer', $get['output_schema']['properties']['logo_attachment_id']['type'] );
+		$this->assertSame( array( 'object', 'null' ), $get['output_schema']['properties']['logo']['type'] );
+		$this->assertSame(
+			array( 'attachment_id', 'site_id', 'url', 'alt', 'mime_type', 'width', 'height' ),
+			$get['output_schema']['properties']['logo']['required']
+		);
+		$this->assertContains( 'logo_attachment_id', $get['output_schema']['required'] );
+		$this->assertContains( 'logo', $get['output_schema']['required'] );
 
 		$GLOBALS['venue_membership_test']['current_user_id'] = 4;
 		$this->set_current_user( 4 );


### PR DESCRIPTION
## Summary
- align the venue profile ability with DME's canonical logo contract so the Venue tab can load
- turn booking detail into a focused workspace with readable nested intake data, progressive disclosures, and recoverable errors
- simplify booking settings, expose human team identities, and clarify selected-venue context

## Verification
- `npm run lint:js`
- `npm run test:js -- --runInBand` (100 tests)
- `npm run build`
- PHP syntax checks for every modified PHP file
- `git diff --check`

## Evidence note
The post-change WP Codebox browser rerun was blocked by intermittent synthetic `/events` routing and then a concurrent readonly DME mount snapshot change. The same populated fixture was visually reviewed before implementation; changed UI paths are covered by the passing React tests and production build.

Closes #654
Closes #655
Closes #656
Closes #657
Closes #658