### PR TITLE
fix: prevent booking preview clipping

### DIFF
--- a/blocks/venue-settings/src/booking-form-tab.js
+++ b/blocks/venue-settings/src/booking-form-tab.js
@@ -78,7 +78,7 @@ export function BookingFormTab( {
 		} );
 	}, [ config, profile?.website, setConfig, websites.length ] );
 	useEffect( () => {
-		const mobilePreview = window.matchMedia( '(max-width: 960px)' );
+		const mobilePreview = window.matchMedia( '(max-width: 1200px)' );
 		const syncPreview = () => setPreviewOpen( ! mobilePreview.matches );
 		syncPreview();
 		mobilePreview.addEventListener( 'change', syncPreview );

--- a/blocks/venue-settings/src/booking-form-tab.test.js
+++ b/blocks/venue-settings/src/booking-form-tab.test.js
@@ -114,5 +114,8 @@ describe( 'booking form workspace', () => {
 		);
 		expect( workspace ).toContain( '<BookingInquiry' );
 		expect( workspace ).not.toContain( 'booking-embed=1' );
+		expect( workspace ).toContain(
+			"window.matchMedia( '(max-width: 1200px)' )"
+		);
 	} );
 } );

--- a/blocks/venue-settings/src/style.scss
+++ b/blocks/venue-settings/src/style.scss
@@ -42,7 +42,7 @@
 
 .ec-booking-form-editor {
 	display: grid;
-	grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+	grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
 	gap: var(--spacing-lg);
 	align-items: start;
 }
@@ -505,7 +505,7 @@
 	text-align: center;
 }
 
-@media screen and (max-width: 960px) {
+@media screen and (max-width: 1200px) {
 	.ec-booking-form-editor {
 		grid-template-columns: minmax(0, 1fr);
 	}

--- a/blocks/venue-settings/src/style.test.js
+++ b/blocks/venue-settings/src/style.test.js
@@ -67,6 +67,12 @@ describe( 'venue booking workspace composition', () => {
 		expect( styles ).toContain(
 			'.ec-booking-form-editor__preview-toggle.button-2'
 		);
-		expect( styles ).toContain( '@media screen and (max-width: 960px)' );
+		expect( styles ).toContain( '@media screen and (max-width: 1200px)' );
+	} );
+
+	it( 'reserves enough desktop width for the production form preview', () => {
+		expect( styles ).toContain(
+			'grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);'
+		);
 	} );
 } );

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"test:browser": "node tests/browser/local-support.evidence.js",
 		"test:browser:vendor-request": "node tests/browser/vendor-request.evidence.js",
 		"test:browser:booking-inquiry": "node tests/browser/booking-inquiry.evidence.js",
+		"test:browser:booking-form-preview": "node tests/browser/booking-form-preview.evidence.js",
 		"test:browser:booking-embed": "node tests/browser/booking-embed.evidence.js",
 		"lint:js": "wp-scripts lint-js",
 		"lint:js:fix": "wp-scripts lint-js --fix"

--- a/tests/browser/booking-form-preview.evidence.js
+++ b/tests/browser/booking-form-preview.evidence.js
@@ -1,0 +1,149 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+const assert = require( 'node:assert/strict' );
+const path = require( 'node:path' );
+const { chromium } = require( 'playwright' );
+
+const root = path.resolve( __dirname, '../..' );
+
+const fixture = `<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width,initial-scale=1">
+	</head>
+	<body>
+		<main>
+			<div class="ec-booking-form-editor">
+				<div class="ec-booking-form-editor__controls ec-panel">Booking form controls</div>
+				<aside class="ec-booking-form-editor__preview" aria-label="Booking form preview">
+					<button class="ec-booking-form-editor__preview-toggle button-2">Preview booking form</button>
+					<div class="ec-booking-form-editor__preview-content">
+						<div class="ec-panel-header"><div class="ec-panel-header__main"><h2 class="ec-panel-header__title">Preview</h2></div></div>
+						<div class="ec-venue-booking-inquiry">
+							<div class="ec-block-shell">
+								<div class="ec-block-shell-header"><h2 class="ec-block-shell-header__title">Booking at The Room</h2></div>
+								<div class="ec-block-shell-inner ec-panel ec-booking-inquiry__panel">
+									<form class="ec-booking-inquiry__form">
+										<section class="ec-booking-inquiry__step">
+											<h3>Complete your booking inquiry</h3>
+											<div class="ec-card-grid" style="--ec-card-grid-min:16rem;max-width:calc(16rem * 2 + var(--spacing-md, 1rem))">
+												<label class="ec-field-group"><span class="ec-field-group__label">Artist or project name</span><span class="ec-field-group__control"><input></span></label>
+												<label class="ec-field-group"><span class="ec-field-group__label">Phone (Emergency use only)</span><span class="ec-field-group__control"><input type="tel"></span></label>
+											</div>
+										</section>
+										<label class="ec-checkbox-row"><input type="checkbox"><span>I agree that this venue may use these details to review and respond to my booking inquiry.</span></label>
+									</form>
+								</div>
+							</div>
+						</div>
+					</div>
+				</aside>
+			</div>
+		</main>
+	</body>
+</html>`;
+
+const fixtureStyles = `
+	* { box-sizing: border-box; }
+	html, body { margin: 0; }
+	body { color: var(--text-color); font: 16px/1.5 Arial, sans-serif; }
+	body.is-dark { --background-color: #111; --card-background: #222; --text-color: #eee; --border-color: #555; }
+	body:not(.is-dark) { --background-color: #fff; --card-background: #f5f5f5; --text-color: #111; --border-color: #ddd; }
+	main { margin-inline: auto; max-width: 1120px; padding: 1rem; }
+`;
+
+const measure = ( page ) =>
+	page.evaluate( () => {
+		const preview = document.querySelector(
+			'.ec-booking-form-editor__preview'
+		);
+		const form = document.querySelector( '.ec-booking-inquiry__form' );
+		const toggle = document.querySelector(
+			'.ec-booking-form-editor__preview-toggle'
+		);
+		return {
+			previewWidth: preview.clientWidth,
+			formClientWidth: form.clientWidth,
+			formScrollWidth: form.scrollWidth,
+			toggleDisplay: getComputedStyle( toggle ).display,
+		};
+	} );
+
+( async () => {
+	const browser = await chromium.launch( { headless: true } );
+	try {
+		const page = await browser.newPage( {
+			viewport: { width: 1440, height: 900 },
+		} );
+		await page.setContent( fixture );
+		await page.addStyleTag( { content: fixtureStyles } );
+		await page.addStyleTag( {
+			path: path.join( root, 'build/venue-settings/style-index.css' ),
+		} );
+
+		const results = {};
+		for ( const theme of [ 'light', 'dark' ] ) {
+			await page.locator( 'body' ).evaluate( ( body, currentTheme ) => {
+				body.classList.toggle( 'is-dark', currentTheme === 'dark' );
+			}, theme );
+			results[ `desktop-${ theme }` ] = await measure( page );
+			assert.ok(
+				results[ `desktop-${ theme }` ].formScrollWidth <=
+					results[ `desktop-${ theme }` ].formClientWidth
+			);
+			assert.equal(
+				results[ `desktop-${ theme }` ].toggleDisplay,
+				'none'
+			);
+		}
+
+		await page.setViewportSize( { width: 1100, height: 900 } );
+		results.narrowDesktop = await measure( page );
+		assert.ok(
+			results.narrowDesktop.formScrollWidth <=
+				results.narrowDesktop.formClientWidth
+		);
+		assert.notEqual( results.narrowDesktop.toggleDisplay, 'none' );
+
+		await page.setViewportSize( { width: 768, height: 1024 } );
+		results.tablet = await measure( page );
+		assert.ok(
+			results.tablet.formScrollWidth <= results.tablet.formClientWidth
+		);
+		assert.notEqual( results.tablet.toggleDisplay, 'none' );
+
+		await page.setViewportSize( { width: 390, height: 844 } );
+		await page
+			.locator( '.ec-booking-form-editor__preview-content' )
+			.evaluate( ( preview ) => {
+				preview.hidden = true;
+			} );
+		results.mobile = await page.evaluate( () => ( {
+			previewHidden: document.querySelector(
+				'.ec-booking-form-editor__preview-content'
+			).hidden,
+			toggleDisplay: getComputedStyle(
+				document.querySelector(
+					'.ec-booking-form-editor__preview-toggle'
+				)
+			).display,
+			documentScrollWidth: document.documentElement.scrollWidth,
+			documentClientWidth: document.documentElement.clientWidth,
+		} ) );
+		assert.equal( results.mobile.previewHidden, true );
+		assert.notEqual( results.mobile.toggleDisplay, 'none' );
+		assert.equal(
+			results.mobile.documentScrollWidth,
+			results.mobile.documentClientWidth
+		);
+
+		// eslint-disable-next-line no-console -- Emits deterministic evidence for CI and PR logs.
+		console.log( JSON.stringify( { status: 'passed', results } ) );
+	} finally {
+		await browser.close();
+	}
+} )().catch( ( error ) => {
+	console.error( error );
+	process.exitCode = 1;
+} );


### PR DESCRIPTION
## Summary
- give the production booking form preview the larger desktop editor column so its two-field grid fits without horizontal clipping
- collapse the editor to one column at 1200px and keep the preview toggle state synchronized with that breakpoint
- add focused source assertions and Playwright layout coverage for desktop, narrower desktop, tablet, mobile, light mode, and dark mode

## Root cause
The editor assigned the preview the smaller `0.85fr` column. At the live 1440px viewport, that left the form with a 443px client width while the production form grid retained a 544px scroll width. The preview wrapper's `overflow: hidden` then concealed the overflow and visibly cut off content.

## Layout decision
The preview now receives the `1.15fr` desktop column because it renders the real production form and must honor that form's intrinsic layout. At 1200px and below, the editor uses its existing single-column, toggleable preview rather than squeezing either the controls or production form into an unrepresentative side-by-side layout. No preview-only form or production-form override was introduced.

## Responsive and theme verification
The browser regression compiles the real venue settings stylesheet and compares preview form `clientWidth` with `scrollWidth` using production form classes:
- 1440px light: 590px client / 590px scroll
- 1440px dark: 590px client / 590px scroll
- 1100px narrower desktop: 1032px client / 1032px scroll
- 768px tablet: 700px client / 700px scroll
- 390px mobile: preview collapsed, toggle visible, no document overflow

## Tests run
- `npm run build:venue-settings`
- `npm run test:js -- blocks/venue-settings/src/style.test.js blocks/venue-settings/src/booking-form-tab.test.js --runInBand`
- `npm run test:browser:booking-form-preview`
- `npm run lint:js -- blocks/venue-settings/src/booking-form-tab.js blocks/venue-settings/src/style.test.js blocks/venue-settings/src/booking-form-tab.test.js tests/browser/booking-form-preview.evidence.js`
- `git diff --check`

Existing dependencies from the DMC primary checkout were temporarily linked for verification; no dependencies were installed in this worktree.

## Residual gap
The focused browser proof uses compiled production CSS and representative production form markup rather than logging into the live authenticated venue editor. The width behavior and responsive/theme states are covered deterministically, but the full live editor was not mutated or exercised end-to-end.

Closes #666