### PR TITLE
feat: make booking fields scannable

### DIFF
--- a/blocks/venue-settings/src/booking-form-tab.test.js
+++ b/blocks/venue-settings/src/booking-form-tab.test.js
@@ -83,6 +83,11 @@ describe( 'booking form workspace', () => {
 		expect( intake ).toContain( 'Multiple choice' );
 		expect( intake ).toContain( 'Enter one choice per line.' );
 		expect( intake ).toContain( 'ec-booking-field__row' );
+		expect( intake ).toContain( '<details' );
+		expect( intake ).toContain( '<summary' );
+		expect( intake ).toContain( 'ec-booking-field__summary-meta' );
+		expect( intake ).toContain( "'Optional'" );
+		expect( intake ).toContain( 'pendingFocusKey.current = key' );
 		expect( intake ).toContain( 'Move ${ field.label } up' );
 		expect( intake ).toContain( 'Move ${ field.label } down' );
 		expect( intake ).not.toContain( 'Add question' );
@@ -98,6 +103,16 @@ describe( 'booking form workspace', () => {
 		expect( styles ).not.toContain( '.ec-booking-fields__add {' );
 		expect( intake ).toContain( 'button-danger button-small' );
 		expect( workspace + intake ).not.toContain( 'button-link-delete' );
+	} );
+
+	it( 'uses theme tokens and a compact mobile field summary', () => {
+		expect( styles ).toContain( '.ec-booking-field__summary-meta' );
+		expect( styles ).toContain( 'color: var(--muted-text)' );
+		expect( styles ).toContain( 'background: var(--background-color)' );
+		expect( styles ).toContain( '@media screen and (max-width: 480px)' );
+		expect( styles ).toContain(
+			'.ec-booking-field__summary-content {\n\t\tgrid-template-columns: auto minmax(0, 1fr);'
+		);
 	} );
 
 	it( 'edits and renders link fields independently', () => {

--- a/blocks/venue-settings/src/intake-tab.js
+++ b/blocks/venue-settings/src/intake-tab.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+/**
  * External dependencies
  */
 import { FieldGroup, Panel, PanelHeader } from '@extrachill/components';
@@ -35,6 +40,9 @@ const nextCustomFieldKey = ( fields ) => {
 
 export function IntakeTab( { config, setConfig, idPrefix = '' } ) {
 	const fields = config.intake.fields;
+	const [ openFieldKey, setOpenFieldKey ] = useState( null );
+	const fieldLabelRefs = useRef( new Map() );
+	const pendingFocusKey = useRef( null );
 	const setFields = ( next ) =>
 		setConfig( { ...config, intake: { ...config.intake, fields: next } } );
 	const updateField = ( field, patch ) =>
@@ -65,6 +73,13 @@ export function IntakeTab( { config, setConfig, idPrefix = '' } ) {
 		reordered.splice( target, 0, field );
 		return hasValidFieldOrder( reordered );
 	};
+	useEffect( () => {
+		if ( pendingFocusKey.current !== openFieldKey ) {
+			return;
+		}
+		fieldLabelRefs.current.get( openFieldKey )?.focus();
+		pendingFocusKey.current = null;
+	}, [ fields, openFieldKey ] );
 	return (
 		<>
 			<PublicBookingDetails
@@ -88,157 +103,218 @@ export function IntakeTab( { config, setConfig, idPrefix = '' } ) {
 							( candidate ) =>
 								field.key === candidate.visible_when?.field
 						);
+						const typeLabel = FIELD_TYPES.find(
+							( [ value ] ) => value === field.type
+						)?.[ 1 ];
 						return (
-							<div className="ec-booking-field" key={ field.key }>
-								<div className="ec-booking-field__row">
-									<span
-										className="ec-booking-field__position"
-										aria-hidden="true"
-									>
-										{ rowIndex + 1 }
+							<details
+								className="ec-booking-field"
+								key={ field.key }
+								open={ openFieldKey === field.key }
+							>
+								<summary
+									className="ec-booking-field__summary"
+									onClick={ ( event ) => {
+										event.preventDefault();
+										setOpenFieldKey( ( current ) =>
+											current === field.key
+												? null
+												: field.key
+										);
+									} }
+								>
+									<span className="ec-booking-field__summary-content">
+										<span
+											className="ec-booking-field__position"
+											aria-hidden="true"
+										>
+											{ rowIndex + 1 }
+										</span>
+										<span className="ec-booking-field__question">
+											{ field.label ||
+												`Field ${ rowIndex + 1 }` }
+										</span>
+										<span className="ec-booking-field__summary-meta">
+											<span>
+												{ typeLabel || field.type }
+											</span>
+											<span>
+												{ field.required
+													? 'Required'
+													: 'Optional' }
+											</span>
+										</span>
 									</span>
-									<input
-										id={ `${ idPrefix }intake-label-${ rowIndex }` }
-										className="ec-booking-field__label"
-										aria-label={ `Field ${
-											rowIndex + 1
-										} label` }
-										value={ field.label }
-										placeholder="Field label"
-										required
-										onChange={ ( event ) =>
-											updateField( field, {
-												label: event.target.value,
-											} )
-										}
-									/>
-									<select
-										id={ `${ idPrefix }intake-type-${ rowIndex }` }
-										className="ec-booking-field__type"
-										aria-label={ `${
-											field.label ||
-											`Field ${ rowIndex + 1 }`
-										} type` }
-										value={ field.type }
-										onChange={ ( event ) =>
-											updateField( field, {
-												type: event.target.value,
-												options:
-													event.target.value ===
-													'select'
-														? field.options
-														: [],
-											} )
-										}
-									>
-										{ FIELD_TYPES.map(
-											( [ value, label ] ) => (
-												<option
-													key={ value }
-													value={ value }
-												>
-													{ label }
-												</option>
-											)
-										) }
-									</select>
-									<label
-										className="ec-booking-field__required"
-										htmlFor={ `${ idPrefix }intake-required-${ rowIndex }` }
-									>
+								</summary>
+								<div className="ec-booking-field__editor">
+									<div className="ec-booking-field__row">
 										<input
-											id={ `${ idPrefix }intake-required-${ rowIndex }` }
+											id={ `${ idPrefix }intake-label-${ rowIndex }` }
+											className="ec-booking-field__label"
+											ref={ ( element ) => {
+												if ( element ) {
+													fieldLabelRefs.current.set(
+														field.key,
+														element
+													);
+												} else {
+													fieldLabelRefs.current.delete(
+														field.key
+													);
+												}
+											} }
+											aria-label={ `Field ${
+												rowIndex + 1
+											} label` }
+											value={ field.label }
+											placeholder="Field label"
+											required
+											onChange={ ( event ) =>
+												updateField( field, {
+													label: event.target.value,
+												} )
+											}
+										/>
+										<select
+											id={ `${ idPrefix }intake-type-${ rowIndex }` }
+											className="ec-booking-field__type"
 											aria-label={ `${
 												field.label ||
 												`Field ${ rowIndex + 1 }`
-											} required` }
-											type="checkbox"
-											checked={ field.required }
+											} type` }
+											value={ field.type }
 											onChange={ ( event ) =>
 												updateField( field, {
-													required:
-														event.target.checked,
+													type: event.target.value,
+													options:
+														event.target.value ===
+														'select'
+															? field.options
+															: [],
 												} )
 											}
-										/>
-										Required
-									</label>
-									<div className="ec-booking-field__actions">
-										<button
-											type="button"
-											className="button-3 button-small"
-											disabled={
-												! canMove( rowIndex, -1 )
-											}
-											onClick={ () =>
-												moveField( rowIndex, -1 )
-											}
-											aria-label={ `Move ${ field.label } up` }
 										>
-											Up
-										</button>
-										<button
-											type="button"
-											className="button-3 button-small"
-											disabled={
-												! canMove( rowIndex, 1 )
-											}
-											onClick={ () =>
-												moveField( rowIndex, 1 )
-											}
-											aria-label={ `Move ${ field.label } down` }
-										>
-											Down
-										</button>
-										<button
-											type="button"
-											className="button-danger button-small"
-											disabled={ isReferenced }
-											onClick={ () =>
-												setFields(
-													fields.filter(
-														( candidate ) =>
-															candidate !== field
-													)
+											{ FIELD_TYPES.map(
+												( [ value, label ] ) => (
+													<option
+														key={ value }
+														value={ value }
+													>
+														{ label }
+													</option>
 												)
-											}
+											) }
+										</select>
+										<label
+											className="ec-booking-field__required"
+											htmlFor={ `${ idPrefix }intake-required-${ rowIndex }` }
 										>
-											Remove
-										</button>
-									</div>
-								</div>
-								{ field.type === 'select' && (
-									<FieldGroup
-										className="ec-booking-field__choices"
-										label="Choices"
-										htmlFor={ `${ idPrefix }intake-options-${ rowIndex }` }
-										help="Enter one choice per line."
-										required
-									>
-										<textarea
-											id={ `${ idPrefix }intake-options-${ rowIndex }` }
-											rows="4"
-											value={ field.options.join( '\n' ) }
-											onChange={ ( event ) =>
-												updateField( field, {
-													options: event.target.value
-														.split( /\r?\n/ )
-														.map( ( option ) =>
-															option.trim()
+											<input
+												id={ `${ idPrefix }intake-required-${ rowIndex }` }
+												aria-label={ `${
+													field.label ||
+													`Field ${ rowIndex + 1 }`
+												} required` }
+												type="checkbox"
+												checked={ field.required }
+												onChange={ ( event ) =>
+													updateField( field, {
+														required:
+															event.target
+																.checked,
+													} )
+												}
+											/>
+											Required
+										</label>
+										<div className="ec-booking-field__actions">
+											<button
+												type="button"
+												className="button-3 button-small"
+												disabled={
+													! canMove( rowIndex, -1 )
+												}
+												onClick={ () =>
+													moveField( rowIndex, -1 )
+												}
+												aria-label={ `Move ${ field.label } up` }
+											>
+												Up
+											</button>
+											<button
+												type="button"
+												className="button-3 button-small"
+												disabled={
+													! canMove( rowIndex, 1 )
+												}
+												onClick={ () =>
+													moveField( rowIndex, 1 )
+												}
+												aria-label={ `Move ${ field.label } down` }
+											>
+												Down
+											</button>
+											<button
+												type="button"
+												className="button-danger button-small"
+												disabled={ isReferenced }
+												onClick={ () =>
+													setFields(
+														fields.filter(
+															( candidate ) =>
+																candidate !==
+																field
 														)
-														.filter( Boolean ),
-												} )
-											}
-										/>
-									</FieldGroup>
-								) }
-								{ isReferenced && (
-									<p className="ec-booking-field__note">
-										This field controls another saved field
-										and cannot be removed.
-									</p>
-								) }
-							</div>
+													)
+												}
+											>
+												Remove
+											</button>
+										</div>
+									</div>
+									{ field.type === 'select' && (
+										<FieldGroup
+											className="ec-booking-field__choices"
+											label="Choices"
+											htmlFor={ `${ idPrefix }intake-options-${ rowIndex }` }
+											help="Enter one choice per line."
+											required
+										>
+											<textarea
+												id={ `${ idPrefix }intake-options-${ rowIndex }` }
+												rows="4"
+												value={ field.options.join(
+													'\n'
+												) }
+												onChange={ ( event ) =>
+													updateField( field, {
+														options:
+															event.target.value
+																.split(
+																	/\r?\n/
+																)
+																.map(
+																	(
+																		option
+																	) =>
+																		option.trim()
+																)
+																.filter(
+																	Boolean
+																),
+													} )
+												}
+											/>
+										</FieldGroup>
+									) }
+									{ isReferenced && (
+										<p className="ec-booking-field__note">
+											This field controls another saved
+											field and cannot be removed.
+										</p>
+									) }
+								</div>
+							</details>
 						);
 					} ) }
 				</div>
@@ -247,6 +323,8 @@ export function IntakeTab( { config, setConfig, idPrefix = '' } ) {
 					className="ec-booking-fields__add button-2 button-medium button-block"
 					onClick={ () => {
 						const key = nextCustomFieldKey( fields );
+						pendingFocusKey.current = key;
+						setOpenFieldKey( key );
 						setFields( [
 							...fields,
 							{

--- a/blocks/venue-settings/src/intake-tab.test.js
+++ b/blocks/venue-settings/src/intake-tab.test.js
@@ -1,9 +1,195 @@
-/* global describe, expect, it */
+/* global afterAll, beforeAll, beforeEach, describe, expect, it, jest */
+
+/**
+ * WordPress dependencies
+ */
+import { createRoot, useState } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { act } from 'react';
 
 /**
  * Internal dependencies
  */
+import { IntakeTab } from './intake-tab';
 import { hasValidFieldOrder } from './intake-field-order';
+
+jest.mock( '@extrachill/components', () => {
+	const React = require( 'react' );
+	const Wrapper = ( { children, className } ) =>
+		React.createElement( 'div', { className }, children );
+	return {
+		FieldGroup: ( { children, className, help, label } ) =>
+			React.createElement(
+				'div',
+				{ className },
+				React.createElement( 'span', null, label ),
+				children,
+				help && React.createElement( 'span', null, help )
+			),
+		Panel: Wrapper,
+		PanelHeader: ( { description, title } ) =>
+			React.createElement(
+				'div',
+				null,
+				React.createElement( 'h2', null, title ),
+				React.createElement( 'p', null, description )
+			),
+	};
+} );
+
+const presentation = {
+	artist_name_label: 'Artist or project name',
+	contact_name_label: 'Contact name',
+	contact_email_label: 'Contact email',
+	contact_phone_label: 'Contact phone',
+	message_label: 'Anything else?',
+	message_help: 'Share details.',
+};
+
+const field = ( index, overrides = {} ) => ( {
+	key: `field_${ index }`,
+	label: `Question ${ index }`,
+	type: index % 3 === 0 ? 'select' : 'text',
+	required: index % 2 === 0,
+	options: index % 3 === 0 ? [ 'Yes', 'No' ] : [],
+	visible_when: null,
+	...overrides,
+} );
+
+function Harness( { initialFields } ) {
+	const [ config, setConfig ] = useState( {
+		intake: { fields: initialFields, presentation },
+	} );
+	return <IntakeTab config={ config } setConfig={ setConfig } />;
+}
+
+async function renderIntake( fields ) {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+	await act( async () =>
+		root.render( <Harness initialFields={ fields } /> )
+	);
+	return { container, root };
+}
+
+async function click( element ) {
+	await act( async () => {
+		element.click();
+		await Promise.resolve();
+	} );
+}
+
+describe( 'custom booking field disclosures', () => {
+	beforeAll( () => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+	} );
+	afterAll( () => {
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	} );
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'keeps the empty state clear and ready for its first field', async () => {
+		const { container, root } = await renderIntake( [] );
+
+		expect( container.textContent ).toContain( 'No custom fields added.' );
+		expect(
+			container.querySelectorAll( '.ec-booking-field' )
+		).toHaveLength( 0 );
+		expect( container.textContent ).toContain( 'Add custom field' );
+
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'keeps a 12-field form scannable and opens one editor at a time', async () => {
+		const { container, root } = await renderIntake(
+			Array.from( { length: 12 }, ( unused, index ) =>
+				field( index + 1 )
+			)
+		);
+		const disclosures = [
+			...container.querySelectorAll( '.ec-booking-field' ),
+		];
+		const summaries = disclosures.map( ( item ) =>
+			item.querySelector( 'summary' )
+		);
+
+		expect( disclosures ).toHaveLength( 12 );
+		expect( disclosures.every( ( item ) => ! item.open ) ).toBe( true );
+		expect( summaries[ 1 ].textContent ).toContain( 'Question 2' );
+		expect( summaries[ 1 ].textContent ).toContain( 'Short text' );
+		expect( summaries[ 1 ].textContent ).toContain( 'Required' );
+		expect( summaries[ 2 ].textContent ).toContain( 'Multiple choice' );
+		expect( summaries[ 2 ].textContent ).toContain( 'Optional' );
+
+		await click( summaries[ 0 ] );
+		expect( disclosures[ 0 ].open ).toBe( true );
+		await click( summaries[ 1 ] );
+		expect( disclosures.filter( ( item ) => item.open ) ).toEqual( [
+			disclosures[ 1 ],
+		] );
+
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'opens and focuses a newly added field', async () => {
+		const { container, root } = await renderIntake( [ field( 1 ) ] );
+		const addButton = [ ...container.querySelectorAll( 'button' ) ].find(
+			( button ) => button.textContent === 'Add custom field'
+		);
+
+		await click( addButton );
+		const disclosures = container.querySelectorAll( '.ec-booking-field' );
+		const newDisclosure = disclosures[ disclosures.length - 1 ];
+		const newLabel = newDisclosure.querySelector(
+			'input[aria-label="Field 2 label"]'
+		);
+
+		expect( newDisclosure.open ).toBe( true );
+		expect( document.activeElement ).toBe( newLabel );
+		expect(
+			newDisclosure.querySelector( 'summary' ).textContent
+		).toContain( 'New field' );
+
+		await act( async () => root.unmount() );
+	} );
+
+	it( 'retains accessible reorder controls and referenced-field removal rules', async () => {
+		const controller = field( 1 );
+		const dependent = field( 2, {
+			visible_when: { field: controller.key, value: 'Yes' },
+		} );
+		const { container, root } = await renderIntake( [
+			controller,
+			dependent,
+		] );
+
+		await click( container.querySelector( 'summary' ) );
+		expect(
+			container.querySelector( 'button[aria-label="Move Question 1 up"]' )
+		).toHaveProperty( 'disabled', true );
+		expect(
+			container.querySelector(
+				'button[aria-label="Move Question 1 down"]'
+			)
+		).toHaveProperty( 'disabled', true );
+		expect(
+			[ ...container.querySelectorAll( 'button' ) ].find(
+				( button ) => button.textContent === 'Remove'
+			)
+		).toHaveProperty( 'disabled', true );
+		expect( container.textContent ).toContain(
+			'This field controls another saved field and cannot be removed.'
+		);
+
+		await act( async () => root.unmount() );
+	} );
+} );
 
 describe( 'booking custom field order', () => {
 	it( 'allows independent fields in any order', () => {

--- a/blocks/venue-settings/src/style.scss
+++ b/blocks/venue-settings/src/style.scss
@@ -20,6 +20,7 @@
 	}
 
 	button:focus-visible,
+	summary:focus-visible,
 	input:focus-visible,
 	select:focus-visible,
 	textarea:focus-visible {
@@ -96,21 +97,53 @@
 }
 
 .ec-booking-field {
-	padding: var(--spacing-sm);
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius-md);
 	background: var(--background-color);
 }
 
-.ec-booking-field__row {
+.ec-booking-field__summary {
+	padding: var(--spacing-sm);
+	cursor: pointer;
+}
+
+.ec-booking-field__summary-content {
 	display: grid;
-	grid-template-columns: auto minmax(0, 1fr) minmax(9rem, 0.65fr);
+	grid-template-columns: auto minmax(0, 1fr) auto;
+	gap: var(--spacing-sm);
+	align-items: center;
+	margin-inline-start: var(--spacing-xs);
+}
+
+.ec-booking-field__question {
+	font-weight: 700;
+	overflow-wrap: anywhere;
+}
+
+.ec-booking-field__summary-meta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--spacing-xs) var(--spacing-sm);
+	justify-content: flex-end;
+	color: var(--muted-text);
+	font-size: var(--font-size-sm);
+}
+
+.ec-booking-field__editor {
+	padding: 0 var(--spacing-sm) var(--spacing-sm);
+	border-block-start: 1px solid var(--border-color);
+}
+
+.ec-booking-field__row {
+	padding-block-start: var(--spacing-sm);
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(9rem, 0.65fr);
 	gap: var(--spacing-sm);
 	align-items: center;
 }
 
 .ec-booking-field__required {
-	grid-column: 2;
+	grid-column: 1;
 }
 
 .ec-booking-field__position {
@@ -140,7 +173,7 @@
 .ec-booking-field__actions {
 	display: flex;
 	gap: var(--spacing-xs);
-	grid-column: 3;
+	grid-column: 2;
 	justify-content: flex-end;
 }
 
@@ -548,13 +581,22 @@
 	}
 
 	.ec-booking-field__row {
-		grid-template-columns: auto minmax(0, 1fr);
+		grid-template-columns: minmax(0, 1fr);
 	}
 
 	.ec-booking-field__type,
 	.ec-booking-field__required,
 	.ec-booking-field__actions {
+		grid-column: 1;
+	}
+
+	.ec-booking-field__summary-content {
+		grid-template-columns: auto minmax(0, 1fr);
+	}
+
+	.ec-booking-field__summary-meta {
 		grid-column: 2;
+		justify-content: flex-start;
 	}
 
 	.ec-booking-calendar__weekdays {


### PR DESCRIPTION
## Summary
- replace the fully expanded custom-field wall with compact summaries showing question, type, and required/optional state
- keep one field editor open at a time while preserving reorder, referenced-field removal, dirty-state, and save behavior
- open and focus newly added fields so owners can start typing immediately

## Owner rationale
Venue owners can now scan a realistic 12-field booking form before choosing the one question they need to edit. Multiple-choice textareas and repeated ordering/removal controls stay out of the way until that field is opened.

## Primitive reused
Reuses the native HTML `<details>` / `<summary>` disclosure pattern already used in the venue settings UI. No new shared component or infrastructure was introduced.

## Interaction details
- saved fields start collapsed with question, human-readable type, and required/optional metadata visible
- opening a summary closes the previously open field
- expanded editors retain label, type, requirement, choices, keyboard-focusable Up/Down buttons, and removal controls
- referenced fields retain disabled reorder/removal constraints and explanatory text
- Add custom field opens the new field and moves focus to its question input

## Accessibility, responsive, and theme verification
- native summary controls retain keyboard activation and disclosure semantics
- summary controls use the existing focus-visible treatment
- interaction tests cover single-open behavior, focus transfer, accessible reorder labels, and referenced-field safeguards
- empty, short, and 12-field forms are covered
- mobile summaries collapse metadata beneath the question at the existing 480px breakpoint
- styling uses existing background, border, spacing, focus, and muted-text tokens for light/dark compatibility

## Tests
- `wp-scripts lint-js blocks/venue-settings/src/intake-tab.js blocks/venue-settings/src/intake-tab.test.js blocks/venue-settings/src/booking-form-tab.test.js`
- `wp-scripts test-unit-js --runInBand` (17 suites, 104 tests)
- focused disclosure tests (2 suites, 14 tests)
- `wp-scripts build blocks/venue-settings/src/index.js blocks/venue-settings/src/view.js --output-path=build/venue-settings`
- `git diff --check`

## Residual gap
No live browser screenshot pass was run because this worktree has no isolated venue-settings runtime and dependencies could not be installed under the inode constraint. Responsive/theme behavior is covered through existing tokenized CSS, breakpoint assertions, successful production compilation, and DOM interaction tests using the shared dependency checkout.

Closes #667