### PR TITLE
fix: normalize location reconciliation identity

### DIFF
--- a/inc/Cli/ReconcileRootLocationsCommand.php
+++ b/inc/Cli/ReconcileRootLocationsCommand.php
@@ -21,7 +21,7 @@ final class ReconcileRootLocationsCommand {
 	 * ## OPTIONS
 	 *
 	 * [--apply]
-	 * : Move relationships, create and verify redirects, and delete safe duplicates. Default is dry-run.
+	 * : Move relationships, create and verify redirects, and delete safe duplicates. Requires an administrator user context. Default is dry-run.
 	 *
 	 * [--format=<format>]
 	 * : Output format: table, json, or csv. Default: table.
@@ -29,7 +29,7 @@ final class ReconcileRootLocationsCommand {
 	 * ## EXAMPLES
 	 *
 	 *     wp extrachill events locations reconcile-roots --url=events.extrachill.com
-	 *     wp extrachill events locations reconcile-roots --url=events.extrachill.com --apply
+	 *     wp extrachill events locations reconcile-roots --url=events.extrachill.com --user=<administrator-login-or-id> --apply
 	 *
 	 * @param array $args       Positional arguments (unused).
 	 * @param array $assoc_args Named arguments.
@@ -38,6 +38,11 @@ final class ReconcileRootLocationsCommand {
 		unset( $args );
 		if ( ! taxonomy_exists( 'location' ) ) {
 			\WP_CLI::error( 'The location taxonomy is not registered. Use --url=events.extrachill.com.' );
+		}
+
+		$apply = ! empty( $assoc_args['apply'] );
+		if ( $apply ) {
+			$this->assert_apply_ready();
 		}
 
 		$terms = get_terms(
@@ -51,7 +56,6 @@ final class ReconcileRootLocationsCommand {
 			\WP_CLI::error( $terms->get_error_message() );
 		}
 
-		$apply  = ! empty( $assoc_args['apply'] );
 		$repair = $apply ? $this->repair_service() : null;
 		$rows   = array();
 
@@ -92,6 +96,26 @@ final class ReconcileRootLocationsCommand {
 
 		if ( ! $apply ) {
 			\WP_CLI::log( 'Dry run: no redirects, relationships, or terms changed. Re-run with --apply only after reviewing every row.' );
+		}
+	}
+
+	/** Ensure apply mode can use every redirect ability before inspecting candidates. */
+	private function assert_apply_ready(): void {
+		$ability_names = array(
+			'extrachill-seo/list-redirects',
+			'extrachill-seo/add-redirect',
+			'extrachill-seo/delete-redirect',
+		);
+
+		foreach ( $ability_names as $ability_name ) {
+			$ability = wp_get_ability( $ability_name );
+			if ( ! $ability ) {
+				\WP_CLI::error( sprintf( 'Apply requires the %s ability, but it is unavailable.', $ability_name ) );
+			}
+
+			if ( true !== $ability->check_permissions() ) {
+				\WP_CLI::error( 'Apply requires an authorized WordPress administrator context for redirect management. Re-run with --user=<administrator-login-or-id>.' );
+			}
 		}
 	}
 

--- a/inc/core/location-normalizer.php
+++ b/inc/core/location-normalizer.php
@@ -194,10 +194,10 @@ function extrachill_events_resolve_location_term_for_venue_city( $venue_city, $v
 function extrachill_events_filter_locations_by_hierarchy( array $matches, string $venue_state, string $country ): array {
 	$venue_state = trim( $venue_state );
 	$country     = trim( $country );
-	$state_names = array( strtolower( $venue_state ) );
+	$state_names = array( extrachill_events_location_identity_key( $venue_state ) );
 	$full_name   = extrachill_events_get_state_abbreviation_map()[ strtoupper( $venue_state ) ] ?? null;
 	if ( $full_name ) {
-		$state_names[] = strtolower( $full_name );
+		$state_names[] = extrachill_events_location_identity_key( $full_name );
 	}
 	$country_name = extrachill_events_normalize_country_name( $country );
 	$filtered     = array();
@@ -212,7 +212,7 @@ function extrachill_events_filter_locations_by_hierarchy( array $matches, string
 			continue;
 		}
 
-		if ( '' !== $venue_state && ! in_array( strtolower( $parent->name ), $state_names, true ) ) {
+		if ( '' !== $venue_state && ! in_array( extrachill_events_location_identity_key( $parent->name ), $state_names, true ) ) {
 			continue;
 		}
 
@@ -230,13 +230,23 @@ function extrachill_events_filter_locations_by_hierarchy( array $matches, string
 }
 
 /**
+ * Normalize a location hierarchy identity for exact comparison.
+ *
+ * @param string $value Location identity.
+ * @return string Normalized identity.
+ */
+function extrachill_events_location_identity_key( string $value ): string {
+	return strtolower( remove_accents( trim( $value ) ) );
+}
+
+/**
  * Normalize common country names and ISO codes for hierarchy comparisons.
  *
  * @param string $country Country name or code.
  * @return string Normalized country identity.
  */
 function extrachill_events_normalize_country_name( string $country ): string {
-	$country = strtolower( trim( $country ) );
+	$country = extrachill_events_location_identity_key( $country );
 	$aliases = array(
 		'us'                       => 'united states',
 		'usa'                      => 'united states',

--- a/tests/Unit/Core/ReconcileRootLocationsCommandTest.php
+++ b/tests/Unit/Core/ReconcileRootLocationsCommandTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Qualified root reconciliation CLI tests.
+ *
+ * @package ExtraChillEvents\Tests
+ */
+
+use ExtraChillEvents\Cli\ReconcileRootLocationsCommand;
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable -- Test doubles intentionally share global WordPress and WP-CLI state.
+
+require_once dirname( __DIR__, 2 ) . '/Integration/Stubs/wp-cli-stubs.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Core/QualifiedRootLocation.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Core/RootLocationRepair.php';
+require_once dirname( __DIR__, 3 ) . '/inc/Cli/ReconcileRootLocationsCommand.php';
+
+if ( ! function_exists( 'taxonomy_exists' ) ) {
+	function taxonomy_exists(): bool {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_terms' ) ) {
+	function get_terms(): array {
+		++$GLOBALS['ec_reconcile_cli_test']['term_queries'];
+		return $GLOBALS['ec_reconcile_cli_test']['terms'];
+	}
+}
+
+/** Verifies dry-run and apply authorization boundaries. */
+final class ReconcileRootLocationsCommandTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['ec_reconcile_cli_test'] = array(
+			'term_queries' => 0,
+			'terms'        => array(),
+		);
+		\WP_CLI::$logs                       = array();
+		\WP_CLI::$formatted                  = array();
+		$GLOBALS['ec_test_ability_resolver'] = null;
+	}
+
+	/** Dry runs inspect candidates without loading or authorizing redirect abilities. */
+	public function test_dry_run_does_not_require_redirect_permissions(): void {
+		$ability_requests = array();
+		$GLOBALS['ec_test_ability_resolver'] = static function ( string $name ) use ( &$ability_requests ) {
+			$ability_requests[] = $name;
+			return null;
+		};
+
+		( new ReconcileRootLocationsCommand() )( array(), array() );
+
+		$this->assertSame( array(), $ability_requests );
+		$this->assertSame( 1, $GLOBALS['ec_reconcile_cli_test']['term_queries'] );
+		$this->assertStringStartsWith( 'Dry run:', end( \WP_CLI::$logs ) );
+	}
+
+	/** Apply mode fails before candidate retrieval when the user lacks permission. */
+	public function test_apply_fails_fast_without_redirect_permission(): void {
+		$GLOBALS['ec_test_ability_resolver'] = static fn() => new ReconcileAbilityDouble( false );
+
+		try {
+			( new ReconcileRootLocationsCommand() )( array(), array( 'apply' => true ) );
+			$this->fail( 'Expected apply authorization to fail.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertStringContainsString( '--user=<administrator-login-or-id>', $exception->getMessage() );
+		}
+
+		$this->assertSame( 0, $GLOBALS['ec_reconcile_cli_test']['term_queries'] );
+	}
+
+	/** Authorized apply mode verifies all redirect abilities before retrieval. */
+	public function test_apply_checks_all_redirect_abilities_with_authorized_context(): void {
+		$ability_requests = array();
+		$GLOBALS['ec_test_ability_resolver'] = static function ( string $name ) use ( &$ability_requests ) {
+			$ability_requests[] = $name;
+			return new ReconcileAbilityDouble( true );
+		};
+
+		( new ReconcileRootLocationsCommand() )( array(), array( 'apply' => true ) );
+
+		$this->assertSame(
+			array(
+				'extrachill-seo/list-redirects',
+				'extrachill-seo/add-redirect',
+				'extrachill-seo/delete-redirect',
+			),
+			$ability_requests
+		);
+		$this->assertSame( 1, $GLOBALS['ec_reconcile_cli_test']['term_queries'] );
+	}
+}
+
+/** Minimal ability permission test double. */
+final class ReconcileAbilityDouble {
+
+	private bool $allowed;
+
+	public function __construct( bool $allowed ) {
+		$this->allowed = $allowed;
+	}
+
+	public function check_permissions(): bool {
+		return $this->allowed;
+	}
+}

--- a/tests/location-market-map-smoke.php
+++ b/tests/location-market-map-smoke.php
@@ -52,6 +52,12 @@ if ( ! function_exists( 'is_wp_error' ) ) {
 		return false;
 	}
 }
+if ( ! function_exists( 'remove_accents' ) ) {
+	/** Return unchanged ASCII fixtures in the isolated smoke runtime. */
+	function remove_accents( $text ) {
+		return $text;
+	}
+}
 
 require_once dirname( __DIR__ ) . '/inc/core/location-normalizer.php';
 

--- a/tests/location-resolution-smoke.php
+++ b/tests/location-resolution-smoke.php
@@ -43,7 +43,7 @@ $GLOBALS['ec_resolution_terms'] = array(
 	13 => new WP_Term( 13, 'London', 'london-uk', 7 ),
 	14 => new WP_Term( 14, 'Oxford', 'oxford-uk', 7 ),
 	15 => new WP_Term( 15, 'South Carolina', 'south-carolina', 1 ),
-	16 => new WP_Term( 16, 'Quebec', 'quebec', 4 ),
+	16 => new WP_Term( 16, 'Québec', 'quebec', 4 ),
 	17 => new WP_Term( 17, 'Charleston', 'charleston-sc', 15 ),
 	18 => new WP_Term( 18, 'Montreal', 'montreal-qc', 16 ),
 	19 => new WP_Term( 19, 'Toronto', 'toronto-on', 5 ),
@@ -62,6 +62,9 @@ function add_action() {}
 function add_filter() {}
 function is_wp_error() {
 	return false;
+}
+function remove_accents( $text ) {
+	return strtr( $text, array( 'é' => 'e', 'É' => 'E' ) );
 }
 function wp_is_post_revision() {
 	return false;
@@ -101,6 +104,7 @@ function get_terms() {
 
 require_once dirname( __DIR__ ) . '/inc/core/location-normalizer.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/EventLocationAlignmentAbilities.php';
+require_once dirname( __DIR__ ) . '/inc/Core/QualifiedRootLocation.php';
 
 $cases = array(
 	array( 'Wilmington', 'NC', '', 'US', 10, 'state abbreviation selects North Carolina' ),
@@ -113,6 +117,8 @@ $cases = array(
 	array( 'Oxford', 'Mississippi', '', 'US', null, 'sole city match rejects conflicting hierarchy' ),
 	array( 'Charleston', 'SC', '', 'US', 17, 'Charleston resolves through South Carolina hierarchy' ),
 	array( 'Montreal', 'QC', '', 'CA', 18, 'Montreal resolves through Quebec hierarchy' ),
+	array( 'Montreal', 'Quebec', '', 'Canada', 18, 'unaccented province name matches accented hierarchy' ),
+	array( 'Montreal', 'Québec', '', 'Canada', 18, 'accented province name remains resolvable' ),
 	array( 'Toronto', 'ON', '', 'CA', 19, 'Toronto resolves through Ontario hierarchy' ),
 );
 
@@ -125,6 +131,16 @@ foreach ( $cases as $case ) {
 		++$failures;
 		printf( "FAIL: %s: got %s, expected %s\n", $label, var_export( $actual, true ), var_export( $expected_id, true ) );
 	}
+}
+
+$qualified_root = new WP_Term( 21, 'Montreal, QC', 'montreal-qc-duplicate' );
+$root_match     = ExtraChillEvents\Core\QualifiedRootLocation::match(
+	$qualified_root,
+	array_merge( array_values( $GLOBALS['ec_resolution_terms'] ), array( $qualified_root ) )
+);
+if ( 'safe_match' !== $root_match['status'] || 18 !== $root_match['canonical']->term_id ) {
+	++$failures;
+	printf( "FAIL: Montreal, QC root must match Montreal under Québec\n" );
 }
 
 if ( 'philadelphia' !== extrachill_events_get_market_slug_for_venue( 'Wilmington', 'DE', '', 'US' ) ) {
@@ -163,5 +179,5 @@ if ( null !== $result['term'] || 'ambiguous_location_hierarchy' !== $result['rea
 	printf( "FAIL: ambiguous hierarchy must not fall back to a flow term in audit/fix mode\n" );
 }
 
-printf( "%d passed, %d failed\n", count( $cases ) + 6 - $failures, $failures );
+printf( "%d passed, %d failed\n", count( $cases ) + 7 - $failures, $failures );
 exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary
- normalize hierarchy identity with WordPress core's `remove_accents()` so `QC`, `Quebec`, and `Québec` resolve to the same canonical subdivision
- preflight the existing SEO redirect abilities and their permissions before apply-mode candidate retrieval
- document the required administrator context while preserving permission-free dry runs

## Root cause
The shared hierarchy resolver expanded `QC` to `Quebec` but compared that value to the lowercase canonical parent name `québec` without accent normalization. The reconciliation command also reached capability-gated SEO abilities only while iterating safe rows, so a missing WordPress user context surfaced repeatedly as misleading `redirect_lookup_failed` rows.

## Existing primitives investigated and reused
- WordPress core `remove_accents()` for Unicode accent normalization
- WordPress core `WP_Ability::check_permissions()` for permission preflight
- Extra Chill SEO's existing `extrachill-seo/list-redirects`, `extrachill-seo/add-redirect`, and `extrachill-seo/delete-redirect` abilities, whose contracts require `manage_options`

No Montreal-specific alias, duplicate subdivision map, permission bypass, or direct SEO API was added.

## Normalization seam
`extrachill_events_location_identity_key()` now owns accent-insensitive hierarchy identity. Subdivision inputs, canonical parent names, and country identities pass through that seam before the existing exact comparisons and alias maps. Existing U.S./Canadian abbreviation, full-name, country, market-rollup, and ambiguous-city behavior remains intact.

## Permission behavior
`--apply` resolves all three redirect abilities and calls each ability's real `check_permissions()` method before loading or iterating location candidates. Missing abilities fail clearly; denied permissions fail once with an actionable `--user=<administrator-login-or-id>` instruction. SEO ability permissions remain unchanged and all redirect operations still execute through the Abilities API.

## Dry-run/apply contract
Dry run remains the default, performs no mutation, and does not resolve or check redirect abilities. Apply mode requires an authorized WordPress administrator context and retains the existing redirect-first repair/compensation behavior.

## Tests run
- `php tests/location-resolution-smoke.php` (20 passed, 0 failed)
- `php tests/location-market-map-smoke.php` (51 passed, 0 failed)
- `./vendor/bin/phpunit tests/Unit/Core/ReconcileRootLocationsCommandTest.php` (3 tests, 7 assertions)
- `./vendor/bin/phpunit tests/Unit/Core/QualifiedRootLocationTest.php` (3 tests, 11 assertions)
- `./vendor/bin/phpunit tests/Unit/Core/CanonicalLocationInvariantTest.php` (1 test, 4 assertions)
- `./vendor/bin/phpunit tests/Unit/Core/FeatureProviderBootstrapTest.php` (9 tests, 70 assertions)
- PHP syntax checks for every changed PHP file
- focused WordPress PHPCS for production changes and new regression coverage
- `git diff --check`

The repository's aggregate `qualify-v2-unit` suite still cannot bootstrap its listed WP integration tests in the plain PHPUnit runtime because `WP_UnitTestCase` is unavailable, matching the existing limitation documented in `phpunit.xml.dist`.

## Residual operator follow-up
After this change is merged, released, and deployed, rerun the production dry-run and review the single Montreal row. Then run `wp extrachill events locations reconcile-roots --url=events.extrachill.com --user=<administrator-login-or-id> --apply` to reconcile term 72014 into canonical Montreal term 71135. No production taxonomy mutation was performed in this PR.

Closes #675