### PR TITLE
fix: restore dark booking label inputs

### DIFF
--- a/blocks/venue-settings/src/booking-form-tab.test.js
+++ b/blocks/venue-settings/src/booking-form-tab.test.js
@@ -89,6 +89,15 @@ describe( 'booking form workspace', () => {
 		expect( intake ).not.toContain( 'fieldset' );
 	} );
 
+	it( 'keeps custom field labels on theme-native form surfaces', () => {
+		const labelInput = intake.match(
+			/<input[\s\S]*?className="ec-booking-field__label"[\s\S]*?\/>/
+		)?.[ 0 ];
+
+		expect( labelInput ).toContain( 'type="text"' );
+		expect( styles ).not.toContain( '.ec-booking-field__label {' );
+	} );
+
 	it( 'uses complete theme button variants', () => {
 		expect( workspace ).toContain( 'button-1 button-medium' );
 		expect( intake ).toContain( 'ec-booking-fields__add' );

--- a/blocks/venue-settings/src/intake-tab.js
+++ b/blocks/venue-settings/src/intake-tab.js
@@ -99,6 +99,7 @@ export function IntakeTab( { config, setConfig, idPrefix = '' } ) {
 									</span>
 									<input
 										id={ `${ idPrefix }intake-label-${ rowIndex }` }
+										type="text"
 										className="ec-booking-field__label"
 										aria-label={ `Field ${
 											rowIndex + 1


### PR DESCRIPTION
## Summary
- declare custom booking-field label controls as text inputs so they match the theme's canonical form selector
- add focused regression coverage that requires the explicit input type without introducing a booking-specific palette

## Root cause
The custom-field label input omitted its `type` attribute. Although browsers treat the control as text behaviorally, the Extra Chill theme's form styles target explicit text-like selectors such as `input[type=\"text\"]`. The control therefore inherited dark-mode text while retaining the browser's white default background.

## Minimal fix
Add `type=\"text\"` to the existing label input. This lets the owning theme layer provide its established surface, text, border, focus, placeholder, disabled, and read-only behavior instead of duplicating those rules in block CSS.

## Light/dark verification
- Light mode: the control resolves through `--background-color`, `--text-color`, and `--border-color`, matching adjacent form controls.
- Dark mode: the same selector resolves through the dark token overrides, eliminating light text on a white surface.
- Focus continues to use the theme border plus the venue-settings `:focus-visible` outline.
- Placeholder, disabled, and read-only states retain the text-input surface and readable theme colors in either color scheme.

## Tests
- `npm run test:js -- blocks/venue-settings/src/booking-form-tab.test.js --runInBand` (8 tests passed)
- `npm run lint:js -- --quiet blocks/venue-settings/src/intake-tab.js blocks/venue-settings/src/booking-form-tab.test.js`
- `npm run build:venue-settings`
- `git diff --check`

## Residual gap
No integrated browser screenshot was captured because the fix is not deployed and this focused worktree has no standalone WordPress browser fixture. Verification covers the actual production theme cascade, the source regression, lint, and the production block build.

Closes #665