### PR TITLE
fix: defer hidden My Shows map mounting

### DIFF
--- a/blocks/concert-stats/render.php
+++ b/blocks/concert-stats/render.php
@@ -268,18 +268,14 @@ $wrapper_attributes = get_block_wrapper_attributes(
 
 	<?php if ( $render_embedded_map ) : ?>
 		<div class="ec-concert-stats__embedded-map" data-tab="map" hidden>
-			<?php
-			// Same auto-gating pattern as the calendar wrapper above.
-			// The my-shows-map-filter callbacks scope the venue set +
-			// per-venue events to the user's tracked shows; the events-map
-			// block stays generic and unaware of the concert-tracking
-			// table. chronologicalRouteMode = true: polyline + first/last
-			// marker styling + multi-date popups against the user's
-			// attendance timeline. height=500 matches the calendar
-			// block's vertical footprint so tab swapping doesn't shift
-			// page layout.
-			echo do_blocks( '<!-- wp:data-machine-events/events-map {"chronologicalRouteMode":true,"height":500} /-->' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- block render output is trusted.
-			?>
+			<template class="ec-concert-stats__embedded-map-template">
+				<?php
+				// Keep the map inert until its tab is opened. This prevents
+				// Leaflet from mounting inside a hidden ancestor and avoids
+				// requesting tiles for users who never open the Map tab.
+				echo do_blocks( '<!-- wp:data-machine-events/events-map {"chronologicalRouteMode":true,"height":500} /-->' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- block render output is trusted.
+				?>
+			</template>
 		</div>
 	<?php endif; ?>
 </div>

--- a/blocks/concert-stats/src/view.js
+++ b/blocks/concert-stats/src/view.js
@@ -328,6 +328,18 @@ export function ConcertStatsApp( {
 		}
 		const wasHidden = map.hidden;
 		map.hidden = activeTab !== 'map';
+		if ( ! map.hidden ) {
+			const template = map.querySelector(
+				'.ec-concert-stats__embedded-map-template'
+			);
+			if ( template ) {
+				map.appendChild( template.content.cloneNode( true ) );
+				template.remove();
+				document.dispatchEvent(
+					new CustomEvent( 'data-machine-events-loaded' )
+				);
+			}
+		}
 		if ( wasHidden && ! map.hidden && typeof window !== 'undefined' ) {
 			// Leaflet listens for window resize via invalidateSize hooks.
 			// Defer to next frame so the layout has settled before the

--- a/blocks/concert-stats/src/view.test.js
+++ b/blocks/concert-stats/src/view.test.js
@@ -37,12 +37,19 @@ jest.mock( '@extrachill/components', () => {
 			React.createElement( 'h2', null, title ),
 		Grid: Wrapper,
 		InlineStatus: Wrapper,
-		ResponsiveTabs: ( { tabs, active, renderPanel } ) =>
+		ResponsiveTabs: ( { tabs, active, onChange, renderPanel } ) =>
 			React.createElement(
 				'div',
 				null,
 				tabs.map( ( tab ) =>
-					React.createElement( 'button', { key: tab.id }, tab.label )
+					React.createElement(
+						'button',
+						{
+							key: tab.id,
+							onClick: () => onChange( tab.id ),
+						},
+						tab.label
+					)
 				),
 				renderPanel( active )
 			),
@@ -118,7 +125,18 @@ async function renderApp( { isOwn, tab, userId = 34 } ) {
 		`/my-shows/?user_id=34${ tab ? `&tab=${ tab }` : '' }`
 	);
 	const container = document.createElement( 'div' );
-	document.body.appendChild( container );
+	const shell = document.createElement( 'div' );
+	shell.className = 'ec-concert-stats-shell';
+	const map = document.createElement( 'div' );
+	map.className = 'ec-concert-stats__embedded-map';
+	map.hidden = true;
+	map.innerHTML = `
+		<template class="ec-concert-stats__embedded-map-template">
+			<div class="data-machine-events-map-root"></div>
+		</template>
+	`;
+	shell.append( container, map );
+	document.body.appendChild( shell );
 	const root = createRoot( container );
 	const render = ( nextUserId ) => (
 		<ConcertStatsApp
@@ -139,6 +157,7 @@ async function renderApp( { isOwn, tab, userId = 34 } ) {
 
 	return {
 		container,
+		map,
 		root,
 		rerenderUser: async ( nextUserId ) => {
 			await act( async () => {
@@ -239,6 +258,58 @@ describe( 'ConcertStatsApp request boundaries', () => {
 			)
 		).toBe( true );
 
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'mounts the embedded map only when its tab is opened', async () => {
+		let loadedEvents = 0;
+		const onLoaded = () => loadedEvents++;
+		document.addEventListener( 'data-machine-events-loaded', onLoaded );
+		const { container, map, root } = await renderApp( {
+			isOwn: true,
+			tab: 'past',
+		} );
+
+		expect( map.hidden ).toBe( true );
+		expect( map.querySelector( 'template' ) ).not.toBeNull();
+		expect(
+			map.querySelector( '.data-machine-events-map-root' )
+		).toBeNull();
+
+		const mapButton = [ ...container.querySelectorAll( 'button' ) ].find(
+			( button ) => button.textContent === 'Map'
+		);
+		const pastButton = [ ...container.querySelectorAll( 'button' ) ].find(
+			( button ) => button.textContent === 'Past'
+		);
+		expect( mapButton ).toBeDefined();
+		expect( pastButton ).toBeDefined();
+		await act( async () => {
+			mapButton.click();
+			await Promise.resolve();
+		} );
+
+		expect( map.hidden ).toBe( false );
+		expect( map.querySelector( 'template' ) ).toBeNull();
+		expect(
+			map.querySelector( '.data-machine-events-map-root' )
+		).not.toBeNull();
+		expect( loadedEvents ).toBe( 1 );
+
+		await act( async () => {
+			pastButton.click();
+			await Promise.resolve();
+		} );
+		expect( map.hidden ).toBe( true );
+
+		await act( async () => {
+			mapButton.click();
+			await Promise.resolve();
+		} );
+		expect( map.hidden ).toBe( false );
+		expect( loadedEvents ).toBe( 1 );
+
+		document.removeEventListener( 'data-machine-events-loaded', onLoaded );
 		await act( async () => root.unmount() );
 	} );
 


### PR DESCRIPTION
## Summary
- keep My Shows map markup inert until the Map tab is opened
- initialize the generic DME map through its existing content-loaded event only after the wrapper is visible
- preserve the mounted map across subsequent tab switches without duplicate initialization

Closes #660.

## Verification
- `npm run test:js -- --runInBand` (101 tests)
- `npm run lint:js`
- `npm run build`
- `php -l blocks/concert-stats/render.php`
- `git diff --check`