### PR TITLE
fix: preserve canonical location hierarchy

### DIFF
--- a/inc/Cli/ReconcileRootLocationsCommand.php
+++ b/inc/Cli/ReconcileRootLocationsCommand.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Dry-run-first repair for qualified root location terms.
+ *
+ * @package ExtraChillEvents\Cli
+ */
+
+namespace ExtraChillEvents\Cli;
+
+use ExtraChillEvents\Core\QualifiedRootLocation;
+use ExtraChillEvents\Core\RootLocationRepair;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Reports and optionally repairs exact qualified root location duplicates. */
+final class ReconcileRootLocationsCommand {
+
+	/**
+	 * Report or reconcile safe "City, State/Province" root terms.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--apply]
+	 * : Move relationships, create and verify redirects, and delete safe duplicates. Default is dry-run.
+	 *
+	 * [--format=<format>]
+	 * : Output format: table, json, or csv. Default: table.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill events locations reconcile-roots --url=events.extrachill.com
+	 *     wp extrachill events locations reconcile-roots --url=events.extrachill.com --apply
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		unset( $args );
+		if ( ! taxonomy_exists( 'location' ) ) {
+			\WP_CLI::error( 'The location taxonomy is not registered. Use --url=events.extrachill.com.' );
+		}
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'location',
+				'hide_empty' => false,
+				'number'     => 0,
+			)
+		);
+		if ( is_wp_error( $terms ) ) {
+			\WP_CLI::error( $terms->get_error_message() );
+		}
+
+		$apply  = ! empty( $assoc_args['apply'] );
+		$repair = $apply ? $this->repair_service() : null;
+		$rows   = array();
+
+		foreach ( $terms as $term ) {
+			$match = QualifiedRootLocation::match( $term, $terms );
+			if ( 'not_candidate' === $match['status'] ) {
+				continue;
+			}
+
+			$status = $match['status'];
+			$reason = $match['reason'];
+			if ( 'safe_match' === $status ) {
+				if ( $apply ) {
+					$result = $repair->repair( $term, $match['canonical'] );
+					$status = $result['status'];
+					$reason = $result['reason'];
+				} else {
+					$status = 'would_reconcile';
+				}
+			}
+
+			$rows[] = array(
+				'candidate_id'  => (int) $term->term_id,
+				'candidate'     => $term->name,
+				'canonical_id'  => $match['canonical'] ? (int) $match['canonical']->term_id : '',
+				'canonical'     => $match['canonical'] ? $match['canonical']->name : '',
+				'relationships' => (int) $term->count,
+				'status'        => $status,
+				'reason'        => $reason,
+			);
+		}
+
+		\WP_CLI\Utils\format_items(
+			(string) ( $assoc_args['format'] ?? 'table' ),
+			$rows,
+			array( 'candidate_id', 'candidate', 'canonical_id', 'canonical', 'relationships', 'status', 'reason' )
+		);
+
+		if ( ! $apply ) {
+			\WP_CLI::log( 'Dry run: no redirects, relationships, or terms changed. Re-run with --apply only after reviewing every row.' );
+		}
+	}
+
+	/** Build the repair service with WordPress and SEO ability adapters. */
+	private function repair_service(): RootLocationRepair {
+		return new RootLocationRepair(
+			array(
+				'prepare_redirect'    => array( $this, 'prepare_redirect' ),
+				'get_objects'         => static fn( int $term_id ) => get_objects_in_term( $term_id, 'location' ),
+				'get_object_terms'    => static fn( int $object_id ) => wp_get_object_terms( $object_id, 'location', array( 'fields' => 'ids' ) ),
+				'add_relationship'    => static fn( int $object_id, int $term_id ) => wp_set_object_terms( $object_id, array( $term_id ), 'location', true ),
+				'remove_relationship' => static fn( int $object_id, int $term_id ) => wp_remove_object_terms( $object_id, array( $term_id ), 'location' ),
+				'create_redirect'     => array( $this, 'create_redirect' ),
+				'verify_redirect'     => array( $this, 'verify_redirect' ),
+				'delete_redirect'     => array( $this, 'delete_redirect' ),
+				'delete_term'         => static fn( int $term_id ) => wp_delete_term( $term_id, 'location' ),
+				'term_exists'         => static function ( int $term_id ): bool {
+					$term = get_term( $term_id, 'location' );
+					return $term && ! is_wp_error( $term );
+				},
+			)
+		);
+	}
+
+	/**
+	 * Preflight redirect URLs, abilities, and existing-rule conflicts.
+	 *
+	 * @param object $duplicate Duplicate root location term.
+	 * @param object $canonical Canonical hierarchy location term.
+	 */
+	public function prepare_redirect( object $duplicate, object $canonical ) {
+		$from_link = get_term_link( $duplicate );
+		$to_link   = get_term_link( $canonical );
+		if ( is_wp_error( $from_link ) || is_wp_error( $to_link ) ) {
+			return new \WP_Error( 'invalid_term_url', 'Could not resolve both term archive URLs.' );
+		}
+
+		$from = wp_parse_url( $from_link, PHP_URL_PATH );
+		$to   = wp_parse_url( $to_link, PHP_URL_PATH );
+		if ( ! is_string( $from ) || ! is_string( $to ) || '' === $from || '' === $to ) {
+			return new \WP_Error( 'invalid_term_url', 'Could not resolve both term archive paths.' );
+		}
+
+		$context = array(
+			'from'     => untrailingslashit( '/' . ltrim( $from, '/' ) ),
+			'to'       => untrailingslashit( '/' . ltrim( $to, '/' ) ),
+			'existing' => false,
+		);
+		$rules   = $this->redirect_rules( $context['from'] );
+		if ( is_wp_error( $rules ) ) {
+			return $rules;
+		}
+
+		foreach ( $rules as $rule ) {
+			$rule_from = untrailingslashit( '/' . ltrim( (string) $this->rule_field( $rule, 'from_url' ), '/' ) );
+			if ( $rule_from !== $context['from'] ) {
+				continue;
+			}
+			$rule_to = untrailingslashit( '/' . ltrim( (string) $this->rule_field( $rule, 'to_url' ), '/' ) );
+			if ( $rule_to !== $context['to'] || 301 !== (int) $this->rule_field( $rule, 'status_code' ) ) {
+				return new \WP_Error( 'conflicting_redirect_exists', 'The legacy path already has a different active redirect.' );
+			}
+			$context['existing'] = true;
+			return $context;
+		}
+
+		if ( ! wp_get_ability( 'extrachill-seo/add-redirect' ) || ! wp_get_ability( 'extrachill-seo/delete-redirect' ) ) {
+			return new \WP_Error( 'redirect_abilities_unavailable', 'Redirect create/delete abilities are required before relationship mutation.' );
+		}
+
+		return $context;
+	}
+
+	/**
+	 * Create the preflighted redirect and return its ID.
+	 *
+	 * @param array $context Redirect paths and preflight state.
+	 */
+	public function create_redirect( array $context ) {
+		$ability = wp_get_ability( 'extrachill-seo/add-redirect' );
+		$result  = $ability ? $ability->execute(
+			array(
+				'from_url'    => $context['from'],
+				'to_url'      => $context['to'],
+				'status_code' => 301,
+				'note'        => 'Qualified root location reconciliation',
+			)
+		) : null;
+
+		return is_array( $result ) && ! empty( $result['success'] ) ? (int) $result['id'] : new \WP_Error( 'redirect_creation_failed', 'The redirect ability did not create a rule.' );
+	}
+
+	/**
+	 * Verify the exact active redirect after creation.
+	 *
+	 * @param array $context Redirect paths and preflight state.
+	 */
+	public function verify_redirect( array $context ): bool {
+		$rules = $this->redirect_rules( $context['from'] );
+		if ( is_wp_error( $rules ) ) {
+			return false;
+		}
+
+		foreach ( $rules as $rule ) {
+			$from = untrailingslashit( '/' . ltrim( (string) $this->rule_field( $rule, 'from_url' ), '/' ) );
+			$to   = untrailingslashit( '/' . ltrim( (string) $this->rule_field( $rule, 'to_url' ), '/' ) );
+			if ( $from === $context['from'] && $to === $context['to'] && 301 === (int) $this->rule_field( $rule, 'status_code' ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Remove a redirect created by this run during compensation.
+	 *
+	 * @param int $redirect_id Redirect rule ID.
+	 */
+	public function delete_redirect( int $redirect_id ): bool {
+		$ability = wp_get_ability( 'extrachill-seo/delete-redirect' );
+		$result  = $ability ? $ability->execute( array( 'id' => $redirect_id ) ) : null;
+		return is_array( $result ) && ! empty( $result['success'] );
+	}
+
+	/**
+	 * Retrieve active redirect rules through the read-only SEO ability.
+	 *
+	 * @param string $from Legacy source path.
+	 */
+	private function redirect_rules( string $from ) {
+		$ability = wp_get_ability( 'extrachill-seo/list-redirects' );
+		if ( ! $ability ) {
+			return new \WP_Error( 'redirect_lookup_unavailable', 'The redirect lookup ability is required before relationship mutation.' );
+		}
+		$result = $ability->execute(
+			array(
+				'search' => $from,
+				'active' => 1,
+				'limit'  => 100,
+			)
+		);
+		return is_wp_error( $result ) || ! is_array( $result ) ? new \WP_Error( 'redirect_lookup_failed', 'Could not verify redirects.' ) : $result;
+	}
+
+	/**
+	 * Read a redirect field from ability object/array output.
+	 *
+	 * @param object|array $rule  Redirect ability row.
+	 * @param string       $field Field name.
+	 */
+	private function rule_field( $rule, string $field ) {
+		return is_object( $rule ) ? ( $rule->{$field} ?? null ) : ( $rule[ $field ] ?? null );
+	}
+}

--- a/inc/Core/QualifiedRootLocation.php
+++ b/inc/Core/QualifiedRootLocation.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Exact hierarchy matching for state/province-qualified root locations.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Matches qualified root terms against canonical location hierarchy identity. */
+final class QualifiedRootLocation {
+
+	/**
+	 * Match a root "City, subdivision" term to one canonical hierarchy term.
+	 *
+	 * @param object        $root             Root candidate.
+	 * @param array<object> $terms            All location terms.
+	 * @param callable|null $hierarchy_filter Optional test seam matching the shared resolver callback.
+	 * @return array{status:string,canonical:?object,reason:string}
+	 */
+	public static function match( object $root, array $terms, ?callable $hierarchy_filter = null ): array {
+		if ( 0 !== (int) ( $root->parent ?? 0 ) ) {
+			return self::result( 'not_candidate', null, 'term_is_not_root' );
+		}
+
+		if ( ! preg_match( '/^(.+),\s*([^,]+)$/', trim( (string) ( $root->name ?? '' ) ), $parts ) ) {
+			return self::result( 'not_candidate', null, 'name_has_no_subdivision_qualifier' );
+		}
+
+		foreach ( $terms as $term ) {
+			if ( (int) ( $term->parent ?? 0 ) === (int) ( $root->term_id ?? 0 ) ) {
+				return self::result( 'ambiguous', null, 'candidate_has_children' );
+			}
+		}
+
+		$city        = self::key( $parts[1] );
+		$subdivision = trim( $parts[2] );
+		$matches     = array_values(
+			array_filter(
+				$terms,
+				static fn( object $term ): bool => self::key( $term->name ?? '' ) === $city && (int) ( $term->parent ?? 0 ) > 0
+			)
+		);
+
+		if ( null === $hierarchy_filter ) {
+			if ( ! function_exists( 'extrachill_events_filter_locations_by_hierarchy' ) ) {
+				return self::result( 'unresolved', null, 'canonical_hierarchy_resolver_unavailable' );
+			}
+			$hierarchy_filter = 'extrachill_events_filter_locations_by_hierarchy';
+		}
+
+		$matches = array_values( $hierarchy_filter( $matches, $subdivision, '' ) );
+		if ( 1 === count( $matches ) ) {
+			return self::result( 'safe_match', $matches[0], 'exact_city_and_subdivision_hierarchy' );
+		}
+
+		return self::result(
+			count( $matches ) > 1 ? 'ambiguous' : 'unresolved',
+			null,
+			count( $matches ) > 1 ? 'multiple_canonical_hierarchy_matches' : 'no_canonical_hierarchy_match'
+		);
+	}
+
+	/**
+	 * Normalize a location identity for exact comparison.
+	 *
+	 * @param string $value Location identity.
+	 */
+	private static function key( string $value ): string {
+		return strtolower( trim( preg_replace( '/\s+/', ' ', $value ) ) );
+	}
+
+	/**
+	 * Build one classification result.
+	 *
+	 * @param string      $status    Classification status.
+	 * @param object|null $canonical Canonical term, when uniquely resolved.
+	 * @param string      $reason    Machine-readable reason.
+	 */
+	private static function result( string $status, ?object $canonical, string $reason ): array {
+		return array(
+			'status'    => $status,
+			'canonical' => $canonical,
+			'reason'    => $reason,
+		);
+	}
+}

--- a/inc/Core/RootLocationRepair.php
+++ b/inc/Core/RootLocationRepair.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Verified, compensating repair for one qualified root location.
+ *
+ * @package ExtraChillEvents\Core
+ */
+
+namespace ExtraChillEvents\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Executes a verified repair with compensation before term deletion. */
+final class RootLocationRepair {
+
+	/**
+	 * WordPress operation adapters.
+	 *
+	 * @var array<string,callable>
+	 */
+	private array $operations;
+
+	/**
+	 * Store WordPress operation adapters.
+	 *
+	 * @param array<string,callable> $operations WordPress operation adapters.
+	 */
+	public function __construct( array $operations ) {
+		$this->operations = $operations;
+	}
+
+	/**
+	 * Move relationships, verify a redirect, then delete the duplicate.
+	 *
+	 * @param object $duplicate Duplicate root location term.
+	 * @param object $canonical Canonical hierarchy location term.
+	 * @return array{status:string,reason:string}
+	 */
+	public function repair( object $duplicate, object $canonical ): array {
+		$redirect = $this->call( 'prepare_redirect', $duplicate, $canonical );
+		if ( is_wp_error( $redirect ) ) {
+			return $this->result( 'blocked', $redirect->get_error_code() );
+		}
+
+		$objects = $this->call( 'get_objects', (int) $duplicate->term_id );
+		if ( is_wp_error( $objects ) ) {
+			return $this->result( 'failed', 'relationship_lookup_failed' );
+		}
+
+		$original = array();
+		foreach ( $objects as $object_id ) {
+			$term_ids = $this->call( 'get_object_terms', (int) $object_id );
+			if ( is_wp_error( $term_ids ) ) {
+				return $this->result( 'failed', 'relationship_snapshot_failed' );
+			}
+			$original[ (int) $object_id ] = array_map( 'intval', $term_ids );
+		}
+
+		foreach ( $objects as $object_id ) {
+			$result = $this->call( 'add_relationship', (int) $object_id, (int) $canonical->term_id );
+			if ( is_wp_error( $result ) || false === $result ) {
+				return $this->rollback( $original, $duplicate, $canonical, 0, 'relationship_add_failed' );
+			}
+		}
+
+		if ( ! $this->verify_relationships( $original, (int) $duplicate->term_id, (int) $canonical->term_id, true ) ) {
+			return $this->rollback( $original, $duplicate, $canonical, 0, 'relationship_add_verification_failed' );
+		}
+
+		foreach ( $objects as $object_id ) {
+			$result = $this->call( 'remove_relationship', (int) $object_id, (int) $duplicate->term_id );
+			if ( is_wp_error( $result ) || false === $result ) {
+				return $this->rollback( $original, $duplicate, $canonical, 0, 'relationship_remove_failed' );
+			}
+		}
+
+		if ( ! $this->verify_relationships( $original, (int) $duplicate->term_id, (int) $canonical->term_id, false ) ) {
+			return $this->rollback( $original, $duplicate, $canonical, 0, 'relationship_remove_verification_failed' );
+		}
+
+		$remaining = $this->call( 'get_objects', (int) $duplicate->term_id );
+		if ( is_wp_error( $remaining ) || ! empty( $remaining ) ) {
+			return $this->rollback( $original, $duplicate, $canonical, 0, 'duplicate_relationships_remain' );
+		}
+
+		$redirect_id = 0;
+		if ( empty( $redirect['existing'] ) ) {
+			$created = $this->call( 'create_redirect', $redirect );
+			if ( is_wp_error( $created ) || (int) $created <= 0 ) {
+				return $this->rollback( $original, $duplicate, $canonical, 0, 'redirect_creation_failed' );
+			}
+			$redirect_id = (int) $created;
+		}
+
+		if ( true !== $this->call( 'verify_redirect', $redirect ) ) {
+			return $this->rollback( $original, $duplicate, $canonical, $redirect_id, 'redirect_verification_failed' );
+		}
+
+		$deleted = $this->call( 'delete_term', (int) $duplicate->term_id );
+		if ( true !== $deleted || true === $this->call( 'term_exists', (int) $duplicate->term_id ) ) {
+			return $this->rollback( $original, $duplicate, $canonical, $redirect_id, 'term_deletion_failed' );
+		}
+
+		return $this->result( 'reconciled', 'relationships_redirect_and_deletion_verified' );
+	}
+
+	/**
+	 * Verify every affected object is at the expected migration boundary.
+	 *
+	 * @param array $original           Original relationships by object ID.
+	 * @param int   $duplicate_id       Duplicate term ID.
+	 * @param int   $canonical_id       Canonical term ID.
+	 * @param bool  $duplicate_expected Whether the duplicate should remain attached.
+	 */
+	private function verify_relationships( array $original, int $duplicate_id, int $canonical_id, bool $duplicate_expected ): bool {
+		foreach ( array_keys( $original ) as $object_id ) {
+			$terms = $this->call( 'get_object_terms', $object_id );
+			if ( is_wp_error( $terms ) ) {
+				return false;
+			}
+			$terms = array_map( 'intval', $terms );
+			if ( ! in_array( $canonical_id, $terms, true ) || in_array( $duplicate_id, $terms, true ) !== $duplicate_expected ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Restore relationships and remove a redirect created by this run.
+	 *
+	 * @param array  $original    Original relationships by object ID.
+	 * @param object $duplicate   Duplicate root location term.
+	 * @param object $canonical   Canonical hierarchy location term.
+	 * @param int    $redirect_id Redirect created by this run, if any.
+	 * @param string $reason      Failure reason.
+	 */
+	private function rollback( array $original, object $duplicate, object $canonical, int $redirect_id, string $reason ): array {
+		$ok = true;
+		foreach ( $original as $object_id => $term_ids ) {
+			if ( in_array( (int) $duplicate->term_id, $term_ids, true ) ) {
+				$result = $this->call( 'add_relationship', $object_id, (int) $duplicate->term_id );
+				$ok     = $ok && ! is_wp_error( $result ) && false !== $result;
+			}
+			if ( ! in_array( (int) $canonical->term_id, $term_ids, true ) ) {
+				$result = $this->call( 'remove_relationship', $object_id, (int) $canonical->term_id );
+				$ok     = $ok && ! is_wp_error( $result ) && false !== $result;
+			}
+		}
+
+		if ( $redirect_id > 0 ) {
+			$ok = true === $this->call( 'delete_redirect', $redirect_id ) && $ok;
+		}
+
+		return $this->result( 'failed', $reason . ( $ok ? '_rolled_back' : '_rollback_failed' ) );
+	}
+
+	/**
+	 * Invoke one injected operation.
+	 *
+	 * @param string $operation Operation name.
+	 * @param mixed  ...$args   Operation arguments.
+	 */
+	private function call( string $operation, ...$args ) {
+		return ( $this->operations[ $operation ] )( ...$args );
+	}
+
+	/**
+	 * Build one repair result.
+	 *
+	 * @param string $status Repair status.
+	 * @param string $reason Machine-readable reason.
+	 */
+	private function result( string $status, string $reason ): array {
+		return array(
+			'status' => $status,
+			'reason' => $reason,
+		);
+	}
+}

--- a/inc/Providers/CliProvider.php
+++ b/inc/Providers/CliProvider.php
@@ -74,6 +74,11 @@ final class CliProvider {
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/AuditLocationIntegrityCommand.php';
 		\WP_CLI::add_command( 'extrachill events locations audit-integrity', \ExtraChillEvents\Cli\AuditLocationIntegrityCommand::class );
 
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/QualifiedRootLocation.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Core/RootLocationRepair.php';
+		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/ReconcileRootLocationsCommand.php';
+		\WP_CLI::add_command( 'extrachill events locations reconcile-roots', \ExtraChillEvents\Cli\ReconcileRootLocationsCommand::class );
+
 		require_once EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Cli/BackfillVenueMetaCommand.php';
 		\WP_CLI::add_command( 'extrachill events venues backfill-meta', \ExtraChillEvents\Cli\BackfillVenueMetaCommand::class );
 

--- a/inc/core/location-normalizer.php
+++ b/inc/core/location-normalizer.php
@@ -32,6 +32,41 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 add_action( 'datamachine_event_taxonomy_processed', 'extrachill_events_normalize_location' );
+add_filter( 'datamachine_taxonomy_assign_value', 'extrachill_events_prevent_dynamic_location_creation', 10, 3 );
+
+/**
+ * Resolve AI-decided event locations without allowing dynamic term creation.
+ *
+ * Data Machine's generic taxonomy handler creates unknown AI values. Location
+ * identity is instead owned by the event venue and the canonical hierarchy, so
+ * return an existing term ID or skip assignment. The normalizer runs after the
+ * taxonomy pass and applies the same resolver as a final invariant.
+ *
+ * @param mixed  $value     AI-supplied taxonomy value.
+ * @param string $taxonomy Taxonomy slug.
+ * @param int    $post_id   Event post ID.
+ * @return mixed
+ */
+function extrachill_events_prevent_dynamic_location_creation( $value, string $taxonomy, int $post_id ) {
+	if ( 'location' !== $taxonomy || 'data_machine_events' !== get_post_type( $post_id ) ) {
+		return $value;
+	}
+
+	$venues = get_the_terms( $post_id, 'venue' );
+	if ( ! $venues || is_wp_error( $venues ) ) {
+		return '';
+	}
+
+	$venue    = reset( $venues );
+	$resolved = extrachill_events_resolve_location_term_for_venue_city(
+		(string) get_term_meta( $venue->term_id, '_venue_city', true ),
+		(string) get_term_meta( $venue->term_id, '_venue_state', true ),
+		(string) get_term_meta( $venue->term_id, '_venue_zip', true ),
+		(string) get_term_meta( $venue->term_id, '_venue_country', true )
+	);
+
+	return $resolved instanceof \WP_Term ? (string) $resolved->term_id : '';
+}
 
 /**
  * Normalize event location based on venue city/state/zip.

--- a/tests/Unit/Core/FeatureProviderBootstrapTest.php
+++ b/tests/Unit/Core/FeatureProviderBootstrapTest.php
@@ -40,7 +40,7 @@ final class FeatureProviderBootstrapTest extends TestCase {
 	public function test_cli_boot_registers_commands_once(): void {
 		$result = $this->run_fixture( 'cli' );
 
-		$this->assertSame( 14, $result['cli_commands'] );
+		$this->assertSame( 15, $result['cli_commands'] );
 		$this->assertSame(
 			array(
 				'extrachill events ramp',
@@ -55,6 +55,7 @@ final class FeatureProviderBootstrapTest extends TestCase {
 				'extrachill events flows repair-locations',
 				'extrachill events locations prune-orphans',
 				'extrachill events locations audit-integrity',
+				'extrachill events locations reconcile-roots',
 				'extrachill events venues backfill-meta',
 				'extrachill events backfill-authorship',
 			),

--- a/tests/Unit/Core/QualifiedRootLocationTest.php
+++ b/tests/Unit/Core/QualifiedRootLocationTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Qualified root location matching tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Core\QualifiedRootLocation;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__, 3 ) . '/inc/Core/QualifiedRootLocation.php';
+
+/** Verifies exact U.S. and Canadian hierarchy matching. */
+final class QualifiedRootLocationTest extends TestCase {
+
+	/** U.S. states and Canadian provinces use the same hierarchy contract. */
+	public function test_matches_us_and_canadian_qualified_roots_by_existing_hierarchy(): void {
+		$terms = $this->terms();
+		foreach ( array(
+			10 => 3,
+			11 => 6,
+			12 => 7,
+		) as $root_id => $canonical_id ) {
+			$result = QualifiedRootLocation::match( $terms[ $root_id ], array_values( $terms ), $this->hierarchy_filter() );
+			$this->assertSame( 'safe_match', $result['status'] );
+			$this->assertSame( $canonical_id, $result['canonical']->term_id );
+		}
+	}
+
+	/** Duplicate canonical candidates remain report-only. */
+	public function test_reports_ambiguous_same_name_city_without_mutation_instruction(): void {
+		$terms    = $this->terms();
+		$terms[8] = $this->term( 8, 'Charleston', 2 );
+		$result   = QualifiedRootLocation::match( $terms[10], array_values( $terms ), $this->hierarchy_filter() );
+
+		$this->assertSame( 'ambiguous', $result['status'] );
+		$this->assertNull( $result['canonical'] );
+	}
+
+	/** Unresolved candidates and roots with children remain report-only. */
+	public function test_reports_unresolved_root_and_rejects_roots_with_children(): void {
+		$terms      = $this->terms();
+		$unresolved = $this->term( 20, 'Kingston, ZZ', 0 );
+		$terms[20]  = $unresolved;
+		$result     = QualifiedRootLocation::match( $unresolved, array_values( $terms ), $this->hierarchy_filter() );
+		$this->assertSame( 'unresolved', $result['status'] );
+
+		$terms[21] = $this->term( 21, 'District', 10 );
+		$result    = QualifiedRootLocation::match( $terms[10], array_values( $terms ), $this->hierarchy_filter() );
+		$this->assertSame( 'ambiguous', $result['status'] );
+		$this->assertSame( 'candidate_has_children', $result['reason'] );
+	}
+
+	/** Build the hierarchy-filter test double. */
+	private function hierarchy_filter(): callable {
+		$parents = array(
+			'SC' => 2,
+			'QC' => 5,
+			'ON' => 4,
+		);
+		return static function ( array $matches, string $subdivision ) use ( $parents ): array {
+			$parent = $parents[ strtoupper( $subdivision ) ] ?? 0;
+			return array_values( array_filter( $matches, static fn( object $term ): bool => $term->parent === $parent ) );
+		};
+	}
+
+	/**
+	 * Build canonical and qualified-root fixtures.
+	 *
+	 * @return array<int,object>
+	 */
+	private function terms(): array {
+		return array(
+			1  => $this->term( 1, 'United States', 0 ),
+			2  => $this->term( 2, 'South Carolina', 1 ),
+			3  => $this->term( 3, 'Charleston', 2 ),
+			4  => $this->term( 4, 'Ontario', 9 ),
+			5  => $this->term( 5, 'Quebec', 9 ),
+			6  => $this->term( 6, 'Montreal', 5 ),
+			7  => $this->term( 7, 'Toronto', 4 ),
+			9  => $this->term( 9, 'Canada', 0 ),
+			10 => $this->term( 10, 'Charleston, SC', 0 ),
+			11 => $this->term( 11, 'Montreal, QC', 0 ),
+			12 => $this->term( 12, 'Toronto, ON', 0 ),
+		);
+	}
+
+	/**
+	 * Build one term fixture.
+	 *
+	 * @param int    $id        Term ID.
+	 * @param string $name      Term name.
+	 * @param int    $parent_id Parent term ID.
+	 */
+	private function term( int $id, string $name, int $parent_id ): object {
+		return (object) array(
+			'term_id' => $id,
+			'name'    => $name,
+			'parent'  => $parent_id,
+			'count'   => 0,
+		);
+	}
+}

--- a/tests/Unit/Core/RootLocationRepairTest.php
+++ b/tests/Unit/Core/RootLocationRepairTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Root location repair boundary tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Core\RootLocationRepair;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__, 3 ) . '/inc/Core/RootLocationRepair.php';
+
+/** Verifies mutation ordering and compensating rollback. */
+final class RootLocationRepairTest extends TestCase {
+
+	/** Relationships and redirects are verified before deletion. */
+	public function test_verifies_relationships_and_redirect_before_deletion(): void {
+		$fixture = $this->fixture();
+		$result  = $fixture['repair']->repair( $fixture['duplicate'], $fixture['canonical'] );
+
+		$this->assertSame(
+			array(
+				'status' => 'reconciled',
+				'reason' => 'relationships_redirect_and_deletion_verified',
+			),
+			$result
+		);
+		$this->assertSame( array( 200 ), $fixture['state']->relationships[101] );
+		$this->assertFalse( $fixture['state']->term_exists );
+		$this->assertSame( array( 'prepare_redirect', 'add:101:200', 'remove:101:100', 'create_redirect', 'verify_redirect', 'delete_term' ), $fixture['state']->events );
+	}
+
+	/** Redirect failure restores original relationships and blocks deletion. */
+	public function test_redirect_failure_rolls_relationships_back_before_deletion(): void {
+		$fixture                        = $this->fixture();
+		$fixture['state']->create_fails = true;
+		$result                         = $fixture['repair']->repair( $fixture['duplicate'], $fixture['canonical'] );
+
+		$this->assertSame( 'failed', $result['status'] );
+		$this->assertSame( 'redirect_creation_failed_rolled_back', $result['reason'] );
+		$this->assertSame( array( 100 ), $fixture['state']->relationships[101] );
+		$this->assertTrue( $fixture['state']->term_exists );
+		$this->assertNotContains( 'delete_term', $fixture['state']->events );
+	}
+
+	/** Partial relationship failure is compensated before returning. */
+	public function test_relationship_failure_compensates_partial_mutation(): void {
+		$fixture                        = $this->fixture();
+		$fixture['state']->remove_fails = true;
+		$result                         = $fixture['repair']->repair( $fixture['duplicate'], $fixture['canonical'] );
+
+		$this->assertSame( 'relationship_remove_failed_rolled_back', $result['reason'] );
+		$this->assertSame( array( 100 ), $fixture['state']->relationships[101] );
+		$this->assertTrue( $fixture['state']->term_exists );
+	}
+
+	/** Build an in-memory operation adapter fixture. */
+	private function fixture(): array {
+		$state      = (object) array(
+			'relationships' => array( 101 => array( 100 ) ),
+			'events'        => array(),
+			'redirect'      => false,
+			'term_exists'   => true,
+			'create_fails'  => false,
+			'remove_fails'  => false,
+		);
+		$operations = array(
+			'prepare_redirect'    => static function () use ( $state ) {
+				$state->events[] = 'prepare_redirect';
+				return array( 'existing' => false );
+			},
+			'get_objects'         => static function ( int $term_id ) use ( $state ): array {
+				return array_keys( array_filter( $state->relationships, static fn( array $terms ): bool => in_array( $term_id, $terms, true ) ) );
+			},
+			'get_object_terms'    => static fn( int $object_id ): array => $state->relationships[ $object_id ],
+			'add_relationship'    => static function ( int $object_id, int $term_id ) use ( $state ): bool {
+				$state->events[] = "add:{$object_id}:{$term_id}";
+				if ( ! in_array( $term_id, $state->relationships[ $object_id ], true ) ) {
+					$state->relationships[ $object_id ][] = $term_id;
+					sort( $state->relationships[ $object_id ] );
+				}
+				return true;
+			},
+			'remove_relationship' => static function ( int $object_id, int $term_id ) use ( $state ): bool {
+				$state->events[] = "remove:{$object_id}:{$term_id}";
+				if ( $state->remove_fails && 100 === $term_id ) {
+					$state->remove_fails = false;
+					return false;
+				}
+				$state->relationships[ $object_id ] = array_values( array_diff( $state->relationships[ $object_id ], array( $term_id ) ) );
+				return true;
+			},
+			'create_redirect'     => static function () use ( $state ) {
+				$state->events[] = 'create_redirect';
+				if ( $state->create_fails ) {
+					return new WP_Error( 'redirect_creation_failed' );
+				}
+				$state->redirect = true;
+				return 55;
+			},
+			'verify_redirect'     => static function () use ( $state ): bool {
+				$state->events[] = 'verify_redirect';
+				return $state->redirect;
+			},
+			'delete_redirect'     => static function () use ( $state ): bool {
+				$state->redirect = false;
+				return true;
+			},
+			'delete_term'         => static function () use ( $state ): bool {
+				$state->events[]     = 'delete_term';
+				$state->term_exists = false;
+				return true;
+			},
+			'term_exists'         => static fn(): bool => $state->term_exists,
+		);
+
+		return array(
+			'repair'    => new RootLocationRepair( $operations ),
+			'state'     => $state,
+			'duplicate' => (object) array(
+				'term_id' => 100,
+				'name'    => 'Charleston, SC',
+			),
+			'canonical' => (object) array(
+				'term_id' => 200,
+				'name'    => 'Charleston',
+			),
+		);
+	}
+}

--- a/tests/location-market-map-smoke.php
+++ b/tests/location-market-map-smoke.php
@@ -25,7 +25,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Minimal WP shims used while loading the normalizer file. Only the market-map
 // resolver path is exercised here, which performs no WP lookups.
 if ( ! function_exists( 'add_action' ) ) {
+	/** Ignore hook registration in this isolated smoke test. */
 	function add_action() {}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+	/** Ignore filter registration in this isolated smoke test. */
+	function add_filter() {}
 }
 if ( ! function_exists( 'get_term_by' ) ) {
 	function get_term_by() {

--- a/tests/location-resolution-smoke.php
+++ b/tests/location-resolution-smoke.php
@@ -42,6 +42,11 @@ $GLOBALS['ec_resolution_terms'] = array(
 	12 => new WP_Term( 12, 'London', 'london-on', 5 ),
 	13 => new WP_Term( 13, 'London', 'london-uk', 7 ),
 	14 => new WP_Term( 14, 'Oxford', 'oxford-uk', 7 ),
+	15 => new WP_Term( 15, 'South Carolina', 'south-carolina', 1 ),
+	16 => new WP_Term( 16, 'Quebec', 'quebec', 4 ),
+	17 => new WP_Term( 17, 'Charleston', 'charleston-sc', 15 ),
+	18 => new WP_Term( 18, 'Montreal', 'montreal-qc', 16 ),
+	19 => new WP_Term( 19, 'Toronto', 'toronto-on', 5 ),
 );
 $GLOBALS['ec_resolution_venue']       = new WP_Term( 20, 'Resolution Venue', 'resolution-venue' );
 $GLOBALS['ec_resolution_location']    = $GLOBALS['ec_resolution_terms'][10];
@@ -54,6 +59,7 @@ $GLOBALS['ec_resolution_meta']        = array(
 );
 
 function add_action() {}
+function add_filter() {}
 function is_wp_error() {
 	return false;
 }
@@ -62,6 +68,9 @@ function wp_is_post_revision() {
 }
 function wp_is_post_autosave() {
 	return false;
+}
+function get_post_type() {
+	return 'data_machine_events';
 }
 function get_the_terms( $post_id, $taxonomy ) {
 	return 'venue' === $taxonomy
@@ -102,6 +111,9 @@ $cases = array(
 	array( 'London', '', '', 'Canada', 12, 'country context selects Canada hierarchy' ),
 	array( 'London', '', '', 'GB', 13, 'country code selects United Kingdom hierarchy' ),
 	array( 'Oxford', 'Mississippi', '', 'US', null, 'sole city match rejects conflicting hierarchy' ),
+	array( 'Charleston', 'SC', '', 'US', 17, 'Charleston resolves through South Carolina hierarchy' ),
+	array( 'Montreal', 'QC', '', 'CA', 18, 'Montreal resolves through Quebec hierarchy' ),
+	array( 'Toronto', 'ON', '', 'CA', 19, 'Toronto resolves through Ontario hierarchy' ),
 );
 
 $failures = 0;
@@ -130,6 +142,19 @@ if ( array() !== $GLOBALS['ec_resolution_assignments'] ) {
 	printf( "FAIL: an already-correct canonical assignment must not be rewritten\n" );
 }
 
+$guarded = extrachill_events_prevent_dynamic_location_creation( 'Wilmington, NC', 'location', 150479 );
+if ( '10' !== $guarded ) {
+	++$failures;
+	printf( "FAIL: AI-decided location must resolve to an existing canonical term ID\n" );
+}
+$GLOBALS['ec_resolution_meta']['_venue_state'] = 'PA';
+$guarded = extrachill_events_prevent_dynamic_location_creation( 'Wilmington, PA', 'location', 150479 );
+if ( '' !== $guarded ) {
+	++$failures;
+	printf( "FAIL: unresolved AI-decided location must be refused instead of created\n" );
+}
+$GLOBALS['ec_resolution_meta']['_venue_state'] = 'NC';
+
 $ability = new ExtraChillEvents\Abilities\EventLocationAlignmentAbilities();
 $method  = new ReflectionMethod( $ability, 'resolveExpectedLocationTerm' );
 $result  = $method->invoke( $ability, 'Wilmington', '', '', 'US', $GLOBALS['ec_resolution_terms'][11] );
@@ -138,5 +163,5 @@ if ( null !== $result['term'] || 'ambiguous_location_hierarchy' !== $result['rea
 	printf( "FAIL: ambiguous hierarchy must not fall back to a flow term in audit/fix mode\n" );
 }
 
-printf( "%d passed, %d failed\n", count( $cases ) + 4 - $failures, $failures );
+printf( "%d passed, %d failed\n", count( $cases ) + 6 - $failures, $failures );
 exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary
- prevent Data Machine's AI-decided event taxonomy path from dynamically creating noncanonical location terms
- add a dry-run-first repair command for exact `City, State/Province` root duplicates using the existing canonical hierarchy resolver
- preserve and verify relationships and redirects before deletion, with compensating rollback at each pre-delete failure boundary

## Traced root cause
The current event upsert has two distinct location paths:

1. `EventTaxonomyAssigner::processLocation()` owns `PRE_SELECTED` locations, resolves an existing term ID from venue city/state/zip, and assigns that ID. It does not create location terms.
2. `AI_DECIDES` falls through `EventUpsert::upsert()` into Data Machine's generic `TaxonomyHandler::processAiDecidedTaxonomy()` -> `assignTaxonomy()` -> `ResolveTermAbility::resolve(..., true)` -> `wp_insert_term()`. A model value such as `Charleston, SC`, `Montreal, QC`, or `Toronto, ON` therefore becomes a new root term when no exact term with that qualified name exists.

Other creation paths were checked:

- `CityAbilities::executeAddCity()` derives an unqualified city label and `ensureLocationTerm()` creates Country -> State/Province -> City; it does not pass the qualified input through as a root name.
- current preselected flow assignment and location normalization use numeric existing term IDs.
- WordPress core's REST terms controller and string-valued `wp_set_object_terms()` can call `wp_insert_term()`, but those are generic/manual surfaces rather than the recurring event import path. This PR deliberately avoids an expensive global `pre_insert_term` taxonomy query.

## Existing primitives reused
- Data Machine's existing `datamachine_taxonomy_assign_value` owner hook, specifically documented for preventing generic dynamic creation in an owned taxonomy
- `extrachill_events_resolve_location_term_for_venue_city()` for event creation-path prevention
- `extrachill_events_filter_locations_by_hierarchy()` and its existing U.S. state and Canadian province identity map for repair classification
- the existing `extrachill/reconcile-event-locations` ability remains the event-assignment audit/repair primitive
- Extra Chill SEO's existing add/list/delete redirect abilities for redirect creation, exact verification, and compensation
- WordPress relationship APIs rather than direct taxonomy table writes

## Why #232 stays obsolete
#232 predates provider-based CLI registration, duplicates subdivision mapping, only models U.S. states, and installs a global `pre_insert_term` query. This PR does not revive that implementation. It fixes the proven Data Machine creation seam and uses the current canonical resolver and provider registration. The repair path also verifies every relationship boundary and the exact active 301 before deletion, with rollback when a pre-delete step fails.

## Prevention behavior
For `data_machine_events` posts only, AI-decided `location` values are replaced with the existing canonical term ID resolved from attached venue city/state/zip/country. If venue identity is missing, ambiguous, or unresolved, assignment is skipped, so Data Machine cannot create the model-supplied value. The existing post-taxonomy normalizer then applies the same resolver as the final invariant. Other taxonomies and post types are unchanged.

## Dry-run/apply safety contract
`wp extrachill events locations reconcile-roots` is dry-run by default. It reports `would_reconcile`, `ambiguous`, and `unresolved` candidates without mutation. `--apply` is the only mutation switch.

For each safe candidate, apply mode:

1. preflights both term URLs and redirect abilities, rejecting conflicting redirects
2. snapshots every current relationship
3. adds and verifies canonical relationships
4. removes and verifies duplicate relationships, including a final zero-relationship check
5. creates or reuses and verifies the exact active 301 redirect
6. deletes the duplicate and verifies deletion

Any failure before successful deletion compensates the relationships and removes a redirect created by that run. Candidates with children, multiple hierarchy matches, unresolved hierarchy identity, or redirect conflicts remain untouched.

## International hierarchy handling
Classification parses the subdivision qualifier but does not own a new map. It delegates identity matching to the existing hierarchy filter, which already resolves both U.S. state abbreviations and Canadian province abbreviations. Coverage includes Charleston, SC; Montreal, QC; and Toronto, ON.

## Tests run
- `php tests/location-resolution-smoke.php` -> 17 passed, 0 failed
- `php tests/location-market-map-smoke.php` -> 51 passed, 0 failed
- explicit PHPUnit files -> 20 tests, 106 assertions passed across qualified-root matching, repair ordering/rollback, existing integrity audit, canonical invariant, and CLI provider bootstrap
- focused WordPress PHPCS on changed production/new unit files with the repository's existing CamelCase filename sniff excluded -> passed
- PHP syntax checks for every changed PHP file -> passed
- `git diff --check` -> passed

The aggregate `vendor/bin/phpunit` command remains blocked before filtering because `phpunit.xml.dist` includes `CanonicalLocationsAbilityTest.php`, which extends unavailable `WP_UnitTestCase` under the plain bootstrap. Explicit relevant files all pass. No dependencies were installed; temporary links to the DMC primary's `vendor` and `node_modules` were removed before commit.

## Operator follow-up
No production apply command was run. After deployment, review first:

```bash
wp --allow-root --path=/var/www/extrachill.com --url=https://events.extrachill.com extrachill events locations reconcile-roots --format=json
```

After separately reviewing every safe candidate, apply explicitly:

```bash
wp --allow-root --path=/var/www/extrachill.com --url=https://events.extrachill.com extrachill events locations reconcile-roots --apply --format=json
```

The existing event-level audit remains available through `extrachill/reconcile-event-locations` before or after taxonomy reconciliation.

Closes #673