### PR TITLE
fix: keep booking website prefill clean

### DIFF
--- a/blocks/venue-settings/src/booking-form-tab.js
+++ b/blocks/venue-settings/src/booking-form-tab.js
@@ -45,6 +45,7 @@ export function BookingFormTab( {
 	config,
 	baseline,
 	setConfig,
+	onInitializeConfig,
 	onSave,
 	saving,
 	status,
@@ -72,11 +73,11 @@ export function BookingFormTab( {
 			return;
 		}
 		initializedWebsite.current = true;
-		setConfig( {
+		onInitializeConfig( {
 			...config,
 			embed: { allowed_parent_origins: [ origin ] },
 		} );
-	}, [ config, profile?.website, setConfig, websites.length ] );
+	}, [ config, onInitializeConfig, profile?.website, websites.length ] );
 	useEffect( () => {
 		const mobilePreview = window.matchMedia( '(max-width: 960px)' );
 		const syncPreview = () => setPreviewOpen( ! mobilePreview.matches );

--- a/blocks/venue-settings/src/booking-form-tab.test.js
+++ b/blocks/venue-settings/src/booking-form-tab.test.js
@@ -51,6 +51,7 @@ describe( 'booking form workspace', () => {
 		expect( workspace ).toContain(
 			'embed: { allowed_parent_origins: [ origin ] }'
 		);
+		expect( workspace ).toContain( 'onInitializeConfig( {' );
 		expect( workspace ).toContain(
 			'initializedWebsite.current || websites.length'
 		);

--- a/blocks/venue-settings/src/view.js
+++ b/blocks/venue-settings/src/view.js
@@ -377,6 +377,10 @@ export function VenueSettingsApp( { context } ) {
 					setConfig={ ( value ) =>
 						setVenueState( setConfigs, venue.id, value )
 					}
+					onInitializeConfig={ ( value ) => {
+						setVenueState( setConfigs, venue.id, value );
+						setVenueState( setConfigBaselines, venue.id, value );
+					} }
 					onSave={ () => saveConfig( venue ) }
 					saving={ Boolean( savingConfigs[ venue.id ] ) }
 					status={ configStatuses[ venue.id ] }

--- a/blocks/venue-settings/src/view.test.js
+++ b/blocks/venue-settings/src/view.test.js
@@ -894,6 +894,70 @@ describe( 'venue settings authorization-facing states', () => {
 		await act( async () => root.unmount() );
 	} );
 
+	it.each( [
+		[ 'profile before config', 'profile', 'config' ],
+		[ 'config before profile', 'config', 'profile' ],
+	] )(
+		'keeps automatic booking website initialization clean when %s loads',
+		async ( label, firstRequest, secondRequest ) => {
+			const requests = {
+				profile: deferred(),
+				config: deferred(),
+			};
+			apiFetch.mockImplementation( ( request ) => {
+				if ( request.path.includes( 'get-venue-profile' ) ) {
+					return requests.profile.promise;
+				}
+				if ( request.path.includes( 'get-venue-booking-config' ) ) {
+					return requests.config.promise;
+				}
+				return Promise.resolve( [] );
+			} );
+			const { container, root } = await renderApp( context() );
+			await act( async () =>
+				buttonByText( container, 'Booking Form' ).click()
+			);
+
+			await act( async () => {
+				requests[ firstRequest ].resolve(
+					firstRequest === 'profile'
+						? {
+								...profile( 44 ),
+								website: 'https://venue.example/about',
+						  }
+						: config( 44 )
+				);
+				await Promise.resolve();
+			} );
+			await act( async () => {
+				requests[ secondRequest ].resolve(
+					secondRequest === 'profile'
+						? {
+								...profile( 44 ),
+								website: 'https://venue.example/about',
+						  }
+						: config( 44 )
+				);
+				await Promise.resolve();
+			} );
+
+			expect(
+				container.querySelector( '#venue-booking-websites' ).value
+			).toBe( 'https://venue.example' );
+			expect(
+				buttonByText( container, 'Save booking form' ).disabled
+			).toBe( true );
+			expect( container.textContent ).not.toContain(
+				'Unsaved booking form changes'
+			);
+			const unload = new Event( 'beforeunload', { cancelable: true } );
+			window.dispatchEvent( unload );
+			expect( unload.defaultPrevented ).toBe( false );
+
+			await act( async () => root.unmount() );
+		}
+	);
+
 	it( 'shows human-readable hold duration choices in booking settings', async () => {
 		const { container, root } = await renderApp( context() );
 		await act( async () => buttonByText( container, 'Settings' ).click() );


### PR DESCRIPTION
## Summary
- treat the profile website prefill as booking-config initialization rather than a user edit
- advance the parent-owned current config and dirty-check baseline together during automatic initialization
- preserve normal dirty tracking for subsequent user changes

## Root cause
`BookingFormTab` copied `profile.website` into the current config after the independently loaded profile became available, but the saved config baseline remained unchanged. The parent therefore compared the system-prefilled current config against an empty saved baseline and enabled dirty UI and unload protection.

## State ownership
`VenueSettingsApp` owns both the editable config and its baseline, so the child now reports automatic initialization through a dedicated callback. The parent updates both documents together for initialization; ordinary `setConfig` edits continue changing only the editable document.

## Load-order coverage
The rendered-app regression test defers profile and config requests and covers both profile-before-config and config-before-profile completion. Each case verifies the normalized website remains visible, Save stays disabled, the unsaved warning stays absent, and `beforeunload` is not prevented.

## Tests
- `npm run test:js -- blocks/venue-settings/src/view.test.js blocks/venue-settings/src/booking-form-tab.test.js --runInBand`
- `npm run lint:js -- blocks/venue-settings/src/booking-form-tab.js blocks/venue-settings/src/view.js blocks/venue-settings/src/booking-form-tab.test.js blocks/venue-settings/src/view.test.js`
- `npm run build:venue-settings`

## Residual gap
None. Existing dependencies were reused through a temporary ignored symlink; no dependencies were installed in the worktree.

Closes #664