### PR TITLE
fix: label virtual event breadcrumbs

### DIFF
--- a/inc/single-event/breadcrumbs.php
+++ b/inc/single-event/breadcrumbs.php
@@ -93,6 +93,8 @@ add_filter( 'extrachill_breadcrumbs_override_trail', 'ec_events_breadcrumb_trail
  * "Extra Chill → Events" prefix. Only applies on blog ID 7 (events.extrachill.com).
  *
  * Output patterns:
+ * - Location directory: "Extra Chill → Events → Live Music by Location"
+ * - All events: "Extra Chill → Events → All Live Music Events"
  * - Taxonomy: "Extra Chill → Events → [Term Name]"
  * - Post type: "Extra Chill → Events"
  *
@@ -104,6 +106,12 @@ add_filter( 'extrachill_breadcrumbs_override_trail', 'ec_events_breadcrumb_trail
 function ec_events_breadcrumb_trail_archives( $custom_trail ) {
 	if ( ! ec_is_events_site() ) {
 		return $custom_trail;
+	}
+	if ( extrachill_events_is_location_index() ) {
+		return '<span>' . esc_html__( 'Live Music by Location', 'extrachill-events' ) . '</span>';
+	}
+	if ( extrachill_events_is_all_events_page() ) {
+		return '<span>' . esc_html__( 'All Live Music Events', 'extrachill-events' ) . '</span>';
 	}
 	if ( is_tax() ) {
 		$term = get_queried_object();

--- a/tests/Unit/Core/BreadcrumbsTest.php
+++ b/tests/Unit/Core/BreadcrumbsTest.php
@@ -85,9 +85,20 @@ require_once dirname( __DIR__, 3 ) . '/inc/single-event/breadcrumbs.php';
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- Focused WordPress function doubles live with their tests.
 /** Verifies breadcrumb labels for Events archives and virtual routes. */
 final class BreadcrumbsTest extends TestCase {
+	/**
+	 * Whether this test switched into the Events site.
+	 *
+	 * @var bool
+	 */
+	private bool $switched_to_events_site = false;
+
 	/** Reset request state before each test. */
 	protected function setUp(): void {
 		parent::setUp();
+		if ( ! ec_is_events_site() && function_exists( 'switch_to_blog' ) ) {
+			switch_to_blog( (int) ec_get_blog_id( 'events' ) );
+			$this->switched_to_events_site = true;
+		}
 		$GLOBALS['test_query_vars']   = array();
 		$GLOBALS['test_is_tax']       = false;
 		$GLOBALS['test_queried_term'] = null;
@@ -96,6 +107,10 @@ final class BreadcrumbsTest extends TestCase {
 	/** Remove request state after each test. */
 	protected function tearDown(): void {
 		unset( $GLOBALS['test_query_vars'], $GLOBALS['test_is_tax'], $GLOBALS['test_queried_term'] );
+		if ( $this->switched_to_events_site ) {
+			restore_current_blog();
+			$this->switched_to_events_site = false;
+		}
 		parent::tearDown();
 	}
 

--- a/tests/Unit/Core/BreadcrumbsTest.php
+++ b/tests/Unit/Core/BreadcrumbsTest.php
@@ -102,10 +102,22 @@ final class BreadcrumbsTest extends TestCase {
 		$GLOBALS['test_query_vars']   = array();
 		$GLOBALS['test_is_tax']       = false;
 		$GLOBALS['test_queried_term'] = null;
+		$this->set_test_query_var( 'ec_events_location_index', '' );
+		$this->set_test_query_var( 'ec_events_router', '' );
+		if ( isset( $GLOBALS['wp_query'] ) ) {
+			$GLOBALS['wp_query']->is_tax         = false;
+			$GLOBALS['wp_query']->queried_object = null;
+		}
 	}
 
 	/** Remove request state after each test. */
 	protected function tearDown(): void {
+		$this->set_test_query_var( 'ec_events_location_index', '' );
+		$this->set_test_query_var( 'ec_events_router', '' );
+		if ( isset( $GLOBALS['wp_query'] ) ) {
+			$GLOBALS['wp_query']->is_tax         = false;
+			$GLOBALS['wp_query']->queried_object = null;
+		}
 		unset( $GLOBALS['test_query_vars'], $GLOBALS['test_is_tax'], $GLOBALS['test_queried_term'] );
 		if ( $this->switched_to_events_site ) {
 			restore_current_blog();
@@ -116,7 +128,7 @@ final class BreadcrumbsTest extends TestCase {
 
 	/** The location directory identifies its destination. */
 	public function test_location_directory_has_destination_specific_breadcrumb(): void {
-		$GLOBALS['test_query_vars']['ec_events_location_index'] = '1';
+		$this->set_test_query_var( 'ec_events_location_index', '1' );
 
 		$this->assertSame(
 			'<span>Live Music by Location</span>',
@@ -126,7 +138,7 @@ final class BreadcrumbsTest extends TestCase {
 
 	/** The all-events page identifies its destination. */
 	public function test_all_events_page_has_destination_specific_breadcrumb(): void {
-		$GLOBALS['test_query_vars']['ec_events_router'] = 'all';
+		$this->set_test_query_var( 'ec_events_router', 'all' );
 
 		$this->assertSame(
 			'<span>All Live Music Events</span>',
@@ -138,10 +150,29 @@ final class BreadcrumbsTest extends TestCase {
 	public function test_taxonomy_archive_keeps_term_breadcrumb(): void {
 		$GLOBALS['test_is_tax']       = true;
 		$GLOBALS['test_queried_term'] = (object) array( 'name' => 'Charleston' );
+		if ( isset( $GLOBALS['wp_query'] ) ) {
+			$GLOBALS['wp_query']->is_tax         = true;
+			$GLOBALS['wp_query']->queried_object = $GLOBALS['test_queried_term'];
+		}
 
 		$this->assertSame(
 			'<span>Charleston</span>',
 			ec_events_breadcrumb_trail_archives( '' )
 		);
+	}
+
+	/**
+	 * Set a query variable in either WordPress or the plain unit fixture.
+	 *
+	 * @param string $name  Query variable name.
+	 * @param string $value Query variable value.
+	 */
+	private function set_test_query_var( string $name, string $value ): void {
+		if ( function_exists( 'set_query_var' ) ) {
+			set_query_var( $name, $value );
+			return;
+		}
+
+		$GLOBALS['test_query_vars'][ $name ] = $value;
 	}
 }

--- a/tests/Unit/Core/BreadcrumbsTest.php
+++ b/tests/Unit/Core/BreadcrumbsTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Events breadcrumb integration tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'ec_is_events_site' ) ) {
+	/** Return the Events-site context for this fixture. */
+	function ec_is_events_site() {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_query_var' ) ) {
+	/**
+	 * Return a query variable from the test request.
+	 *
+	 * @param string $name          Query variable name.
+	 * @param mixed  $default_value Default value.
+	 * @return mixed
+	 */
+	function get_query_var( $name, $default_value = '' ) {
+		return $GLOBALS['test_query_vars'][ $name ] ?? $default_value;
+	}
+}
+
+if ( ! function_exists( 'is_front_page' ) ) {
+	/** Router breadcrumb tests never represent the front page. */
+	function is_front_page() {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'is_tax' ) ) {
+	/** Return the fixture's taxonomy condition. */
+	function is_tax() {
+		return (bool) ( $GLOBALS['test_is_tax'] ?? false );
+	}
+}
+
+if ( ! function_exists( 'get_queried_object' ) ) {
+	/** Return the fixture's queried taxonomy term. */
+	function get_queried_object() {
+		return $GLOBALS['test_queried_term'] ?? null;
+	}
+}
+
+if ( ! function_exists( 'is_post_type_archive' ) ) {
+	/** Router breadcrumb tests never represent the post type archive. */
+	function is_post_type_archive() {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	/**
+	 * Escape fixture output as HTML.
+	 *
+	 * @param mixed $value Value to escape.
+	 * @return string
+	 */
+	function esc_html( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_html__' ) ) {
+	/**
+	 * Return escaped, untranslated fixture text.
+	 *
+	 * @param mixed $value Value to escape.
+	 * @return string
+	 */
+	function esc_html__( $value ) {
+		return esc_html( $value );
+	}
+}
+
+require_once dirname( __DIR__, 3 ) . '/inc/core/router-pages.php';
+require_once dirname( __DIR__, 3 ) . '/inc/single-event/breadcrumbs.php';
+
+// phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- Focused WordPress function doubles live with their tests.
+/** Verifies breadcrumb labels for Events archives and virtual routes. */
+final class BreadcrumbsTest extends TestCase {
+	/** Reset request state before each test. */
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['test_query_vars']   = array();
+		$GLOBALS['test_is_tax']       = false;
+		$GLOBALS['test_queried_term'] = null;
+	}
+
+	/** Remove request state after each test. */
+	protected function tearDown(): void {
+		unset( $GLOBALS['test_query_vars'], $GLOBALS['test_is_tax'], $GLOBALS['test_queried_term'] );
+		parent::tearDown();
+	}
+
+	/** The location directory identifies its destination. */
+	public function test_location_directory_has_destination_specific_breadcrumb(): void {
+		$GLOBALS['test_query_vars']['ec_events_location_index'] = '1';
+
+		$this->assertSame(
+			'<span>Live Music by Location</span>',
+			ec_events_breadcrumb_trail_archives( '' )
+		);
+	}
+
+	/** The all-events page identifies its destination. */
+	public function test_all_events_page_has_destination_specific_breadcrumb(): void {
+		$GLOBALS['test_query_vars']['ec_events_router'] = 'all';
+
+		$this->assertSame(
+			'<span>All Live Music Events</span>',
+			ec_events_breadcrumb_trail_archives( '' )
+		);
+	}
+
+	/** Ordinary taxonomy archives retain the queried term label. */
+	public function test_taxonomy_archive_keeps_term_breadcrumb(): void {
+		$GLOBALS['test_is_tax']       = true;
+		$GLOBALS['test_queried_term'] = (object) array( 'name' => 'Charleston' );
+
+		$this->assertSame(
+			'<span>Charleston</span>',
+			ec_events_breadcrumb_trail_archives( '' )
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- label `/location/` with `Live Music by Location` instead of the generic `Archives` crumb
- label `/all/` with `All Live Music Events` while preserving ordinary taxonomy term breadcrumbs
- add focused regression coverage for both virtual routes and a taxonomy archive

## Before / After
- Before: both virtual routes rendered `Extra Chill > Events Calendar > Archives`
- After: the final crumb matches each route's existing page heading
- Taxonomy archives continue to render the queried term name

## Implementation
Extends the existing Events archive breadcrumb override with the router-page detectors already used by template and title routing. The current destinations remain non-linked `<span>` crumbs, matching existing breadcrumb semantics.

## Verification
- `./vendor/bin/phpunit --configuration phpunit.xml.dist tests/Unit/Core/BreadcrumbsTest.php` (3 tests, 3 assertions)
- `./vendor/bin/phpcs --standard=WordPress tests/Unit/Core/BreadcrumbsTest.php`
- `php -l inc/single-event/breadcrumbs.php`
- `php -l tests/Unit/Core/BreadcrumbsTest.php`
- `git diff --check`

The repository-wide PHPUnit config still encounters its documented unmanaged WordPress bootstrap limitation (`WP_UnitTestCase` is unavailable); the focused standalone regression suite passes.

Fixes #662